### PR TITLE
Don't generate invalid JSON for unprintable chars

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/generic/GenericData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/generic/GenericData.java
@@ -445,9 +445,9 @@ public class GenericData {
           if((ch>='\u0000' && ch<='\u001F') || (ch>='\u007F' && ch<='\u009F') || (ch>='\u2000' && ch<='\u20FF')){
             String hex = Integer.toHexString(ch);
             builder.append("\\u");
-            for(int j = 0; j < 4-builder.length(); j++)
+            for(int j = 0; j < 4-hex.length(); j++)
               builder.append('0');
-            builder.append(string.toUpperCase());
+            builder.append(hex.toUpperCase());
           } else {
             builder.append(ch);
           }


### PR DESCRIPTION
`GenericData.toString()` references the wrong variable, which causes it to generate invalid JSON if an unprintable character appears in a string field. This patch fixes it.
