### PR TITLE
AVRO-1562: Support classes extending Maps/Collections in Avro

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/AvroCollectionContainer.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/AvroCollectionContainer.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.avro.reflect;
+
+import java.util.Collection;
+
+public class AvroCollectionContainer {
+
+  Collection collection;
+
+  public Collection getCollection() {
+    return collection;
+  }
+  public void setCollection(Collection collection) {
+    this.collection = collection;
+  }
+}

--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/AvroMapContainer.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/AvroMapContainer.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.avro.reflect;
+
+import java.util.Map;
+
+public class AvroMapContainer {
+  private Map<?, ?> map;
+
+  public Map<?, ?> getMap() {
+    return map;
+  }
+  public void setMap(Map<?, ?> map) {
+    this.map = map;
+  }
+}

--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectData.java.orig
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectData.java.orig
@@ -46,7 +46,6 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericContainer;
 import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.generic.IndexedRecord;
-import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.BinaryData;
 import org.apache.avro.util.ClassUtils;
 import org.apache.avro.io.DatumReader;
@@ -131,44 +130,12 @@ public class ReflectData extends SpecificData {
       return;
     }
     try {
-      if (canSetCustomMapOrCollection(record, o))
-        return;
-      FieldAccessor accessor = getAccessorForField(record, name, pos, state);
-      accessor.set(record, o);
+      getAccessorForField(record, name, pos, state).set(record, o);
     } catch (IllegalAccessException e) {
       throw new AvroRuntimeException(e);
     } catch (IOException e) {
       throw new AvroRuntimeException(e);
     }
-  }
-
-  /**
-   * If the record is an instance of a class which extends a Map or a Collection,
-   * and the current field is an implicit map/collection field, then this
-   * implicit field cannot be set as a field in the record.
-   * We have to move all the values from the implicit field to the original
-   * instance extending map/collection
-   */
-  private boolean canSetCustomMapOrCollection(Object record, Object readField) {
-    if (!(readField instanceof GenericRecord))
-      return false;
-    GenericRecord rec = (GenericRecord)readField;
-
-    if (getBaseClassOfType(record.getClass(), Map.class) != null) {
-      Object mapField = rec.get(IMPLICIT_MAP_ACTUAL_FIELD);
-      if (isFieldSchemaCustomMap(rec.getSchema())) {
-        ((Map)record).putAll((Map)mapField);
-        return true;
-      }
-    }
-    else if (getBaseClassOfType(record.getClass(), Collection.class) != null) {
-      Object collectionField = rec.get(IMPLICIT_COLLECTION_ACTUAL_FIELD);
-      if (isFieldSchemaCustomCollection(rec.getSchema())) {
-        ((Collection)record).addAll((Collection)collectionField);
-        return true;
-      }
-    }
-    return false;
   }
 
   @Override
@@ -200,16 +167,8 @@ public class ReflectData extends SpecificData {
   protected boolean isRecord(Object datum) {
     if (datum == null) return false;
     if (super.isRecord(datum)) return true;
-    if (datum instanceof Collection) {
-      if (getBaseClassOfType(datum.getClass(), Collection.class) != null)
-        return true;
-      return false;
-    }
-    if (datum instanceof Map) {
-      if (getBaseClassOfType(datum.getClass(), Map.class) != null)
-        return true;
-      return false;
-    }
+    if (datum instanceof Collection) return false;
+    if (datum instanceof Map) return false;
     if (datum instanceof GenericFixed) return false;
     return getSchema(datum.getClass()).getType() == Schema.Type.RECORD;
   }
@@ -349,16 +308,6 @@ public class ReflectData extends SpecificData {
   private static final Map<String,Class> CLASS_CACHE =
                new ConcurrentHashMap<String, Class>();
 
-  // For a class extending map/collection, these are the names of the
-  // virtual-fields holding the map/collection 
-  public static final String IMPLICIT_MAP_VIRTUAL_FIELD = "_avro_implicit_map_";
-  public static final String IMPLICIT_COLLECTION_VIRTUAL_FIELD
-                                    = "_avro_implicit_collection_";
-  // For a class extending map/collection, these are the names of the fields
-  // inside the AvroMapContainer/AvroCollectionContainer
-  public static final String IMPLICIT_MAP_ACTUAL_FIELD = "map";
-  public static final String IMPLICIT_COLLECTION_ACTUAL_FIELD = "collection";
-
   static Class getClassProp(Schema schema, String prop) {
     String name = schema.getProp(prop);
     if (name == null) return null;
@@ -487,6 +436,8 @@ public class ReflectData extends SpecificData {
         return Schema.create(Schema.Type.STRING);
       if (ByteBuffer.class.isAssignableFrom(c))              // bytes
         return Schema.create(Schema.Type.BYTES);
+      if (Collection.class.isAssignableFrom(c))              // array
+        throw new AvroRuntimeException("Can't find element type of Collection");
       String fullName = c.getName();
       Schema schema = names.get(fullName);
       if (schema == null) {
@@ -556,7 +507,6 @@ public class ReflectData extends SpecificData {
           if (error)                              // add Throwable message
             fields.add(new Schema.Field("detailMessage", THROWABLE_MESSAGE,
                                         null, null));
-          addImplicitMapOrCollection(fields, c, names, space);
           schema.setFields(fields);
           AvroMeta meta = c.getAnnotation(AvroMeta.class);
           if (meta != null) 
@@ -567,173 +517,6 @@ public class ReflectData extends SpecificData {
       return schema;
     }
     return super.createSchema(type, names);
-  }
-
-  /**
-   * If the class itself is neither a Map nor a Collection, but
-   * extends a Map or a Collection, then it is implicitly holding a
-   * Map/Collection. For such a case, we need to add that implicit
-   * object as another field.
-   */
-  private void addImplicitMapOrCollection(
-      List<org.apache.avro.Schema.Field> fields,
-      Class<?> c,
-      Map<String, Schema> names,
-      String space) {
-
-    boolean isMap = false;
-    boolean isCollection = false;
-    Class<?> derivedClass = c;
-    Type superClass = c.getGenericSuperclass();
-
-    while (superClass != Object.class) {
-      // Base class should belong to java.* package
-      // While derived class should NOT belong to java.* package
-      // Only then the derived class is a custom implementation of an
-      // existing java class
-      Package pkg = derivedClass.getPackage();
-      if (pkg == null || pkg.getName().startsWith("java."))
-        break;
-      if (superClass instanceof ParameterizedType) {
-        ParameterizedType ptype = (ParameterizedType)superClass;
-        Class <?> rawClass = (Class<?>) ptype.getRawType();
-        if (Map.class.isAssignableFrom((Class<?>)rawClass)) {
-          isMap = true;
-          break;
-        }
-        else if (Collection.class.isAssignableFrom((Class<?>)rawClass)) {
-          isCollection = true;
-          break;
-        }
-        derivedClass = rawClass;
-      }
-      if (!(superClass instanceof Class))
-        break;
-      superClass = ((Class<?>)superClass).getGenericSuperclass();
-    }
-    if (isMap) {
-      Schema mapSchema = createSchema (superClass, names);
-      String mapName = null;
-      if (mapSchema.getType() == Schema.Type.ARRAY) {
-        mapName = mapSchema.getElementType().getName();
-      }
-      else {
-        mapName = mapSchema.getName();
-      }
-      String name = AvroMapContainer.class.getSimpleName();
-      String namespace = AvroMapContainer.class.getPackage().getName();
-      name = name + "For" + mapName;
-      Schema containerSchema = Schema.createRecord(name, null, namespace, false);
-      List<Schema.Field> containerFields =  new ArrayList<Schema.Field> ();
-      Schema.Field recordField = new Schema.Field(IMPLICIT_MAP_ACTUAL_FIELD,
-          mapSchema, null, null);
-      containerFields.add(recordField);
-      containerSchema.setFields(containerFields);
-      containerSchema.addProp(CLASS_PROP,
-          AvroMapContainer.class.getCanonicalName());
-      names.put(containerSchema.getFullName(), containerSchema);
-      fields.add(new Schema.Field(IMPLICIT_MAP_VIRTUAL_FIELD,
-          containerSchema, null, null));
-    }
-    else if (isCollection) {
-      Schema collectionSchema = createSchema (superClass, names);
-      String collectionName = null;
-      Schema elementSchema = collectionSchema.getElementType();
-      if (elementSchema.getType() == Schema.Type.UNION) {
-        List <Schema> nonAvroSchemas = getNonAvroSchemasFromUnion(elementSchema);
-        if (nonAvroSchemas.size() == 1) {
-          collectionName = nonAvroSchemas.get(0).getName();
-        } else {
-          throw new AvroRuntimeException(
-              "Unexpected schema for a custom-collection: " + elementSchema);
-        }
-      }
-      else {
-        collectionName = collectionSchema.getName();
-      }
-      String name = AvroCollectionContainer.class.getSimpleName();
-      String namespace = AvroCollectionContainer.class.getPackage().getName();
-      name = name + "For" + collectionName;
-      Schema containerSchema = Schema.createRecord(name, null, namespace, false);
-      List<Schema.Field> containerFields =  new ArrayList<Schema.Field> ();
-      Schema.Field recordField =
-          new Schema.Field(IMPLICIT_COLLECTION_ACTUAL_FIELD,
-                           collectionSchema, null, null);
-      containerFields.add(recordField);
-      containerSchema.setFields(containerFields);
-      containerSchema.addProp(CLASS_PROP,
-          AvroCollectionContainer.class.getCanonicalName());
-      names.put(containerSchema.getFullName(), containerSchema);
-      fields.add(new Schema.Field(IMPLICIT_COLLECTION_VIRTUAL_FIELD,
-          containerSchema, null, null));
-    }
-  }
-
-  private static List <Schema> getNonAvroSchemasFromUnion(Schema unionSchema) {
-    List <Schema> nonAvroSchemas = new ArrayList<Schema> ();
-    if (unionSchema.getType() != Schema.Type.UNION) {
-      nonAvroSchemas.add(unionSchema);
-    }
-    else {
-      for (Schema u: unionSchema.getTypes()) {
-        if (u.getType() == Schema.Type.NULL) {
-          continue;
-        }
-        nonAvroSchemas.add(u);
-      }
-    }
-    return nonAvroSchemas;
-  }
-
-  public static ParameterizedType getBaseClassOfType (
-      Class<?> c, Class<?> expectedBaseClass) {
-
-    Class<?> derivedClass = c;
-    Type superClass = c.getGenericSuperclass();
-
-    while (superClass != Object.class && superClass != null) {
-      // Base class should belong to java.* package
-      // While derived class should NOT belong to java.* package
-      // Only then the derived class is a custom implementation of
-      // an existing java class
-      Package pkg = derivedClass.getPackage();
-      if (pkg == null || pkg.getName().startsWith("java."))
-        break;
-      if (superClass instanceof ParameterizedType) {
-        ParameterizedType ptype = (ParameterizedType)superClass;
-        Class <?> rawClass = (Class<?>) ptype.getRawType();
-        if (expectedBaseClass.isAssignableFrom((Class<?>)rawClass)) {
-          return ptype;
-        }
-        derivedClass = rawClass;
-      }
-      if (!(superClass instanceof Class))
-        break;
-      superClass = ((Class<?>)superClass).getGenericSuperclass();
-    }
-    return null;
-  }
-
-  public static boolean isFieldSchemaCustomMap (Schema s) {
-    if (s.getType() == Schema.Type.RECORD) {
-      Class<?> c = ReflectData.getClassProp(s, ReflectData.CLASS_PROP);
-      if (c == AvroMapContainer.class)
-        return true;
-    }
-    return false;
-  }
-
-  public static boolean isFieldSchemaCustomCollection (Schema s) {
-    if (s.getType() == Schema.Type.RECORD) {
-      Class<?> c = ReflectData.getClassProp(s, ReflectData.CLASS_PROP);
-      if (c == AvroCollectionContainer.class)
-        return true;
-    }
-    return false;
-  }
-
-  public static boolean isFieldSchemaCustomMapOrCollection (Schema s) {
-    return isFieldSchemaCustomMap(s) || isFieldSchemaCustomCollection(s);
   }
 
   @Override protected boolean isStringable(Class<?> c) {

--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectDatumWriter.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectDatumWriter.java
@@ -172,6 +172,10 @@ public class ReflectDatumWriter<T> extends SpecificDatumWriter<T> {
         }  
       }
     }
+    if (ReflectData.isFieldSchemaCustomMapOrCollection(f.schema())) {
+      write (f.schema().getFields().get(0).schema(), record, out);
+      return;
+    }
     super.writeField(record, f, out, state);
   }
 }

--- a/lang/java/avro/src/test/java/org/apache/avro/reflect/TestCustomCollections.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/reflect/TestCustomCollections.java
@@ -1,0 +1,237 @@
+package org.apache.avro.reflect;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.avro.Schema;
+import org.apache.avro.file.DataFileReader;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.file.SeekableByteArrayInput;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.util.Utf8;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * Test serialization and de-serialization of classes extending Collections
+ * 
+ * @author sachingoyal
+ */
+@RunWith(Parameterized.class)
+public class TestCustomCollections {
+
+  private ReflectData rdata = null;
+
+  @Parameters
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][] {
+        { ReflectData.AllowNull.get() },
+        { ReflectData.get() },
+    });
+  }
+
+  public TestCustomCollections(ReflectData rdata) {
+    this.rdata = rdata;
+  }
+
+  @SuppressWarnings("rawtypes")
+  @Test
+  public void testSimpleCustomCollection() throws Exception {
+
+    CustomListRoot1 entityObj1 = buildCustomListRoot1();
+
+    String testType = "SimpleStringKeyCustomMap";
+    CustomListRoot1 [] entityObjs = {entityObj1};
+    byte[] bytes = testCircularSerialization(testType, entityObj1);
+    List<GenericRecord> genRecords =
+        (List<GenericRecord>) testGenericDatumRead(testType, bytes, entityObjs);
+    assertNotNull ("Unable to serialize and read field extending map", genRecords);
+
+    GenericRecord genRecord = genRecords.get(0);
+    log (genRecord.toString());
+    assertNotNull ("No records in the deserialized data", genRecord);
+    GenericRecord genCollection = (GenericRecord) genRecord.get("customList");
+    assertNotNull ("Custom collection field could not be read", genCollection);
+    assertNotNull ("Unable to read generic field 'a'", genCollection.get("a"));
+    assertNotNull ("Unable to read generic field 'b'", genCollection.get("b"));
+    GenericRecord genAvroCollectionContainer =
+        (GenericRecord) genCollection.get(ReflectData.IMPLICIT_COLLECTION_VIRTUAL_FIELD);
+    String msg = "Unable to read generic field " + ReflectData.IMPLICIT_COLLECTION_VIRTUAL_FIELD;
+    assertNotNull (msg, genAvroCollectionContainer);
+    GenericArray genCustomList =
+        (GenericArray) genAvroCollectionContainer.get(ReflectData.IMPLICIT_COLLECTION_ACTUAL_FIELD);
+    assertNotNull ("Unable to read generic field 'customList'", genCustomList);
+    assertNotNull ("Unable to read generic field 'key'", genCustomList.get(0));
+    assertNotNull ("Unable to read generic field 'value'", genCustomList.get(1));
+    
+    List<CustomListRoot1> objs =
+        testReflectDatumRead(testType, bytes, entityObjs);
+    assertNotNull ("Unable to serialize and read field extending map", objs);
+    CustomListRoot1 record = objs.get(0);
+    assertNotNull ("Unable to read object", record);
+    assertNotNull ("Unable to read field 'customList'", record.customList);
+    assertNotNull ("Unable to read field 'a'", record.customList.a);
+    assertNotNull ("Unable to read field 'b'", record.customList.b);
+    assertTrue ("Unable to read implicit collection", record.customList.size() > 0);
+
+    assertEquals (entityObj1.customList.size(), record.customList.size());
+    Iterator<Node1> itr1 = entityObj1.customList.iterator();
+    Iterator<Node1> itr2 = record.customList.iterator();
+    
+    Node1 list1entry1 = itr1.next();
+    Node1 list1entry2 = itr1.next();
+    Node1 list2entry1 = itr2.next();
+    Node1 list2entry2 = itr2.next();
+    assertEquals (list1entry1.name, list2entry1.name);
+    assertEquals (list1entry2.name, list2entry2.name);
+
+    byte[] jsonBytes = testJsonEncoder (testType, entityObj1);
+    assertNotNull ("Unable to serialize using jsonEncoder", jsonBytes);
+    GenericRecord jsonRecord = testJsonDecoder(testType, jsonBytes, entityObj1);
+    assertEquals ("JSON decoder output not same as Binary Decoder", 
+      genRecord.get("customList"), jsonRecord.get("customList"));
+  }
+
+  public <T> byte[] testCircularSerialization(
+      String testType, T ... entityObjs) throws Exception {
+
+    log ("\n---- Beginning " + testType + " (" + rdata.getClass().getSimpleName() + ") ----");
+    T entityObj1 = entityObjs[0];
+
+    Schema schema = rdata.getSchema(entityObj1.getClass());
+    assertNotNull("Unable to get schema for circular reference in " + testType, schema);
+    log (schema.toString(true));
+
+    ReflectDatumWriter<T> datumWriter =
+        new ReflectDatumWriter (entityObj1.getClass(), rdata);
+    DataFileWriter<T> fileWriter = new DataFileWriter<T> (datumWriter);
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    fileWriter.create(schema, baos);
+    for (T entityObj : entityObjs) {
+      fileWriter.append(entityObj);
+    }
+    fileWriter.close();
+
+    byte[] bytes = baos.toByteArray();
+    return bytes;
+  }
+
+  private <T> List<GenericRecord> testGenericDatumRead(
+      String testType, byte[] bytes, T ... entityObjs) throws IOException {
+
+    GenericDatumReader<GenericRecord> datumReader = new GenericDatumReader<GenericRecord> ();
+    SeekableByteArrayInput avroInputStream = new SeekableByteArrayInput(bytes);
+    DataFileReader<GenericRecord> fileReader =
+        new DataFileReader<GenericRecord>(avroInputStream, datumReader);
+
+    Schema schema = fileReader.getSchema();
+    assertNotNull("Unable to get schema for " + testType, schema);
+    GenericRecord record = null;
+    List<GenericRecord> records = new ArrayList<GenericRecord> ();
+    while (fileReader.hasNext()) {
+      records.add (fileReader.next(record));
+    }
+    return records;
+  }
+
+  private <T> List<T> testReflectDatumRead (
+      String testType, byte[] bytes, T ... entityObjs) throws IOException {
+
+    ReflectDatumReader<T> datumReader = new ReflectDatumReader<T> (rdata);
+    SeekableByteArrayInput avroInputStream = new SeekableByteArrayInput(bytes);
+    DataFileReader<T> fileReader =
+        new DataFileReader<T>(avroInputStream, datumReader);
+
+    Schema schema = fileReader.getSchema();
+    T record = null;
+    List<T> records = new ArrayList<T> ();
+    while (fileReader.hasNext()) {
+      records.add (fileReader.next(record));
+    }
+    return records;
+  }
+
+  private <T> byte[] testJsonEncoder
+  (String testType, T entityObj) throws IOException {
+
+    Schema schema = rdata.getSchema(entityObj.getClass());
+    ByteArrayOutputStream os = new ByteArrayOutputStream();
+    Encoder encoder = EncoderFactory.get().jsonEncoder(schema, os);
+    ReflectDatumWriter<T> datumWriter = new ReflectDatumWriter<T>(schema, rdata);
+    datumWriter.write(entityObj, encoder);
+    encoder.flush();
+
+    byte[] bytes = os.toByteArray();
+    log ("\n---- JSON encoder output " + testType + " (" + rdata.getClass().getSimpleName() + "): ----\n" + new String(bytes));
+    return bytes;
+  }
+
+  private <T> GenericRecord testJsonDecoder
+  (String testType, byte[] bytes, T entityObj) throws IOException {
+
+    Schema schema = rdata.getSchema(entityObj.getClass());
+    GenericDatumReader<GenericRecord> datumReader =
+        new GenericDatumReader<GenericRecord>(schema);
+
+    Decoder decoder = DecoderFactory.get().jsonDecoder(schema, new String(bytes));
+    GenericRecord r = datumReader.read(null, decoder);
+    return r;
+  }
+
+  private void log(String s) {
+    System.out.println (s);
+  }
+
+  private CustomListRoot1 buildCustomListRoot1 () {
+    CustomListRoot1 obj = new CustomListRoot1();
+    obj.customList = new CustomList1();
+    obj.customList.a = 1;
+    obj.customList.b = "Hello";
+    
+    Node1 n = new Node1();
+    n.name = "foo";
+    obj.customList.add(n);
+    
+    n = new Node1();
+    n.name = "bar";
+    obj.customList.add(n);
+    
+    return obj;
+  }
+}
+
+/////////////////////////////////////////////////////////////////
+////// Temporary classes to test class deriving a Collection ////
+/////////////////////////////////////////////////////////////////
+class CustomListRoot1 {
+  CustomList1 customList;
+}
+
+class Node1 {
+  String name;
+}
+
+class CustomList1 extends ArrayList <Node1> {
+  Integer a;
+  String b;
+}

--- a/lang/java/avro/src/test/java/org/apache/avro/reflect/TestCustomMaps.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/reflect/TestCustomMaps.java
@@ -1,0 +1,237 @@
+package org.apache.avro.reflect;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.avro.Schema;
+import org.apache.avro.file.DataFileReader;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.file.SeekableByteArrayInput;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.util.Utf8;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * Test serialization and de-serialization of classes extending Maps
+ * 
+ * @author sachingoyal
+ */
+@RunWith(Parameterized.class)
+public class TestCustomMaps {
+
+  private ReflectData rdata = null;
+
+  @Parameters
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][] {
+        { ReflectData.AllowNull.get() },
+        { ReflectData.get() },
+    });
+  }
+
+  public TestCustomMaps(ReflectData rdata) {
+    this.rdata = rdata;
+  }
+
+  @SuppressWarnings("rawtypes")
+  @Test
+  public void testSimpleStringKeyCustomMap() throws Exception {
+
+    CustomHashMapRoot1 entityObj1 = buildCustomHashMapRoot1();
+
+    String testType = "SimpleStringKeyCustomMap";
+    CustomHashMapRoot1 [] entityObjs = {entityObj1};
+    byte[] bytes = testReflectDataSerialization(testType, entityObj1);
+    List<GenericRecord> genRecords =
+        (List<GenericRecord>) testGenericDatumRead(testType, bytes, entityObjs);
+    assertNotNull ("Unable to serialize and read field extending map", genRecords);
+
+    GenericRecord genRecord = genRecords.get(0);
+    assertNotNull ("No records in the deserialized data", genRecord);
+    GenericRecord genMap = (GenericRecord) genRecord.get("map");
+    assertNotNull ("Custom hash-map field could not be read", genMap);
+    assertNotNull ("Unable to read generic field 'a'", genMap.get("a"));
+    assertNotNull ("Unable to read generic field 'b'", genMap.get("b"));
+    GenericRecord genAvroMapContainer =
+        (GenericRecord) genMap.get(ReflectData.IMPLICIT_MAP_VIRTUAL_FIELD);
+    String msg = "Unable to read generic field " + ReflectData.IMPLICIT_MAP_VIRTUAL_FIELD;
+    assertNotNull (msg, genAvroMapContainer);
+    HashMap genAmcMap =
+        (HashMap) genAvroMapContainer.get(ReflectData.IMPLICIT_MAP_ACTUAL_FIELD);
+    assertNotNull ("Unable to read generic field 'map'", genAmcMap);
+    assertNotNull ("Unable to read generic field 'key'", genAmcMap.get(new Utf8("1")));
+    assertNotNull ("Unable to read generic field 'value'", genAmcMap.get(new Utf8("2")));
+    
+    List<CustomHashMapRoot1> objs =
+        testReflectDatumRead(testType, bytes, entityObjs);
+    assertNotNull ("Unable to serialize and read field extending map", objs);
+    CustomHashMapRoot1 record = objs.get(0);
+    assertNotNull ("Unable to read object", record);
+    assertNotNull ("Unable to read field 'map'", record.map);
+    assertNotNull ("Unable to read field 'a'", record.map.a);
+    assertNotNull ("Unable to read field 'b'", record.map.b);
+    assertTrue ("Unable to read implicit map", record.map.entrySet().size() > 0);
+    Iterator<Entry<String, BarValue1>> itr1 = entityObj1.map.entrySet().iterator();
+    Iterator<Entry<String, BarValue1>> itr2 = record.map.entrySet().iterator();
+    
+    Entry<String, BarValue1> map1entry1 = itr1.next();
+    Entry<String, BarValue1> map2entry1 = itr2.next();
+    Entry<String, BarValue1> map2entry2 = itr2.next();
+    assertTrue (map1entry1.getKey().equals(map2entry1.getKey()) ||
+        map1entry1.getKey().equals(map2entry2.getKey()));
+    assertTrue (map1entry1.getValue().name.equals(map2entry1.getValue().name) ||
+        map1entry1.getValue().name.equals(map2entry2.getValue().name));
+
+    byte[] jsonBytes = testJsonEncoder (testType, entityObj1);
+    assertNotNull ("Unable to serialize using jsonEncoder", jsonBytes);
+    GenericRecord jsonRecord = testJsonDecoder(testType, jsonBytes, entityObj1);
+    assertEquals ("JSON decoder output not same as Binary Decoder", 
+      genRecord.get("map"), jsonRecord.get("map"));
+  }
+
+  public <T> byte[] testReflectDataSerialization(
+      String testType, T ... entityObjs) throws Exception {
+
+    log ("\n---- Beginning " + testType + " (" + rdata.getClass().getSimpleName() + ") ----");
+    T entityObj1 = entityObjs[0];
+
+    Schema schema = rdata.getSchema(entityObj1.getClass());
+    assertNotNull("Unable to get schema for " + testType, schema);
+    log (schema.toString(true));
+
+    ReflectDatumWriter<T> datumWriter =
+        new ReflectDatumWriter (entityObj1.getClass(), rdata);
+    DataFileWriter<T> fileWriter = new DataFileWriter<T> (datumWriter);
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    fileWriter.create(schema, baos);
+    for (T entityObj : entityObjs) {
+      fileWriter.append(entityObj);
+    }
+    fileWriter.close();
+
+    byte[] bytes = baos.toByteArray();
+    return bytes;
+  }
+
+  private <T> List<GenericRecord> testGenericDatumRead(
+      String testType, byte[] bytes, T ... entityObjs) throws IOException {
+
+    GenericDatumReader<GenericRecord> datumReader = new GenericDatumReader<GenericRecord> ();
+    SeekableByteArrayInput avroInputStream = new SeekableByteArrayInput(bytes);
+    DataFileReader<GenericRecord> fileReader =
+        new DataFileReader<GenericRecord>(avroInputStream, datumReader);
+
+    Schema schema = fileReader.getSchema();
+    assertNotNull("Unable to get schema for " + testType, schema);
+    GenericRecord record = null;
+    List<GenericRecord> records = new ArrayList<GenericRecord> ();
+    while (fileReader.hasNext()) {
+      records.add (fileReader.next(record));
+    }
+    return records;
+  }
+
+  private <T> List<T> testReflectDatumRead (
+      String testType, byte[] bytes, T ... entityObjs) throws IOException {
+
+    ReflectDatumReader<T> datumReader = new ReflectDatumReader<T> (rdata);
+    SeekableByteArrayInput avroInputStream = new SeekableByteArrayInput(bytes);
+    DataFileReader<T> fileReader =
+        new DataFileReader<T>(avroInputStream, datumReader);
+
+    Schema schema = fileReader.getSchema();
+    T record = null;
+    List<T> records = new ArrayList<T> ();
+    while (fileReader.hasNext()) {
+      records.add (fileReader.next(record));
+    }
+    return records;
+  }
+
+  private <T> byte[] testJsonEncoder
+  (String testType, T entityObj) throws IOException {
+
+    Schema schema = rdata.getSchema(entityObj.getClass());
+    ByteArrayOutputStream os = new ByteArrayOutputStream();
+    Encoder encoder = EncoderFactory.get().jsonEncoder(schema, os);
+    ReflectDatumWriter<T> datumWriter = new ReflectDatumWriter<T>(schema, rdata);
+    datumWriter.write(entityObj, encoder);
+    encoder.flush();
+
+    byte[] bytes = os.toByteArray();
+    log ("\n---- JSON encoder output " + testType + " (" + rdata.getClass().getSimpleName() + "): ----\n" + new String(bytes));
+    return bytes;
+  }
+
+  private <T> GenericRecord testJsonDecoder
+  (String testType, byte[] bytes, T entityObj) throws IOException {
+
+    Schema schema = rdata.getSchema(entityObj.getClass());
+    GenericDatumReader<GenericRecord> datumReader =
+        new GenericDatumReader<GenericRecord>(schema);
+
+    Decoder decoder = DecoderFactory.get().jsonDecoder(schema, new String(bytes));
+    GenericRecord r = datumReader.read(null, decoder);
+    return r;
+  }
+
+  private void log(String s) {
+    System.out.println (s);
+  }
+
+  private CustomHashMapRoot1 buildCustomHashMapRoot1 () {
+    CustomHashMapRoot1 obj = new CustomHashMapRoot1();
+    obj.map = new CustomHashMap1();
+    obj.map.a = 1;
+    obj.map.b = "Hello";
+    
+    BarValue1 v1 = new BarValue1();
+    v1.name = "Hello";
+    obj.map.put("1", v1);
+    
+    BarValue1 v2 = new BarValue1();
+    v2.name = "Hello";
+    obj.map.put("2", v2);
+    
+    return obj;
+  }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////
+////// Temporary classes to test simple class deriving a HashMap with string-keys ////
+//////////////////////////////////////////////////////////////////////////////////////
+class CustomHashMapRoot1 {
+  CustomHashMap1 map;
+}
+
+class BarValue1 {
+  String name;
+}
+
+class CustomHashMap1 extends HashMap <String, BarValue1> {
+  Integer a;
+  String b;
+}
+


### PR DESCRIPTION
For classes extending collections and maps, "_avro_implicit_collection_" and "_avro_implicit_map_" fields are added in the Avro representation while the class itself continues to hold other fields normally like a record.
The implicit field-names are currently hardcoded as above.
We will need to have an API in ReflectData for making this configurable.

We may also need some name-mangling to have different names for classes extending different parameterized collections/maps.