### PR TITLE
Added a getter for the keySchema and valSchema

### DIFF
--- a/lang/java/mapred/src/main/java/org/apache/avro/mapreduce/AvroMultipleOutputs.java
+++ b/lang/java/mapred/src/main/java/org/apache/avro/mapreduce/AvroMultipleOutputs.java
@@ -503,6 +503,18 @@ public class AvroMultipleOutputs{
     return taskContext;
   }
   
+  public Schema getKeySchema(String nameOutput)
+  {
+      return keySchemas.get(nameOutput);
+  }
+
+  public Schema getValSchema(String nameOutput)
+  {
+      return valSchemas.get(nameOutput);
+  }
+
+
+
   /**
    * Closes all the opened outputs.
    * 


### PR DESCRIPTION
I have a need to get the schemas while in the reducer.  The schemas are unknown at compile time and are read from local files at run time.    

I know I could grab them out of the config but that wouldn't be as clean as getting them from AvroMultipleOutputs.

Also I'm new to cloudera (just finished my 3rd week and would love to help out with avro).