### PR TITLE
AVRO-1955: fix avrogen.exe output dir path format

### DIFF
--- a/lang/csharp/src/apache/main/CodeGen/CodeGen.cs
+++ b/lang/csharp/src/apache/main/CodeGen/CodeGen.cs
@@ -828,7 +828,11 @@ namespace Avro
             {
                 var ns = nsc[i];
 
-                string dir = outputdir + "\\" + CodeGenUtil.Instance.UnMangle(ns.Name).Replace('.', '\\');
+                string dir = outputdir;
+                foreach (string name in CodeGenUtil.Instance.UnMangle(ns.Name).Split('.'))
+                {
+                    dir = Path.Combine(dir, name);
+                }
                 Directory.CreateDirectory(dir);
 
                 var new_ns = new CodeNamespace(ns.Name);
@@ -840,7 +844,7 @@ namespace Avro
                 for (int j = 0; j < types.Count; j++)
                 {
                     var ctd = types[j];
-                    string file = dir + "\\" + CodeGenUtil.Instance.UnMangle(ctd.Name) + ".cs";
+                    string file = Path.Combine(dir, Path.ChangeExtension(CodeGenUtil.Instance.UnMangle(ctd.Name), "cs"));
                     using (var writer = new StreamWriter(file, false))
                     {
                         new_ns.Types.Add(ctd);


### PR DESCRIPTION
this uses System.IO.Path API when creating output file path.

please review it.
