### PR TITLE
Fix dependency gem name

### DIFF
--- a/lang/ruby/Rakefile
+++ b/lang/ruby/Rakefile
@@ -23,7 +23,7 @@ Echoe.new('avro', VERSION) do |p|
   p.summary = "Apache Avro for Ruby"
   p.description = "Avro is a data serialization and RPC format"
   p.url = "http://hadoop.apache.org/avro/"
-  p.runtime_dependencies = %w[multi-json]
+  p.runtime_dependencies = %w[multi_json]
 end
 
 t = Rake::TestTask.new(:interop)


### PR DESCRIPTION
There is no such gem 'multi-json'. http://rubygems.org/search?utf8=%E2%9C%93&query=multi-json

Authors probably mean multi_json