### PR TITLE
AVRO-1956 Workaround incompatibility in testing CSharp code

### DIFF
--- a/lang/csharp/build.sh
+++ b/lang/csharp/build.sh
@@ -30,7 +30,11 @@ case "$1" in
 
   test)
     xbuild
-    nunit-console Avro.nunit
+    if [[ ${INSIDE_AVRO_DOCKER} == 'Yes' ]]; then
+      nunit-console --framework=4.0 Avro.nunit
+    else
+      nunit-console Avro.nunit
+    fi
     ;;
 
   perf)

--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -21,6 +21,8 @@ FROM java:7-jdk
 
 WORKDIR /root
 
+ENV INSIDE_AVRO_DOCKER Yes
+
 # Add the repository for node.js 4.x
 RUN curl -sL https://deb.nodesource.com/setup_4.x | bash -
 


### PR DESCRIPTION
I'm not quite sure this is the right solution direction.
An alternative would be to verify if the 'missing component is installed or not.