### PR TITLE
use bytesize on buffer string

### DIFF
--- a/lang/ruby/lib/avro/ipc.rb
+++ b/lang/ruby/lib/avro/ipc.rb
@@ -410,7 +410,7 @@ module Avro::IPC
     end
 
     def write_framed_message(message)
-      message_length = message.size
+      message_length = message.bytesize
       total_bytes_sent = 0
       while message_length - total_bytes_sent > 0
         if message_length - total_bytes_sent > BUFFER_SIZE
@@ -426,7 +426,7 @@ module Avro::IPC
     end
 
     def write_buffer(chunk)
-      buffer_length = chunk.size
+      buffer_length = chunk.bytesize
       write_buffer_length(buffer_length)
       total_bytes_sent = 0
       while total_bytes_sent < buffer_length


### PR DESCRIPTION
If your character encoding is UTF-8 or some other multibyte encoding, then the message length header is incorrectly calculated.

In ruby, `String#size` returns the semantic length, but we really want `String#bytesize` here. `bytesize` has been available on `String` since at least ruby 1.8.7
