### PR TITLE
AVRO-1788: Implement Python 2 API

### DIFF
--- a/lang/py3/avro/__init__.py
+++ b/lang/py3/avro/__init__.py
@@ -24,11 +24,11 @@ __all__ = ('schema', 'io', 'datafile', 'protocol', 'ipc')
 import os
 
 
-def LoadResource(name):
+def load_resource(name):
   dir_path = os.path.dirname(__file__)
   rsrc_path = os.path.join(dir_path, name)
   with open(rsrc_path, 'r') as f:
     return f.read()
 
 
-VERSION = LoadResource('VERSION.txt').strip()
+VERSION = load_resource('VERSION.txt').strip()

--- a/lang/py3/avro/datafile.py
+++ b/lang/py3/avro/datafile.py
@@ -57,7 +57,7 @@ SYNC_SIZE = 16
 SYNC_INTERVAL = 1000 * SYNC_SIZE
 
 # Schema of the container header:
-META_SCHEMA = schema.Parse("""
+META_SCHEMA = schema.parse("""
 {
   "type": "record", "name": "org.apache.avro.file.Header",
   "fields": [{
@@ -164,7 +164,7 @@ class DataFileWriter(object):
       # get schema used to write existing file
       schema_from_file = dfr.GetMeta('avro.schema').decode('utf-8')
       self.SetMeta('avro.schema', schema_from_file)
-      self.datum_writer.writer_schema = schema.Parse(schema_from_file)
+      self.datum_writer.writer_schema = schema.parse(schema_from_file)
 
       # seek to the end of the file and prepare for writing
       writer.seek(0, 2)
@@ -364,7 +364,7 @@ class DataFileReader(object):
     # get ready to read
     self._block_count = 0
     self.datum_reader.writer_schema = (
-        schema.Parse(self.GetMeta(SCHEMA_KEY).decode('utf-8')))
+        schema.parse(self.GetMeta(SCHEMA_KEY).decode('utf-8')))
 
   def __enter__(self):
     return self

--- a/lang/py3/avro/protocol.py
+++ b/lang/py3/avro/protocol.py
@@ -54,8 +54,8 @@ class Protocol(object):
   """An application protocol."""
 
   @staticmethod
-  def _ParseTypeDesc(type_desc, names):
-    type_schema = schema.SchemaFromJSONData(type_desc, names=names)
+  def _parse_type_desc(type_desc, names):
+    type_schema = schema.schema_from_JSON_data(type_desc, names=names)
     if type_schema.type not in VALID_TYPE_SCHEMA_TYPES:
       raise ProtocolParseException(
           'Invalid type %r in protocol %r: '
@@ -64,7 +64,7 @@ class Protocol(object):
     return type_schema
 
   @staticmethod
-  def _ParseMessageDesc(name, message_desc, names):
+  def _parse_message_desc(name, message_desc, names):
     """Parses a protocol message descriptor.
 
     Args:
@@ -80,7 +80,7 @@ class Protocol(object):
     if request_desc is None:
       raise ProtocolParseException(
           'Invalid message descriptor with no "request": %r.' % message_desc)
-    request_schema = Message._ParseRequestFromJSONDesc(
+    request_schema = Message._parse_request_from_JSON_desc(
         request_desc=request_desc,
         names=names,
     )
@@ -89,14 +89,14 @@ class Protocol(object):
     if response_desc is None:
       raise ProtocolParseException(
           'Invalid message descriptor with no "response": %r.' % message_desc)
-    response_schema = Message._ParseResponseFromJSONDesc(
+    response_schema = Message._parse_response_from_JSON_desc(
         response_desc=response_desc,
         names=names,
     )
 
     # Errors are optional:
     errors_desc = message_desc.get('errors', tuple())
-    error_union_schema = Message._ParseErrorsFromJSONDesc(
+    error_union_schema = Message._parse_errors_from_JSON_desc(
         errors_desc=errors_desc,
         names=names,
     )
@@ -109,9 +109,9 @@ class Protocol(object):
     )
 
   @staticmethod
-  def _ParseMessageDescMap(message_desc_map, names):
+  def _parse_message_desc_map(message_desc_map, names):
     for name, message_desc in message_desc_map.items():
-      yield Protocol._ParseMessageDesc(
+      yield Protocol._parse_message_desc(
           name=name,
           message_desc=message_desc,
           names=names,
@@ -241,7 +241,7 @@ class Message(object):
   """A Protocol message."""
 
   @staticmethod
-  def _ParseRequestFromJSONDesc(request_desc, names):
+  def _parse_request_from_JSON_desc(request_desc, names):
     """Parses the request descriptor of a protocol message.
 
     Args:
@@ -251,7 +251,7 @@ class Message(object):
     Returns:
       The parsed request schema, as an unnamed record.
     """
-    fields = schema.RecordSchema._MakeFieldList(request_desc, names=names)
+    fields = schema.RecordSchema._make_field_list(request_desc, names=names)
     return schema.RecordSchema(
         name=None,
         namespace=None,
@@ -261,7 +261,7 @@ class Message(object):
     )
 
   @staticmethod
-  def _ParseResponseFromJSONDesc(response_desc, names):
+  def _parse_response_from_JSON_desc(response_desc, names):
     """Parses the response descriptor of a protocol message.
 
     Args:
@@ -270,10 +270,10 @@ class Message(object):
     Returns:
       The parsed response schema.
     """
-    return schema.SchemaFromJSONData(response_desc, names=names)
+    return schema.schema_from_JSON_data(response_desc, names=names)
 
   @staticmethod
-  def _ParseErrorsFromJSONDesc(errors_desc, names):
+  def _parse_errors_from_JSON_desc(errors_desc, names):
     """Parses the errors descriptor of a protocol message.
 
     Args:
@@ -288,7 +288,7 @@ class Message(object):
         'type': schema.ERROR_UNION,
         'declared_errors': errors_desc,
     }
-    return schema.SchemaFromJSONData(error_union_desc, names=names)
+    return schema.schema_from_JSON_data(error_union_desc, names=names)
 
   def __init__(self,  name, request, response, errors=None):
     self._name = name
@@ -338,7 +338,7 @@ class Message(object):
 # ------------------------------------------------------------------------------
 
 
-def ProtocolFromJSONData(json_data):
+def protocol_from_JSON_data(json_data):
   """Builds an Avro  Protocol from its JSON descriptor.
 
   Args:
@@ -365,11 +365,11 @@ def ProtocolFromJSONData(json_data):
 
   type_desc_list = json_data.get('types', tuple())
   types = tuple(map(
-      lambda desc: Protocol._ParseTypeDesc(desc, names=names),
+      lambda desc: Protocol._parse_type_desc(desc, names=names),
       type_desc_list))
 
   message_desc_map = json_data.get('messages', dict())
-  messages = tuple(Protocol._ParseMessageDescMap(message_desc_map, names=names))
+  messages = tuple(Protocol._parse_message_desc_map(message_desc_map, names=names))
 
   return Protocol(
       name=name,
@@ -379,7 +379,7 @@ def ProtocolFromJSONData(json_data):
   )
 
 
-def Parse(json_string):
+def parse(json_string):
   """Constructs a Protocol from its JSON descriptor in text form.
 
   Args:
@@ -398,5 +398,5 @@ def Parse(json_string):
         'Error message: %r.'
         % (json_string, exn))
 
-  return ProtocolFromJSONData(json_data)
+  return protocol_from_JSON_data(json_data)
 

--- a/lang/py3/avro/tests/test_datafile.py
+++ b/lang/py3/avro/tests/test_datafile.py
@@ -136,7 +136,7 @@ class TestDataFile(unittest.TestCase):
         logging.debug('Creating data file %r', file_path)
         with open(file_path, 'wb') as writer:
           datum_writer = io.DatumWriter()
-          schema_object = schema.Parse(writer_schema)
+          schema_object = schema.parse(writer_schema)
           with datafile.DataFileWriter(
               writer=writer,
               datum_writer=datum_writer,
@@ -185,7 +185,7 @@ class TestDataFile(unittest.TestCase):
         logging.debug('Creating data file %r', file_path)
         with open(file_path, 'wb') as writer:
           datum_writer = io.DatumWriter()
-          schema_object = schema.Parse(writer_schema)
+          schema_object = schema.parse(writer_schema)
           with datafile.DataFileWriter(
               writer=writer,
               datum_writer=datum_writer,
@@ -231,7 +231,7 @@ class TestDataFile(unittest.TestCase):
     with open(file_path, 'wb') as writer:
       datum_writer = io.DatumWriter()
       sample_schema, sample_datum = SCHEMAS_TO_VALIDATE[1]
-      schema_object = schema.Parse(sample_schema)
+      schema_object = schema.parse(sample_schema)
       with datafile.DataFileWriter(writer, datum_writer, schema_object) as dfw:
         dfw.append(sample_datum)
       self.assertTrue(writer.closed)
@@ -252,7 +252,7 @@ class TestDataFile(unittest.TestCase):
     with open(file_path, 'wb') as writer:
       datum_writer = io.DatumWriter()
       sample_schema, sample_datum = SCHEMAS_TO_VALIDATE[1]
-      schema_object = schema.Parse(sample_schema)
+      schema_object = schema.parse(sample_schema)
       with datafile.DataFileWriter(writer, datum_writer, schema_object) as dfw:
         dfw.SetMeta('test.string', 'foo')
         dfw.SetMeta('test.number', '1')

--- a/lang/py3/avro/tests/test_datafile_interop.py
+++ b/lang/py3/avro/tests/test_datafile_interop.py
@@ -33,7 +33,7 @@ def GetInteropSchema():
   schema_json_path = os.path.join(test_dir, 'interop.avsc')
   with open(schema_json_path, 'r') as f:
     schema_json = f.read()
-  return schema.Parse(schema_json)
+  return schema.parse(schema_json)
 
 
 INTEROP_SCHEMA = GetInteropSchema()

--- a/lang/py3/avro/tests/test_io.py
+++ b/lang/py3/avro/tests/test_io.py
@@ -98,7 +98,7 @@ DEFAULT_VALUE_EXAMPLES = (
    '{"A": 5}', {'A': 5}),
 )
 
-LONG_RECORD_SCHEMA = schema.Parse("""
+LONG_RECORD_SCHEMA = schema.parse("""
 {
   "type": "record",
   "name": "Test",
@@ -150,7 +150,7 @@ def check_binary_encoding(number_type):
     logging.debug('Datum: %d', datum)
     logging.debug('Correct Encoding: %s', hex_encoding)
 
-    writer_schema = schema.Parse('"%s"' % number_type.lower())
+    writer_schema = schema.parse('"%s"' % number_type.lower())
     writer, encoder, datum_writer = write_datum(datum, writer_schema)
     writer.seek(0)
     hex_val = avro_hexlify(writer)
@@ -168,7 +168,7 @@ def check_skip_number(number_type):
     logging.debug('Value to Skip: %d', value_to_skip)
 
     # write the value to skip and a known value
-    writer_schema = schema.Parse('"%s"' % number_type.lower())
+    writer_schema = schema.parse('"%s"' % number_type.lower())
     writer, encoder, datum_writer = write_datum(value_to_skip, writer_schema)
     datum_writer.write(VALUE_TO_READ, encoder)
 
@@ -181,7 +181,7 @@ def check_skip_number(number_type):
     datum_reader = avro_io.DatumReader(writer_schema)
     read_value = datum_reader.read(decoder)
 
-    logging.debug('Read Value: %d', read_value)
+    logging.debug('read Value: %d', read_value)
     if read_value == VALUE_TO_READ: correct += 1
   return correct
 
@@ -199,7 +199,7 @@ class TestIO(unittest.TestCase):
     for example_schema, datum in SCHEMAS_TO_VALIDATE:
       logging.debug('Schema: %r', example_schema)
       logging.debug('Datum: %r', datum)
-      validated = avro_io.Validate(schema.Parse(example_schema), datum)
+      validated = avro_io.validate(schema.parse(example_schema), datum)
       logging.debug('Valid: %s', validated)
       if validated: passed += 1
     self.assertEqual(passed, len(SCHEMAS_TO_VALIDATE))
@@ -210,7 +210,7 @@ class TestIO(unittest.TestCase):
       logging.debug('Schema: %s', example_schema)
       logging.debug('Datum: %s', datum)
 
-      writer_schema = schema.Parse(example_schema)
+      writer_schema = schema.parse(example_schema)
       writer, encoder, datum_writer = write_datum(datum, writer_schema)
       round_trip_datum = read_datum(writer, writer_schema)
 
@@ -248,10 +248,10 @@ class TestIO(unittest.TestCase):
     promotable_schemas = ['"int"', '"long"', '"float"', '"double"']
     incorrect = 0
     for i, ws in enumerate(promotable_schemas):
-      writer_schema = schema.Parse(ws)
+      writer_schema = schema.parse(ws)
       datum_to_write = 219
       for rs in promotable_schemas[i + 1:]:
-        reader_schema = schema.Parse(rs)
+        reader_schema = schema.parse(rs)
         writer, enc, dw = write_datum(datum_to_write, writer_schema)
         datum_read = read_datum(writer, writer_schema, reader_schema)
         logging.debug('Writer: %s Reader: %s', writer_schema, reader_schema)
@@ -260,12 +260,12 @@ class TestIO(unittest.TestCase):
     self.assertEqual(incorrect, 0)
 
   def testUnknownSymbol(self):
-    writer_schema = schema.Parse("""\
+    writer_schema = schema.parse("""\
       {"type": "enum", "name": "Test",
        "symbols": ["FOO", "BAR"]}""")
     datum_to_write = 'FOO'
 
-    reader_schema = schema.Parse("""\
+    reader_schema = schema.parse("""\
       {"type": "enum", "name": "Test",
        "symbols": ["BAR", "BAZ"]}""")
 
@@ -281,7 +281,7 @@ class TestIO(unittest.TestCase):
 
     correct = 0
     for field_type, default_json, default_datum in DEFAULT_VALUE_EXAMPLES:
-      reader_schema = schema.Parse("""\
+      reader_schema = schema.parse("""\
         {"type": "record", "name": "Test",
          "fields": [{"name": "H", "type": %s, "default": %s}]}
         """ % (field_type, default_json))
@@ -297,7 +297,7 @@ class TestIO(unittest.TestCase):
     writer_schema = LONG_RECORD_SCHEMA
     datum_to_write = LONG_RECORD_DATUM
 
-    reader_schema = schema.Parse("""\
+    reader_schema = schema.parse("""\
       {"type": "record", "name": "Test",
        "fields": [{"name": "H", "type": "int"}]}""")
 
@@ -311,7 +311,7 @@ class TestIO(unittest.TestCase):
     writer_schema = LONG_RECORD_SCHEMA
     datum_to_write = LONG_RECORD_DATUM
 
-    reader_schema = schema.Parse("""\
+    reader_schema = schema.parse("""\
       {"type": "record", "name": "Test",
        "fields": [{"name": "E", "type": "int"},
                   {"name": "F", "type": "int"}]}""")
@@ -326,7 +326,7 @@ class TestIO(unittest.TestCase):
     writer_schema = LONG_RECORD_SCHEMA
     datum_to_write = LONG_RECORD_DATUM
 
-    reader_schema = schema.Parse("""\
+    reader_schema = schema.parse("""\
       {"type": "record", "name": "Test",
        "fields": [{"name": "F", "type": "int"},
                   {"name": "E", "type": "int"}]}""")
@@ -338,7 +338,7 @@ class TestIO(unittest.TestCase):
     self.assertEqual(datum_to_read, datum_read)
 
   def testTypeException(self):
-    writer_schema = schema.Parse("""\
+    writer_schema = schema.parse("""\
       {"type": "record", "name": "Test",
        "fields": [{"name": "F", "type": "int"},
                   {"name": "E", "type": "int"}]}""")

--- a/lang/py3/avro/tests/test_ipc.py
+++ b/lang/py3/avro/tests/test_ipc.py
@@ -77,7 +77,7 @@ ECHO_PROTOCOL_JSON = """
 """
 
 
-ECHO_PROTOCOL = protocol.Parse(ECHO_PROTOCOL_JSON)
+ECHO_PROTOCOL = protocol.parse(ECHO_PROTOCOL_JSON)
 
 
 class EchoResponder(ipc.Responder):
@@ -86,7 +86,7 @@ class EchoResponder(ipc.Responder):
         local_protocol=ECHO_PROTOCOL,
     )
 
-  def Invoke(self, message, request):
+  def invoke(self, message, request):
     logging.info('Message: %s', message)
     logging.info('Request: %s', request)
     ping = request['ping']
@@ -136,19 +136,19 @@ class TestIPC(unittest.TestCase):
           local_protocol=ECHO_PROTOCOL,
           transceiver=transceiver,
       )
-      response = requestor.Request(
+      response = requestor.request(
           message_name='ping',
           request_datum={'ping': {'timestamp': 31415, 'text': 'hello ping'}},
       )
       logging.info('Received echo response: %s', response)
 
-      response = requestor.Request(
+      response = requestor.request(
           message_name='ping',
           request_datum={'ping': {'timestamp': 123456, 'text': 'hello again'}},
       )
       logging.info('Received echo response: %s', response)
 
-      transceiver.Close()
+      transceiver.close()
 
     finally:
       self.StopEchoServer()

--- a/lang/py3/avro/tests/test_protocol.py
+++ b/lang/py3/avro/tests/test_protocol.py
@@ -407,7 +407,7 @@ class TestProtocol(unittest.TestCase):
           'Parsing protocol #%d:\n%s',
           iexample, example.protocol_string)
       try:
-        parsed = protocol.Parse(example.protocol_string)
+        parsed = protocol.parse(example.protocol_string)
         if example.valid:
           correct += 1
         else:
@@ -428,17 +428,17 @@ class TestProtocol(unittest.TestCase):
     self.assertEqual(
       correct,
       len(EXAMPLES),
-      'Parse behavior correct on %d out of %d protocols.'
+      'parse behavior correct on %d out of %d protocols.'
       % (correct, len(EXAMPLES)))
 
   def testInnerNamespaceSet(self):
-    proto = protocol.Parse(HELLO_WORLD.protocol_string)
+    proto = protocol.parse(HELLO_WORLD.protocol_string)
     self.assertEqual(proto.namespace, 'com.acme')
     greeting_type = proto.type_map['com.acme.Greeting']
     self.assertEqual(greeting_type.namespace, 'com.acme')
 
   def testInnerNamespaceNotRendered(self):
-    proto = protocol.Parse(HELLO_WORLD.protocol_string)
+    proto = protocol.parse(HELLO_WORLD.protocol_string)
     self.assertEqual('com.acme.Greeting', proto.types[0].fullname)
     self.assertEqual('Greeting', proto.types[0].name)
     # but there shouldn't be 'namespace' rendered to json on the inner type
@@ -451,9 +451,9 @@ class TestProtocol(unittest.TestCase):
     """
     num_correct = 0
     for example in VALID_EXAMPLES:
-      proto = protocol.Parse(example.protocol_string)
+      proto = protocol.parse(example.protocol_string)
       try:
-        protocol.Parse(str(proto))
+        protocol.parse(str(proto))
         logging.debug(
             'Successfully reparsed protocol:\n%s',
             example.protocol_string)
@@ -477,8 +477,8 @@ class TestProtocol(unittest.TestCase):
     """
     num_correct = 0
     for example in VALID_EXAMPLES:
-      original_protocol = protocol.Parse(example.protocol_string)
-      round_trip_protocol = protocol.Parse(str(original_protocol))
+      original_protocol = protocol.parse(example.protocol_string)
+      round_trip_protocol = protocol.parse(str(original_protocol))
 
       if original_protocol == round_trip_protocol:
         num_correct += 1

--- a/lang/py3/avro/tests/test_schema.py
+++ b/lang/py3/avro/tests/test_schema.py
@@ -451,7 +451,7 @@ VALID_EXAMPLES = [e for e in EXAMPLES if e.valid]
 class TestSchema(unittest.TestCase):
 
   def testCorrectRecursiveExtraction(self):
-    parsed = schema.Parse("""
+    parsed = schema.parse("""
       {
         "type": "record",
         "name": "X",
@@ -467,7 +467,7 @@ class TestSchema(unittest.TestCase):
     """)
     logging.debug('Parsed schema:\n%s', parsed)
     logging.debug('Fields: %s', parsed.fields)
-    t = schema.Parse(str(parsed.fields[0].type))
+    t = schema.parse(str(parsed.fields[0].type))
     # If we've made it this far, the subschema was reasonably stringified;
     # it could be reparsed.
     self.assertEqual("X", t.fields[0].type.name)
@@ -477,7 +477,7 @@ class TestSchema(unittest.TestCase):
     for iexample, example in enumerate(EXAMPLES):
       logging.debug('Testing example #%d\n%s', iexample, example.schema_string)
       try:
-        schema.Parse(example.schema_string)
+        schema.parse(example.schema_string)
         if example.valid:
           correct += 1
         else:
@@ -497,7 +497,7 @@ class TestSchema(unittest.TestCase):
     self.assertEqual(
         correct,
         len(EXAMPLES),
-        'Parse behavior correct on %d out of %d schemas.'
+        'parse behavior correct on %d out of %d schemas.'
         % (correct, len(EXAMPLES)),
     )
 
@@ -508,8 +508,8 @@ class TestSchema(unittest.TestCase):
     """
     correct = 0
     for example in VALID_EXAMPLES:
-      schema_data = schema.Parse(example.schema_string)
-      schema.Parse(str(schema_data))
+      schema_data = schema.parse(example.schema_string)
+      schema.parse(str(schema_data))
       correct += 1
 
     fail_msg = "Cast to string success on %d out of %d schemas" % \
@@ -525,8 +525,8 @@ class TestSchema(unittest.TestCase):
     """
     correct = 0
     for example in VALID_EXAMPLES:
-      original_schema = schema.Parse(example.schema_string)
-      round_trip_schema = schema.Parse(str(original_schema))
+      original_schema = schema.parse(example.schema_string)
+      round_trip_schema = schema.parse(str(original_schema))
       if original_schema == round_trip_schema:
         correct += 1
         debug_msg = "%s: ROUND TRIP SUCCESS" % example.name
@@ -580,7 +580,7 @@ class TestSchema(unittest.TestCase):
   def testDocAttributes(self):
     correct = 0
     for example in DOC_EXAMPLES:
-      original_schema = schema.Parse(example.schema_string)
+      original_schema = schema.parse(example.schema_string)
       if original_schema.doc is not None:
         correct += 1
       if original_schema.type == 'record':
@@ -595,8 +595,8 @@ class TestSchema(unittest.TestCase):
     correct = 0
     props = {}
     for example in OTHER_PROP_EXAMPLES:
-      original_schema = schema.Parse(example.schema_string)
-      round_trip_schema = schema.Parse(str(original_schema))
+      original_schema = schema.parse(example.schema_string)
+      round_trip_schema = schema.parse(str(original_schema))
       self.assertEqual(original_schema.other_props,round_trip_schema.other_props)
       if original_schema.type == "record":
         field_props = 0

--- a/lang/py3/avro/tests/test_script.py
+++ b/lang/py3/avro/tests/test_script.py
@@ -119,7 +119,7 @@ class TestCat(unittest.TestCase):
 
   @staticmethod
   def WriteAvroFile(file_path):
-    schema = avro.schema.Parse(SCHEMA)
+    schema = avro.schema.parse(SCHEMA)
     with open(file_path, 'wb') as writer:
       with avro.datafile.DataFileWriter(
           writer=writer,

--- a/lang/py3/avro/txipc.py
+++ b/lang/py3/avro/txipc.py
@@ -82,14 +82,14 @@ class RequestStreamingProducer(object):
 
   total_bytes_sent = property(_get_total_bytes_sent, _set_total_bytes_sent)
 
-  def startProducing(self, consumer):
+  def start_producing(self, consumer):
     if self.started:
       return
 
     self.started = True
     self._consumer = consumer
     # Keep writing data to the consumer until we're finished,
-    # paused (pauseProducing()) or stopped (stopProducing())
+    # paused (pause_producing()) or stopped (stop_producing())
     while self.length - self.total_bytes_sent > 0 and \
       not self.paused and not self.stopped:
       self.write()
@@ -97,14 +97,14 @@ class RequestStreamingProducer(object):
     # the entire message to the consumer
     return self.deferred
 
-  def resumeProducing(self):
+  def resume_producing(self):
     self.paused = False
     self.write(self)
 
-  def pauseProducing(self):
+  def pause_producing(self):
     self.paused = True
 
-  def stopProducing(self):
+  def stop_producing(self):
     self.stopped = True
 
   def write(self):
@@ -117,7 +117,7 @@ class RequestStreamingProducer(object):
     self.total_bytes_sent += buffer_length
     # Make sure we wrote the entire message
     if self.total_bytes_sent == self.length and not self.stopped:
-      self.stopProducing()
+      self.stop_producing()
       # A message is always terminated by a zero-length buffer.
       self.write_buffer_length(0)
       self.deferred.callback(None)
@@ -139,7 +139,7 @@ class AvroProtocol(Protocol):
     self.finished = finished
     self.message = []
 
-  def dataReceived(self, data):
+  def data_received(self, data):
     self.recvd = self.recvd + data
     while len(self.recvd) >= ipc.BUFFER_HEADER_LENGTH:
       buffer_length ,= ipc.BIG_ENDIAN_INT_STRUCT.unpack(
@@ -155,7 +155,7 @@ class AvroProtocol(Protocol):
       self.recvd = self.recvd[buffer_length + ipc.BUFFER_HEADER_LENGTH:]
       self.message.append(buffer)
 
-  def connectionLost(self, reason):
+  def connection_lost(self, reason):
     if not self.done:
       self.finished.errback(ipc.ConnectionClosedException("Reader read 0 bytes."))
 

--- a/lang/py3/scripts/avro
+++ b/lang/py3/scripts/avro
@@ -213,7 +213,7 @@ def write(opts, files):
   try:
     with open(opts.schema, 'rt') as f:
       json_schema = f.read()
-    writer_schema = schema.Parse(json_schema)
+    writer_schema = schema.parse(json_schema)
     out = _open(opts.output, 'wb')
   except (IOError, OSError) as e:
     raise AvroError('Cannot open file - %s' % e)


### PR DESCRIPTION
The Python 2 API and the Python 3 API differ unnecessarily, making it more difficult to write code that supports both major Python versions. Additionally, a lot of these function names were non-Pythonic.

This contribution is my original work, and I license the work to the project under the project's open source license.

Tests pass:

```
/Users/sam/dev/avro/lang/py3/env/lib/python3.5/site-packages/setuptools/dist.py:294: UserWarning: The version specified ('1.9.0-SNAPSHOT') is an invalid version, this may not work as expected with newer versions of setuptools, pip, and PyPI. Please see PEP 440 for more details.
  "details." % self.metadata.version
testCsv (avro.tests.test_script.TestCat) ... ok
testCsvHeader (avro.tests.test_script.TestCat) ... ok
testFields (avro.tests.test_script.TestCat) ... ok
testFiles (avro.tests.test_script.TestCat) ... ok
testFilter (avro.tests.test_script.TestCat) ... ok
testHelp (avro.tests.test_script.TestCat) ... ok
testJsonPretty (avro.tests.test_script.TestCat) ... ok
testPrint (avro.tests.test_script.TestCat) ... ok
testPrintSchema (avro.tests.test_script.TestCat) ... ok
testSkip (avro.tests.test_script.TestCat) ... ok
testVersion (avro.tests.test_script.TestCat) ... ok
testAppend (avro.tests.test_datafile.TestDataFile) ... ok
testContextManager (avro.tests.test_datafile.TestDataFile) ... ok
testMetadata (avro.tests.test_datafile.TestDataFile) ... ok
testRoundTrip (avro.tests.test_datafile.TestDataFile) ... ok
testInterop (avro.tests.test_datafile_interop.TestDataFileInterop) ... ok
testSymbolsInOrder (avro.tests.test_enum.TestEnum) ... ok
testSymbolsInReverseOrder (avro.tests.test_enum.TestEnum) ... ok
testBinaryIntEncoding (avro.tests.test_io.TestIO) ... ok
testBinaryLongEncoding (avro.tests.test_io.TestIO) ... ok
testDefaultValue (avro.tests.test_io.TestIO) ... ok
testFieldOrder (avro.tests.test_io.TestIO) ... ok
testNoDefaultValue (avro.tests.test_io.TestIO) ... ok
testProjection (avro.tests.test_io.TestIO) ... ok
testRoundTrip (avro.tests.test_io.TestIO) ... ok
testSchemaPromotion (avro.tests.test_io.TestIO) ... ok
testSkipInt (avro.tests.test_io.TestIO) ... ok
testSkipLong (avro.tests.test_io.TestIO) ... ok
testTypeException (avro.tests.test_io.TestIO) ... ok
testUnknownSymbol (avro.tests.test_io.TestIO) ... ok
testValidate (avro.tests.test_io.TestIO) ... ok
testEchoService (avro.tests.test_ipc.TestIPC)
Tests client-side of the Echo service. ... 2016-09-27 18:14:00,348 INFO test_ipc.py:118 : Echo RPC Server listening on 127.0.0.1:57632
2016-09-27 18:14:00,348 INFO test_ipc.py:119 : RPC socket: <socket.socket fd=4, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 57632)>
2016-09-27 18:14:00,349 INFO ipc.py:179 : Sending handshake request: {'serverHash': b'\xcc9\x86\xfb\xb6\xad\x8a\ni\xf9X\xbb\x06\xc6\x15\xb2', 'clientHash': b'\xcc9\x86\xfb\xb6\xad\x8a\ni\xf9X\xbb\x06\xc6\x15\xb2'}
2016-09-27 18:14:00,350 INFO ipc.py:204 : writing request: {'ping': {'text': 'hello ping', 'timestamp': 31415}}
2016-09-27 18:14:00,350 INFO ipc.py:654 : Serialized request: b'\xcc9\x86\xfb\xb6\xad\x8a\ni\xf9X\xbb\x06\xc6\x15\xb2\x00\xcc9\x86\xfb\xb6\xad\x8a\ni\xf9X\xbb\x06\xc6\x15\xb2\x00\x00\x08ping\xee\xea\x03\x14hello ping'
2016-09-27 18:14:00,351 INFO ipc.py:412 : Processing handshake request: {'serverHash': b'\xcc9\x86\xfb\xb6\xad\x8a\ni\xf9X\xbb\x06\xc6\x15\xb2', 'clientProtocol': None, 'meta': None, 'clientHash': b'\xcc9\x86\xfb\xb6\xad\x8a\ni\xf9X\xbb\x06\xc6\x15\xb2'}
2016-09-27 18:14:00,351 INFO ipc.py:441 : Handshake response: {'match': 'BOTH'}
2016-09-27 18:14:00,351 INFO ipc.py:375 : Processing request: {'ping': {'text': 'hello ping', 'timestamp': 31415}}
2016-09-27 18:14:00,351 INFO test_ipc.py:90 : Message: {"response": {"type": "record", "namespace": "org.apache.avro.ipc.echo", "name": "Pong", "fields": [{"type": "long", "name": "timestamp", "default": -1}, {"type": "org.apache.avro.ipc.echo.Ping", "name": "ping"}]}, "errors": [], "request": [{"type": {"type": "record", "namespace": "org.apache.avro.ipc.echo", "name": "Ping", "fields": [{"type": "long", "name": "timestamp", "default": -1}, {"type": "string", "name": "text", "default": ""}]}, "name": "ping"}]}
2016-09-27 18:14:00,351 INFO test_ipc.py:91 : Request: {'ping': {'text': 'hello ping', 'timestamp': 31415}}
2016-09-27 18:14:00,352 INFO ipc.py:656 : Serialized response: b'\x00\x00\x00\x00\x00\x00\xbe\x90\xe9\xde\xedU\xee\xea\x03\x14hello ping'
127.0.0.1 - - [27/Sep/2016 18:14:00] "POST / HTTP/1.1" 200 -
2016-09-27 18:14:00,352 INFO ipc.py:665 : Response sent
2016-09-27 18:14:00,353 INFO ipc.py:219 : Processing handshake response: {'serverHash': None, 'match': 'BOTH', 'meta': None, 'serverProtocol': None}
2016-09-27 18:14:00,353 INFO test_ipc.py:143 : Received echo response: {'timestamp': 1475018040351, 'ping': {'text': 'hello ping', 'timestamp': 31415}}
2016-09-27 18:14:00,353 INFO ipc.py:179 : Sending handshake request: {'serverHash': b'\xcc9\x86\xfb\xb6\xad\x8a\ni\xf9X\xbb\x06\xc6\x15\xb2', 'clientHash': b'\xcc9\x86\xfb\xb6\xad\x8a\ni\xf9X\xbb\x06\xc6\x15\xb2'}
2016-09-27 18:14:00,353 INFO ipc.py:204 : writing request: {'ping': {'text': 'hello again', 'timestamp': 123456}}
2016-09-27 18:14:00,354 INFO ipc.py:654 : Serialized request: b'\xcc9\x86\xfb\xb6\xad\x8a\ni\xf9X\xbb\x06\xc6\x15\xb2\x00\xcc9\x86\xfb\xb6\xad\x8a\ni\xf9X\xbb\x06\xc6\x15\xb2\x00\x00\x08ping\x80\x89\x0f\x16hello again'
2016-09-27 18:14:00,354 INFO ipc.py:412 : Processing handshake request: {'serverHash': b'\xcc9\x86\xfb\xb6\xad\x8a\ni\xf9X\xbb\x06\xc6\x15\xb2', 'clientProtocol': None, 'meta': None, 'clientHash': b'\xcc9\x86\xfb\xb6\xad\x8a\ni\xf9X\xbb\x06\xc6\x15\xb2'}
2016-09-27 18:14:00,355 INFO ipc.py:441 : Handshake response: {'match': 'BOTH'}
2016-09-27 18:14:00,355 INFO ipc.py:375 : Processing request: {'ping': {'text': 'hello again', 'timestamp': 123456}}
2016-09-27 18:14:00,355 INFO test_ipc.py:90 : Message: {"response": {"type": "record", "namespace": "org.apache.avro.ipc.echo", "name": "Pong", "fields": [{"type": "long", "name": "timestamp", "default": -1}, {"type": "org.apache.avro.ipc.echo.Ping", "name": "ping"}]}, "errors": [], "request": [{"type": {"type": "record", "namespace": "org.apache.avro.ipc.echo", "name": "Ping", "fields": [{"type": "long", "name": "timestamp", "default": -1}, {"type": "string", "name": "text", "default": ""}]}, "name": "ping"}]}
2016-09-27 18:14:00,355 INFO test_ipc.py:91 : Request: {'ping': {'text': 'hello again', 'timestamp': 123456}}
2016-09-27 18:14:00,355 INFO ipc.py:656 : Serialized response: b'\x00\x00\x00\x00\x00\x00\xc6\x90\xe9\xde\xedU\x80\x89\x0f\x16hello again'
127.0.0.1 - - [27/Sep/2016 18:14:00] "POST / HTTP/1.1" 200 -
2016-09-27 18:14:00,355 INFO ipc.py:665 : Response sent
2016-09-27 18:14:00,356 INFO ipc.py:219 : Processing handshake response: {'serverHash': None, 'match': 'BOTH', 'meta': None, 'serverProtocol': None}
2016-09-27 18:14:00,356 INFO test_ipc.py:149 : Received echo response: {'timestamp': 1475018040355, 'ping': {'text': 'hello again', 'timestamp': 123456}}
ok
testEquivalenceAfterRoundTrip (avro.tests.test_protocol.TestProtocol) ... ok
testInnerNamespaceNotRendered (avro.tests.test_protocol.TestProtocol) ... ok
testInnerNamespaceSet (avro.tests.test_protocol.TestProtocol) ... ok
testParse (avro.tests.test_protocol.TestProtocol) ... ok
testValidCastToStringAfterParse (avro.tests.test_protocol.TestProtocol) ... ok
testCorrectRecursiveExtraction (avro.tests.test_schema.TestSchema) ... ok
testDocAttributes (avro.tests.test_schema.TestSchema) ... ok
testEquivalenceAfterRoundTrip (avro.tests.test_schema.TestSchema) ... ok
testFullname (avro.tests.test_schema.TestSchema)
The fullname is determined in one of the following ways: ... ok
testOtherAttributes (avro.tests.test_schema.TestSchema) ... ok
testParse (avro.tests.test_schema.TestSchema) ... ok
testValidCastToStringAfterParse (avro.tests.test_schema.TestSchema) ... ok
testMultiFile (avro.tests.test_script.TestWrite) ... ok
testOutfile (avro.tests.test_script.TestWrite) ... ok
testStdin (avro.tests.test_script.TestWrite) ... ok
testVersion (avro.tests.test_script.TestWrite) ... ok
testWriteCsv (avro.tests.test_script.TestWrite) ... ok
testWriteJson (avro.tests.test_script.TestWrite) ... ok

----------------------------------------------------------------------
Ran 50 tests in 2.305s

OK
```
