### PR TITLE
AVRO-1940: C++: namespace scoped enums/dev

### DIFF
--- a/lang/c++/test/AvrogencppTests.cc
+++ b/lang/c++/test/AvrogencppTests.cc
@@ -76,7 +76,7 @@ void setRecord(testgen::RootRecord &myRecord)
     myRecord.myarray.push_back(3434.9);
     myRecord.myarray.push_back(7343.9);
     myRecord.myarray.push_back(-63445.9);
-    myRecord.myenum = testgen::one;
+    myRecord.myenum = testgen::ExampleEnum::one;
 
     map<string, int32_t> m;
     m["one"] = 1;


### PR DESCRIPTION
Sorry I should rebased this to only include 14e0aa2. 

But as this is now, it is a breaking change, so I will leave it open here for comments and rebase/resubmit a PR once the maintainers or users have given some feedback.

14e0aa2 adds a namespace of the same name around all enums. as is, it is a breaking change, but it could be optional as a command line argument.

It could also be done using c++11 enum class, but avro c++ doesn't look like anyone is actively working on introducing c++11. 