### PR TITLE
AVRO-1819 and AVRO-1820: Parsing aliases and custom properties of request's field

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/Protocol.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Protocol.java
@@ -70,6 +70,12 @@ public class Protocol extends JsonProperties {
                        "doc", "response","request", "errors", "one-way");
   }
 
+  private static final Set<String> FIELD_RESERVED = new HashSet<String>();
+  static {
+    Collections.addAll(FIELD_RESERVED,
+                       "name", "type", "doc", "default", "aliases");
+  }
+
   /** A protocol message. */
   public class Message extends JsonProperties {
     private String name;
@@ -482,9 +488,20 @@ public class Protocol extends JsonProperties {
       JsonNode fieldDocNode = field.get("doc");
       if (fieldDocNode != null)
         fieldDoc = fieldDocNode.getTextValue();
-      fields.add(new Field(name, Schema.parse(fieldTypeNode,types),
-                           fieldDoc,
-                           field.get("default")));
+      Field newField = new Field(name, Schema.parse(fieldTypeNode,types),
+                                 fieldDoc, field.get("default"));
+      JsonNode aliasesNode = field.get("aliases");
+      if (aliasesNode != null && aliasesNode.isArray()) {
+        for (JsonNode aliasNode : aliasesNode)
+          newField.addAlias(aliasNode.getTextValue());
+      }
+      Iterator<String> i = field.getFieldNames();
+      while (i.hasNext()) {                       // add properties
+        String prop = i.next();
+        if (!FIELD_RESERVED.contains(prop))      // ignore reserved
+          newField.addProp(prop, field.get(prop));
+      }
+      fields.add(newField);
     }
     Schema request = Schema.createRecord(fields);
     

--- a/lang/java/avro/src/main/java/org/apache/avro/Protocol.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Protocol.java
@@ -490,11 +490,11 @@ public class Protocol extends JsonProperties {
         fieldDoc = fieldDocNode.getTextValue();
       Field newField = new Field(name, Schema.parse(fieldTypeNode,types),
                                  fieldDoc, field.get("default"));
-      JsonNode aliasesNode = field.get("aliases");
-      if (aliasesNode != null && aliasesNode.isArray()) {
-        for (JsonNode aliasNode : aliasesNode)
-          newField.addAlias(aliasNode.getTextValue());
-      }
+      Set<String> aliases = Schema.parseAliases(field);
+      if (aliases != null)                      // add aliases
+        for (String alias : aliases)
+          newField.addAlias(alias);
+
       Iterator<String> i = field.getFieldNames();
       while (i.hasNext()) {                       // add properties
         String prop = i.next();

--- a/lang/java/avro/src/main/java/org/apache/avro/Schema.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Schema.java
@@ -1344,7 +1344,7 @@ public abstract class Schema extends JsonProperties {
     }
   }
 
-  private static Set<String> parseAliases(JsonNode node) {
+  static Set<String> parseAliases(JsonNode node) {
     JsonNode aliasesNode = node.get("aliases");
     if (aliasesNode == null)
       return null;

--- a/lang/java/ipc/src/test/java/org/apache/avro/TestProtocolParsing.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/TestProtocolParsing.java
@@ -18,6 +18,7 @@
 package org.apache.avro;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -30,19 +31,18 @@ import org.apache.avro.Protocol.Message;
 public class TestProtocolParsing {
   public static Protocol getSimpleProtocol() throws IOException {
     File file = new File("../../../share/test/schemas/simple.avpr");
-    Protocol protocol = Protocol.parse(file);
-    return protocol;
+    return Protocol.parse(file);
   }
-  
+
   @Test
   public void testParsing() throws IOException {
     Protocol protocol = getSimpleProtocol();
-    
+
     assertEquals(protocol.getDoc(), "Protocol used for testing.");
     assertEquals(6, protocol.getMessages().size());
-    assertEquals("Pretend you're in a cave!", protocol.getMessages().get("echo").getDoc());    
+    assertEquals("Pretend you're in a cave!", protocol.getMessages().get("echo").getDoc());
   }
-  
+
   private static Message parseMessage(String message) throws Exception {
     return Protocol.parse("{\"protocol\": \"org.foo.Bar\","
                           +"\"types\": [],"
@@ -51,7 +51,8 @@ public class TestProtocolParsing {
                           + "}}").getMessages().values().iterator().next();
   }
 
-  @Test public void oneWay() throws Exception {
+  @Test
+  public void oneWay() throws Exception {
     Message m;
     // permit one-way messages w/ null resposne
     m = parseMessage("\"ack\": {"
@@ -84,4 +85,23 @@ public class TestProtocolParsing {
                  +"\"one-way\": true}");
   }
 
+  @Test
+  public void testMessageFieldAliases() throws IOException{
+    Protocol protocol = getSimpleProtocol();
+    final Message msg = protocol.getMessages().get("hello");
+    assertNotNull(msg);
+    final Schema.Field field = msg.getRequest().getField("greeting");
+    assertNotNull(field);
+    assertTrue(field.aliases().contains("salute"));
+  }
+
+  @Test
+  public void testMessageCustomProperties() throws IOException{
+    Protocol protocol = getSimpleProtocol();
+    final Message msg = protocol.getMessages().get("hello");
+    assertNotNull(msg);
+    final Schema.Field field = msg.getRequest().getField("greeting");
+    assertNotNull(field);
+    assertEquals("customValue", field.getProp("customProp"));
+  }
 }

--- a/share/test/schemas/simple.avpr
+++ b/share/test/schemas/simple.avpr
@@ -40,7 +40,7 @@
 
      "hello": {
          "doc": "Send a greeting",
-         "request": [{"name": "greeting", "type": "string"}],
+         "request": [{"name": "greeting", "type": "string", "aliases" : [ "salute" ], "customProp" : "customValue"}],
          "response": "string"
      },
 


### PR DESCRIPTION
AVRO-1819: Parsing aliases of request's field
AVRO-1820: Parsing custom properties of request's field

Fixed bug in org.apache.avro.Protocol.parseMessage of loss field's aliases and custom properties.
