### PR TITLE
AVRO-1704: Standardized format for encoding messages with Avro

### DIFF
--- a/lang/ruby/lib/avro/message.rb
+++ b/lang/ruby/lib/avro/message.rb
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Avro
+  module Message
+    VERSION = 0
+
+    class Writer
+      def initialize(schema)
+        @schema = schema
+        @writer = Avro::IO::DatumWriter.new(schema)
+      end
+
+      def write(datum)
+        buffer = StringIO.new('', 'w')
+        buffer.set_encoding('BINARY') if buffer.respond_to?(:set_encoding)
+
+        encoder = IO::BinaryEncoder.new(buffer)
+
+        buffer.write([VERSION].pack("c"))
+        @writer.write(datum, encoder)
+
+        buffer.string
+      end
+    end
+
+    class Reader
+      def initialize(schema)
+        @schema = schema
+        @reader = Avro::IO::DatumReader.new(schema, schema)
+      end
+
+      def read(encoded_datum)
+        buffer = StringIO.new(encoded_datum, "r")
+        version = buffer.read(1).unpack("c").first
+
+        if version != VERSION
+          raise "unsupported version #{version}"
+        end
+
+        decoder = IO::BinaryDecoder.new(buffer)
+
+        @reader.read(decoder)
+      end
+    end
+  end
+end

--- a/lang/ruby/lib/avro/schema.rb
+++ b/lang/ruby/lib/avro/schema.rb
@@ -141,6 +141,10 @@ module Avro
       other.is_a?(Schema) && type_sym == other.type_sym
     end
 
+    def md5_fingerprint
+      42
+    end
+
     def hash(seen=nil)
       type_sym.hash
     end

--- a/lang/ruby/test/test_message.rb
+++ b/lang/ruby/test/test_message.rb
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'test_help'
+require 'avro/message'
+
+class TestMessage < Test::Unit::TestCase
+  def test_encoding_and_decoding
+    schema = Avro::Schema.parse(<<-JSON)
+      {
+        "type": "record",
+        "name": "Pageview",
+        "fields" : [
+          { "name": "url", "type": "string" }
+        ]
+      }
+    JSON
+
+    message_writer = Avro::Message::Writer.new(schema)
+    message_reader = Avro::Message::Reader.new(schema)
+
+    datum = { "url" => "http://example.com/test" }
+    encoded_datum = message_writer.write(datum)
+    decoded_datum = message_reader.read(encoded_datum)
+
+    assert_equal datum, decoded_datum
+  end
+end


### PR DESCRIPTION
This is a proof of concept implementation of [AVRO-1704](https://issues.apache.org/jira/browse/AVRO-1704).

- The fingerprint implementation is mocked out.
- Only 64-bit fingerprints are supported.
- There's no metadata map yet.