### PR TITLE
AVRO-1860 - DefaultValue() returns Ints for Long fields

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/Schema.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Schema.java
@@ -44,6 +44,8 @@ import org.codehaus.jackson.JsonParser;
 import org.codehaus.jackson.JsonGenerator;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.node.DoubleNode;
+import org.codehaus.jackson.node.IntNode;
+import org.codehaus.jackson.node.LongNode;
 
 /** An abstract data type.
  * <p>A schema may be one of:
@@ -1168,7 +1170,7 @@ public abstract class Schema extends JsonProperties {
         +": "+defaultValue+" not a "+schema;
       throw new AvroTypeException(message);     // throw exception
     }
-    return defaultValue;
+    return convertToProperType(schema, defaultValue);
   }
 
   private static boolean isValidDefault(Schema schema, JsonNode defaultValue) {
@@ -1218,6 +1220,32 @@ public abstract class Schema extends JsonProperties {
     default:
       return false;
     }
+  }
+
+  private static JsonNode convertToProperType(Schema schema, JsonNode defaultValue) {
+    if (defaultValue == null)
+      return null;
+    switch (schema.getType()) {
+    case DOUBLE:
+      if (!defaultValue.isDouble() && defaultValue.isFloatingPointNumber())
+        return new DoubleNode(defaultValue.asDouble());
+      break;
+    case FLOAT:
+      // TODO: FloatNode exists in Jackson >=2.2, use it after upgrade
+      break;
+    case LONG:
+      if (!defaultValue.isLong() && defaultValue.isIntegralNumber())
+        return new LongNode(defaultValue.asLong());
+      break;
+    case INT:
+      if (!defaultValue.isInt() && defaultValue.isIntegralNumber())
+        return new IntNode(defaultValue.asInt());
+      break;
+    default:
+      // Nothing to do; returning the original defaultValue
+      break;
+    }
+    return defaultValue;
   }
 
   /** @see #parse(String) */

--- a/lang/java/avro/src/main/java/org/apache/avro/Schema.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Schema.java
@@ -44,8 +44,6 @@ import org.codehaus.jackson.JsonParser;
 import org.codehaus.jackson.JsonGenerator;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.node.DoubleNode;
-import org.codehaus.jackson.node.IntNode;
-import org.codehaus.jackson.node.LongNode;
 
 /** An abstract data type.
  * <p>A schema may be one of:
@@ -437,7 +435,7 @@ public abstract class Schema extends JsonProperties {
      * @return the default value for this field specified using the mapping
      *  in {@link JsonProperties}
      */
-    public Object defaultVal() { return JacksonUtils.toObject(defaultValue); }
+    public Object defaultVal() { return JacksonUtils.toObject(defaultValue, schema); }
     public Order order() { return order; }
     @Deprecated public Map<String,String> props() { return getProps(); }
     public void addAlias(String alias) {
@@ -1170,7 +1168,7 @@ public abstract class Schema extends JsonProperties {
         +": "+defaultValue+" not a "+schema;
       throw new AvroTypeException(message);     // throw exception
     }
-    return convertToProperType(schema, defaultValue);
+    return defaultValue;
   }
 
   private static boolean isValidDefault(Schema schema, JsonNode defaultValue) {
@@ -1220,32 +1218,6 @@ public abstract class Schema extends JsonProperties {
     default:
       return false;
     }
-  }
-
-  private static JsonNode convertToProperType(Schema schema, JsonNode defaultValue) {
-    if (defaultValue == null)
-      return null;
-    switch (schema.getType()) {
-    case DOUBLE:
-      if (!defaultValue.isDouble() && defaultValue.isFloatingPointNumber())
-        return new DoubleNode(defaultValue.asDouble());
-      break;
-    case FLOAT:
-      // TODO: FloatNode exists in Jackson >=2.2, use it after upgrade
-      break;
-    case LONG:
-      if (!defaultValue.isLong() && defaultValue.isIntegralNumber())
-        return new LongNode(defaultValue.asLong());
-      break;
-    case INT:
-      if (!defaultValue.isInt() && defaultValue.isIntegralNumber())
-        return new IntNode(defaultValue.asInt());
-      break;
-    default:
-      // Nothing to do; returning the original defaultValue
-      break;
-    }
-    return defaultValue;
   }
 
   /** @see #parse(String) */

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemaBuilder.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemaBuilder.java
@@ -740,8 +740,7 @@ public class TestSchemaBuilder {
 
     Assert.assertEquals("int field default type or value mismatch", intDef, schema.getField("int").defaultVal());
     Assert.assertEquals("long field default type or value mismatch", longDef, schema.getField("long").defaultVal());
-    // TODO: Currently failing; will be solved after having the Jackson >=2.2 upgrade
-//    Assert.assertEquals("float field default type or value mismatch", floatDef, schema.getField("float").defaultVal());
+    Assert.assertEquals("float field default type or value mismatch", floatDef, schema.getField("float").defaultVal());
     Assert.assertEquals("double field default type or value mismatch", doubleDef,
         schema.getField("double").defaultVal());
   }

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemaBuilder.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemaBuilder.java
@@ -725,4 +725,25 @@ public class TestSchemaBuilder {
     Assert.assertEquals(5, rec2read.get("newNullableIntWithDefault"));
   }
 
+  @Test
+  public void testDefaultTypes() {
+    Integer intDef = 1;
+    Long longDef = 2L;
+    Float floatDef = 3F;
+    Double doubleDef = 4D;
+    Schema schema = SchemaBuilder.record("r").fields()
+        .name("int").type().intType().intDefault(intDef)
+        .name("long").type().longType().longDefault(longDef)
+        .name("float").type().floatType().floatDefault(floatDef)
+        .name("double").type().doubleType().doubleDefault(doubleDef)
+        .endRecord();
+
+    Assert.assertEquals("int field default type or value mismatch", intDef, schema.getField("int").defaultVal());
+    Assert.assertEquals("long field default type or value mismatch", longDef, schema.getField("long").defaultVal());
+    // TODO: Currently failing; will be solved after having the Jackson >=2.2 upgrade
+//    Assert.assertEquals("float field default type or value mismatch", floatDef, schema.getField("float").defaultVal());
+    Assert.assertEquals("double field default type or value mismatch", doubleDef,
+        schema.getField("double").defaultVal());
+  }
+
 }


### PR DESCRIPTION
Added conversions to the proper JsonNode implementation to support returning the proper object type (e.g. Long from a LongNode in case of the schema has Long type).