### PR TITLE
AVRO-1709: Ignore generated files

### DIFF
--- a/lang/ruby/.gitignore
+++ b/lang/ruby/.gitignore
@@ -1,1 +1,3 @@
 tmp
+data.avr
+Gemfile.lock


### PR DESCRIPTION
[AVRO-1709](https://issues.apache.org/jira/browse/AVRO-1709)

The data.avr file is generated every times the tests are run; Gemfile.lock is generated every time `bundle install` is run.

When working on the Ruby library it's annoying to constantly have to make sure not to commit these files. Since they should never be committed, they're safe to ignore.