### PR TITLE
AVRO-1693: Allow writing arbitrary metadata to data files

### DIFF
--- a/lang/ruby/test/test_datafile.rb
+++ b/lang/ruby/test/test_datafile.rb
@@ -185,4 +185,17 @@ JSON
     end
     assert_equal records, ['a' * 10_000, 'b' * 10_000]
   end
+
+  def test_custom_meta
+    meta = { 'x.greeting' => 'yo' }
+
+    schema = Avro::Schema.parse('"string"')
+    writer = Avro::IO::DatumWriter.new(schema)
+    file = Avro::DataFile::Writer.new(File.open('data.avr', 'wb'), writer, schema, nil, meta)
+    file.close
+
+    Avro::DataFile.open('data.avr') do |reader|
+      assert_equal 'yo', reader.meta['x.greeting']
+    end
+  end
 end


### PR DESCRIPTION
[AVRO-1693](https://issues.apache.org/jira/browse/AVRO-1693).

This allows writers to add custom metadata to data files.