### PR TITLE
Make numeric schemas not valid for boolean datums

### DIFF
--- a/lang/py/src/avro/io.py
+++ b/lang/py/src/avro/io.py
@@ -110,12 +110,12 @@ def validate(expected_schema, datum):
   elif schema_type == 'bytes':
     return isinstance(datum, str)
   elif schema_type == 'int':
-    return ((isinstance(datum, int) and not isinstance(datum, bool)) or
-            isinstance(datum, long) and
+    return (((isinstance(datum, int) and not isinstance(datum, bool)) or
+            isinstance(datum, long)) and
             INT_MIN_VALUE <= datum <= INT_MAX_VALUE)
   elif schema_type == 'long':
-    return ((isinstance(datum, int) and not isinstance(datum, bool)) or
-            isinstance(datum, long) and
+    return (((isinstance(datum, int) and not isinstance(datum, bool)) or
+            isinstance(datum, long)) and
             LONG_MIN_VALUE <= datum <= LONG_MAX_VALUE)
   elif schema_type in ['float', 'double']:
     return (isinstance(datum, long) or

--- a/lang/py/src/avro/io.py
+++ b/lang/py/src/avro/io.py
@@ -116,7 +116,8 @@ def validate(expected_schema, datum):
     return ((isinstance(datum, int) or isinstance(datum, long)) 
             and LONG_MIN_VALUE <= datum <= LONG_MAX_VALUE)
   elif schema_type in ['float', 'double']:
-    return (isinstance(datum, int) or isinstance(datum, long)
+    return (isinstance(datum, long) or
+            (isinstance(datum, int) and not isinstance(datum, bool))
             or isinstance(datum, float))
   elif schema_type == 'fixed':
     return isinstance(datum, str) and len(datum) == expected_schema.size

--- a/lang/py/src/avro/io.py
+++ b/lang/py/src/avro/io.py
@@ -117,8 +117,8 @@ def validate(expected_schema, datum):
             and LONG_MIN_VALUE <= datum <= LONG_MAX_VALUE)
   elif schema_type in ['float', 'double']:
     return (isinstance(datum, long) or
-            (isinstance(datum, int) and not isinstance(datum, bool))
-            or isinstance(datum, float))
+            (isinstance(datum, int) and not isinstance(datum, bool)) or
+            isinstance(datum, float))
   elif schema_type == 'fixed':
     return isinstance(datum, str) and len(datum) == expected_schema.size
   elif schema_type == 'enum':

--- a/lang/py/src/avro/io.py
+++ b/lang/py/src/avro/io.py
@@ -110,10 +110,12 @@ def validate(expected_schema, datum):
   elif schema_type == 'bytes':
     return isinstance(datum, str)
   elif schema_type == 'int':
-    return ((isinstance(datum, int) or isinstance(datum, long)) 
+    return ((isinstance(datum, int) and not isinstance(datum, bool)) or
+            isinstance(datum, long)) 
             and INT_MIN_VALUE <= datum <= INT_MAX_VALUE)
   elif schema_type == 'long':
-    return ((isinstance(datum, int) or isinstance(datum, long)) 
+    return ((isinstance(datum, int) and not isinstance(datum, bool)) or
+            isinstance(datum, long)) 
             and LONG_MIN_VALUE <= datum <= LONG_MAX_VALUE)
   elif schema_type in ['float', 'double']:
     return (isinstance(datum, long) or

--- a/lang/py/src/avro/io.py
+++ b/lang/py/src/avro/io.py
@@ -111,12 +111,12 @@ def validate(expected_schema, datum):
     return isinstance(datum, str)
   elif schema_type == 'int':
     return ((isinstance(datum, int) and not isinstance(datum, bool)) or
-            isinstance(datum, long)) 
-            and INT_MIN_VALUE <= datum <= INT_MAX_VALUE)
+            isinstance(datum, long) and
+            INT_MIN_VALUE <= datum <= INT_MAX_VALUE)
   elif schema_type == 'long':
     return ((isinstance(datum, int) and not isinstance(datum, bool)) or
-            isinstance(datum, long)) 
-            and LONG_MIN_VALUE <= datum <= LONG_MAX_VALUE)
+            isinstance(datum, long) and
+            LONG_MIN_VALUE <= datum <= LONG_MAX_VALUE)
   elif schema_type in ['float', 'double']:
     return (isinstance(datum, long) or
             (isinstance(datum, int) and not isinstance(datum, bool)) or

--- a/lang/py/test/test_io.py
+++ b/lang/py/test/test_io.py
@@ -199,11 +199,6 @@ class TestIO(unittest.TestCase):
             return type(round_trip_datum) == bool
         else:
             return True
-    def is_boolean_int(datum, round_trip_datum):
-        datum_type = type(datum)
-        round_trip_datum_type = type(round_trip_datum)
-        return ((datum_type == bool and round_trip_datum_type == int) or
-                (round_trip_datum_type == bool and datum_type == int))
     for example_schema, datum in SCHEMAS_TO_VALIDATE:
       print 'Schema: %s' % example_schema
       print 'Datum: %s' % datum

--- a/lang/py/test/test_io.py
+++ b/lang/py/test/test_io.py
@@ -39,6 +39,8 @@ SCHEMAS_TO_VALIDATE = (
   ('{"type": "array", "items": "long"}', [1, 3, 2]),
   ('{"type": "map", "values": "long"}', {'a': 1, 'b': 3, 'c': 2}),
   ('["string", "null", "long"]', None),
+  ('["double", "boolean"]', True),
+  ('["boolean", "double"]', True),
   ("""\
    {"type": "record",
     "name": "Test",
@@ -190,6 +192,18 @@ class TestIO(unittest.TestCase):
   def test_round_trip(self):
     print_test_name('TEST ROUND TRIP')
     correct = 0
+    def are_equal(datum, round_trip_datum):
+        if datum != round_trip_datum:
+            return False
+        if type(datum) == bool:
+            return type(round_trip_datum) == bool
+        else:
+            return True
+    def is_boolean_int(datum, round_trip_datum):
+        datum_type = type(datum)
+        round_trip_datum_type = type(round_trip_datum)
+        return ((datum_type == bool and round_trip_datum_type == int) or
+                (round_trip_datum_type == bool and datum_type == int))
     for example_schema, datum in SCHEMAS_TO_VALIDATE:
       print 'Schema: %s' % example_schema
       print 'Datum: %s' % datum
@@ -199,7 +213,7 @@ class TestIO(unittest.TestCase):
       round_trip_datum = read_datum(writer, writers_schema)
 
       print 'Round Trip Datum: %s' % round_trip_datum
-      if datum == round_trip_datum: correct += 1
+      if are_equal(datum, round_trip_datum): correct += 1
     self.assertEquals(correct, len(SCHEMAS_TO_VALIDATE))
 
   #


### PR DESCRIPTION
 In python 2.x True and False values are instances of int, so we have to check that int value is not also a boolean.
