### PR TITLE
AVRO-1649: Teach SchemaCompatability to be more descriptive with failing compatibility checks.

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/SchemaCompatibility.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/SchemaCompatibility.java
@@ -45,6 +45,8 @@ public class SchemaCompatibility {
   /** Message to annotate reader/writer schema pairs that are compatible. */
   public static final String READER_WRITER_COMPATIBLE_MESSAGE =
       "Reader schema can always successfully decode data written using the writer schema.";
+  public static final String READER_WRITER_INCOMPATABLE_MESSAGE =
+      "Data encoded using writer schema:%n%s%nwill or may fail to decode using reader schema:%n%s%n";
 
   /**
    * Validates that the provided reader schema can be used to decode avro data written with the
@@ -62,28 +64,10 @@ public class SchemaCompatibility {
         new ReaderWriterCompatiblityChecker()
             .getCompatibility(reader, writer);
 
-    final String message;
-    switch (compatibility) {
-      case INCOMPATIBLE: {
-        message = String.format(
-            "Data encoded using writer schema:%n%s%n"
-            + "will or may fail to decode using reader schema:%n%s%n",
-            writer.toString(true),
-            reader.toString(true));
-        break;
-      }
-      case COMPATIBLE: {
-        message = READER_WRITER_COMPATIBLE_MESSAGE;
-        break;
-      }
-      default: throw new AvroRuntimeException("Unknown compatibility: " + compatibility);
-    }
-
     return new SchemaPairCompatibility(
         compatibility,
         reader,
-        writer,
-        message);
+        writer);
   }
 
   // -----------------------------------------------------------------------------------------------
@@ -282,32 +266,29 @@ public class SchemaCompatibility {
           case FIXED: {
             // fixed size and name must match:
             if (!schemaNameEquals(reader, writer)) {
-              return SchemaCompatibilityType.INCOMPATIBLE;
+              return SchemaCompatibilityType.INCOMPATIBLE_NAME;
             }
             if (reader.getFixedSize() != writer.getFixedSize()) {
-              return SchemaCompatibilityType.INCOMPATIBLE;
+              return SchemaCompatibilityType.INCOMPATIBLE_SIZE;
             }
             return SchemaCompatibilityType.COMPATIBLE;
           }
           case ENUM: {
             // enum names must match:
             if (!schemaNameEquals(reader, writer)) {
-              return SchemaCompatibilityType.INCOMPATIBLE;
+              return SchemaCompatibilityType.INCOMPATIBLE_NAME;
             }
             // reader symbols must contain all writer symbols:
             final Set<String> symbols = new HashSet<String>(writer.getEnumSymbols());
             symbols.removeAll(reader.getEnumSymbols());
-            // TODO: Report a human-readable error.
-            // if (!symbols.isEmpty()) {
-            // }
             return symbols.isEmpty()
                 ? SchemaCompatibilityType.COMPATIBLE
-                : SchemaCompatibilityType.INCOMPATIBLE;
+                : SchemaCompatibilityType.INCOMPATIBLE_ENUM_MISSING_FIELDS;
           }
           case RECORD: {
             // record names must match:
             if (!schemaNameEquals(reader, writer)) {
-              return SchemaCompatibilityType.INCOMPATIBLE;
+              return SchemaCompatibilityType.INCOMPATIBLE_NAME;
             }
 
             // Check that each field in the reader record can be populated from the writer record:
@@ -318,12 +299,12 @@ public class SchemaCompatibility {
                 // reader field must have a default value.
                 if (readerField.defaultValue() == null) {
                   // reader field has no default value
-                  return SchemaCompatibilityType.INCOMPATIBLE;
+                  return SchemaCompatibilityType.INCOMPATIBLE_MISSING_DEFAULT;
                 }
               } else {
-                if (getCompatibility(readerField.schema(), writerField.schema())
-                    == SchemaCompatibilityType.INCOMPATIBLE) {
-                  return SchemaCompatibilityType.INCOMPATIBLE;
+                SchemaCompatibilityType compatibilityType = getCompatibility(readerField.schema(), writerField.schema());
+                if (!compatibilityType.isCompatible()) {
+                    return compatibilityType;
                 }
               }
             }
@@ -334,8 +315,9 @@ public class SchemaCompatibility {
           case UNION: {
             // Check that each individual branch of the writer union can be decoded:
             for (final Schema writerBranch : writer.getTypes()) {
-              if (getCompatibility(reader, writerBranch) == SchemaCompatibilityType.INCOMPATIBLE) {
-                return SchemaCompatibilityType.INCOMPATIBLE;
+              SchemaCompatibilityType schemaCompatibilityType = getCompatibility(reader, writerBranch);
+              if (!schemaCompatibilityType.isCompatible()) {
+                return schemaCompatibilityType;
               }
             }
             // Each schema in the writer union can be decoded with the reader:
@@ -357,19 +339,19 @@ public class SchemaCompatibility {
         }
 
         switch (reader.getType()) {
-          case NULL: return SchemaCompatibilityType.INCOMPATIBLE;
-          case BOOLEAN: return SchemaCompatibilityType.INCOMPATIBLE;
-          case INT: return SchemaCompatibilityType.INCOMPATIBLE;
+          case NULL: return SchemaCompatibilityType.INCOMPATIBLE_TYPE;
+          case BOOLEAN: return SchemaCompatibilityType.INCOMPATIBLE_TYPE;
+          case INT: return SchemaCompatibilityType.INCOMPATIBLE_TYPE;
           case LONG: {
             return (writer.getType() == Type.INT)
                 ? SchemaCompatibilityType.COMPATIBLE
-                : SchemaCompatibilityType.INCOMPATIBLE;
+                : SchemaCompatibilityType.INCOMPATIBLE_TYPE;
           }
           case FLOAT: {
             return ((writer.getType() == Type.INT)
                 || (writer.getType() == Type.LONG))
                 ? SchemaCompatibilityType.COMPATIBLE
-                : SchemaCompatibilityType.INCOMPATIBLE;
+                : SchemaCompatibilityType.INCOMPATIBLE_TYPE;
 
           }
           case DOUBLE: {
@@ -377,15 +359,15 @@ public class SchemaCompatibility {
                 || (writer.getType() == Type.LONG)
                 || (writer.getType() == Type.FLOAT))
                 ? SchemaCompatibilityType.COMPATIBLE
-                : SchemaCompatibilityType.INCOMPATIBLE;
+                : SchemaCompatibilityType.INCOMPATIBLE_TYPE;
           }
-          case BYTES: return SchemaCompatibilityType.INCOMPATIBLE;
-          case STRING: return SchemaCompatibilityType.INCOMPATIBLE;
-          case ARRAY: return SchemaCompatibilityType.INCOMPATIBLE;
-          case MAP: return SchemaCompatibilityType.INCOMPATIBLE;
-          case FIXED: return SchemaCompatibilityType.INCOMPATIBLE;
-          case ENUM: return SchemaCompatibilityType.INCOMPATIBLE;
-          case RECORD: return SchemaCompatibilityType.INCOMPATIBLE;
+          case BYTES: return SchemaCompatibilityType.INCOMPATIBLE_TYPE;
+          case STRING: return SchemaCompatibilityType.INCOMPATIBLE_TYPE;
+          case ARRAY: return SchemaCompatibilityType.INCOMPATIBLE_TYPE;
+          case MAP: return SchemaCompatibilityType.INCOMPATIBLE_TYPE;
+          case FIXED: return SchemaCompatibilityType.INCOMPATIBLE_TYPE;
+          case ENUM: return SchemaCompatibilityType.INCOMPATIBLE_TYPE;
+          case RECORD: return SchemaCompatibilityType.INCOMPATIBLE_TYPE;
           case UNION: {
             for (final Schema readerBranch : reader.getTypes()) {
               if (getCompatibility(readerBranch, writer) == SchemaCompatibilityType.COMPATIBLE) {
@@ -393,7 +375,7 @@ public class SchemaCompatibility {
               }
             }
             // No branch in the reader union has been found compatible with the writer schema:
-            return SchemaCompatibilityType.INCOMPATIBLE;
+            return SchemaCompatibilityType.INCOMPATIBLE_TYPE;
           }
 
           default: {
@@ -408,11 +390,30 @@ public class SchemaCompatibility {
    * Identifies the type of a schema compatibility result.
    */
   public static enum SchemaCompatibilityType {
-    COMPATIBLE,
-    INCOMPATIBLE,
+    COMPATIBLE(READER_WRITER_COMPATIBLE_MESSAGE),
+
+    INCOMPATIBLE_NAME(READER_WRITER_INCOMPATABLE_MESSAGE + "Schema names must match."),
+    INCOMPATIBLE_SIZE(READER_WRITER_INCOMPATABLE_MESSAGE + " Fixed schemas are no the same size."),
+    INCOMPATIBLE_ENUM_MISSING_FIELDS(READER_WRITER_INCOMPATABLE_MESSAGE + " Reader schema is missing ENUM values."),
+    INCOMPATIBLE_MISSING_DEFAULT(READER_WRITER_INCOMPATABLE_MESSAGE + " New fields must have a default value."),
+    INCOMPATIBLE_TYPE(READER_WRITER_INCOMPATABLE_MESSAGE + " Schema types are incompatable."),
 
     /** Used internally to tag a reader/writer schema pair and prevent recursion. */
-    RECURSION_IN_PROGRESS;
+    RECURSION_IN_PROGRESS("");
+
+    private final String description;
+
+    SchemaCompatibilityType(String description) {
+      this.description = description;
+    }
+
+    protected String description(Schema reader, Schema writer) {
+      return String.format(description, writer.toString(true), reader.toString(true));
+    }
+
+    public boolean isCompatible() {
+      return this == COMPATIBLE;
+    }
   }
 
   // -----------------------------------------------------------------------------------------------
@@ -432,26 +433,20 @@ public class SchemaCompatibility {
     /** Validated writer schema. */
     private final Schema mWriter;
 
-    /** Human readable description of this result. */
-    private final String mDescription;
-
     /**
      * Constructs a new instance.
      *
      * @param type of the schema compatibility.
      * @param reader schema that was validated.
      * @param writer schema that was validated.
-     * @param description of this compatibility result.
      */
     public SchemaPairCompatibility(
         SchemaCompatibilityType type,
         Schema reader,
-        Schema writer,
-        String description) {
+        Schema writer) {
       mType = type;
       mReader = reader;
       mWriter = writer;
-      mDescription = description;
     }
 
     /**
@@ -487,7 +482,7 @@ public class SchemaCompatibility {
      * @return a human readable description of this validation result.
      */
     public String getDescription() {
-      return mDescription;
+      return mType.description(mReader, mWriter);
     }
 
     /** {@inheritDoc} */
@@ -495,7 +490,7 @@ public class SchemaCompatibility {
     public String toString() {
       return String.format(
           "SchemaPairCompatibility{type:%s, readerSchema:%s, writerSchema:%s, description:%s}",
-          mType, mReader, mWriter, mDescription);
+          mType, mReader, mWriter, mType.description(mReader, mWriter));
     }
 
     /** {@inheritDoc} */
@@ -505,8 +500,7 @@ public class SchemaCompatibility {
         final SchemaPairCompatibility result = (SchemaPairCompatibility) other;
         return objectsEqual(result.mType, mType)
             && objectsEqual(result.mReader, mReader)
-            && objectsEqual(result.mWriter, mWriter)
-            && objectsEqual(result.mDescription, mDescription);
+            && objectsEqual(result.mWriter, mWriter);
       } else {
         return false;
       }
@@ -515,7 +509,7 @@ public class SchemaCompatibility {
     /** {@inheritDoc} */
     @Override
     public int hashCode() {
-      return Arrays.hashCode(new Object[]{mType, mReader, mWriter, mDescription});
+      return Arrays.hashCode(new Object[]{mType, mReader, mWriter});
     }
   }
 


### PR DESCRIPTION
Also adds enums to SchemaCompatability.SchemaCompatibilityType for the various compatability checks.