### PR TITLE
AVRO-1938: Py2 support for generating canonical form of schemas

### DIFF
--- a/lang/py/setup.py
+++ b/lang/py/setup.py
@@ -19,11 +19,6 @@ try:
   from setuptools import setup
 except ImportError:
   from distutils.core import setup
-from sys import version_info
-
-install_requires = []
-if version_info[:2] <= (2, 5):
-    install_requires.append('simplejson >= 2.0.9')
 
 setup(
   name = 'avro',
@@ -37,7 +32,7 @@ setup(
 
   # Project uses simplejson, so ensure that it gets installed or upgraded
   # on the target machine
-  install_requires = install_requires,
+  install_requires = ['simplejson>=2.0.9'],
 
   # metadata for upload to PyPI
   author = 'Apache Avro',

--- a/lang/py/src/avro/schema.py
+++ b/lang/py/src/avro/schema.py
@@ -526,8 +526,12 @@ class EnumSchema(NamedSchema):
       return names.prune_namespace(self.props)
 
   def to_canonical_json(self, names=None):
-    to_dump = self._keep_canonical_properties(self.to_json(names))
-    to_dump["name"] = self.fullname
+    names_as_json = self.to_json(names)
+    if isinstance(names_as_json, basestring):
+      to_dump = self.fullname
+    else:
+      to_dump = self._keep_canonical_properties(names_as_json)
+      to_dump["name"] = self.fullname
 
     return to_dump
 

--- a/lang/py/test/test_schema.py
+++ b/lang/py/test/test_schema.py
@@ -295,7 +295,8 @@ OTHER_PROP_EXAMPLES = [
     """, True)
 ]
 
-EXAMPLES = PRIMITIVE_EXAMPLES
+EXAMPLES = []
+EXAMPLES += PRIMITIVE_EXAMPLES
 EXAMPLES += FIXED_EXAMPLES
 EXAMPLES += ENUM_EXAMPLES
 EXAMPLES += ARRAY_EXAMPLES
@@ -484,12 +485,17 @@ class TestSchema(unittest.TestCase):
         schema.parse('/not/a/real/file')
         caught_exception = False
     except schema.SchemaParseException, e:
-        expected_message = 'Error parsing JSON: /not/a/real/file, error = ' \
-                           'No JSON object could be decoded'
-        self.assertEqual(expected_message, e.args[0])
+        expected_messages = ['Error parsing JSON: /not/a/real/file, error = No JSON object could be decoded',
+                             'Error parsing JSON: /not/a/real/file, error = Expecting value: line 1 column 1 (char 0)']
+        assert e.args[0] in expected_messages
         caught_exception = True
 
     self.assertTrue(caught_exception, 'Exception was not caught')
+
+  def test_canonical_form(self):
+    for example in VALID_EXAMPLES:
+      # Quick test: We can make canonical schemas of all valid schemas
+      schema.parse(example.schema_string).canonical_form()
 
 if __name__ == '__main__':
   unittest.main()

--- a/lang/py/test/test_schema.py
+++ b/lang/py/test/test_schema.py
@@ -131,6 +131,20 @@ UNION_EXAMPLES = [
     """, False),
 ]
 
+NAMED_IN_UNION_EXAMPLES = [
+  ExampleSchema("""{"namespace": "org.apache.avro.test",
+                    "type": "record",
+                    "name": "Test",
+                    "fields": [{"type": {"symbols": ["one", "two"],
+                                         "type": "enum",
+                                         "name": "NamedEnum"},
+                                         "name": "thenamedenum"},
+                               {"type": ["null", "NamedEnum"],
+                                "name": "unionwithreftoenum"}
+                              ]
+                    }""", True)
+]
+
 RECORD_EXAMPLES = [
   ExampleSchema("""\
     {"type": "record",
@@ -302,6 +316,7 @@ EXAMPLES += ENUM_EXAMPLES
 EXAMPLES += ARRAY_EXAMPLES
 EXAMPLES += MAP_EXAMPLES
 EXAMPLES += UNION_EXAMPLES
+EXAMPLES += NAMED_IN_UNION_EXAMPLES
 EXAMPLES += RECORD_EXAMPLES
 EXAMPLES += DOC_EXAMPLES
 


### PR DESCRIPTION
Adds support for generating canonical form of schema in Python 2 implementation.

Notes:
- Adds dependency on simplejson, since built-in json module lacks support for sorting keys when writing JSON dictionaries.
- Did not update nor remove lib/simplejson, which means tests don't pass right now. Should the lib/simplejson directory be updated to the latest version of simplejson, or should it be removed? Is it needed for anything except tests? 
- Simple unit test included. Also tested output against output from java implementation on a few schemas.
