### PR TITLE
AVRO-1944: Fixed invalid toString in records with duplicate values

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -76,7 +76,7 @@ Trunk (not yet released)
     AVRO-1853: C++: Compiler::toBin crashes on empty string.
     (Zoltan Ivanfi via tomwhite)
 
-    AVRO-1923: Stop infinite recursion in GenericData.toString. (Niels Basjes)
+    AVRO-1923, AVRO-1944: Stop infinite recursion in GenericData.toString. (Niels Basjes)
 
     AVRO-1860: Java: Field#DefaultVal() returns Ints for Long fields.
     (Gabor Szadovszky via cutting)

--- a/lang/java/avro/src/main/java/org/apache/avro/generic/GenericData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/generic/GenericData.java
@@ -506,12 +506,12 @@ public class GenericData {
   }
   /** Renders a Java datum as <a href="http://www.json.org/">JSON</a>. */
   protected void toString(Object datum, StringBuilder buffer, IdentityHashMap<Object, Object> seenObjects) {
-    if (seenObjects.containsKey(datum)) {
-      buffer.append(" \">>> CIRCULAR REFERENCE CANNOT BE PUT IN JSON STRING, ABORTING RECURSION<<<\" ");
-      return;
-    }
-    seenObjects.put(datum, datum);
     if (isRecord(datum)) {
+      if (seenObjects.containsKey(datum)) {
+        buffer.append(" \">>> CIRCULAR REFERENCE CANNOT BE PUT IN JSON STRING, ABORTING RECURSION<<<\" ");
+        return;
+      }
+      seenObjects.put(datum, datum);
       buffer.append("{");
       int count = 0;
       Schema schema = getRecordSchema(datum);

--- a/lang/java/avro/src/main/java/org/apache/avro/generic/GenericData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/generic/GenericData.java
@@ -527,6 +527,7 @@ public class GenericData {
           buffer.append(", ");
       }
       buffer.append("}");
+      seenObjects.remove(datum);
     } else if (isArray(datum)) {
       if (seenObjects.containsKey(datum)) {
         buffer.append(TOSTRING_CIRCULAR_REFERENCE_ERROR_TEXT);
@@ -543,6 +544,7 @@ public class GenericData {
           buffer.append(", ");
       }
       buffer.append("]");
+      seenObjects.remove(datum);
     } else if (isMap(datum)) {
       if (seenObjects.containsKey(datum)) {
         buffer.append(TOSTRING_CIRCULAR_REFERENCE_ERROR_TEXT);
@@ -561,6 +563,7 @@ public class GenericData {
           buffer.append(", ");
       }
       buffer.append("}");
+      seenObjects.remove(datum);
     } else if (isString(datum)|| isEnum(datum)) {
       buffer.append("\"");
       writeEscapedString(datum.toString(), buffer);
@@ -584,6 +587,7 @@ public class GenericData {
       }
       seenObjects.put(datum, datum);
       toString(datum, buffer, seenObjects);
+      seenObjects.remove(datum);
     } else {
       buffer.append(datum);
     }

--- a/lang/java/avro/src/main/java/org/apache/avro/generic/GenericData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/generic/GenericData.java
@@ -582,8 +582,8 @@ public class GenericData {
         buffer.append(TOSTRING_CIRCULAR_REFERENCE_ERROR_TEXT);
         return;
       }
-      toString(datum, buffer, seenObjects);
       seenObjects.put(datum, datum);
+      toString(datum, buffer, seenObjects);
     } else {
       buffer.append(datum);
     }

--- a/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericData.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericData.java
@@ -21,6 +21,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Collection;
 import java.util.ArrayDeque;
@@ -30,6 +31,7 @@ import static org.apache.avro.TestCircularReferences.Referenceable;
 import static org.junit.Assert.*;
 
 import java.util.Arrays;
+import java.util.Map;
 
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field;
@@ -528,6 +530,25 @@ public class TestGenericData {
     fields.add(new Field("boolean1",Schema.create(Type.BOOLEAN ), null, (Object)null));
     fields.add(new Field("boolean2",Schema.create(Type.BOOLEAN ), null, (Object)null));
 
+    List<String> enumValues = new ArrayList<String>();
+    enumValues.add("One");
+    enumValues.add("Two");
+    Schema enumSchema = Schema.createEnum("myEnum", null, null, enumValues);
+    fields.add(new Field("enum1", enumSchema, null, (Object)null));
+    fields.add(new Field("enum2", enumSchema, null, (Object)null));
+
+    Schema recordSchema = SchemaBuilder.record("aRecord").fields().requiredString("myString").endRecord();
+    fields.add(new Field("record1", recordSchema, null, (Object)null));
+    fields.add(new Field("record2", recordSchema, null, (Object)null));
+
+    Schema arraySchema = Schema.createArray(Schema.create(Type.STRING));
+    fields.add(new Field("array1", arraySchema, null, (Object)null));
+    fields.add(new Field("array2", arraySchema, null, (Object)null));
+
+    Schema mapSchema = Schema.createMap(Schema.create(Type.STRING));
+    fields.add(new Field("map1", mapSchema, null, (Object)null));
+    fields.add(new Field("map2", mapSchema, null, (Object)null));
+
     Schema schema = Schema.createRecord("Foo", "test", "mytest", false);
     schema.setFields(fields);
 
@@ -551,6 +572,25 @@ public class TestGenericData {
     testRecord.put("double2",  42D);
     testRecord.put("boolean1", true);
     testRecord.put("boolean2", true);
+
+    testRecord.put("enum1", "One");
+    testRecord.put("enum2", "One");
+
+    GenericRecord record = new GenericData.Record(recordSchema);
+    record.put("myString","42");
+    testRecord.put("record1",  record);
+    testRecord.put("record2",  record);
+
+    GenericArray<String> array = new GenericData.Array<String>(1, arraySchema);
+    array.clear();
+    array.add("42");
+    testRecord.put("array1",   array);
+    testRecord.put("array2",   array);
+
+    Map<String, String> map = new HashMap<String, String>();
+    map.put("42", "42");
+    testRecord.put("map1",     map);
+    testRecord.put("map2",     map);
 
     String testString = testRecord.toString();
     assertFalse("Record with duplicated values results in wrong 'toString()'", testString.contains("CIRCULAR REFERENCE"));

--- a/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericData.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericData.java
@@ -496,6 +496,66 @@ public class TestGenericData {
     assertTrue(GenericData.get().validate(unionSchema, record));
   }
 
+  /*
+   * The toString has a detection for circular references to abort.
+   * This detection has the risk of detecting that same value as being a circular reference.
+   * For Record, Map and Array this is correct, for the rest is is not.
+   */
+  @Test
+  public void testToStringSameValues() throws IOException {
+    List<Field> fields = new ArrayList<Field>();
+    fields.add(new Field("nullstring1", Schema.create(Type.STRING), null, (Object)null));
+    fields.add(new Field("nullstring2", Schema.create(Type.STRING), null, (Object)null));
+
+    fields.add(new Field("string1", Schema.create(Type.STRING  ), null, (Object)null));
+    fields.add(new Field("string2", Schema.create(Type.STRING  ), null, (Object)null));
+
+    fields.add(new Field("bytes1",  Schema.create(Type.BYTES   ), null, (Object)null));
+    fields.add(new Field("bytes2",  Schema.create(Type.BYTES   ), null, (Object)null));
+
+    fields.add(new Field("int1",    Schema.create(Type.INT     ), null, (Object)null));
+    fields.add(new Field("int2",    Schema.create(Type.INT     ), null, (Object)null));
+
+    fields.add(new Field("long1",   Schema.create(Type.LONG    ), null, (Object)null));
+    fields.add(new Field("long2",   Schema.create(Type.LONG    ), null, (Object)null));
+
+    fields.add(new Field("float1",  Schema.create(Type.FLOAT   ), null, (Object)null));
+    fields.add(new Field("float2",  Schema.create(Type.FLOAT   ), null, (Object)null));
+
+    fields.add(new Field("double1", Schema.create(Type.DOUBLE  ), null, (Object)null));
+    fields.add(new Field("double2", Schema.create(Type.DOUBLE  ), null, (Object)null));
+
+    fields.add(new Field("boolean1",Schema.create(Type.BOOLEAN ), null, (Object)null));
+    fields.add(new Field("boolean2",Schema.create(Type.BOOLEAN ), null, (Object)null));
+
+    Schema schema = Schema.createRecord("Foo", "test", "mytest", false);
+    schema.setFields(fields);
+
+    Record testRecord = new Record(schema);
+
+    testRecord.put("nullstring1", null);
+    testRecord.put("nullstring2", null);
+
+    String fortyTwo = "42";
+    testRecord.put("string1",  fortyTwo);
+    testRecord.put("string2",  fortyTwo);
+    testRecord.put("bytes1",   0x42 );
+    testRecord.put("bytes2",   0x42 );
+    testRecord.put("int1",     42 );
+    testRecord.put("int2",     42 );
+    testRecord.put("long1",    42L);
+    testRecord.put("long2",    42L);
+    testRecord.put("float1",   42F);
+    testRecord.put("float2",   42F);
+    testRecord.put("double1",  42D);
+    testRecord.put("double2",  42D);
+    testRecord.put("boolean1", true);
+    testRecord.put("boolean2", true);
+
+    String testString = testRecord.toString();
+    assertFalse("Record with duplicated values results in wrong 'toString()'", testString.contains("CIRCULAR REFERENCE"));
+  }
+
   // Test copied from Apache Parquet: org.apache.parquet.avro.TestCircularReferences
   @Test
   public void testToStringRecursive() throws IOException {
@@ -550,30 +610,5 @@ public class TestGenericData {
     } catch (StackOverflowError e) {
       fail("StackOverflowError occurred");
     }
-  }
-
-  @Test
-  public void testToString() throws IOException {
-    List<Field> fields = new ArrayList<Field>();
-    fields.add(new Field("nullstring1", Schema.create(Type.STRING), null, null));
-    fields.add(new Field("nullstring2", Schema.create(Type.STRING), null, null));
-    fields.add(new Field("string1", Schema.create(Type.STRING), null, null));
-    fields.add(new Field("string2", Schema.create(Type.STRING), null, null));
-    fields.add(new Field("int1", Schema.create(Type.INT), null, null));
-    fields.add(new Field("int2", Schema.create(Type.INT), null, null));
-    Schema schema = Schema.createRecord("Foo", "test", "mytest", false);
-    schema.setFields(fields);
-
-    Record testRecord = new Record(schema);
-
-    testRecord.put("nullstring1", null);
-    testRecord.put("nullstring2", null);
-    testRecord.put("string1", "Hello World");
-    testRecord.put("string2", "Hello World");
-    testRecord.put("int1", 42);
-    testRecord.put("int2", 42);
-
-    String testString = testRecord.toString();
-    assertFalse("Record with duplicated values results in wrong 'toString()'", testString.contains("CIRCULAR REFERENCE"));
   }
 }

--- a/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericData.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericData.java
@@ -552,4 +552,28 @@ public class TestGenericData {
     }
   }
 
+  @Test
+  public void testToString() throws IOException {
+    List<Field> fields = new ArrayList<Field>();
+    fields.add(new Field("nullstring1", Schema.create(Type.STRING), null, null));
+    fields.add(new Field("nullstring2", Schema.create(Type.STRING), null, null));
+    fields.add(new Field("string1", Schema.create(Type.STRING), null, null));
+    fields.add(new Field("string2", Schema.create(Type.STRING), null, null));
+    fields.add(new Field("int1", Schema.create(Type.INT), null, null));
+    fields.add(new Field("int2", Schema.create(Type.INT), null, null));
+    Schema schema = Schema.createRecord("Foo", "test", "mytest", false);
+    schema.setFields(fields);
+
+    Record testRecord = new Record(schema);
+
+    testRecord.put("nullstring1", null);
+    testRecord.put("nullstring2", null);
+    testRecord.put("string1", "Hello World");
+    testRecord.put("string2", "Hello World");
+    testRecord.put("int1", 42);
+    testRecord.put("int2", 42);
+
+    String testString = testRecord.toString();
+    assertFalse("Record with duplicated values results in wrong 'toString()'", testString.contains("CIRCULAR REFERENCE"));
+  }
 }


### PR DESCRIPTION
I ran into the effect that a record with two fields with the same value (or even both null) would result in a toString that shows the "CIRCULAR REFERENCE" message. This is incorrect and this fixes that.

Please verify.
