### PR TITLE
AVRO-1947 - Inconsistent maven profile activation

### DIFF
--- a/lang/java/mapred/pom.xml
+++ b/lang/java/mapred/pom.xml
@@ -211,7 +211,8 @@
       <id>hadoop2</id>
       <activation>
         <property>
-          <name>!hadoop.version</name> <!-- if no hadoop.version is set -->
+          <name>hadoop.version</name>
+          <value>!1</value> <!-- if the hadoop.version is not 1 (or not set) -->
         </property>
       </activation>
       <properties>

--- a/lang/java/trevni/avro/pom.xml
+++ b/lang/java/trevni/avro/pom.xml
@@ -104,7 +104,8 @@
       <id>hadoop2</id>
       <activation>
         <property>
-          <name>!hadoop.version</name> <!-- if no hadoop.version is set -->
+          <name>hadoop.version</name>
+          <value>!1</value> <!-- if hadoop.version is not 1 (or not set) -->
         </property>
       </activation>
       <properties>


### PR DESCRIPTION
Made the build backward compatible to be able to use -Dhadoop.version=2.