### PR TITLE
AVRO-1822 - Move TestSpecificCompiler into org.apache.avro.compiler.specific

### DIFF
--- a/lang/java/compiler/src/test/java/org/apache/avro/compiler/specific/TestSpecificCompiler.java
+++ b/lang/java/compiler/src/test/java/org/apache/avro/compiler/specific/TestSpecificCompiler.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.avro.compiler;
+package org.apache.avro.compiler.specific;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;


### PR DESCRIPTION
See AVRO-1822. 

This moves TestSpecificCompiler from org.apache.avro.compiler into org.apache.avro.compiler.specific so tests can be updated for AVRO-1642