### PR TITLE
AVRO-1363 Fix the C# parsing of a union schema 

### DIFF
--- a/lang/csharp/src/apache/main/Schema/NamedSchema.cs
+++ b/lang/csharp/src/apache/main/Schema/NamedSchema.cs
@@ -52,7 +52,7 @@ namespace Avro
         /// <summary>
         /// Namespace.Name of the schema
         /// </summary>
-        public string Fullname
+        public override string Fullname
         {
             get { return SchemaName.Fullname; }
         }

--- a/lang/csharp/src/apache/main/Schema/Schema.cs
+++ b/lang/csharp/src/apache/main/Schema/Schema.cs
@@ -71,11 +71,19 @@ namespace Avro
         }
 
         /// <summary>
+        /// If this is a record, enum or fixed, returns its name, otherwise the name the primitive type. 
+        /// </summary>
+        public abstract string Name { get; }
+        
+        /// <summary>
         /// The name of this schema. If this is a named schema such as an enum, it returns the fully qualified
         /// name for the schema. For other schemas, it returns the type of the schema.
         /// </summary>
-        public abstract string Name { get; }
-
+        public virtual string Fullname 
+        {
+            get { return Name; }
+        }
+        
         /// <summary>
         /// Static class to return new instance of schema object
         /// </summary>

--- a/lang/csharp/src/apache/main/Schema/UnionSchema.cs
+++ b/lang/csharp/src/apache/main/Schema/UnionSchema.cs
@@ -56,7 +56,7 @@ namespace Avro
                 if (null == unionType)
                     throw new SchemaParseException("Invalid JSON in union" + jvalue.ToString());
 
-                string name = unionType.Name;
+                string name = unionType.Fullname;
                 if (uniqueSchemas.ContainsKey(name))
                     throw new SchemaParseException("Duplicate type in union: " + name);
 

--- a/lang/csharp/src/apache/test/Schema/SchemaTests.cs
+++ b/lang/csharp/src/apache/test/Schema/SchemaTests.cs
@@ -69,7 +69,8 @@ namespace Avro.Test
             Description = "No fields", ExpectedException = typeof(SchemaParseException))]
         [TestCase("{\"type\":\"record\",\"name\":\"LongList\", \"fields\": \"hi\"}",
             Description = "Fields not an array", ExpectedException = typeof(SchemaParseException))]
-
+        [TestCase("[{\"type\": \"record\",\"name\": \"Test\",\"namespace\":\"ns1\",\"fields\": [{\"name\": \"f\",\"type\": \"long\"}]}," + 
+                   "{\"type\": \"record\",\"name\": \"Test\",\"namespace\":\"ns2\",\"fields\": [{\"name\": \"f\",\"type\": \"long\"}]}]")]
         // Enum
         [TestCase("{\"type\": \"enum\", \"name\": \"Test\", \"symbols\": [\"A\", \"B\"]}")]
         [TestCase("{\"type\": \"enum\", \"name\": \"Status\", \"symbols\": \"Normal Caution Critical\"}",


### PR DESCRIPTION
 Fix the C# parsing of a union schema that contains  duplicate names but in different namespaces. The full name is now used when parsing the schema. This is identical to my previous pull request on this topic, but I've rebased to apache/master and squashed all the commits to a single commit. 