### PR TITLE
Install the Snappy packages to the Docker image

### DIFF
--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -31,7 +31,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   perl \
   php5 phpunit php5-gmp \
   python python-setuptools python3-setuptools \
-  ruby ruby-dev rake
+  ruby ruby-dev rake \
+  libsnappy1 libsnappy-dev
 
 # Install Forrest
 RUN mkdir -p /usr/local/apache-forrest


### PR DESCRIPTION
These packages are required dependencies for the `snappy` Rubygem.