### PR TITLE
AVRO-1593. Use classic locale to escape control chars

### DIFF
--- a/lang/c++/impl/json/JsonIO.hh
+++ b/lang/c++/impl/json/JsonIO.hh
@@ -19,6 +19,7 @@
 #ifndef avro_json_JsonIO_hh__
 #define avro_json_JsonIO_hh__
 
+#include <locale>
 #include <stack>
 #include <string>
 #include <sstream>
@@ -193,7 +194,7 @@ class AVRO_DECL JsonGenerator {
                 escape('t', b, p);
                 break;
             default:
-                if (! iscntrl(*p)) {
+                if (! std::iscntrl(*p, std::locale::classic())) {
                     continue;
                 }
                 write(b, p);


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/AVRO-1593