### PR TITLE
io.rb: Fixing typo writer_scheam -> writer_schema under error case 

### DIFF
--- a/lang/ruby/lib/avro/io.rb
+++ b/lang/ruby/lib/avro/io.rb
@@ -244,7 +244,7 @@ module Avro
           when 'record'
             return check_props(writers_schema, readers_schema, [:fullname])
           when 'error'
-            return check_props(writers_scheam, readers_schema, [:fullname])
+            return check_props(writers_schema, readers_schema, [:fullname])
           when 'request'
             return true
           when 'fixed'


### PR DESCRIPTION
seems like a pretty straightforward typo. 