### PR TITLE
AVRO-1702 Add LogicalType support to c++ library

### DIFF
--- a/lang/c++/CMakeLists.txt
+++ b/lang/c++/CMakeLists.txt
@@ -51,7 +51,6 @@ if (CMAKE_COMPILER_IS_GNUCXX)
     set(CMAKE_CXX_FLAGS "-Wall")
 endif ()
 
-
 find_package (Boost 1.38 REQUIRED
     COMPONENTS filesystem system program_options iostreams)
 
@@ -74,6 +73,7 @@ set (AVRO_SOURCE_FILES
         impl/json/JsonIO.cc
         impl/json/JsonDom.cc
         impl/Resolver.cc impl/Validator.cc
+        impl/LogicalType.cc
         )
 
 add_library (avrocpp SHARED ${AVRO_SOURCE_FILES})
@@ -142,6 +142,7 @@ unittest (SpecificTests)
 unittest (DataFileTests)
 unittest (JsonTests)
 unittest (AvrogencppTests)
+unittest (LogicalTypeTests)
 
 add_dependencies (AvrogencppTests bigrecord_hh bigrecord_r_hh bigrecord2_hh
     tweet_hh

--- a/lang/c++/api/LogicalType.hh
+++ b/lang/c++/api/LogicalType.hh
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef avro_LogicalType_hh__
+#define avro_LogicalType_hh__
+
+#include "Exception.hh"
+#include "Types.hh"
+#include <vector>
+#include <map>
+#include <boost/lexical_cast.hpp>
+
+namespace avro {
+
+///
+/// logical type interface
+///
+class LogicalType
+{
+public:
+    /// return the logical type name
+    virtual const std::string& getName() const = 0;
+
+    /// get the required fields, e.g. "precision" of "decimal" logical type
+    virtual void getRequiredFields(std::vector<std::string>& fields) const = 0;
+
+    /// get the optional fields, e.g. "scale" of "decimal" logical type
+    virtual void getOptionalFields(std::vector<std::string>& fields) const = 0;
+
+    /// get value for a required or optional field
+    virtual const std::string& getFieldValue(const std::string& field) = 0;
+
+    /// set value for a required or optional field
+    virtual void setFieldValue(const std::string& field, const std::string& value) = 0;
+
+    /// validate if a logical type is compatible with given type
+    virtual void validate(Type type) const = 0;
+};
+typedef boost::shared_ptr<LogicalType> LogicalTypePtr;
+
+///
+/// logical type factory interface,
+/// user could implement this interface for custom logical type
+///
+class LogicalTypeFactory
+{
+public:
+    /// create a new logical type
+    virtual LogicalTypePtr create() = 0;
+};
+typedef boost::shared_ptr<LogicalTypeFactory> LogicalTypeFactoryPtr;
+
+///
+/// base class of logical type, which implements logical type interfaces
+/// all logical types should derived from this class
+///
+class LogicalTypeImpl : public LogicalType
+{
+public:
+    LogicalTypeImpl() { }
+    LogicalTypeImpl(std::string name) :
+        name_(name) { }
+    virtual ~LogicalTypeImpl() { }
+
+    virtual const std::string& getName() const
+    {
+        return name_;
+    }
+    virtual void getRequiredFields(std::vector<std::string>& fields) const;
+    virtual void getOptionalFields(std::vector<std::string>& fields) const;
+
+    virtual const std::string& getFieldValue(const std::string& field);
+    virtual void setFieldValue(const std::string& field, const std::string& value);
+
+    virtual void validate(Type type) const;
+
+    typedef std::map<std::string /*fieldName*/, std::string /*fieldVavlue*/> FieldMap;
+
+protected:
+    std::string name_;
+    std::vector<Type> compatibleTypes_;
+    FieldMap requiredFields_;
+    FieldMap optionalFields_;
+};
+
+class Decimal : public LogicalTypeImpl
+{
+public:
+    Decimal() : LogicalTypeImpl("decimal")
+    {
+        LogicalTypeImpl::compatibleTypes_.push_back(AVRO_BYTES);
+        LogicalTypeImpl::compatibleTypes_.push_back(AVRO_FIXED);
+        // initialize the required and optional fields as empty strings
+        LogicalTypeImpl::requiredFields_.insert(
+                std::pair<std::string, std::string>("precision", ""));
+        LogicalTypeImpl::optionalFields_.insert(
+                std::pair<std::string, std::string>("scale", ""));
+    }
+
+    virtual ~Decimal() { }
+
+    void validate(Type type) const
+    {
+        LogicalTypeImpl::validate(type);
+        int precision = boost::lexical_cast<int>(requiredFields_.find("precision")->second);
+        if (precision < 0)
+        {
+            throw Exception("precision can not be negative");
+        }
+
+        if (!(optionalFields_.find("scale")->second).empty())
+        {
+            int scale = boost::lexical_cast<int>(optionalFields_.find("scale")->second);
+            if (scale < 0)
+            {
+                throw Exception("scale can not be negative");
+            }
+        }
+    }
+};
+
+class DecimalFactory : public LogicalTypeFactory
+{
+public:
+    DecimalFactory() { }
+    virtual ~DecimalFactory() { }
+
+    virtual LogicalTypePtr create()
+    {
+        return LogicalTypePtr(new Decimal());
+    }
+};
+
+class LogicalTypes : boost::noncopyable
+{
+public:
+    LogicalTypes();
+    virtual ~LogicalTypes() {}
+
+    typedef std::map<std::string /*LogicalTypeName*/, LogicalTypeFactoryPtr> FactoryMap;
+
+    LogicalTypePtr createLogicalType(const std::string& name);
+    void registerNewLogicalType(std::string& name, LogicalTypeFactoryPtr& factory);
+
+private:
+    FactoryMap registeredLogicalTypes_;
+};
+
+extern LogicalTypes logicalTypes;
+
+
+} // namespace avro
+
+#endif //avro_LogicalType_hh__

--- a/lang/c++/api/Node.hh
+++ b/lang/c++/api/Node.hh
@@ -27,6 +27,7 @@
 
 #include "Exception.hh"
 #include "Types.hh"
+#include "LogicalType.hh"
 #include "SchemaResolution.hh"
 
 namespace avro {
@@ -142,6 +143,13 @@ class AVRO_DECL Node : private boost::noncopyable
     }
     virtual int fixedSize() const = 0;
 
+    virtual void addLogicalType(const LogicalTypePtr& logicalType) {
+        checkLock();
+        doAddLogicalType(logicalType);
+    }
+
+    virtual const LogicalTypePtr& getLogicalType() const = 0;
+
     virtual bool isValid() const = 0;
 
     virtual SchemaResolution resolve(const Node &reader) const = 0;
@@ -168,7 +176,7 @@ class AVRO_DECL Node : private boost::noncopyable
     virtual void doAddLeaf(const NodePtr &newLeaf) = 0;
     virtual void doAddName(const std::string &name) = 0;
     virtual void doSetFixedSize(int size) = 0;
-
+    virtual void doAddLogicalType(const LogicalTypePtr& logicalType) = 0;
   private:
 
     const Type type_;

--- a/lang/c++/api/NodeImpl.hh
+++ b/lang/c++/api/NodeImpl.hh
@@ -51,7 +51,8 @@ class NodeImpl : public Node
         nameAttribute_(),
         leafAttributes_(),
         leafNameAttributes_(),
-        sizeAttribute_()
+        sizeAttribute_(),
+        logicalTypeAttribute_()
     { }
 
     NodeImpl(Type type, 
@@ -63,7 +64,8 @@ class NodeImpl : public Node
         nameAttribute_(name),
         leafAttributes_(leaves),
         leafNameAttributes_(leafNames),
-        sizeAttribute_(size)
+        sizeAttribute_(size),
+        logicalTypeAttribute_()
     { }
 
     void swap(NodeImpl& impl) {
@@ -125,6 +127,14 @@ class NodeImpl : public Node
         return sizeAttribute_.get();
     }
 
+    void doAddLogicalType(const LogicalTypePtr& logicalType) {
+        logicalTypeAttribute_.add(logicalType);
+    }
+
+    const LogicalTypePtr& getLogicalType() const {
+        return logicalTypeAttribute_.get();
+    }
+
     virtual bool isValid() const = 0;
 
     void printBasicInfo(std::ostream &os) const;
@@ -172,6 +182,7 @@ class NodeImpl : public Node
     LeavesConcept leafAttributes_;
     LeafNamesConcept leafNameAttributes_;
     SizeConcept sizeAttribute_;
+    concepts::SingleAttribute<LogicalTypePtr> logicalTypeAttribute_;
     concepts::NameIndexConcept<LeafNamesConcept> nameIndex_;
 };
 

--- a/lang/c++/api/buffer/BufferStreambuf.hh
+++ b/lang/c++/api/buffer/BufferStreambuf.hh
@@ -17,7 +17,7 @@
  */
 
 #ifndef avro_BufferStreambuf_hh__
-#define avro_BufferStreambuf_HH__
+#define avro_BufferStreambuf_hh__
 
 #include "Buffer.hh"
 

--- a/lang/c++/impl/LogicalType.cc
+++ b/lang/c++/impl/LogicalType.cc
@@ -1,0 +1,132 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "LogicalType.hh"
+
+namespace avro {
+
+LogicalTypes logicalTypes;
+
+// Wrap an indentation in a struct for ostream operator<<
+struct indent {
+    indent(int depth) :
+        d(depth)
+    { }
+    int d;
+};
+
+void LogicalTypeImpl::getRequiredFields(std::vector<std::string>& fields) const
+{
+    for (FieldMap::const_iterator it = requiredFields_.begin();
+            it != requiredFields_.end(); ++it)
+    {
+        fields.push_back(it->first);
+    }
+}
+
+void LogicalTypeImpl::getOptionalFields(std::vector<std::string>& fields) const
+{
+    for (FieldMap::const_iterator it = optionalFields_.begin();
+            it != optionalFields_.end(); ++it)
+    {
+        fields.push_back(it->first);
+    }
+}
+
+const std::string& LogicalTypeImpl::getFieldValue(const std::string& field)
+{
+    for (FieldMap::iterator it = requiredFields_.begin();
+            it != requiredFields_.end(); ++it)
+    {
+        if (field.compare(it->first) == 0)
+        {
+            return requiredFields_[field];
+        }
+    }
+    for (FieldMap::iterator it = optionalFields_.begin();
+            it != optionalFields_.end(); ++it)
+    {
+        if (field.compare(it->first) == 0)
+        {
+            return optionalFields_[field];
+        }
+    }
+    throw Exception("No such field " + field);
+}
+
+void LogicalTypeImpl::setFieldValue(const std::string& field, const std::string& value)
+{
+    FieldMap::iterator it = requiredFields_.find(field);
+    if (it != requiredFields_.end())
+    {
+        it->second = value;
+    }
+    else
+    {
+        it = optionalFields_.find(field);
+        if (it != optionalFields_.end())
+        {
+            it->second = value;
+        }
+    }
+}
+
+void LogicalTypeImpl::validate(Type type) const
+{
+    bool compatible = false;
+    for (std::vector<Type>::const_iterator it = compatibleTypes_.begin();
+            it != compatibleTypes_.end(); ++it) {
+        if (type == *it) {
+            compatible = true;
+        }
+    }
+    if (!compatible)
+    {
+        throw Exception("LogicalType " + name_ +
+                    " doesn't support type " + toString(type));
+    }
+}
+
+LogicalTypes::LogicalTypes()
+{
+    std::string name = "decimal";
+    LogicalTypeFactoryPtr factory(new DecimalFactory());
+    registerNewLogicalType(name, factory);
+}
+
+LogicalTypePtr LogicalTypes::createLogicalType(const std::string& name)
+{
+
+    for (FactoryMap::iterator it = registeredLogicalTypes_.begin();
+            it != registeredLogicalTypes_.end(); ++it)
+    {
+        if (name.compare(it->first) == 0)
+        {
+            return LogicalTypePtr(it->second->create());
+        }
+    }
+    throw Exception("No logicalType called " + name);
+}
+
+void LogicalTypes::registerNewLogicalType(std::string& name, LogicalTypeFactoryPtr& factory)
+{
+    registeredLogicalTypes_.insert(std::make_pair<std::string,
+            LogicalTypeFactoryPtr>(name, factory));
+}
+
+} // namespace avro

--- a/lang/c++/impl/NodeImpl.cc
+++ b/lang/c++/impl/NodeImpl.cc
@@ -166,9 +166,9 @@ std::ostream& operator <<(std::ostream &os, indent x)
 static void printLogicalType(std::ostream& os,
         const LogicalTypePtr& logicalType, int depth)
 {
-	if (logicalType == NULL){
-		return;
-	}
+    if (logicalType == NULL){
+        return;
+    }
     os << indent(depth) << "\"logicalType\": \"" << logicalType->getName() << "\",\n";
 
     std::vector<std::string> requiredFields;

--- a/lang/c++/impl/NodeImpl.cc
+++ b/lang/c++/impl/NodeImpl.cc
@@ -166,6 +166,9 @@ std::ostream& operator <<(std::ostream &os, indent x)
 static void printLogicalType(std::ostream& os,
         const LogicalTypePtr& logicalType, int depth)
 {
+	if (logicalType == NULL){
+		return;
+	}
     os << indent(depth) << "\"logicalType\": \"" << logicalType->getName() << "\",\n";
 
     std::vector<std::string> requiredFields;

--- a/lang/c++/test/AvrogencppTests.cc
+++ b/lang/c++/test/AvrogencppTests.cc
@@ -98,6 +98,11 @@ void setRecord(testgen::RootRecord &myRecord)
     myRecord.bytes.push_back(20);
 }
 
+bool enumCompare(int lhs, int rhs)
+{
+	return lhs == rhs;
+}
+
 template <typename T1, typename T2>
 void checkRecord(const T1& r1, const T2& r2)
 {
@@ -121,7 +126,7 @@ void checkRecord(const T1& r1, const T2& r2)
     BOOST_CHECK_EQUAL(r1.bytes.size(), r2.bytes.size());
     BOOST_CHECK_EQUAL_COLLECTIONS(r1.bytes.begin(), r1.bytes.end(),
         r2.bytes.begin(), r2.bytes.end());
-    BOOST_CHECK_EQUAL(r1.myenum, r2.myenum);
+    BOOST_CHECK(enumCompare(r1.myenum, r2.myenum));
 }
 
 void checkDefaultValues(const testgen_r::RootRecord& r)
@@ -130,7 +135,6 @@ void checkDefaultValues(const testgen_r::RootRecord& r)
     BOOST_CHECK_EQUAL(r.withDefaultValue.i1, 99);
     BOOST_CHECK_CLOSE(r.withDefaultValue.d1, 5.67, 1e-10);
 }
-
 
 void testEncoding()
 {

--- a/lang/c++/test/LogicalTypeTests.cc
+++ b/lang/c++/test/LogicalTypeTests.cc
@@ -1,0 +1,160 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "LogicalType.hh"
+#include "Compiler.hh"
+#include "ValidSchema.hh"
+
+#include <boost/test/included/unit_test_framework.hpp>
+#include <boost/test/unit_test.hpp>
+#include <boost/test/parameterized_test.hpp>
+
+#include <sstream>
+#include <iostream>
+
+namespace avro {
+namespace schema {
+
+const char* basicSchemas[] = {
+    "{ \"type\": \"bytes\", \"logicalType\": \"decimal\", \"precision\" : \"2\" }",
+    "{ \"type\": \"fixed\", \"name\": \"Test\", \"logicalType\": \"decimal\", \"precision\" : \"2\", \"size\": 1 }",
+};
+
+const char* basicSchemaErrors[] = {
+    // incompatible types
+    "{ \"type\": \"null\", \"logicalType\": \"decimal\", \"precision\" : \"2\" }",
+    "{ \"type\": \"boolean\", \"logicalType\": \"decimal\", \"precision\" : \"2\" }",
+    "{ \"type\": \"int\", \"logicalType\": \"decimal\", \"precision\" : \"2\" }",
+    "{ \"type\": \"long\", \"logicalType\": \"decimal\", \"precision\" : \"2\" }",
+    "{ \"type\": \"float\", \"logicalType\": \"decimal\", \"precision\" : \"2\" }",
+    "{ \"type\": \"double\", \"logicalType\": \"decimal\", \"precision\" : \"2\" }",
+    // missing required field
+    "{ \"type\": \"bytes\", \"logicalType\": \"decimal\" }",
+    // invalid required field value
+    "{ \"type\": \"bytes\", \"logicalType\": \"decimal\", \"precision\" : \"-12\" }",
+    // invalid optional field value
+    "{ \"type\": \"bytes\", \"logicalType\": \"decimal\", \"precision\" : \"2\", \"scale\" : \"-1\" }",
+    // unsupported logical type
+    "{ \"type\": \"bytes\", \"logicalType\": \"unsupported\" }",
+};
+
+const char* pairSchema = "{"
+                "\"name\": \"Pair\","
+                "\"type\": \"record\","
+                "\"fields\": ["
+                "    {\"name\": \"x\", \"type\": \"long\"},"
+                "    {\"name\": \"y\", \"type\": \"long\"}"
+                "  ],"
+                "\"logicalType\": \"pair\""
+                "}";
+
+
+class Pair : public LogicalTypeImpl
+{
+public:
+    Pair() : LogicalTypeImpl("pair")
+    {
+        LogicalTypeImpl::compatibleTypes_.push_back(AVRO_RECORD);
+    }
+
+    virtual ~Pair() { }
+
+    void validate(Type type) const
+    {
+        LogicalTypeImpl::validate(type);
+    }
+};
+
+class PairFactory : public LogicalTypeFactory
+{
+public:
+    PairFactory() { }
+    virtual ~PairFactory() { }
+
+    virtual LogicalTypePtr create()
+    {
+        std::cout << "creating pair\n";
+        return LogicalTypePtr(new Pair());
+    }
+};
+
+static void testBasic(const char* schema)
+{
+    BOOST_CHECKPOINT(schema);
+    ValidSchema validSchema = compileJsonSchemaFromString(schema);
+    LogicalTypePtr logicalType = validSchema.root()->getLogicalType();
+    std::vector<std::string> fields;
+    logicalType->getRequiredFields(fields);
+    BOOST_CHECK_EQUAL(*fields.begin(), "precision");
+    BOOST_CHECK_EQUAL(logicalType->getFieldValue("precision"), "2");
+    BOOST_CHECK_EQUAL(logicalType->getName(), "decimal");
+}
+
+static void testBasic_fail(const char* schema)
+{
+    BOOST_CHECKPOINT(schema);
+    BOOST_CHECK_THROW(compileJsonSchemaFromString(schema), Exception);
+}
+
+static void testPrintJson()
+{
+    ValidSchema validSchema = compileJsonSchemaFromString(basicSchemas[1]);
+    std::ostringstream oss;
+    validSchema.toJson(oss);
+    BOOST_CHECK(oss.str().find("\"logicalType\": \"decimal\",") > 0);
+    BOOST_CHECK(oss.str().find("\"precision\": \"2\",") > 0);
+}
+
+static void testCreateDecimal()
+{
+    LogicalTypePtr decimal = logicalTypes.createLogicalType("decimal");
+    BOOST_CHECK_EQUAL(decimal->getName(), "decimal");
+}
+
+static void testCustomLogicalType()
+{
+    std::string name = "pair";
+    LogicalTypeFactoryPtr factory(new PairFactory());
+    logicalTypes.registerNewLogicalType(name, factory);
+    ValidSchema validSchema = compileJsonSchemaFromString(pairSchema);
+    LogicalTypePtr pair = validSchema.root()->getLogicalType();
+    BOOST_CHECK_EQUAL(pair->getName(), name);
+}
+
+} //namespace avro
+} //namespace schema
+
+#define ENDOF(x)  (x + sizeof(x) / sizeof(x[0]))
+
+#define ADD_PARAM_TEST(ts, func, data) \
+    ts->add(BOOST_PARAM_TEST_CASE(&func, data, ENDOF(data)))
+
+boost::unit_test::test_suite*
+init_unit_test_suite( int argc, char* argv[] )
+{
+    using namespace boost::unit_test;
+
+    test_suite* ts= BOOST_TEST_SUITE("Avro C++ unit tests for logical types");
+
+    ADD_PARAM_TEST(ts, avro::schema::testBasic, avro::schema::basicSchemas);
+    ADD_PARAM_TEST(ts, avro::schema::testBasic_fail, avro::schema::basicSchemaErrors);
+    ts->add(BOOST_TEST_CASE(&avro::schema::testPrintJson));
+    ts->add(BOOST_TEST_CASE(&avro::schema::testCreateDecimal));
+    ts->add(BOOST_TEST_CASE(&avro::schema::testCustomLogicalType));
+    return ts;
+}


### PR DESCRIPTION
this change will add the logicalType support in the schema, what is next:
1. convert the real data type to logical type data
2. add more predefined logical types