### PR TITLE
Fixed link 'How To Contribute'

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -6,4 +6,4 @@ Learn more about Avro, please visit our website at:
 
 To contribute to Avro, please read:
 
-  https://cwiki.apache.org/AVRO/how-to-contribute.html
+  https://cwiki.apache.org/confluence/display/AVRO/How+To+Contribute


### PR DESCRIPTION
The link to the Confluence page was broken.