### PR TITLE
JSON serialization: fix unicode encoding character

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/generic/GenericData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/generic/GenericData.java
@@ -397,9 +397,9 @@ public class GenericData {
           if((ch>='\u0000' && ch<='\u001F') || (ch>='\u007F' && ch<='\u009F') || (ch>='\u2000' && ch<='\u20FF')){
             String hex = Integer.toHexString(ch);
             builder.append("\\u");
-            for(int j = 0; j < 4-builder.length(); j++)
+            for(int j = 0; j < 4 - hex.length(); j++)
               builder.append('0');
-            builder.append(string.toUpperCase());
+            builder.append(hex.toUpperCase());
           } else {
             builder.append(ch);
           }

--- a/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericData.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericData.java
@@ -218,7 +218,8 @@ public class TestGenericData {
     schema.setFields(Arrays.asList(stringField, enumField));
     
     GenericRecord r = new GenericData.Record(schema);
-    r.put(stringField.name(), "hello\nthere\"\tyou}");
+    // \u2013 is EN DASH
+    r.put(stringField.name(), "hello\nthere\"\tyou\u2013}");
     r.put(enumField.name(), new GenericData.EnumSymbol(enumField.schema(),"a"));
     
     String json = r.toString();


### PR DESCRIPTION
- fix GenericData.writeEscapedString() to return valid unicode character
- in TestGenericData.testToStringIsJson, add \u2013 (EN DASH) to check that
  the output JSON is parseable
