### PR TITLE
Adding SeekableInput that supports data as byte[]

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/file/SeekableByteArrayInput.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/file/SeekableByteArrayInput.java
@@ -20,7 +20,7 @@ package org.apache.avro.file;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-/** A {@link SeekableInput} backed data in a byte array. */
+/** A {@link SeekableInput} backed with data in a byte array. */
 public class SeekableByteArrayInput extends ByteArrayInputStream implements SeekableInput {
 
 	public SeekableByteArrayInput(byte[] data) {
@@ -32,9 +32,8 @@ public class SeekableByteArrayInput extends ByteArrayInputStream implements Seek
 	}
 
 	public void seek(long p) throws IOException {
-		if (p < this.pos)
-			throw new IOException("Cannot seek to a previously read part of the input.");
-		this.skip(p - this.pos);
+		this.reset();
+		this.skip(p);
 	}
 
 	public long tell() throws IOException {


### PR DESCRIPTION
Adding SeekableInput that supports data as byte[] instead of just from Files.   Updated original implementation to subclass ByteArrayInputStream based on recommendation from cutting@github, and implemented 'seek'ing backwards.
