### PR TITLE
Avro 1910 - HttpTransceiver buffering

### DIFF
--- a/lang/csharp/Avro.sln
+++ b/lang/csharp/Avro.sln
@@ -92,4 +92,33 @@ Global
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		Policies = $0
+		$0.TextStylePolicy = $1
+		$1.FileWidth = 120
+		$1.inheritsSet = VisualStudio
+		$1.inheritsScope = text/plain
+		$1.scope = text/x-csharp
+		$0.CSharpFormattingPolicy = $2
+		$2.IndentSwitchSection = True
+		$2.NewLinesForBracesInProperties = True
+		$2.NewLinesForBracesInAccessors = True
+		$2.NewLinesForBracesInAnonymousMethods = True
+		$2.NewLinesForBracesInControlBlocks = True
+		$2.NewLinesForBracesInAnonymousTypes = True
+		$2.NewLinesForBracesInObjectCollectionArrayInitializers = True
+		$2.NewLinesForBracesInLambdaExpressionBody = True
+		$2.NewLineForElse = True
+		$2.NewLineForCatch = True
+		$2.NewLineForFinally = True
+		$2.NewLineForMembersInObjectInit = True
+		$2.NewLineForMembersInAnonymousTypes = True
+		$2.NewLineForClausesInQuery = True
+		$2.SpacingAfterMethodDeclarationName = False
+		$2.SpaceAfterMethodCallName = False
+		$2.SpaceBeforeOpenSquareBracket = False
+		$2.inheritsSet = Mono
+		$2.inheritsScope = text/x-csharp
+		$2.scope = text/x-csharp
+	EndGlobalSection
 EndGlobal

--- a/lang/csharp/build.sh
+++ b/lang/csharp/build.sh
@@ -30,7 +30,7 @@ case "$1" in
 
   test)
     xbuild
-    nunit-console -framework=4.0 Avro.nunit
+    nunit-console Avro.nunit
     ;;
 
   perf)

--- a/lang/csharp/src/apache/ipc/HttpTransceiver.cs
+++ b/lang/csharp/src/apache/ipc/HttpTransceiver.cs
@@ -27,16 +27,15 @@ namespace Avro.ipc
 {
     public class HttpTransceiver : Transceiver
     {
-        private byte[] _intBuffer = new byte[4]; //this buffer is used by read/write behind the latch controlled by base class so we are sure there is no race condition
+        private byte[] _intBuffer = new byte[4];
+            //this buffer is used by read/write behind the latch controlled by base class so we are sure there is no race condition
+
         private HttpWebRequest _httpRequest;
         private HttpWebRequest _modelRequest;
 
         public override string RemoteName
         {
-            get
-            {
-                return _modelRequest.RequestUri.AbsoluteUri;
-            }
+            get { return _modelRequest.RequestUri.AbsoluteUri; }
         }
 
         public HttpTransceiver(HttpWebRequest modelRequest)
@@ -46,35 +45,34 @@ namespace Avro.ipc
 
         public HttpTransceiver(Uri serviceUri, int timeoutMs)
         {
-            _modelRequest = (HttpWebRequest)WebRequest.Create(serviceUri);
+            _modelRequest = (HttpWebRequest) WebRequest.Create(serviceUri);
             _modelRequest.Method = "POST";
             _modelRequest.ContentType = "avro/binary";
             _modelRequest.Timeout = timeoutMs;
         }
 
-		public static void ReadFully(Stream stream, byte[] buffer)
-		{
-			int offset = 0;
-			int read = 0;
-
-			do
-			{
-				read = stream.Read(buffer, offset, buffer.Length - offset);
-				offset += read;
-			}
-			while (buffer.Length > offset && read > 0);
-
-			if (buffer.Length > offset)
-			{
-				throw new IOException(
-					String.Format("Only read {0} and expected buffer size of {1}.", offset, buffer.Length)
-				);
-			}
-		}
-
-		public static int ReadInt(Stream stream, byte[] buffer)
+        public static void ReadFully(Stream stream, byte[] buffer)
         {
-			ReadFully(stream, buffer);
+            int offset = 0;
+            int read = 0;
+
+            do
+            {
+                read = stream.Read(buffer, offset, buffer.Length - offset);
+                offset += read;
+            } while (buffer.Length > offset && read > 0);
+
+            if (buffer.Length > offset)
+            {
+                throw new IOException(
+                    String.Format("Only read {0} and expected buffer size of {1}.", offset, buffer.Length)
+                );
+            }
+        }
+
+        public static int ReadInt(Stream stream, byte[] buffer)
+        {
+            ReadFully(stream, buffer);
             return IPAddress.NetworkToHostOrder(BitConverter.ToInt32(buffer, 0));
         }
 
@@ -86,10 +84,10 @@ namespace Avro.ipc
         public static int CalculateLength(IList<MemoryStream> buffers)
         {
             int num = 0;
-            foreach (MemoryStream memoryStream in (IEnumerable<MemoryStream>)buffers)
+            foreach (MemoryStream memoryStream in (IEnumerable<MemoryStream>) buffers)
             {
                 num += 4;
-                num += (int)memoryStream.Length;
+                num += (int) memoryStream.Length;
             }
             return num + 4;
         }
@@ -104,22 +102,22 @@ namespace Avro.ipc
                 if (length == 0) //end of transmission
                     break;
 
-				MemoryStream outStream = new MemoryStream(length);
-				byte[] buffer = new byte[64 * 1024];
-				int read = 0;
-				int totalRead = 0;
-				while ((read = inStream.Read(buffer, length - read, Math.Min(length - read, buffer.Length))) > 0)
-				{
-					outStream.Write(buffer, 0, read);
-					totalRead += read;
-				}
+                MemoryStream outStream = new MemoryStream(length);
+                byte[] buffer = new byte[64 * 1024];
+                int read = 0;
+                int totalRead = 0;
+                while ((read = inStream.Read(buffer, length - read, Math.Min(length - read, buffer.Length))) > 0)
+                {
+                    outStream.Write(buffer, 0, read);
+                    totalRead += read;
+                }
 
-				if (length != totalRead)
-				{
-					throw new IOException(
-						String.Format("Could not read the current chunk. Read {0} Actual Length {1}", totalRead, length)
-					);
-				}
+                if (length != totalRead)
+                {
+                    throw new IOException(
+                        String.Format("Could not read the current chunk. Read {0} Actual Length {1}", totalRead, length)
+                    );
+                }
 
                 list.Add(outStream);
             }
@@ -136,8 +134,8 @@ namespace Avro.ipc
 
         protected HttpWebRequest CreateAvroHttpRequest(long contentLength)
         {
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create(_modelRequest.RequestUri);
-            
+            HttpWebRequest wr = (HttpWebRequest) WebRequest.Create(_modelRequest.RequestUri);
+
             //TODO: what else to copy from model request?
             wr.AllowAutoRedirect = _modelRequest.AllowAutoRedirect;
             wr.AllowWriteStreamBuffering = _modelRequest.AllowWriteStreamBuffering;
@@ -179,7 +177,7 @@ namespace Avro.ipc
         {
             foreach (MemoryStream memoryStream in buffers)
             {
-                int num = (int)memoryStream.Length;
+                int num = (int) memoryStream.Length;
                 outStream.Write(ConvertIntToBytes(num), 0, 4);
                 memoryStream.WriteTo(outStream);
             }

--- a/lang/csharp/src/apache/ipc/HttpTransceiver.cs
+++ b/lang/csharp/src/apache/ipc/HttpTransceiver.cs
@@ -104,9 +104,9 @@ namespace Avro.ipc
 
                 MemoryStream outStream = new MemoryStream(length);
                 byte[] buffer = new byte[64 * 1024];
-                int read = 0;
+                int read;
                 int totalRead = 0;
-                while ((read = inStream.Read(buffer, length - read, Math.Min(length - read, buffer.Length))) > 0)
+                while ((read = inStream.Read(buffer, 0, Math.Min(length - totalRead, buffer.Length))) > 0)
                 {
                     outStream.Write(buffer, 0, read);
                     totalRead += read;

--- a/lang/csharp/src/apache/perf/app.config
+++ b/lang/csharp/src/apache/perf/app.config
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<configuration>
+<startup><supportedRuntime version="v2.0.50727"/></startup></configuration>

--- a/lang/csharp/src/apache/test/Avro.test.csproj
+++ b/lang/csharp/src/apache/test/Avro.test.csproj
@@ -123,6 +123,7 @@
     <Compile Include="Specific\SpecificTests.cs" />
     <Compile Include="Utils\CaseFinder.cs" />
     <Compile Include="Utils\CaseFinderTests.cs" />
+    <Compile Include="Ipc\HttpTransceiverTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ipc\Avro.ipc.csproj">

--- a/lang/csharp/src/apache/test/Ipc/HttpTransceiverTest.cs
+++ b/lang/csharp/src/apache/test/Ipc/HttpTransceiverTest.cs
@@ -1,0 +1,143 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.IO;
+using System.Net;
+using NUnit.Framework;
+using Avro.ipc;
+
+
+namespace Avro.test.ipc
+{
+	[TestFixture]
+	public class HttpTransceiverTest
+	{
+		class MockStream : Stream
+		{
+			public Stack<byte[]> readResults = new Stack<byte[]>();
+
+			public override bool CanRead
+			{
+				get
+				{
+					throw new NotImplementedException();
+				}
+			}
+
+			public override bool CanSeek
+			{
+				get
+				{
+					throw new NotImplementedException();
+				}
+			}
+
+			public override bool CanWrite
+			{
+				get
+				{
+					throw new NotImplementedException();
+				}
+			}
+
+			public override long Length
+			{
+				get
+				{
+					throw new NotImplementedException();
+				}
+			}
+
+			public override long Position
+			{
+				get
+				{
+					throw new NotImplementedException();
+				}
+
+				set
+				{
+					throw new NotImplementedException();
+				}
+			}
+
+			public override void Flush()
+			{
+				throw new NotImplementedException();
+			}
+
+			public override int Read(byte[] buffer, int offset, int count)
+			{
+				byte[] a = this.readResults.Pop();
+				System.Array.Copy(a, 0, buffer, offset, a.Length);
+				return a.Length;
+			}
+
+			public override long Seek(long offset, SeekOrigin origin)
+			{
+				throw new NotImplementedException();
+			}
+
+			public override void SetLength(long value)
+			{
+				throw new NotImplementedException();
+			}
+
+			public override void Write(byte[] buffer, int offset, int count)
+			{
+				throw new NotImplementedException();
+			}
+		}
+
+		[Test]
+		public void ReadFully()
+		{
+			MockStream mockStream = new MockStream();
+			Random random = new Random();
+			byte[] part1 = new byte[25];
+			random.NextBytes(part1);
+			byte[] part2 = new byte[75];
+			random.NextBytes(part2);
+			mockStream.readResults.Push(part1);
+			mockStream.readResults.Push(part2);
+
+			byte[] buffer = new byte[100];
+			HttpTransceiver.ReadFully(mockStream, buffer);
+		}
+
+		[Test]
+		[ExpectedException(typeof(IOException))]
+		public void ReadIntShortBuffer()
+		{
+			byte[] intBuffer = new byte[4];
+			MemoryStream memoryStream = new MemoryStream();
+			memoryStream.WriteByte(1);
+			memoryStream.WriteByte(12);
+			int value = HttpTransceiver.ReadInt(memoryStream, intBuffer);
+		}
+
+
+
+
+	}
+}
+

--- a/lang/csharp/src/apache/test/Ipc/HttpTransceiverTest.cs
+++ b/lang/csharp/src/apache/test/Ipc/HttpTransceiverTest.cs
@@ -28,116 +28,93 @@ using Avro.ipc;
 
 namespace Avro.test.ipc
 {
-	[TestFixture]
-	public class HttpTransceiverTest
-	{
-		class MockStream : Stream
-		{
-			public Stack<byte[]> readResults = new Stack<byte[]>();
+    [TestFixture]
+    public class HttpTransceiverTest
+    {
+        class MockStream : Stream
+        {
+            public Stack<byte[]> readResults = new Stack<byte[]>();
 
-			public override bool CanRead
-			{
-				get
-				{
-					throw new NotImplementedException();
-				}
-			}
+            public override bool CanRead
+            {
+                get { throw new NotImplementedException(); }
+            }
 
-			public override bool CanSeek
-			{
-				get
-				{
-					throw new NotImplementedException();
-				}
-			}
+            public override bool CanSeek
+            {
+                get { throw new NotImplementedException(); }
+            }
 
-			public override bool CanWrite
-			{
-				get
-				{
-					throw new NotImplementedException();
-				}
-			}
+            public override bool CanWrite
+            {
+                get { throw new NotImplementedException(); }
+            }
 
-			public override long Length
-			{
-				get
-				{
-					throw new NotImplementedException();
-				}
-			}
+            public override long Length
+            {
+                get { throw new NotImplementedException(); }
+            }
 
-			public override long Position
-			{
-				get
-				{
-					throw new NotImplementedException();
-				}
+            public override long Position
+            {
+                get { throw new NotImplementedException(); }
 
-				set
-				{
-					throw new NotImplementedException();
-				}
-			}
+                set { throw new NotImplementedException(); }
+            }
 
-			public override void Flush()
-			{
-				throw new NotImplementedException();
-			}
+            public override void Flush()
+            {
+                throw new NotImplementedException();
+            }
 
-			public override int Read(byte[] buffer, int offset, int count)
-			{
-				byte[] a = this.readResults.Pop();
-				System.Array.Copy(a, 0, buffer, offset, a.Length);
-				return a.Length;
-			}
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                byte[] a = this.readResults.Pop();
+                System.Array.Copy(a, 0, buffer, offset, a.Length);
+                return a.Length;
+            }
 
-			public override long Seek(long offset, SeekOrigin origin)
-			{
-				throw new NotImplementedException();
-			}
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                throw new NotImplementedException();
+            }
 
-			public override void SetLength(long value)
-			{
-				throw new NotImplementedException();
-			}
+            public override void SetLength(long value)
+            {
+                throw new NotImplementedException();
+            }
 
-			public override void Write(byte[] buffer, int offset, int count)
-			{
-				throw new NotImplementedException();
-			}
-		}
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                throw new NotImplementedException();
+            }
+        }
 
-		[Test]
-		public void ReadFully()
-		{
-			MockStream mockStream = new MockStream();
-			Random random = new Random();
-			byte[] part1 = new byte[25];
-			random.NextBytes(part1);
-			byte[] part2 = new byte[75];
-			random.NextBytes(part2);
-			mockStream.readResults.Push(part1);
-			mockStream.readResults.Push(part2);
+        [Test]
+        public void ReadFully()
+        {
+            MockStream mockStream = new MockStream();
+            Random random = new Random();
+            byte[] part1 = new byte[25];
+            random.NextBytes(part1);
+            byte[] part2 = new byte[75];
+            random.NextBytes(part2);
+            mockStream.readResults.Push(part1);
+            mockStream.readResults.Push(part2);
 
-			byte[] buffer = new byte[100];
-			HttpTransceiver.ReadFully(mockStream, buffer);
-		}
+            byte[] buffer = new byte[100];
+            HttpTransceiver.ReadFully(mockStream, buffer);
+        }
 
-		[Test]
-		[ExpectedException(typeof(IOException))]
-		public void ReadIntShortBuffer()
-		{
-			byte[] intBuffer = new byte[4];
-			MemoryStream memoryStream = new MemoryStream();
-			memoryStream.WriteByte(1);
-			memoryStream.WriteByte(12);
-			int value = HttpTransceiver.ReadInt(memoryStream, intBuffer);
-		}
-
-
-
-
-	}
+        [Test]
+        [ExpectedException(typeof(IOException))]
+        public void ReadIntShortBuffer()
+        {
+            byte[] intBuffer = new byte[4];
+            MemoryStream memoryStream = new MemoryStream();
+            memoryStream.WriteByte(1);
+            memoryStream.WriteByte(12);
+            int value = HttpTransceiver.ReadInt(memoryStream, intBuffer);
+        }
+    }
 }
-


### PR DESCRIPTION
Corrected build errors of Avro.perf. Added ReadFully method to ensure that buffers are totally populated. Changed to stream 64k buffers instead of the entire buffer in one call.
