### PR TITLE
AVRO-1626: fix csharp build error

### DIFF
--- a/lang/csharp/build.sh
+++ b/lang/csharp/build.sh
@@ -30,7 +30,7 @@ case "$1" in
 
   test)
     xbuild
-    nunit-console -framework=4.0 Avro.nunit
+    nunit-console Avro.nunit
     ;;
 
   perf)

--- a/lang/csharp/src/apache/perf/app.config
+++ b/lang/csharp/src/apache/perf/app.config
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<configuration>
+<startup><supportedRuntime version="v2.0.50727"/></startup></configuration>


### PR DESCRIPTION
- add app.config to Avro.Pref project
- remove '-framework' parameter from nunit-console test command.

Please review it.
