### PR TITLE
fix TestIdl to pass on windows

### DIFF
--- a/lang/java/compiler/src/test/java/org/apache/avro/compiler/idl/TestIdl.java
+++ b/lang/java/compiler/src/test/java/org/apache/avro/compiler/idl/TestIdl.java
@@ -152,7 +152,7 @@ public class TestIdl {
     public void run() throws Exception {
       String output = generate();
       String slurped = slurp(expectedOut);
-      assertEquals(slurped.trim(), output.replace("\r", "").trim());
+      assertEquals(slurped.trim(), output.replace("\\r", "").trim());
     }
 
     public void write() throws Exception {


### PR DESCRIPTION
for some of the avdl input files for the test the copyright statement is picked up as the doc string. when generating jackson escapes \n and \r characters, resulting in a doc string that contains the 2 characters '\' followed by 'r' instead of '\r'. the test tries to strip out \r to "normalize" \r\n into \n, but the input actually contains '\' 'r' '\' 'n', causing the test to fail on windows.
Signed-off-by: radai-rosenblatt radai.rosenblatt@gmail.com
