### PR TITLE
AVRO-1882: ConcurrentHashMap with non-string keys fails in Java 1.8

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/MapEntry.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/MapEntry.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.avro.reflect;
+
+import java.util.Map;
+
+/**
+ * Class to make Avro immune from the naming variations of key/value fields
+ * among several {@link Map.Entry} implementations. If objects of this class
+ * are used instead of the regular ones obtained by {@link Map#entrySet()},
+ * then we need not worry about the actual field-names or any changes to them
+ * in the future.<BR>
+ * Example: {@code ConcurrentHashMap.MapEntry} does not name the fields as key/
+ * value in Java 1.8 while it used to do so in Java 1.7
+ *
+ * @param <K> Key of the map-entry
+ * @param <V> Value of the map-entry
+ */
+public class MapEntry<K, V> implements Map.Entry<K, V> {
+
+    K key;
+    V value;
+
+    public MapEntry(K key, V value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    @Override
+    public K getKey() {
+        return key;
+    }
+
+    @Override
+    public V getValue() {
+        return value;
+    }
+
+    @Override
+    public V setValue(V value) {
+        V oldValue = this.value;
+        this.value = value;
+        return oldValue;
+    }
+}

--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/MapEntry.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/MapEntry.java
@@ -33,28 +33,28 @@ import java.util.Map;
  */
 public class MapEntry<K, V> implements Map.Entry<K, V> {
 
-    K key;
-    V value;
+  K key;
+  V value;
 
-    public MapEntry(K key, V value) {
-        this.key = key;
-        this.value = value;
-    }
+  public MapEntry(K key, V value) {
+    this.key = key;
+    this.value = value;
+  }
 
-    @Override
-    public K getKey() {
-        return key;
-    }
+  @Override
+  public K getKey() {
+    return key;
+  }
 
-    @Override
-    public V getValue() {
-        return value;
-    }
+  @Override
+  public V getValue() {
+    return value;
+  }
 
-    @Override
-    public V setValue(V value) {
-        V oldValue = this.value;
-        this.value = value;
-        return oldValue;
-    }
+  @Override
+  public V setValue(V value) {
+    V oldValue = this.value;
+    this.value = value;
+    return oldValue;
+  }
 }

--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectDatumWriter.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectDatumWriter.java
@@ -142,19 +142,19 @@ public class ReflectDatumWriter<T> extends SpecificDatumWriter<T> {
     else if (datum instanceof Short)
       datum = ((Short)datum).intValue();
     else if (datum instanceof Character)
-        datum = (int)(char)(Character)datum;
+      datum = (int)(char)(Character)datum;
     else if (datum instanceof Map && ReflectData.isNonStringMapSchema(schema)) {
-        // Maps with non-string keys are written as arrays.
-        // Schema for such maps is already changed. Here we
-        // just switch the map to a similar form too.
-        Set entries = ((Map)datum).entrySet();
-        List<Map.Entry> entryList = new ArrayList<Map.Entry>(entries.size());
-        for (Object obj: ((Map)datum).entrySet()) {
-            Map.Entry e = (Map.Entry)obj;
-            entryList.add(new MapEntry(e.getKey(), e.getValue()));
-        }
-        datum = entryList;
+      // Maps with non-string keys are written as arrays.
+      // Schema for such maps is already changed. Here we
+      // just switch the map to a similar form too.
+      Set entries = ((Map)datum).entrySet();
+      List<Map.Entry> entryList = new ArrayList<Map.Entry>(entries.size());
+      for (Object obj: ((Map)datum).entrySet()) {
+          Map.Entry e = (Map.Entry)obj;
+          entryList.add(new MapEntry(e.getKey(), e.getValue()));
       }
+      datum = entryList;
+    }
     try {
       super.write(schema, datum, out);
     } catch (NullPointerException e) {            // improve error message

--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectDatumWriter.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectDatumWriter.java
@@ -18,8 +18,11 @@
 package org.apache.avro.reflect;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.Schema;
@@ -144,7 +147,13 @@ public class ReflectDatumWriter<T> extends SpecificDatumWriter<T> {
         // Maps with non-string keys are written as arrays.
         // Schema for such maps is already changed. Here we
         // just switch the map to a similar form too.
-        datum = ((Map)datum).entrySet();
+        Set entries = ((Map)datum).entrySet();
+        List<Map.Entry> entryList = new ArrayList<Map.Entry>(entries.size());
+        for (Object obj: ((Map)datum).entrySet()) {
+            Map.Entry e = (Map.Entry)obj;
+            entryList.add(new MapEntry(e.getKey(), e.getValue()));
+        }
+        datum = entryList;
       }
     try {
       super.write(schema, datum, out);

--- a/lang/java/avro/src/test/java/org/apache/avro/reflect/TestNonStringMapKeys.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/reflect/TestNonStringMapKeys.java
@@ -17,10 +17,6 @@
  */
 package org.apache.avro.reflect;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -29,6 +25,9 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map.Entry;
+
+import static org.junit.Assert.*;
+
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 

--- a/lang/java/avro/src/test/java/org/apache/avro/reflect/TestNonStringMapKeys.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/reflect/TestNonStringMapKeys.java
@@ -17,15 +17,20 @@
  */
 package org.apache.avro.reflect;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map.Entry;
-
-import static org.junit.Assert.*;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileReader;
@@ -34,10 +39,6 @@ import org.apache.avro.file.SeekableByteArrayInput;
 import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.reflect.ReflectData;
-import org.apache.avro.reflect.ReflectDatumReader;
-import org.apache.avro.reflect.ReflectDatumWriter;
-import org.apache.avro.reflect.ReflectData;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.Encoder;
@@ -206,16 +207,24 @@ public class TestNonStringMapKeys {
       assertEquals ("Foo", value.toString());
     }
     assertEquals (entity.getMap1(), entity.getMap2());
+    assertEquals (entity.getMap1(), entity.getMap3());
+    assertEquals (entity.getMap1(), entity.getMap4());
 
 
     ReflectData rdata = ReflectData.get();
     Schema schema = rdata.getSchema(SameMapSignature.class);
     Schema map1schema = schema.getField("map1").schema().getElementType();
     Schema map2schema = schema.getField("map2").schema().getElementType();
+    Schema map3schema = schema.getField("map3").schema().getElementType();
+    Schema map4schema = schema.getField("map4").schema().getElementType();
     log ("Schema for map1 = " + map1schema);
     log ("Schema for map2 = " + map2schema);
+    log ("Schema for map3 = " + map3schema);
+    log ("Schema for map4 = " + map4schema);
     assertEquals (map1schema.getFullName(), "org.apache.avro.reflect.PairIntegerString");
     assertEquals (map1schema, map2schema);
+    assertEquals (map1schema, map3schema);
+    assertEquals (map1schema, map4schema);
 
 
     byte[] jsonBytes = testJsonEncoder (testType, entityObj1);
@@ -365,8 +374,12 @@ public class TestNonStringMapKeys {
     SameMapSignature obj = new SameMapSignature();
     obj.setMap1(new HashMap<Integer, String>());
     obj.getMap1().put(1, "Foo");
-    obj.setMap2(new HashMap<Integer, String>());
+    obj.setMap2(new ConcurrentHashMap<Integer, String>());
     obj.getMap2().put(1, "Foo");
+    obj.setMap3(new LinkedHashMap<Integer, String>());
+    obj.getMap3().put(1, "Foo");
+    obj.setMap4(new TreeMap<Integer, String>());
+    obj.getMap4().put(1, "Foo");
     return obj;
   }
 
@@ -492,7 +505,9 @@ class EmployeeInfo2 {
 class SameMapSignature {
 
   HashMap<Integer, String> map1;
-  HashMap<Integer, String> map2;
+  ConcurrentHashMap<Integer, String> map2;
+  LinkedHashMap<Integer, String> map3;
+  TreeMap<Integer, String> map4;
 
   public HashMap<Integer, String> getMap1() {
     return map1;
@@ -500,10 +515,22 @@ class SameMapSignature {
   public void setMap1(HashMap<Integer, String> map1) {
     this.map1 = map1;
   }
-  public HashMap<Integer, String> getMap2() {
+  public ConcurrentHashMap<Integer, String> getMap2() {
     return map2;
   }
-  public void setMap2(HashMap<Integer, String> map2) {
+  public void setMap2(ConcurrentHashMap<Integer, String> map2) {
     this.map2 = map2;
+  }
+  public LinkedHashMap<Integer, String> getMap3() {
+    return map3;
+  }
+  public void setMap3(LinkedHashMap<Integer, String> map3) {
+    this.map3 = map3;
+  }
+  public TreeMap<Integer, String> getMap4() {
+    return map4;
+  }
+  public void setMap4(TreeMap<Integer, String> map4) {
+    this.map4 = map4;
   }
 }

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -86,7 +86,7 @@
     <source-plugin.version>2.3</source-plugin.version>
     <surefire-plugin.version>2.17</surefire-plugin.version>
     <file-management.version>1.2.1</file-management.version>
-    <shade-plugin.version>2.4.3</shade-plugin.version>
+    <shade-plugin.version>1.7.1</shade-plugin.version>
     <archetype-plugin.version>2.2</archetype-plugin.version>
   </properties>
 

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -86,7 +86,7 @@
     <source-plugin.version>2.3</source-plugin.version>
     <surefire-plugin.version>2.17</surefire-plugin.version>
     <file-management.version>1.2.1</file-management.version>
-    <shade-plugin.version>1.7.1</shade-plugin.version>
+    <shade-plugin.version>2.4.3</shade-plugin.version>
     <archetype-plugin.version>2.2</archetype-plugin.version>
   </properties>
 


### PR DESCRIPTION
The new MapEntry class removes any dependence on the Map.Entry internal fields which are liable to change between Java versions or between different implementations of Map interface.

Also updated maven-shade-plugin as per [this thread](http://search-hadoop.com/m/F2svI1oJXGf1htLgb&subj=Re+Unable+to+build+clean+checkout+of+avro+from+master)
