### PR TITLE
AVRO-1932: Java: Allow setting the SchemaStore on generated classes.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,6 +13,9 @@ Trunk (not yet released)
     AVRO-1884: Java: Add method to set the compiler output suffix.
     (shijinkui via blue)
 
+    AVRO-1932: Java: Allow setting the SchemaStore on generated classes. 
+    (Niels Basjes)
+
   OPTIMIZATIONS
 
   IMPROVEMENTS

--- a/lang/java/avro/src/main/java/org/apache/avro/message/BinaryMessageDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/message/BinaryMessageDecoder.java
@@ -133,10 +133,8 @@ public class BinaryMessageDecoder<D> extends MessageDecoder.BaseDecoder<D> {
    *
    * @param newResolver a {@link SchemaStore} to use when decoding buffers
    */
-  public void setSchemaStore(SchemaStore newResolver) {
-    if (newResolver != null) {
-      this.resolver = newResolver;
-    }
+  public synchronized void setSchemaStore(SchemaStore newResolver) {
+    resolver = newResolver;
   }
 
   private RawMessageDecoder<D> getDecoder(long fp) {

--- a/lang/java/avro/src/main/java/org/apache/avro/message/BinaryMessageDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/message/BinaryMessageDecoder.java
@@ -169,7 +169,7 @@ public class BinaryMessageDecoder<D> extends MessageDecoder.BaseDecoder<D> {
     if (BinaryMessageEncoder.V1_HEADER[0] != header[0] ||
         BinaryMessageEncoder.V1_HEADER[1] != header[1]) {
       throw new BadHeaderException(String.format(
-          "Unrecognized header bytes: 0x%h%h",
+          "Unrecognized header bytes: 0x%02X 0x%02X",
           header[0], header[1]));
     }
 

--- a/lang/java/avro/src/main/java/org/apache/avro/message/BinaryMessageDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/message/BinaryMessageDecoder.java
@@ -66,7 +66,7 @@ public class BinaryMessageDecoder<D> extends MessageDecoder.BaseDecoder<D> {
 
   private final GenericData model;
   private final Schema readSchema;
-  private final SchemaStore resolver;
+  private SchemaStore resolver;
 
   private final Map<Long, RawMessageDecoder<D>> codecByFingerprint =
       new MapMaker().makeMap();
@@ -126,6 +126,17 @@ public class BinaryMessageDecoder<D> extends MessageDecoder.BaseDecoder<D> {
     long fp = SchemaNormalization.parsingFingerprint64(writeSchema);
     codecByFingerprint.put(fp,
         new RawMessageDecoder<D>(model, writeSchema, readSchema));
+  }
+
+  /**
+   * Sets the new SchemaStore instance that is to be used to retrieve the schemas.
+   *
+   * @param newResolver a {@link SchemaStore} to use when decoding buffers
+   */
+  public void setSchemaStore(SchemaStore newResolver) {
+    if (newResolver != null) {
+      this.resolver = newResolver;
+    }
   }
 
   private RawMessageDecoder<D> getDecoder(long fp) {

--- a/lang/java/avro/src/main/java/org/apache/avro/message/BinaryMessageDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/message/BinaryMessageDecoder.java
@@ -66,7 +66,7 @@ public class BinaryMessageDecoder<D> extends MessageDecoder.BaseDecoder<D> {
 
   private final GenericData model;
   private final Schema readSchema;
-  private SchemaStore resolver;
+  private final SchemaStore resolver;
 
   private final Map<Long, RawMessageDecoder<D>> codecByFingerprint =
       new MapMaker().makeMap();
@@ -126,15 +126,6 @@ public class BinaryMessageDecoder<D> extends MessageDecoder.BaseDecoder<D> {
     long fp = SchemaNormalization.parsingFingerprint64(writeSchema);
     codecByFingerprint.put(fp,
         new RawMessageDecoder<D>(model, writeSchema, readSchema));
-  }
-
-  /**
-   * Sets the new SchemaStore instance that is to be used to retrieve the schemas.
-   *
-   * @param newResolver a {@link SchemaStore} to use when decoding buffers
-   */
-  public synchronized void setSchemaStore(SchemaStore newResolver) {
-    resolver = newResolver;
   }
 
   private RawMessageDecoder<D> getDecoder(long fp) {

--- a/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/record.vm
+++ b/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/record.vm
@@ -47,6 +47,13 @@ public class ${this.mangle($schema.getName())}#if ($schema.isError()) extends or
   private static final BinaryMessageDecoder<${this.mangle($schema.getName())}> DECODER =
       new BinaryMessageDecoder<${this.mangle($schema.getName())}>(MODEL$, SCHEMA$);
 
+  /**
+   * Return the BinaryMessageDecoder instance used by this class.
+   */
+  public static BinaryMessageDecoder<${this.mangle($schema.getName())}> getDecoder() {
+    return DECODER;
+  }
+
   /** Serializes this ${schema.getName()} to a ByteBuffer. */
   public java.nio.ByteBuffer toByteBuffer() throws java.io.IOException {
     return ENCODER.encode(this);

--- a/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/record.vm
+++ b/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/record.vm
@@ -23,6 +23,7 @@ import org.apache.avro.specific.SpecificData;
 #if (!$schema.isError())
 import org.apache.avro.message.BinaryMessageEncoder;
 import org.apache.avro.message.BinaryMessageDecoder;
+import org.apache.avro.message.SchemaStore;
 #end
 
 @SuppressWarnings("all")
@@ -52,6 +53,14 @@ public class ${this.mangle($schema.getName())}#if ($schema.isError()) extends or
    */
   public static BinaryMessageDecoder<${this.mangle($schema.getName())}> getDecoder() {
     return DECODER;
+  }
+
+  /**
+   * Create a new BinaryMessageDecoder instance for this class that uses the specified {@link SchemaStore}.
+   * @param resolver a {@link SchemaStore} used to find schemas by fingerprint
+   */
+  public static BinaryMessageDecoder<${this.mangle($schema.getName())}> createDecoder(SchemaStore resolver) {
+    return new BinaryMessageDecoder<${this.mangle($schema.getName())}>(MODEL$, SCHEMA$, resolver);
   }
 
   /** Serializes this ${schema.getName()} to a ByteBuffer. */

--- a/lang/java/ipc/src/test/java/org/apache/avro/message/TestCustomSchemaStore.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/message/TestCustomSchemaStore.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.avro.message;
+
+import org.apache.avro.Schema;
+import org.apache.avro.compiler.schema.evolve.NestedEvolve1;
+import org.apache.avro.compiler.schema.evolve.NestedEvolve2;
+import org.apache.avro.compiler.schema.evolve.NestedEvolve3;
+import org.apache.avro.compiler.schema.evolve.TestRecord2;
+import org.apache.avro.compiler.schema.evolve.TestRecord3;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestCustomSchemaStore {
+
+  @BeforeClass
+  public static void setUpCustomSchemaStore(){
+    // Set the SchemaStore that is capable of decoding NestedEvolve1 and NestedEvolve2 (and NOT NestedEvolve3).
+    NestedEvolve1.getDecoder().setSchemaStore(new CustomSchemaStore());
+  }
+
+  public static class CustomSchemaStore implements SchemaStore {
+    Cache cache;
+    public CustomSchemaStore() {
+      cache = new Cache();
+      cache.addSchema(NestedEvolve1.getClassSchema());
+      cache.addSchema(NestedEvolve2.getClassSchema());
+    }
+
+    @Override
+    public Schema findByFingerprint(long fingerprint) {
+      return cache.findByFingerprint(fingerprint);
+    }
+  }
+
+  @Test
+  public void testCompatibleReadWithSchemaFromSchemaStore() throws Exception {
+    // Create and encode a NestedEvolve2 record.
+    NestedEvolve2.Builder rootBuilder = NestedEvolve2.newBuilder().setRootName("RootName");
+    rootBuilder.setNested(TestRecord2.newBuilder().setName("Name").setValue(1).setData("Data").build());
+    ByteBuffer nestedEvolve2Buffer = rootBuilder.build().toByteBuffer();
+
+    // Decode it
+    NestedEvolve1 nestedEvolve1 = NestedEvolve1.fromByteBuffer(nestedEvolve2Buffer);
+
+    // Should work
+    assertEquals(nestedEvolve1.getRootName(), "RootName");
+    assertEquals(nestedEvolve1.getNested().getName(), "Name");
+    assertEquals(nestedEvolve1.getNested().getValue(), Long.valueOf(1));
+  }
+
+  @Test(expected = MissingSchemaException.class)
+  public void testIncompatibleReadWithSchemaFromSchemaStore() throws Exception {
+    // Create and encode a NestedEvolve3 record.
+    NestedEvolve3.Builder rootBuilder = NestedEvolve3.newBuilder().setRootName("RootName");
+    rootBuilder.setNested(TestRecord3.newBuilder().setName("Name").setData("Data").build());
+    ByteBuffer nestedEvolve3Buffer = rootBuilder.build().toByteBuffer();
+
+    // Decode it ... should fail because schema for 'NestedEvolve3' is not available in the SchemaStore
+    NestedEvolve1 nestedEvolve1 = NestedEvolve1.fromByteBuffer(nestedEvolve3Buffer);
+  }
+
+}

--- a/lang/java/tools/src/test/compiler/output-string/avro/examples/baseball/Player.java
+++ b/lang/java/tools/src/test/compiler/output-string/avro/examples/baseball/Player.java
@@ -8,6 +8,7 @@ package avro.examples.baseball;
 import org.apache.avro.specific.SpecificData;
 import org.apache.avro.message.BinaryMessageEncoder;
 import org.apache.avro.message.BinaryMessageDecoder;
+import org.apache.avro.message.SchemaStore;
 
 @SuppressWarnings("all")
 /** 選手 is Japanese for player. */
@@ -30,6 +31,14 @@ public class Player extends org.apache.avro.specific.SpecificRecordBase implemen
    */
   public static BinaryMessageDecoder<Player> getDecoder() {
     return DECODER;
+  }
+
+  /**
+   * Create a new BinaryMessageDecoder instance for this class that uses the specified {@link SchemaStore}.
+   * @param resolver a {@link SchemaStore} used to find schemas by fingerprint
+   */
+  public static BinaryMessageDecoder<Player> createDecoder(SchemaStore resolver) {
+    return new BinaryMessageDecoder<Player>(MODEL$, SCHEMA$, resolver);
   }
 
   /** Serializes this Player to a ByteBuffer. */

--- a/lang/java/tools/src/test/compiler/output-string/avro/examples/baseball/Player.java
+++ b/lang/java/tools/src/test/compiler/output-string/avro/examples/baseball/Player.java
@@ -25,6 +25,13 @@ public class Player extends org.apache.avro.specific.SpecificRecordBase implemen
   private static final BinaryMessageDecoder<Player> DECODER =
       new BinaryMessageDecoder<Player>(MODEL$, SCHEMA$);
 
+  /**
+   * Return the BinaryMessageDecoder instance used by this class.
+   */
+  public static BinaryMessageDecoder<Player> getDecoder() {
+    return DECODER;
+  }
+
   /** Serializes this Player to a ByteBuffer. */
   public java.nio.ByteBuffer toByteBuffer() throws java.io.IOException {
     return ENCODER.encode(this);

--- a/lang/java/tools/src/test/compiler/output/Player.java
+++ b/lang/java/tools/src/test/compiler/output/Player.java
@@ -8,6 +8,7 @@ package avro.examples.baseball;
 import org.apache.avro.specific.SpecificData;
 import org.apache.avro.message.BinaryMessageEncoder;
 import org.apache.avro.message.BinaryMessageDecoder;
+import org.apache.avro.message.SchemaStore;
 
 @SuppressWarnings("all")
 /** 選手 is Japanese for player. */
@@ -30,6 +31,14 @@ public class Player extends org.apache.avro.specific.SpecificRecordBase implemen
    */
   public static BinaryMessageDecoder<Player> getDecoder() {
     return DECODER;
+  }
+
+  /**
+   * Create a new BinaryMessageDecoder instance for this class that uses the specified {@link SchemaStore}.
+   * @param resolver a {@link SchemaStore} used to find schemas by fingerprint
+   */
+  public static BinaryMessageDecoder<Player> createDecoder(SchemaStore resolver) {
+    return new BinaryMessageDecoder<Player>(MODEL$, SCHEMA$, resolver);
   }
 
   /** Serializes this Player to a ByteBuffer. */

--- a/lang/java/tools/src/test/compiler/output/Player.java
+++ b/lang/java/tools/src/test/compiler/output/Player.java
@@ -25,6 +25,13 @@ public class Player extends org.apache.avro.specific.SpecificRecordBase implemen
   private static final BinaryMessageDecoder<Player> DECODER =
       new BinaryMessageDecoder<Player>(MODEL$, SCHEMA$);
 
+  /**
+   * Return the BinaryMessageDecoder instance used by this class.
+   */
+  public static BinaryMessageDecoder<Player> getDecoder() {
+    return DECODER;
+  }
+
   /** Serializes this Player to a ByteBuffer. */
   public java.nio.ByteBuffer toByteBuffer() throws java.io.IOException {
     return ENCODER.encode(this);

--- a/share/test/schemas/schemaevolution.avdl
+++ b/share/test/schemas/schemaevolution.avdl
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * A few simple test schemas for testing schema evolution the IDL generated classes
+ */
+@namespace("org.apache.avro.compiler.schema.evolve")
+protocol SchemaEvolveTesting {
+  record TestRecord1 {
+    string name;
+    long   value;
+  }
+
+  record TestRecord2 {
+    string name;
+    long   value;
+    string data;
+  }
+
+  record TestRecord3 {
+    string name;
+    string data;
+  }
+
+  record NestedEvolve1 {
+    string rootName;
+    TestRecord1 nested;
+  }
+
+  record NestedEvolve2 {
+    string rootName;
+    TestRecord2 nested;
+  }
+
+  record NestedEvolve3 {
+    string rootName;
+    TestRecord3 nested;
+  }
+
+}


### PR DESCRIPTION
This change is needed to allow setting a different SchemaStore in the IDL generated classes.