### PR TITLE
AVRO-1649 - More informative messages for schema compatibility checks

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/SchemaCompatibility.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/SchemaCompatibility.java
@@ -60,29 +60,14 @@ public class SchemaCompatibility {
       final Schema reader,
       final Schema writer
   ) {
-    final SchemaCompatibilityType compatibility =
+    final SchemaCompatibilityResult compatibility =
         new ReaderWriterCompatiblityChecker()
-            .getCompatibility(reader, writer);
+            .getCompatibilityResult(reader, writer);
 
-    final String message;
-    switch (compatibility) {
-      case INCOMPATIBLE: {
-        message = String.format(
-            "Data encoded using writer schema:%n%s%n"
-            + "will or may fail to decode using reader schema:%n%s%n",
-            writer.toString(true),
-            reader.toString(true));
-        break;
-      }
-      case COMPATIBLE: {
-        message = READER_WRITER_COMPATIBLE_MESSAGE;
-        break;
-      }
-      default: throw new AvroRuntimeException("Unknown compatibility: " + compatibility);
-    }
+    final String message = compatibility.description(reader, writer);
 
     return new SchemaPairCompatibility(
-        compatibility,
+        compatibility.isCompatible() ? SchemaCompatibilityType.COMPATIBLE : SchemaCompatibilityType.INCOMPATIBLE,
         reader,
         writer,
         message);

--- a/lang/java/avro/src/main/java/org/apache/avro/SchemaCompatibility.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/SchemaCompatibility.java
@@ -45,6 +45,8 @@ public class SchemaCompatibility {
   /** Message to annotate reader/writer schema pairs that are compatible. */
   public static final String READER_WRITER_COMPATIBLE_MESSAGE =
       "Reader schema can always successfully decode data written using the writer schema.";
+  public static final String READER_WRITER_INCOMPATABLE_MESSAGE =
+      "Data encoded using writer schema:%n%s%nwill or may fail to decode using reader schema:%n%s%n";
 
   /**
    * Validates that the provided reader schema can be used to decode avro data written with the
@@ -62,28 +64,10 @@ public class SchemaCompatibility {
         new ReaderWriterCompatiblityChecker()
             .getCompatibility(reader, writer);
 
-    final String message;
-    switch (compatibility) {
-      case INCOMPATIBLE: {
-        message = String.format(
-            "Data encoded using writer schema:%n%s%n"
-            + "will or may fail to decode using reader schema:%n%s%n",
-            writer.toString(true),
-            reader.toString(true));
-        break;
-      }
-      case COMPATIBLE: {
-        message = READER_WRITER_COMPATIBLE_MESSAGE;
-        break;
-      }
-      default: throw new AvroRuntimeException("Unknown compatibility: " + compatibility);
-    }
-
     return new SchemaPairCompatibility(
         compatibility,
         reader,
-        writer,
-        message);
+        writer);
   }
 
   // -----------------------------------------------------------------------------------------------
@@ -282,32 +266,29 @@ public class SchemaCompatibility {
           case FIXED: {
             // fixed size and name must match:
             if (!schemaNameEquals(reader, writer)) {
-              return SchemaCompatibilityType.INCOMPATIBLE;
+              return SchemaCompatibilityType.INCOMPATIBLE_NAME;
             }
             if (reader.getFixedSize() != writer.getFixedSize()) {
-              return SchemaCompatibilityType.INCOMPATIBLE;
+              return SchemaCompatibilityType.INCOMPATIBLE_SIZE;
             }
             return SchemaCompatibilityType.COMPATIBLE;
           }
           case ENUM: {
             // enum names must match:
             if (!schemaNameEquals(reader, writer)) {
-              return SchemaCompatibilityType.INCOMPATIBLE;
+              return SchemaCompatibilityType.INCOMPATIBLE_NAME;
             }
             // reader symbols must contain all writer symbols:
             final Set<String> symbols = new HashSet<String>(writer.getEnumSymbols());
             symbols.removeAll(reader.getEnumSymbols());
-            // TODO: Report a human-readable error.
-            // if (!symbols.isEmpty()) {
-            // }
             return symbols.isEmpty()
                 ? SchemaCompatibilityType.COMPATIBLE
-                : SchemaCompatibilityType.INCOMPATIBLE;
+                : SchemaCompatibilityType.INCOMPATIBLE_ENUM_MISSING_FIELDS;
           }
           case RECORD: {
             // record names must match:
             if (!schemaNameEquals(reader, writer)) {
-              return SchemaCompatibilityType.INCOMPATIBLE;
+              return SchemaCompatibilityType.INCOMPATIBLE_NAME;
             }
 
             // Check that each field in the reader record can be populated from the writer record:
@@ -318,12 +299,12 @@ public class SchemaCompatibility {
                 // reader field must have a default value.
                 if (readerField.defaultValue() == null) {
                   // reader field has no default value
-                  return SchemaCompatibilityType.INCOMPATIBLE;
+                  return SchemaCompatibilityType.INCOMPATIBLE_MISSING_DEFAULT;
                 }
               } else {
-                if (getCompatibility(readerField.schema(), writerField.schema())
-                    == SchemaCompatibilityType.INCOMPATIBLE) {
-                  return SchemaCompatibilityType.INCOMPATIBLE;
+                SchemaCompatibilityType compatibilityType = getCompatibility(readerField.schema(), writerField.schema());
+                if (!compatibilityType.isCompatible()) {
+                    return compatibilityType;
                 }
               }
             }
@@ -334,8 +315,9 @@ public class SchemaCompatibility {
           case UNION: {
             // Check that each individual branch of the writer union can be decoded:
             for (final Schema writerBranch : writer.getTypes()) {
-              if (getCompatibility(reader, writerBranch) == SchemaCompatibilityType.INCOMPATIBLE) {
-                return SchemaCompatibilityType.INCOMPATIBLE;
+              SchemaCompatibilityType schemaCompatibilityType = getCompatibility(reader, writerBranch);
+              if (!schemaCompatibilityType.isCompatible()) {
+                return schemaCompatibilityType;
               }
             }
             // Each schema in the writer union can be decoded with the reader:
@@ -357,19 +339,19 @@ public class SchemaCompatibility {
         }
 
         switch (reader.getType()) {
-          case NULL: return SchemaCompatibilityType.INCOMPATIBLE;
-          case BOOLEAN: return SchemaCompatibilityType.INCOMPATIBLE;
-          case INT: return SchemaCompatibilityType.INCOMPATIBLE;
+          case NULL: return SchemaCompatibilityType.INCOMPATIBLE_TYPE;
+          case BOOLEAN: return SchemaCompatibilityType.INCOMPATIBLE_TYPE;
+          case INT: return SchemaCompatibilityType.INCOMPATIBLE_TYPE;
           case LONG: {
             return (writer.getType() == Type.INT)
                 ? SchemaCompatibilityType.COMPATIBLE
-                : SchemaCompatibilityType.INCOMPATIBLE;
+                : SchemaCompatibilityType.INCOMPATIBLE_TYPE;
           }
           case FLOAT: {
             return ((writer.getType() == Type.INT)
                 || (writer.getType() == Type.LONG))
                 ? SchemaCompatibilityType.COMPATIBLE
-                : SchemaCompatibilityType.INCOMPATIBLE;
+                : SchemaCompatibilityType.INCOMPATIBLE_TYPE;
 
           }
           case DOUBLE: {
@@ -377,15 +359,15 @@ public class SchemaCompatibility {
                 || (writer.getType() == Type.LONG)
                 || (writer.getType() == Type.FLOAT))
                 ? SchemaCompatibilityType.COMPATIBLE
-                : SchemaCompatibilityType.INCOMPATIBLE;
+                : SchemaCompatibilityType.INCOMPATIBLE_TYPE;
           }
-          case BYTES: return SchemaCompatibilityType.INCOMPATIBLE;
-          case STRING: return SchemaCompatibilityType.INCOMPATIBLE;
-          case ARRAY: return SchemaCompatibilityType.INCOMPATIBLE;
-          case MAP: return SchemaCompatibilityType.INCOMPATIBLE;
-          case FIXED: return SchemaCompatibilityType.INCOMPATIBLE;
-          case ENUM: return SchemaCompatibilityType.INCOMPATIBLE;
-          case RECORD: return SchemaCompatibilityType.INCOMPATIBLE;
+          case BYTES: return SchemaCompatibilityType.INCOMPATIBLE_TYPE;
+          case STRING: return SchemaCompatibilityType.INCOMPATIBLE_TYPE;
+          case ARRAY: return SchemaCompatibilityType.INCOMPATIBLE_TYPE;
+          case MAP: return SchemaCompatibilityType.INCOMPATIBLE_TYPE;
+          case FIXED: return SchemaCompatibilityType.INCOMPATIBLE_TYPE;
+          case ENUM: return SchemaCompatibilityType.INCOMPATIBLE_TYPE;
+          case RECORD: return SchemaCompatibilityType.INCOMPATIBLE_TYPE;
           case UNION: {
             for (final Schema readerBranch : reader.getTypes()) {
               if (getCompatibility(readerBranch, writer) == SchemaCompatibilityType.COMPATIBLE) {
@@ -393,7 +375,7 @@ public class SchemaCompatibility {
               }
             }
             // No branch in the reader union has been found compatible with the writer schema:
-            return SchemaCompatibilityType.INCOMPATIBLE;
+            return SchemaCompatibilityType.INCOMPATIBLE_TYPE;
           }
 
           default: {
@@ -408,11 +390,30 @@ public class SchemaCompatibility {
    * Identifies the type of a schema compatibility result.
    */
   public static enum SchemaCompatibilityType {
-    COMPATIBLE,
-    INCOMPATIBLE,
+    COMPATIBLE(READER_WRITER_COMPATIBLE_MESSAGE),
+
+    INCOMPATIBLE_NAME(READER_WRITER_INCOMPATABLE_MESSAGE + "Schema names must match."),
+    INCOMPATIBLE_SIZE(READER_WRITER_INCOMPATABLE_MESSAGE + " Fixed schemas are no the same size."),
+    INCOMPATIBLE_ENUM_MISSING_FIELDS(READER_WRITER_INCOMPATABLE_MESSAGE + " Reader schema is missing ENUM values."),
+    INCOMPATIBLE_MISSING_DEFAULT(READER_WRITER_INCOMPATABLE_MESSAGE + " New fields must have a default value."),
+    INCOMPATIBLE_TYPE(READER_WRITER_INCOMPATABLE_MESSAGE + " Schema types are incompatable."),
 
     /** Used internally to tag a reader/writer schema pair and prevent recursion. */
-    RECURSION_IN_PROGRESS;
+    RECURSION_IN_PROGRESS("");
+
+    private final String description;
+
+    SchemaCompatibilityType(String description) {
+      this.description = description;
+    }
+
+    protected String description(Schema reader, Schema writer) {
+      return String.format(description, writer.toString(true), reader.toString(true));
+    }
+
+    public boolean isCompatible() {
+      return this == COMPATIBLE;
+    }
   }
 
   // -----------------------------------------------------------------------------------------------
@@ -432,26 +433,20 @@ public class SchemaCompatibility {
     /** Validated writer schema. */
     private final Schema mWriter;
 
-    /** Human readable description of this result. */
-    private final String mDescription;
-
     /**
      * Constructs a new instance.
      *
      * @param type of the schema compatibility.
      * @param reader schema that was validated.
      * @param writer schema that was validated.
-     * @param description of this compatibility result.
      */
     public SchemaPairCompatibility(
         SchemaCompatibilityType type,
         Schema reader,
-        Schema writer,
-        String description) {
+        Schema writer) {
       mType = type;
       mReader = reader;
       mWriter = writer;
-      mDescription = description;
     }
 
     /**
@@ -487,7 +482,7 @@ public class SchemaCompatibility {
      * @return a human readable description of this validation result.
      */
     public String getDescription() {
-      return mDescription;
+      return mType.description(mReader, mWriter);
     }
 
     /** {@inheritDoc} */
@@ -495,7 +490,7 @@ public class SchemaCompatibility {
     public String toString() {
       return String.format(
           "SchemaPairCompatibility{type:%s, readerSchema:%s, writerSchema:%s, description:%s}",
-          mType, mReader, mWriter, mDescription);
+          mType, mReader, mWriter, mType.description(mReader, mWriter));
     }
 
     /** {@inheritDoc} */
@@ -505,8 +500,7 @@ public class SchemaCompatibility {
         final SchemaPairCompatibility result = (SchemaPairCompatibility) other;
         return objectsEqual(result.mType, mType)
             && objectsEqual(result.mReader, mReader)
-            && objectsEqual(result.mWriter, mWriter)
-            && objectsEqual(result.mDescription, mDescription);
+            && objectsEqual(result.mWriter, mWriter);
       } else {
         return false;
       }
@@ -515,7 +509,7 @@ public class SchemaCompatibility {
     /** {@inheritDoc} */
     @Override
     public int hashCode() {
-      return Arrays.hashCode(new Object[]{mType, mReader, mWriter, mDescription});
+      return Arrays.hashCode(new Object[]{mType, mReader, mWriter});
     }
   }
 

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemaCompatibility.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemaCompatibility.java
@@ -146,27 +146,19 @@ public class TestSchemaCompatibility {
   private static final class ReaderWriter {
     private final Schema mReader;
     private final Schema mWriter;
-    private final SchemaCompatibilityType mCompatibilityType;
 
-    public ReaderWriter(final Schema reader, final Schema writer, SchemaCompatibilityType schemaCompatibilityType) {
+    public ReaderWriter(final Schema reader, final Schema writer) {
       mReader = reader;
       mWriter = writer;
-      mCompatibilityType = schemaCompatibilityType;
     }
 
-      public ReaderWriter(final Schema reader, final Schema writer) {
-          this(reader, writer, SchemaCompatibilityType.COMPATIBLE);
-      }
-
-      public Schema getReader() {
+    public Schema getReader() {
       return mReader;
     }
 
     public Schema getWriter() {
       return mWriter;
     }
-
-    public SchemaCompatibilityType getSchemaCompatibilityType() { return mCompatibilityType; };
   }
 
   // -----------------------------------------------------------------------------------------------
@@ -184,7 +176,8 @@ public class TestSchemaCompatibility {
         new SchemaCompatibility.SchemaPairCompatibility(
             SchemaCompatibility.SchemaCompatibilityType.COMPATIBLE,
             reader,
-            WRITER_SCHEMA);
+            WRITER_SCHEMA,
+            SchemaCompatibility.READER_WRITER_COMPATIBLE_MESSAGE);
 
     // Test omitting a field.
     assertEquals(expectedResult, checkReaderWriterCompatibility(reader, WRITER_SCHEMA));
@@ -199,7 +192,8 @@ public class TestSchemaCompatibility {
         new SchemaCompatibility.SchemaPairCompatibility(
             SchemaCompatibility.SchemaCompatibilityType.COMPATIBLE,
             reader,
-            WRITER_SCHEMA);
+            WRITER_SCHEMA,
+            SchemaCompatibility.READER_WRITER_COMPATIBLE_MESSAGE);
 
     // Test omitting other field.
     assertEquals(expectedResult, checkReaderWriterCompatibility(reader, WRITER_SCHEMA));
@@ -215,7 +209,8 @@ public class TestSchemaCompatibility {
         new SchemaCompatibility.SchemaPairCompatibility(
             SchemaCompatibility.SchemaCompatibilityType.COMPATIBLE,
             reader,
-            WRITER_SCHEMA);
+            WRITER_SCHEMA,
+            SchemaCompatibility.READER_WRITER_COMPATIBLE_MESSAGE);
 
     // Test with all fields.
     assertEquals(expectedResult, checkReaderWriterCompatibility(reader, WRITER_SCHEMA));
@@ -231,7 +226,8 @@ public class TestSchemaCompatibility {
         new SchemaCompatibility.SchemaPairCompatibility(
             SchemaCompatibility.SchemaCompatibilityType.COMPATIBLE,
             reader,
-            WRITER_SCHEMA);
+            WRITER_SCHEMA,
+            SchemaCompatibility.READER_WRITER_COMPATIBLE_MESSAGE);
 
     // Test new field with default value.
     assertEquals(expectedResult, checkReaderWriterCompatibility(reader, WRITER_SCHEMA));
@@ -245,9 +241,14 @@ public class TestSchemaCompatibility {
     final Schema reader = Schema.createRecord(readerFields);
     final SchemaCompatibility.SchemaPairCompatibility expectedResult =
         new SchemaCompatibility.SchemaPairCompatibility(
-            SchemaCompatibilityType.INCOMPATIBLE_MISSING_DEFAULT,
+            SchemaCompatibility.SchemaCompatibilityType.INCOMPATIBLE,
             reader,
-            WRITER_SCHEMA);
+            WRITER_SCHEMA,
+            String.format(
+                "Data encoded using writer schema:\n%s\n"
+                + "will or may fail to decode using reader schema:\n%s\n",
+                WRITER_SCHEMA.toString(true),
+                reader.toString(true)));
 
     // Test new field without default value.
     assertEquals(expectedResult, checkReaderWriterCompatibility(reader, WRITER_SCHEMA));
@@ -261,12 +262,18 @@ public class TestSchemaCompatibility {
         new SchemaCompatibility.SchemaPairCompatibility(
             SchemaCompatibility.SchemaCompatibilityType.COMPATIBLE,
             validReader,
-            STRING_ARRAY_SCHEMA);
+            STRING_ARRAY_SCHEMA,
+            SchemaCompatibility.READER_WRITER_COMPATIBLE_MESSAGE);
     final SchemaCompatibility.SchemaPairCompatibility invalidResult =
         new SchemaCompatibility.SchemaPairCompatibility(
-            SchemaCompatibility.SchemaCompatibilityType.INCOMPATIBLE_TYPE,
+            SchemaCompatibility.SchemaCompatibilityType.INCOMPATIBLE,
             invalidReader,
-            STRING_ARRAY_SCHEMA);
+            STRING_ARRAY_SCHEMA,
+            String.format(
+                "Data encoded using writer schema:\n%s\n"
+                + "will or may fail to decode using reader schema:\n%s\n",
+                STRING_ARRAY_SCHEMA.toString(true),
+                invalidReader.toString(true)));
 
     assertEquals(
         validResult,
@@ -283,12 +290,18 @@ public class TestSchemaCompatibility {
         new SchemaCompatibility.SchemaPairCompatibility(
             SchemaCompatibility.SchemaCompatibilityType.COMPATIBLE,
             validReader,
-            STRING_SCHEMA);
+            STRING_SCHEMA,
+            SchemaCompatibility.READER_WRITER_COMPATIBLE_MESSAGE);
     final SchemaCompatibility.SchemaPairCompatibility invalidResult =
         new SchemaCompatibility.SchemaPairCompatibility(
-            SchemaCompatibility.SchemaCompatibilityType.INCOMPATIBLE_TYPE,
+            SchemaCompatibility.SchemaCompatibilityType.INCOMPATIBLE,
             INT_SCHEMA,
-            STRING_SCHEMA);
+            STRING_SCHEMA,
+            String.format(
+                "Data encoded using writer schema:\n%s\n"
+                + "will or may fail to decode using reader schema:\n%s\n",
+                STRING_SCHEMA.toString(true),
+                INT_SCHEMA.toString(true)));
 
     assertEquals(
         validResult,
@@ -305,7 +318,7 @@ public class TestSchemaCompatibility {
     final Schema unionReader = Schema.createUnion(list(STRING_SCHEMA));
     final SchemaPairCompatibility result =
         checkReaderWriterCompatibility(unionReader, unionWriter);
-    assertEquals(SchemaCompatibilityType.INCOMPATIBLE_TYPE, result.getType());
+    assertEquals(SchemaCompatibilityType.INCOMPATIBLE, result.getType());
   }
 
   // -----------------------------------------------------------------------------------------------
@@ -381,53 +394,54 @@ public class TestSchemaCompatibility {
 
   /** Collection of reader/writer schema pair that are incompatible. */
   public static final List<ReaderWriter> INCOMPATIBLE_READER_WRITER_TEST_CASES = list(
-      new ReaderWriter(NULL_SCHEMA, INT_SCHEMA, SchemaCompatibilityType.INCOMPATIBLE_TYPE),
-      new ReaderWriter(NULL_SCHEMA, LONG_SCHEMA, SchemaCompatibilityType.INCOMPATIBLE_TYPE),
+      new ReaderWriter(NULL_SCHEMA, INT_SCHEMA),
+      new ReaderWriter(NULL_SCHEMA, LONG_SCHEMA),
 
-      new ReaderWriter(BOOLEAN_SCHEMA, INT_SCHEMA, SchemaCompatibilityType.INCOMPATIBLE_TYPE),
+      new ReaderWriter(BOOLEAN_SCHEMA, INT_SCHEMA),
 
-      new ReaderWriter(INT_SCHEMA, NULL_SCHEMA, SchemaCompatibilityType.INCOMPATIBLE_TYPE),
-      new ReaderWriter(INT_SCHEMA, BOOLEAN_SCHEMA, SchemaCompatibilityType.INCOMPATIBLE_TYPE),
-      new ReaderWriter(INT_SCHEMA, LONG_SCHEMA, SchemaCompatibilityType.INCOMPATIBLE_TYPE),
-      new ReaderWriter(INT_SCHEMA, FLOAT_SCHEMA, SchemaCompatibilityType.INCOMPATIBLE_TYPE),
-      new ReaderWriter(INT_SCHEMA, DOUBLE_SCHEMA, SchemaCompatibilityType.INCOMPATIBLE_TYPE),
+      new ReaderWriter(INT_SCHEMA, NULL_SCHEMA),
+      new ReaderWriter(INT_SCHEMA, BOOLEAN_SCHEMA),
+      new ReaderWriter(INT_SCHEMA, LONG_SCHEMA),
+      new ReaderWriter(INT_SCHEMA, FLOAT_SCHEMA),
+      new ReaderWriter(INT_SCHEMA, DOUBLE_SCHEMA),
 
-      new ReaderWriter(LONG_SCHEMA, FLOAT_SCHEMA, SchemaCompatibilityType.INCOMPATIBLE_TYPE),
-      new ReaderWriter(LONG_SCHEMA, DOUBLE_SCHEMA, SchemaCompatibilityType.INCOMPATIBLE_TYPE),
+      new ReaderWriter(LONG_SCHEMA, FLOAT_SCHEMA),
+      new ReaderWriter(LONG_SCHEMA, DOUBLE_SCHEMA),
 
-      new ReaderWriter(FLOAT_SCHEMA, DOUBLE_SCHEMA, SchemaCompatibilityType.INCOMPATIBLE_TYPE),
+      new ReaderWriter(FLOAT_SCHEMA, DOUBLE_SCHEMA),
 
-      new ReaderWriter(STRING_SCHEMA, BOOLEAN_SCHEMA, SchemaCompatibilityType.INCOMPATIBLE_TYPE),
-      new ReaderWriter(STRING_SCHEMA, INT_SCHEMA, SchemaCompatibilityType.INCOMPATIBLE_TYPE),
-      new ReaderWriter(STRING_SCHEMA, BYTES_SCHEMA, SchemaCompatibilityType.INCOMPATIBLE_TYPE),
+      new ReaderWriter(STRING_SCHEMA, BOOLEAN_SCHEMA),
+      new ReaderWriter(STRING_SCHEMA, INT_SCHEMA),
+      new ReaderWriter(STRING_SCHEMA, BYTES_SCHEMA),
 
-      new ReaderWriter(BYTES_SCHEMA, NULL_SCHEMA, SchemaCompatibilityType.INCOMPATIBLE_TYPE),
-      new ReaderWriter(BYTES_SCHEMA, INT_SCHEMA, SchemaCompatibilityType.INCOMPATIBLE_TYPE),
-      new ReaderWriter(BYTES_SCHEMA, STRING_SCHEMA, SchemaCompatibilityType.INCOMPATIBLE_TYPE),
+      new ReaderWriter(BYTES_SCHEMA, NULL_SCHEMA),
+      new ReaderWriter(BYTES_SCHEMA, INT_SCHEMA),
+      new ReaderWriter(BYTES_SCHEMA, STRING_SCHEMA),
 
-      new ReaderWriter(INT_ARRAY_SCHEMA, LONG_ARRAY_SCHEMA, SchemaCompatibilityType.INCOMPATIBLE_TYPE),
-      new ReaderWriter(INT_MAP_SCHEMA, INT_ARRAY_SCHEMA, SchemaCompatibilityType.INCOMPATIBLE_TYPE),
-      new ReaderWriter(INT_ARRAY_SCHEMA, INT_MAP_SCHEMA, SchemaCompatibilityType.INCOMPATIBLE_TYPE),
-      new ReaderWriter(INT_MAP_SCHEMA, LONG_MAP_SCHEMA, SchemaCompatibilityType.INCOMPATIBLE_TYPE),
+      new ReaderWriter(INT_ARRAY_SCHEMA, LONG_ARRAY_SCHEMA),
+      new ReaderWriter(INT_MAP_SCHEMA, INT_ARRAY_SCHEMA),
+      new ReaderWriter(INT_ARRAY_SCHEMA, INT_MAP_SCHEMA),
+      new ReaderWriter(INT_MAP_SCHEMA, LONG_MAP_SCHEMA),
 
-      new ReaderWriter(ENUM1_BC_SCHEMA, ENUM1_ABC_SCHEMA, SchemaCompatibilityType.INCOMPATIBLE_ENUM_MISSING_FIELDS),
+      new ReaderWriter(ENUM1_AB_SCHEMA, ENUM1_ABC_SCHEMA),
+      new ReaderWriter(ENUM1_BC_SCHEMA, ENUM1_ABC_SCHEMA),
 
-      new ReaderWriter(ENUM1_AB_SCHEMA, ENUM2_AB_SCHEMA, SchemaCompatibilityType.INCOMPATIBLE_NAME),
-      new ReaderWriter(INT_SCHEMA, ENUM2_AB_SCHEMA, SchemaCompatibilityType.INCOMPATIBLE_TYPE),
-      new ReaderWriter(ENUM2_AB_SCHEMA, INT_SCHEMA, SchemaCompatibilityType.INCOMPATIBLE_TYPE),
+      new ReaderWriter(ENUM1_AB_SCHEMA, ENUM2_AB_SCHEMA),
+      new ReaderWriter(INT_SCHEMA, ENUM2_AB_SCHEMA),
+      new ReaderWriter(ENUM2_AB_SCHEMA, INT_SCHEMA),
 
       // Tests involving unions:
-      new ReaderWriter(INT_UNION_SCHEMA, INT_STRING_UNION_SCHEMA, SchemaCompatibilityType.INCOMPATIBLE_TYPE),
-      new ReaderWriter(STRING_UNION_SCHEMA, INT_STRING_UNION_SCHEMA, SchemaCompatibilityType.INCOMPATIBLE_TYPE),
+      new ReaderWriter(INT_UNION_SCHEMA, INT_STRING_UNION_SCHEMA),
+      new ReaderWriter(STRING_UNION_SCHEMA, INT_STRING_UNION_SCHEMA),
 
-      new ReaderWriter(EMPTY_RECORD2, EMPTY_RECORD1, SchemaCompatibilityType.INCOMPATIBLE_NAME),
-      new ReaderWriter(A_INT_RECORD1, EMPTY_RECORD1, SchemaCompatibilityType.INCOMPATIBLE_MISSING_DEFAULT),
-      new ReaderWriter(A_INT_B_DINT_RECORD1, EMPTY_RECORD1, SchemaCompatibilityType.INCOMPATIBLE_MISSING_DEFAULT),
+      new ReaderWriter(EMPTY_RECORD2, EMPTY_RECORD1),
+      new ReaderWriter(A_INT_RECORD1, EMPTY_RECORD1),
+      new ReaderWriter(A_INT_B_DINT_RECORD1, EMPTY_RECORD1),
 
-      new ReaderWriter(INT_LIST_RECORD, LONG_LIST_RECORD, SchemaCompatibilityType.INCOMPATIBLE_TYPE),
+      new ReaderWriter(INT_LIST_RECORD, LONG_LIST_RECORD),
 
       // Last check:
-      new ReaderWriter(NULL_SCHEMA, INT_SCHEMA, SchemaCompatibilityType.INCOMPATIBLE_TYPE)
+      new ReaderWriter(NULL_SCHEMA, INT_SCHEMA)
   );
 
   // -----------------------------------------------------------------------------------------------
@@ -444,7 +458,7 @@ public class TestSchemaCompatibility {
       assertEquals(String.format(
           "Expecting reader %s to be compatible with writer %s, but tested incompatible.",
           reader, writer),
-          readerWriter.getSchemaCompatibilityType(), result.getType());
+          SchemaCompatibilityType.COMPATIBLE, result.getType());
     }
   }
 
@@ -460,7 +474,7 @@ public class TestSchemaCompatibility {
       assertEquals(String.format(
           "Expecting reader %s to be incompatible with writer %s, but tested compatible.",
           reader, writer),
-          readerWriter.getSchemaCompatibilityType(), result.getType());
+          SchemaCompatibilityType.INCOMPATIBLE, result.getType());
     }
   }
 

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemaCompatibility.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemaCompatibility.java
@@ -27,6 +27,7 @@ import java.util.List;
 
 import org.apache.avro.Schema.Field;
 import org.apache.avro.SchemaCompatibility.SchemaCompatibilityType;
+import org.apache.avro.SchemaCompatibility.SchemaCompatibilityResult;
 import org.apache.avro.SchemaCompatibility.SchemaPairCompatibility;
 import org.apache.avro.generic.GenericData.EnumSymbol;
 import org.apache.avro.generic.GenericDatumReader;
@@ -146,19 +147,27 @@ public class TestSchemaCompatibility {
   private static final class ReaderWriter {
     private final Schema mReader;
     private final Schema mWriter;
+    private final SchemaCompatibilityResult mCompatibilityResult;
 
-    public ReaderWriter(final Schema reader, final Schema writer) {
+    public ReaderWriter(final Schema reader, final Schema writer, SchemaCompatibilityResult schemaCompatibilityResult) {
       mReader = reader;
       mWriter = writer;
+      mCompatibilityResult = schemaCompatibilityResult;
     }
 
-    public Schema getReader() {
+      public ReaderWriter(final Schema reader, final Schema writer) {
+          this(reader, writer, SchemaCompatibilityResult.COMPATIBLE);
+      }
+
+      public Schema getReader() {
       return mReader;
     }
 
     public Schema getWriter() {
       return mWriter;
     }
+
+    public SchemaCompatibilityResult getSchemaCompatibilityResult() { return mCompatibilityResult; };
   }
 
   // -----------------------------------------------------------------------------------------------
@@ -244,11 +253,7 @@ public class TestSchemaCompatibility {
             SchemaCompatibility.SchemaCompatibilityType.INCOMPATIBLE,
             reader,
             WRITER_SCHEMA,
-            String.format(
-                "Data encoded using writer schema:\n%s\n"
-                + "will or may fail to decode using reader schema:\n%s\n",
-                WRITER_SCHEMA.toString(true),
-                reader.toString(true)));
+            SchemaCompatibilityResult.INCOMPATIBLE_MISSING_DEFAULT.description(reader, WRITER_SCHEMA));
 
     // Test new field without default value.
     assertEquals(expectedResult, checkReaderWriterCompatibility(reader, WRITER_SCHEMA));
@@ -269,11 +274,8 @@ public class TestSchemaCompatibility {
             SchemaCompatibility.SchemaCompatibilityType.INCOMPATIBLE,
             invalidReader,
             STRING_ARRAY_SCHEMA,
-            String.format(
-                "Data encoded using writer schema:\n%s\n"
-                + "will or may fail to decode using reader schema:\n%s\n",
-                STRING_ARRAY_SCHEMA.toString(true),
-                invalidReader.toString(true)));
+            SchemaCompatibility.SchemaCompatibilityResult.INCOMPATIBLE_TYPE.description(invalidReader,
+                    STRING_ARRAY_SCHEMA));
 
     assertEquals(
         validResult,
@@ -297,11 +299,8 @@ public class TestSchemaCompatibility {
             SchemaCompatibility.SchemaCompatibilityType.INCOMPATIBLE,
             INT_SCHEMA,
             STRING_SCHEMA,
-            String.format(
-                "Data encoded using writer schema:\n%s\n"
-                + "will or may fail to decode using reader schema:\n%s\n",
-                STRING_SCHEMA.toString(true),
-                INT_SCHEMA.toString(true)));
+            SchemaCompatibility.SchemaCompatibilityResult.INCOMPATIBLE_TYPE.description(INT_SCHEMA,
+                    STRING_SCHEMA));
 
     assertEquals(
         validResult,
@@ -394,54 +393,53 @@ public class TestSchemaCompatibility {
 
   /** Collection of reader/writer schema pair that are incompatible. */
   public static final List<ReaderWriter> INCOMPATIBLE_READER_WRITER_TEST_CASES = list(
-      new ReaderWriter(NULL_SCHEMA, INT_SCHEMA),
-      new ReaderWriter(NULL_SCHEMA, LONG_SCHEMA),
+      new ReaderWriter(NULL_SCHEMA, INT_SCHEMA, SchemaCompatibilityResult.INCOMPATIBLE_TYPE),
+      new ReaderWriter(NULL_SCHEMA, LONG_SCHEMA, SchemaCompatibilityResult.INCOMPATIBLE_TYPE),
 
-      new ReaderWriter(BOOLEAN_SCHEMA, INT_SCHEMA),
+      new ReaderWriter(BOOLEAN_SCHEMA, INT_SCHEMA, SchemaCompatibilityResult.INCOMPATIBLE_TYPE),
 
-      new ReaderWriter(INT_SCHEMA, NULL_SCHEMA),
-      new ReaderWriter(INT_SCHEMA, BOOLEAN_SCHEMA),
-      new ReaderWriter(INT_SCHEMA, LONG_SCHEMA),
-      new ReaderWriter(INT_SCHEMA, FLOAT_SCHEMA),
-      new ReaderWriter(INT_SCHEMA, DOUBLE_SCHEMA),
+      new ReaderWriter(INT_SCHEMA, NULL_SCHEMA, SchemaCompatibilityResult.INCOMPATIBLE_TYPE),
+      new ReaderWriter(INT_SCHEMA, BOOLEAN_SCHEMA, SchemaCompatibilityResult.INCOMPATIBLE_TYPE),
+      new ReaderWriter(INT_SCHEMA, LONG_SCHEMA, SchemaCompatibilityResult.INCOMPATIBLE_TYPE),
+      new ReaderWriter(INT_SCHEMA, FLOAT_SCHEMA, SchemaCompatibilityResult.INCOMPATIBLE_TYPE),
+      new ReaderWriter(INT_SCHEMA, DOUBLE_SCHEMA, SchemaCompatibilityResult.INCOMPATIBLE_TYPE),
 
-      new ReaderWriter(LONG_SCHEMA, FLOAT_SCHEMA),
-      new ReaderWriter(LONG_SCHEMA, DOUBLE_SCHEMA),
+      new ReaderWriter(LONG_SCHEMA, FLOAT_SCHEMA, SchemaCompatibilityResult.INCOMPATIBLE_TYPE),
+      new ReaderWriter(LONG_SCHEMA, DOUBLE_SCHEMA, SchemaCompatibilityResult.INCOMPATIBLE_TYPE),
 
-      new ReaderWriter(FLOAT_SCHEMA, DOUBLE_SCHEMA),
+      new ReaderWriter(FLOAT_SCHEMA, DOUBLE_SCHEMA, SchemaCompatibilityResult.INCOMPATIBLE_TYPE),
 
-      new ReaderWriter(STRING_SCHEMA, BOOLEAN_SCHEMA),
-      new ReaderWriter(STRING_SCHEMA, INT_SCHEMA),
-      new ReaderWriter(STRING_SCHEMA, BYTES_SCHEMA),
+      new ReaderWriter(STRING_SCHEMA, BOOLEAN_SCHEMA, SchemaCompatibilityResult.INCOMPATIBLE_TYPE),
+      new ReaderWriter(STRING_SCHEMA, INT_SCHEMA, SchemaCompatibilityResult.INCOMPATIBLE_TYPE),
+      new ReaderWriter(STRING_SCHEMA, BYTES_SCHEMA, SchemaCompatibilityResult.INCOMPATIBLE_TYPE),
 
-      new ReaderWriter(BYTES_SCHEMA, NULL_SCHEMA),
-      new ReaderWriter(BYTES_SCHEMA, INT_SCHEMA),
-      new ReaderWriter(BYTES_SCHEMA, STRING_SCHEMA),
+      new ReaderWriter(BYTES_SCHEMA, NULL_SCHEMA, SchemaCompatibilityResult.INCOMPATIBLE_TYPE),
+      new ReaderWriter(BYTES_SCHEMA, INT_SCHEMA, SchemaCompatibilityResult.INCOMPATIBLE_TYPE),
+      new ReaderWriter(BYTES_SCHEMA, STRING_SCHEMA, SchemaCompatibilityResult.INCOMPATIBLE_TYPE),
 
-      new ReaderWriter(INT_ARRAY_SCHEMA, LONG_ARRAY_SCHEMA),
-      new ReaderWriter(INT_MAP_SCHEMA, INT_ARRAY_SCHEMA),
-      new ReaderWriter(INT_ARRAY_SCHEMA, INT_MAP_SCHEMA),
-      new ReaderWriter(INT_MAP_SCHEMA, LONG_MAP_SCHEMA),
+      new ReaderWriter(INT_ARRAY_SCHEMA, LONG_ARRAY_SCHEMA, SchemaCompatibilityResult.INCOMPATIBLE_TYPE),
+      new ReaderWriter(INT_MAP_SCHEMA, INT_ARRAY_SCHEMA, SchemaCompatibilityResult.INCOMPATIBLE_TYPE),
+      new ReaderWriter(INT_ARRAY_SCHEMA, INT_MAP_SCHEMA, SchemaCompatibilityResult.INCOMPATIBLE_TYPE),
+      new ReaderWriter(INT_MAP_SCHEMA, LONG_MAP_SCHEMA, SchemaCompatibilityResult.INCOMPATIBLE_TYPE),
 
-      new ReaderWriter(ENUM1_AB_SCHEMA, ENUM1_ABC_SCHEMA),
-      new ReaderWriter(ENUM1_BC_SCHEMA, ENUM1_ABC_SCHEMA),
+      new ReaderWriter(ENUM1_BC_SCHEMA, ENUM1_ABC_SCHEMA, SchemaCompatibilityResult.INCOMPATIBLE_ENUM_MISSING_FIELDS),
 
-      new ReaderWriter(ENUM1_AB_SCHEMA, ENUM2_AB_SCHEMA),
-      new ReaderWriter(INT_SCHEMA, ENUM2_AB_SCHEMA),
-      new ReaderWriter(ENUM2_AB_SCHEMA, INT_SCHEMA),
+      new ReaderWriter(ENUM1_AB_SCHEMA, ENUM2_AB_SCHEMA, SchemaCompatibilityResult.INCOMPATIBLE_NAME),
+      new ReaderWriter(INT_SCHEMA, ENUM2_AB_SCHEMA, SchemaCompatibilityResult.INCOMPATIBLE_TYPE),
+      new ReaderWriter(ENUM2_AB_SCHEMA, INT_SCHEMA, SchemaCompatibilityResult.INCOMPATIBLE_TYPE),
 
       // Tests involving unions:
-      new ReaderWriter(INT_UNION_SCHEMA, INT_STRING_UNION_SCHEMA),
-      new ReaderWriter(STRING_UNION_SCHEMA, INT_STRING_UNION_SCHEMA),
+      new ReaderWriter(INT_UNION_SCHEMA, INT_STRING_UNION_SCHEMA, SchemaCompatibilityResult.INCOMPATIBLE_TYPE),
+      new ReaderWriter(STRING_UNION_SCHEMA, INT_STRING_UNION_SCHEMA, SchemaCompatibilityResult.INCOMPATIBLE_TYPE),
 
-      new ReaderWriter(EMPTY_RECORD2, EMPTY_RECORD1),
-      new ReaderWriter(A_INT_RECORD1, EMPTY_RECORD1),
-      new ReaderWriter(A_INT_B_DINT_RECORD1, EMPTY_RECORD1),
+      new ReaderWriter(EMPTY_RECORD2, EMPTY_RECORD1, SchemaCompatibilityResult.INCOMPATIBLE_NAME),
+      new ReaderWriter(A_INT_RECORD1, EMPTY_RECORD1, SchemaCompatibilityResult.INCOMPATIBLE_MISSING_DEFAULT),
+      new ReaderWriter(A_INT_B_DINT_RECORD1, EMPTY_RECORD1, SchemaCompatibilityResult.INCOMPATIBLE_MISSING_DEFAULT),
 
-      new ReaderWriter(INT_LIST_RECORD, LONG_LIST_RECORD),
+      new ReaderWriter(INT_LIST_RECORD, LONG_LIST_RECORD, SchemaCompatibilityResult.INCOMPATIBLE_TYPE),
 
       // Last check:
-      new ReaderWriter(NULL_SCHEMA, INT_SCHEMA)
+      new ReaderWriter(NULL_SCHEMA, INT_SCHEMA, SchemaCompatibilityResult.INCOMPATIBLE_TYPE)
   );
 
   // -----------------------------------------------------------------------------------------------
@@ -471,10 +469,9 @@ public class TestSchemaCompatibility {
       LOG.debug("Testing incompatibility of reader {} with writer {}.", reader, writer);
       final SchemaPairCompatibility result =
           checkReaderWriterCompatibility(reader, writer);
-      assertEquals(String.format(
-          "Expecting reader %s to be incompatible with writer %s, but tested compatible.",
-          reader, writer),
-          SchemaCompatibilityType.INCOMPATIBLE, result.getType());
+      final SchemaPairCompatibility expectedResult = new SchemaPairCompatibility(SchemaCompatibilityType.INCOMPATIBLE,
+              reader, writer, readerWriter.getSchemaCompatibilityResult().description(reader,writer));
+      assertEquals(expectedResult, result);
     }
   }
 


### PR DESCRIPTION
This PR attempts to move forward the the PR originally submitted by @bcotton 
https://github.com/apache/avro/pull/24

The previous PR introduced changes to enum that may have caused backward compatibility changes.  

I initially attempted the proposed resolution of creating and caching the SchemaPairCompatibility objects in calculateCompatibility, but this resulted in SchemaPairCompatibilty objects from leaf nodes being returned in the case of recursion (e.g. line 285 https://github.com/apache/avro/compare/trunk...kurtharriger:AVRO-1649?expand=1#diff-21a81984a51d0e95d688360b526f0b04R285) and on updating the tests found the resulting error messages confusing without more context.  In some cases just recreating a new SchemaPairCompatibility would work, but this became messy and more difficult to test.

I decided instead to create a new enum SchemaCompatibilityResult based on @bcotton's. The private methods now use this more informative enum and a new method getCompatibilityResult. getCompatibility which now maps from SchemaCompatibilityResult to SchemaCompatibility is now marked deprecated.

The static helper method now uses the new method to return SchemaPairCompatibity objects with the new more informative descriptions. 