### PR TITLE
AVRO-1908: Fix TestSpecificCompiler reference to private method.

### DIFF
--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
@@ -406,7 +406,7 @@ public class SpecificCompiler {
     return outputFile;
   }
 
-  private String makePath(String name, String space) {
+  String makePath(String name, String space) {
     if (space == null || space.isEmpty()) {
       return name + suffix;
     } else {

--- a/lang/java/ipc/src/test/java/org/apache/avro/compiler/specific/TestSpecificCompiler.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/compiler/specific/TestSpecificCompiler.java
@@ -79,8 +79,9 @@ public class TestSpecificCompiler {
 
   @Test
   public void testMakePath() {
-    assertEquals("foo/bar/Baz.java".replace("/", File.separator), SpecificCompiler.makePath("Baz", "foo.bar"));
-    assertEquals("baz.java", SpecificCompiler.makePath("baz", ""));
+    SpecificCompiler compiler = new SpecificCompiler();
+    assertEquals("foo/bar/Baz.java".replace("/", File.separator), compiler.makePath("Baz", "foo.bar"));
+    assertEquals("baz.java", compiler.makePath("baz", ""));
   }
 
   @Test


### PR DESCRIPTION
AVRO-1884 changed makePath to a private method from a package-private
static method. This broke the test that references the method in IPC.
The fix is to make the instance method package-private and update the
test to use an instance of SpecificCompiler.