### PR TITLE
AVRO-1799: Fix GenericRecord#toString ByteBuffer bug.

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/generic/GenericData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/generic/GenericData.java
@@ -547,7 +547,7 @@ public class GenericData {
       buffer.append("\"");
     } else if (isBytes(datum)) {
       buffer.append("{\"bytes\": \"");
-      ByteBuffer bytes = (ByteBuffer)datum;
+      ByteBuffer bytes = ((ByteBuffer) datum).duplicate();
       writeEscapedString(StandardCharsets.ISO_8859_1.decode(bytes), buffer);
       buffer.append("\"}");
     } else if (((datum instanceof Float) &&       // quote Nan & Infinity

--- a/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericData.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericData.java
@@ -321,7 +321,9 @@ public class TestGenericData {
 
   @Test public void testToStringEscapesControlCharsInBytes() throws Exception {
     GenericData data = GenericData.get();
-    assertEquals("{\"bytes\": \"a\\nb\"}", data.toString(ByteBuffer.wrap(new byte[] {'a', '\n', 'b'})));
+    ByteBuffer bytes = ByteBuffer.wrap(new byte[] {'a', '\n', 'b'});
+    assertEquals("{\"bytes\": \"a\\nb\"}", data.toString(bytes));
+    assertEquals("{\"bytes\": \"a\\nb\"}", data.toString(bytes));
   }
 
   @Test public void testToStringFixed() throws Exception {


### PR DESCRIPTION
Reading the ByteBuffer to return a string representaton modified the
buffer's position. The solution is to duplicate the buffer before
reading its content.