### PR TITLE
AVRO-1645: Use a special exception class for unknown named type errors

### DIFF
--- a/lang/ruby/lib/avro/schema.rb
+++ b/lang/ruby/lib/avro/schema.rb
@@ -86,8 +86,7 @@ module Avro
       elsif PRIMITIVE_TYPES.include? json_obj
         return PrimitiveSchema.new(json_obj)
       else
-        msg = "#{json_obj.inspect} is not a schema we know about."
-        raise SchemaParseError.new(msg)
+        raise UnknownSchemaError.new(json_obj)
       end
     end
 
@@ -369,6 +368,15 @@ module Avro
   end
 
   class SchemaParseError < AvroError; end
+
+  class UnknownSchemaError < SchemaParseError
+    attr_reader :type_name
+
+    def initialize(type)
+      @type_name = type
+      super("#{type.inspect} is not a schema we know about.")
+    end
+  end
 
   module Name
     def self.extract_namespace(name, namespace)

--- a/lang/ruby/test/test_schema.rb
+++ b/lang/ruby/test/test_schema.rb
@@ -131,4 +131,16 @@ class TestSchema < Test::Unit::TestCase
       ]
     }
   end
+
+  def test_unknown_named_type
+    error = assert_raise Avro::UnknownSchemaError do
+      Avro::Schema.parse <<-SCHEMA
+        {"type": "record", "name": "my.name.space.Record", "fields": [
+          {"name": "reference", "type": "MissingType"}
+        ]}
+      SCHEMA
+    end
+
+    assert_equal '"MissingType" is not a schema we know about.', error.message
+  end
 end


### PR DESCRIPTION
[AVRO-1645](https://issues.apache.org/jira/browse/AVRO-1645).

This allows handling the error be finding and loading the referenced schema.