### PR TITLE
Move management of the file stream into DataFileWriter

### DIFF
--- a/lang/c++/api/Stream.hh
+++ b/lang/c++/api/Stream.hh
@@ -70,7 +70,7 @@ public:
     /**
      * Returns the number of bytes read from this stream so far.
      * All the bytes made available through next are considered
-     * to be used unless, retutned back using backup.
+     * to be used unless, returned back using backup.
      */
     virtual size_t byteCount() const = 0;
 };
@@ -108,7 +108,7 @@ public:
     /**
      * Number of bytes written so far into this stream. The whole buffer
      * returned by next() is assumed to be written unless some of
-     * it was retutned using backup().
+     * it was returned using backup().
      */
     virtual uint64_t byteCount() const = 0;
 
@@ -265,7 +265,7 @@ struct StreamReader {
     }
 
     /**
-     * Get as many byes from the underlying stream as possible in a single
+     * Get as many bytes from the underlying stream as possible in a single
      * chunk.
      * \return true if some data could be obtained. False is no more
      * data is available on the stream.

--- a/lang/c++/impl/DataFile.cc
+++ b/lang/c++/impl/DataFile.cc
@@ -63,14 +63,16 @@ static string toString(const ValidSchema& schema)
     return oss.str();
 }
 
-DataFileWriterBase::DataFileWriterBase(const char* filename,
+DataFileWriterBase::DataFileWriterBase(OutputStream *outputStream,
     const ValidSchema& schema, size_t syncInterval, Codec codec) :
-    filename_(filename), schema_(schema), encoderPtr_(binaryEncoder()),
+    schema_(schema), 
+    encoderPtr_(binaryEncoder()),
     syncInterval_(syncInterval),
     codec_(codec),
-    stream_(fileOutputStream(filename)),
+    stream_(outputStream),
     buffer_(memoryOutputStream()),
-    sync_(makeSync()), objectCount_(0)
+    sync_(makeSync()), 
+    objectCount_(0)
 {
     if (syncInterval < minSyncInterval || syncInterval > maxSyncInterval) {
         throw Exception(boost::format("Invalid sync interval: %1%. "
@@ -92,17 +94,9 @@ DataFileWriterBase::DataFileWriterBase(const char* filename,
     encoderPtr_->init(*buffer_);
 }
 
-DataFileWriterBase::~DataFileWriterBase()
-{
-    if (stream_.get()) {
-        close();
-    }
-}
-
 void DataFileWriterBase::close()
 {
     flush();
-    stream_.reset();
 }
 
 void DataFileWriterBase::sync()


### PR DESCRIPTION
I realize there's another process for submitting changes to Avro, but it looked like the Pull Requests on this repository did get some attention and I figured this might be a good way to get some preliminary feedback.

The goal of this change is to be able to pass an OutputStream* into DataFileWriter, so that I can still maintain control of an InMemoryOutputStream and read its data (using an InputStream) after the schema + data has been written. It looks like you can currently do this in the Java build, but not C++.

My main worry with this approach is that the public DataFileWriterBase now takes a raw pointer to an OutputStream, and will no longer manage it using auto_ptr. Now it's up to the DataFileWriter to manage the OutputStream pointer. Let me know if there's another way to go about this, or if I can achieve the end goal using different methods.