### PR TITLE
AVRO-1749 Java: Introduce induce Maven plugin goal

### DIFF
--- a/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/InduceMojo.java
+++ b/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/InduceMojo.java
@@ -1,0 +1,137 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.avro.mojo;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.List;
+
+import org.apache.avro.reflect.ReflectData;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * Generate Avro files (.avsc and .avpr) from Java classes or interfaces
+ * 
+ * @goal induce
+ * @phase process-classes
+ * @threadSafe
+ */
+public class InduceMojo extends AbstractMojo {
+  /**
+   * The source directory of Java classes.
+   *
+   * @parameter property="sourceDirectory"
+   *            default-value="${basedir}/src/main/java"
+   */
+  private File sourceDirectory;
+
+  /**
+   * Directory where to output Avro schemas (.avsc) or protocols (.avpr).
+   *
+   * @parameter property="outputDirectory"
+   *            default-value="${basedir}/generated-resources/avro"
+   */
+  private File outputDirectory;
+
+  /**
+   * The current Maven project.
+   * 
+   * @parameter default-value="${project}"
+   * @readonly
+   * @required
+   */
+  protected MavenProject project;
+
+  public void execute() throws MojoExecutionException {
+    ClassLoader classLoader = getClassLoader();
+
+    for(File inputFile : sourceDirectory.listFiles()) {
+      String className = parseClassName(inputFile.getPath());
+      Class<?> klass = loadClass(classLoader, className);
+      String fileName = outputDirectory.getPath() + "/" + parseFileName(klass);
+      File outputFile = new File(fileName);
+      outputFile.getParentFile().mkdirs();
+      try {
+        PrintWriter writer = new PrintWriter(fileName, "UTF-8");
+        if(klass.isInterface()) {
+          writer.println(ReflectData.get().getProtocol(klass).toString(true));
+        } else {
+          writer.println(ReflectData.get().getSchema(klass).toString(true));
+        }
+        writer.close();
+      } catch(Exception e) {
+        e.printStackTrace();
+      }
+    }
+  }
+
+  private String parseClassName(String fileName) {
+    String indentifier = "java/";
+    int index = fileName.lastIndexOf(indentifier);
+    String namespacedFileName = fileName.substring(index + indentifier.length());
+
+    return namespacedFileName.replace("/", ".").replace(".java", "");
+  }
+
+  private String parseFileName(Class klass) {
+    String className = klass.getName().replace(".", "/");
+    if(klass.isInterface()) {
+      return className.concat(".avpr");
+    } else {
+      return className.concat(".avsc");
+    }
+  }
+
+  private Class<?> loadClass(ClassLoader classLoader, String className) {
+    Class<?> klass = null;
+
+    try {
+      klass = classLoader.loadClass(className);
+    } catch(ClassNotFoundException e) {
+      e.printStackTrace();
+    }
+
+    return klass;
+  }
+
+  private ClassLoader getClassLoader() {
+    ClassLoader classLoader = null;
+
+    try {
+      List<String> classpathElements = project.getRuntimeClasspathElements();
+      if(null == classpathElements) {
+        return Thread.currentThread().getContextClassLoader();
+      }
+      URL[] urls = new URL[classpathElements.size()];
+
+      for(int i = 0; i < classpathElements.size(); ++i) {
+        urls[i] = new File((String) classpathElements.get(i)).toURI().toURL();
+      }
+      classLoader = new URLClassLoader(urls, getClass().getClassLoader());
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+
+    return classLoader;
+  }
+}

--- a/lang/java/maven-plugin/src/test/java/org/apache/avro/entities/Person.java
+++ b/lang/java/maven-plugin/src/test/java/org/apache/avro/entities/Person.java
@@ -1,0 +1,23 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.avro.entities;
+
+public class Person {
+  private String name;
+}

--- a/lang/java/maven-plugin/src/test/java/org/apache/avro/mojo/TestInduceMojo.java
+++ b/lang/java/maven-plugin/src/test/java/org/apache/avro/mojo/TestInduceMojo.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.avro.mojo;
+
+import java.io.File;
+
+import org.apache.maven.plugin.testing.AbstractMojoTestCase;
+
+public class TestInduceMojo extends AbstractMojoTestCase {
+
+  protected File schemaPom;
+  protected File protocolPom;
+
+  @Override
+  protected void setUp() throws Exception {
+    String baseDir = getBasedir();
+    schemaPom = new File(baseDir, "src/test/resources/unit/schema/induce-pom.xml");
+    protocolPom = new File(baseDir, "src/test/resources/unit/protocol/induce-pom.xml");
+    super.setUp();
+  }
+
+  @Override
+  protected void tearDown() throws Exception {
+    super.tearDown();
+  }
+
+  public void testInduceMojoExists() throws Exception {
+    InduceMojo mojo = (InduceMojo) lookupMojo("induce", schemaPom);
+
+    assertNotNull(mojo);
+  }
+
+  public void testInduceSchema() throws Exception {
+    executeMojo(schemaPom);
+
+    File outputDir = new File(getBasedir(), "target/test-harness/schemas/org/apache/avro/entities");
+    assertTrue(outputDir.listFiles().length != 0);
+  }
+
+  public void testInducedSchemasFileExtension() throws Exception {
+    executeMojo(schemaPom);
+
+    File outputDir = new File(getBasedir(), "target/test-harness/schemas/org/apache/avro/entities");
+    for(File file : outputDir.listFiles()) {
+      assertTrue(file.getName().indexOf(".avsc") != -1);
+    }
+  }
+
+  public void testInduceProtocol() throws Exception {
+    executeMojo(protocolPom);
+
+    File outputDir = new File(getBasedir(), "target/test-harness/protocol/org/apache/avro/protocols");
+    assertTrue(outputDir.listFiles().length != 0);
+  }
+
+  public void testInducedProtocolsFileExtension() throws Exception {
+    executeMojo(protocolPom);
+
+    File outputDir = new File(getBasedir(), "target/test-harness/protocol/org/apache/avro/protocols");
+    for(File file : outputDir.listFiles()) {
+      assertTrue(file.getName().indexOf(".avpr") != -1);
+    }
+  }
+
+  private void executeMojo(File pom) throws Exception {
+    InduceMojo mojo = (InduceMojo) lookupMojo("induce", pom);
+    mojo.execute();
+  }
+}

--- a/lang/java/maven-plugin/src/test/java/org/apache/avro/protocols/Remote.java
+++ b/lang/java/maven-plugin/src/test/java/org/apache/avro/protocols/Remote.java
@@ -1,0 +1,23 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.avro.protocols;
+
+public interface Remote {
+  Object fetch(int id);
+}

--- a/lang/java/maven-plugin/src/test/resources/unit/protocol/induce-pom.xml
+++ b/lang/java/maven-plugin/src/test/resources/unit/protocol/induce-pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>avro-maven-plugin-test</artifactId>
+  <packaging>jar</packaging>
+
+  <name>testproject</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>avro-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>induce</id>
+            <goals>
+              <goal>induce</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <sourceDirectory>${basedir}/src/test/java/org/apache/avro/protocols</sourceDirectory>
+          <outputDirectory>${basedir}/target/test-harness/protocol</outputDirectory>
+          <project implementation="org.apache.maven.plugin.testing.stubs.MavenProjectStub"/>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+      <version>1.7.3-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-mapper-asl</artifactId>
+      <version>1.9.10</version>
+    </dependency> 
+  </dependencies>
+</project>

--- a/lang/java/maven-plugin/src/test/resources/unit/schema/induce-pom.xml
+++ b/lang/java/maven-plugin/src/test/resources/unit/schema/induce-pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>avro-maven-plugin-test</artifactId>
+  <packaging>jar</packaging>
+
+  <name>testproject</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>avro-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>induce</id>
+            <goals>
+              <goal>induce</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <sourceDirectory>${basedir}/src/test/java/org/apache/avro/entities</sourceDirectory>
+          <outputDirectory>${basedir}/target/test-harness/schemas</outputDirectory>
+          <project implementation="org.apache.maven.plugin.testing.stubs.MavenProjectStub"/>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+      <version>1.7.3-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-mapper-asl</artifactId>
+      <version>1.9.10</version>
+    </dependency> 
+  </dependencies>
+</project>


### PR DESCRIPTION
[AVRO-1749](https://issues.apache.org/jira/browse/AVRO-1749)

Maven plugin goal to induce Avro schemas and protocol from Java classes.

(this PR was previously #67)
