### PR TITLE
AVRO-1891: Fix specific nested logical types

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/generic/GenericDatumReader.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/generic/GenericDatumReader.java
@@ -153,12 +153,21 @@ public class GenericDatumReader<D> implements DatumReader<D> {
     Object datum = readWithoutConversion(old, expected, in);
     LogicalType logicalType = expected.getLogicalType();
     if (logicalType != null) {
-      Conversion<?> conversion = getData().getConversionFor(logicalType);
+      Conversion<?> conversion = getConversionFor(logicalType);
       if (conversion != null) {
         return convert(datum, expected, logicalType, conversion);
       }
     }
     return datum;
+  }
+
+  protected Conversion<?> getConversionFor(LogicalType logicalType) {
+    return getData().getConversionFor(logicalType);
+  }
+
+  protected Conversion<?> getConversionByClass(Class<?> type,
+                                               LogicalType logicalType) {
+    return getData().getConversionByClass(type, logicalType);
   }
 
   protected Object readWithConversion(Object old, Schema expected,
@@ -253,7 +262,7 @@ public class GenericDatumReader<D> implements DatumReader<D> {
     long base = 0;
     if (l > 0) {
       LogicalType logicalType = expectedType.getLogicalType();
-      Conversion<?> conversion = getData().getConversionFor(logicalType);
+      Conversion<?> conversion = getConversionFor(logicalType);
       Object array = newArray(old, (int) l, expected);
       do {
         if (logicalType != null && conversion != null) {
@@ -299,7 +308,7 @@ public class GenericDatumReader<D> implements DatumReader<D> {
     Schema eValue = expected.getValueType();
     long l = in.readMapStart();
     LogicalType logicalType = eValue.getLogicalType();
-    Conversion<?> conversion = getData().getConversionFor(logicalType);
+    Conversion<?> conversion = getConversionFor(logicalType);
     Object map = newMap(old, (int) l);
     if (l > 0) {
       do {

--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectDatumReader.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectDatumReader.java
@@ -80,8 +80,8 @@ public class ReflectDatumReader<T> extends SpecificDatumReader<T> {
     if (elementClass == null) {
       // see if the element class will be converted and use that class
       // logical types cannot conflict with java-element-class
-      Conversion<?> elementConversion = getData()
-          .getConversionFor(schema.getElementType().getLogicalType());
+      Conversion<?> elementConversion = getConversionFor(
+          schema.getElementType().getLogicalType());
       if (elementConversion != null) {
         elementClass = elementConversion.getConvertedType();
       }
@@ -176,7 +176,8 @@ public class ReflectDatumReader<T> extends SpecificDatumReader<T> {
   private Object readObjectArray(Object[] array, Schema expectedType, long l,
       ResolvingDecoder in) throws IOException {
     LogicalType logicalType = expectedType.getLogicalType();
-    Conversion<?> conversion = getData().getConversionFor(logicalType);
+    Conversion<?> conversion = getConversionByClass(
+        array.getClass().getComponentType(), logicalType);
     int index = 0;
     if (logicalType != null && conversion != null) {
       do {
@@ -204,7 +205,7 @@ public class ReflectDatumReader<T> extends SpecificDatumReader<T> {
   private Object readCollection(Collection<Object> c, Schema expectedType,
       long l, ResolvingDecoder in) throws IOException {
     LogicalType logicalType = expectedType.getLogicalType();
-    Conversion<?> conversion = getData().getConversionFor(logicalType);
+    Conversion<?> conversion = getConversionFor(logicalType);
     if (logicalType != null && conversion != null) {
       do {
         for (int i = 0; i < l; i++) {
@@ -285,7 +286,7 @@ public class ReflectDatumReader<T> extends SpecificDatumReader<T> {
         }
         LogicalType logicalType = f.schema().getLogicalType();
         if (logicalType != null) {
-          Conversion<?> conversion = getData().getConversionByClass(
+          Conversion<?> conversion = getConversionByClass(
               accessor.getField().getType(), logicalType);
           if (conversion != null) {
             try {

--- a/lang/java/avro/src/test/java/org/apache/avro/specific/TestRecordWithLogicalTypes.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/specific/TestRecordWithLogicalTypes.java
@@ -5,10 +5,13 @@
  */
 package org.apache.avro.specific;
 
+import org.apache.avro.Conversion;
 import org.apache.avro.message.BinaryMessageDecoder;
 import org.apache.avro.message.BinaryMessageEncoder;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collection;
 
 @SuppressWarnings("all")
 @org.apache.avro.specific.AvroGenerated
@@ -268,6 +271,15 @@ public class TestRecordWithLogicalTypes extends org.apache.avro.specific.Specifi
   protected static final org.apache.avro.data.TimeConversions.TimeConversion TIME_CONVERSION = new org.apache.avro.data.TimeConversions.TimeConversion();
   protected static final org.apache.avro.data.TimeConversions.TimestampConversion TIMESTAMP_CONVERSION = new org.apache.avro.data.TimeConversions.TimestampConversion();
   protected static final org.apache.avro.Conversions.DecimalConversion DECIMAL_CONVERSION = new org.apache.avro.Conversions.DecimalConversion();
+
+  public static final Collection<Conversion<?>> CONVERSIONS = new ArrayList<Conversion<?>>();
+  static {
+    CONVERSIONS.add(DATE_CONVERSION);
+    CONVERSIONS.add(TIME_CONVERSION);
+    CONVERSIONS.add(TIMESTAMP_CONVERSION);
+    CONVERSIONS.add(DECIMAL_CONVERSION);
+  }
+
   private final org.apache.avro.Conversion<?>[] conversions =
       new org.apache.avro.Conversion<?>[] {
       null,

--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
@@ -225,6 +225,13 @@ public class SpecificCompiler {
     this.enableDecimalLogicalType = enableDecimalLogicalType;
   }
 
+  /**
+   * @return true if decimal logical type conversion is enabled
+   */
+  public boolean isDecimalEnabled() {
+    return enableDecimalLogicalType;
+  }
+
   private static String logChuteName = null;
 
   private void initializeVelocity() {

--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
@@ -406,7 +406,7 @@ public class SpecificCompiler {
     return outputFile;
   }
 
-  private String makePath(String name, String space) {
+  String makePath(String name, String space) {
     if (space == null || space.isEmpty()) {
       return name + suffix;
     } else {

--- a/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/record.vm
+++ b/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/record.vm
@@ -136,7 +136,19 @@ public class ${this.mangle($schema.getName())}#if ($schema.isError()) extends or
   protected static final org.apache.avro.data.TimeConversions.DateConversion DATE_CONVERSION = new org.apache.avro.data.TimeConversions.DateConversion();
   protected static final org.apache.avro.data.TimeConversions.TimeConversion TIME_CONVERSION = new org.apache.avro.data.TimeConversions.TimeConversion();
   protected static final org.apache.avro.data.TimeConversions.TimestampConversion TIMESTAMP_CONVERSION = new org.apache.avro.data.TimeConversions.TimestampConversion();
+#if ($this.isDecimalEnabled())
   protected static final org.apache.avro.Conversions.DecimalConversion DECIMAL_CONVERSION = new org.apache.avro.Conversions.DecimalConversion();
+#end
+
+  public static final Collection<Conversion<?>> CONVERSIONS = new ArrayList<Conversion<?>>();
+  static {
+    CONVERSIONS.add(DATE_CONVERSION);
+    CONVERSIONS.add(TIME_CONVERSION);
+    CONVERSIONS.add(TIMESTAMP_CONVERSION);
+#if ($this.isDecimalEnabled())
+    CONVERSIONS.add(DECIMAL_CONVERSION);
+#end
+  }
 
   private static final org.apache.avro.Conversion<?>[] conversions =
       new org.apache.avro.Conversion<?>[] {

--- a/lang/java/ipc/src/test/java/org/apache/avro/compiler/specific/TestSpecificCompiler.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/compiler/specific/TestSpecificCompiler.java
@@ -79,8 +79,9 @@ public class TestSpecificCompiler {
 
   @Test
   public void testMakePath() {
-    assertEquals("foo/bar/Baz.java".replace("/", File.separator), SpecificCompiler.makePath("Baz", "foo.bar"));
-    assertEquals("baz.java", SpecificCompiler.makePath("baz", ""));
+    SpecificCompiler compiler = new SpecificCompiler();
+    assertEquals("foo/bar/Baz.java".replace("/", File.separator), compiler.makePath("Baz", "foo.bar"));
+    assertEquals("baz.java", compiler.makePath("baz", ""));
   }
 
   @Test


### PR DESCRIPTION
This changes the datum readers to use `getConversionFor` and `getConversionByClass` instance methods that delegate to the data models. This allows specific to use a set of conversions determined by the current record class to pick up the conversions that were present when it was compiled.
