### PR TITLE
AVRO-1542 replacing auto_ptr by unique_ptr & std::move

### DIFF
--- a/lang/c++/CMakeLists.txt
+++ b/lang/c++/CMakeLists.txt
@@ -37,6 +37,8 @@ set (AVRO_VERSION_MINOR "0")
 
 project (Avro-cpp)
 
+add_definitions(-std=c++11 -fPIC)
+
 if (WIN32 AND NOT CYGWIN AND NOT MSYS)
 add_definitions (/EHa)
 add_definitions (

--- a/lang/c++/api/DataFile.hh
+++ b/lang/c++/api/DataFile.hh
@@ -60,8 +60,8 @@ class AVRO_DECL DataFileWriterBase : boost::noncopyable {
     const size_t syncInterval_;
     Codec codec_;
 
-    std::auto_ptr<OutputStream> stream_;
-    std::auto_ptr<OutputStream> buffer_;
+    std::unique_ptr<OutputStream> stream_;
+    std::unique_ptr<OutputStream> buffer_;
     const DataFileSync sync_;
     int64_t objectCount_;
 
@@ -69,7 +69,7 @@ class AVRO_DECL DataFileWriterBase : boost::noncopyable {
 
     Metadata metadata_;
 
-    static std::auto_ptr<OutputStream> makeStream(const char* filename);
+    static std::unique_ptr<OutputStream> makeStream(const char* filename);
     static DataFileSync makeSync();
 
     void writeHeader();
@@ -127,7 +127,7 @@ public:
  */
 template <typename T>
 class DataFileWriter : boost::noncopyable {
-    std::auto_ptr<DataFileWriterBase> base_;
+    std::unique_ptr<DataFileWriterBase> base_;
 public:
     /**
      * Constructs a new data file.
@@ -167,7 +167,7 @@ public:
  */
 class AVRO_DECL DataFileReaderBase : boost::noncopyable {
     const std::string filename_;
-    const std::auto_ptr<InputStream> stream_;
+    const std::unique_ptr<InputStream> stream_;
     const DecoderPtr decoder_;
     int64_t objectCount_;
     bool eof_;
@@ -176,7 +176,7 @@ class AVRO_DECL DataFileReaderBase : boost::noncopyable {
     ValidSchema readerSchema_;
     ValidSchema dataSchema_;
     DecoderPtr dataDecoder_;
-    std::auto_ptr<InputStream> dataStream_;
+    std::unique_ptr<InputStream> dataStream_;
     typedef std::map<std::string, std::vector<uint8_t> > Metadata;
 
     Metadata metadata_;
@@ -249,7 +249,7 @@ public:
  */
 template <typename T>
 class DataFileReader : boost::noncopyable {
-    std::auto_ptr<DataFileReaderBase> base_;
+    std::unique_ptr<DataFileReaderBase> base_;
 public:
     /**
      * Constructs the reader for the given file and the reader is
@@ -279,7 +279,7 @@ public:
      * The schema present in the data file will be used for reading
      * from this reader.
      */
-    DataFileReader(std::auto_ptr<DataFileReaderBase> base) : base_(base) {
+    DataFileReader(std::unique_ptr<DataFileReaderBase> base) : base_(std::move(base)) {
         base_->init();
     }
 
@@ -292,8 +292,8 @@ public:
      * The argument readerSchema will be used for reading
      * from this reader.
      */
-    DataFileReader(std::auto_ptr<DataFileReaderBase> base,
-        const ValidSchema& readerSchema) : base_(base) {
+    DataFileReader(std::unique_ptr<DataFileReaderBase> base,
+        const ValidSchema& readerSchema) : base_(std::move(base)) {
         base_->init(readerSchema);
     }
 

--- a/lang/c++/api/Stream.hh
+++ b/lang/c++/api/Stream.hh
@@ -122,14 +122,14 @@ public:
 /**
  * Returns a new OutputStream, which grows in memory chunks of specified size.
  */
-AVRO_DECL std::auto_ptr<OutputStream> memoryOutputStream(size_t chunkSize = 4 * 1024);
+AVRO_DECL std::unique_ptr<OutputStream> memoryOutputStream(size_t chunkSize = 4 * 1024);
 
 /**
  * Returns a new InputStream, with the data from the given byte array.
  * It does not copy the data, the byte array should remain valid
  * until the InputStream is used.
  */
-AVRO_DECL std::auto_ptr<InputStream> memoryInputStream(const uint8_t* data, size_t len);
+AVRO_DECL std::unique_ptr<InputStream> memoryInputStream(const uint8_t* data, size_t len);
 
 /**
  * Returns a new InputStream with the contents written into an
@@ -138,7 +138,7 @@ AVRO_DECL std::auto_ptr<InputStream> memoryInputStream(const uint8_t* data, size
  * input stream are the snapshot of the outputstream. One can construct
  * any number of memory input stream from a single memory output stream.
  */
-AVRO_DECL std::auto_ptr<InputStream> memoryInputStream(const OutputStream& source);
+AVRO_DECL std::unique_ptr<InputStream> memoryInputStream(const OutputStream& source);
 
 /**
  * Returns the contents written so far into the output stream, which should
@@ -154,14 +154,14 @@ AVRO_DECL boost::shared_ptr<std::vector<uint8_t> > snapshot(const OutputStream& 
  * If there is a file with the given name, it is truncated and overwritten.
  * If there is no file with the given name, it is created.
  */
-AVRO_DECL std::auto_ptr<OutputStream> fileOutputStream(const char* filename,
+AVRO_DECL std::unique_ptr<OutputStream> fileOutputStream(const char* filename,
     size_t bufferSize = 8 * 1024);
 
 /**
  * Returns a new InputStream whose contents come from the given file.
  * Data is read in chunks of given buffer size.
  */
-AVRO_DECL std::auto_ptr<InputStream> fileInputStream(const char* filename,
+AVRO_DECL std::unique_ptr<InputStream> fileInputStream(const char* filename,
     size_t bufferSize = 8 * 1024);
 
 /**
@@ -169,7 +169,7 @@ AVRO_DECL std::auto_ptr<InputStream> fileInputStream(const char* filename,
  * std::ostream. The std::ostream object should outlive the returned
  * OutputStream.
  */
-AVRO_DECL std::auto_ptr<OutputStream> ostreamOutputStream(std::ostream& os,
+AVRO_DECL std::unique_ptr<OutputStream> ostreamOutputStream(std::ostream& os,
     size_t bufferSize = 8 * 1024);
 
 /**
@@ -177,7 +177,7 @@ AVRO_DECL std::auto_ptr<OutputStream> ostreamOutputStream(std::ostream& os,
  * std::istream. The std::istream object should outlive the returned
  * InputStream.
  */
-AVRO_DECL std::auto_ptr<InputStream> istreamInputStream(std::istream& in,
+AVRO_DECL std::unique_ptr<InputStream> istreamInputStream(std::istream& in,
     size_t bufferSize = 8 * 1024);
 
 /** A convenience class for reading from an InputStream */

--- a/lang/c++/examples/custom.cc
+++ b/lang/c++/examples/custom.cc
@@ -42,13 +42,13 @@ struct codec_traits<std::complex<T> > {
 int
 main()
 {
-    std::auto_ptr<avro::OutputStream> out = avro::memoryOutputStream();
+    std::unique_ptr<avro::OutputStream> out = avro::memoryOutputStream();
     avro::EncoderPtr e = avro::binaryEncoder();
     e->init(*out);
     std::complex<double> c1(1.0, 2.0);
     avro::encode(*e, c1);
 
-    std::auto_ptr<avro::InputStream> in = avro::memoryInputStream(*out);
+    std::unique_ptr<avro::InputStream> in = avro::memoryInputStream(*out);
     avro::DecoderPtr d = avro::binaryDecoder();
     d->init(*in);
 

--- a/lang/c++/examples/generated.cc
+++ b/lang/c++/examples/generated.cc
@@ -24,7 +24,7 @@
 int
 main()
 {
-    std::auto_ptr<avro::OutputStream> out = avro::memoryOutputStream();
+    std::unique_ptr<avro::OutputStream> out = avro::memoryOutputStream();
     avro::EncoderPtr e = avro::binaryEncoder();
     e->init(*out);
     c::cpx c1;
@@ -32,7 +32,7 @@ main()
     c1.im = 2.13;
     avro::encode(*e, c1);
 
-    std::auto_ptr<avro::InputStream> in = avro::memoryInputStream(*out);
+    std::unique_ptr<avro::InputStream> in = avro::memoryInputStream(*out);
     avro::DecoderPtr d = avro::binaryDecoder();
     d->init(*in);
 

--- a/lang/c++/examples/generic.cc
+++ b/lang/c++/examples/generic.cc
@@ -35,7 +35,7 @@ main()
     avro::ValidSchema cpxSchema;
     avro::compileJsonSchema(ifs, cpxSchema);
 
-    std::auto_ptr<avro::OutputStream> out = avro::memoryOutputStream();
+    std::unique_ptr<avro::OutputStream> out = avro::memoryOutputStream();
     avro::EncoderPtr e = avro::binaryEncoder();
     e->init(*out);
     c::cpx c1;
@@ -43,7 +43,7 @@ main()
     c1.im = 105.77;
     avro::encode(*e, c1);
 
-    std::auto_ptr<avro::InputStream> in = avro::memoryInputStream(*out);
+    std::unique_ptr<avro::InputStream> in = avro::memoryInputStream(*out);
     avro::DecoderPtr d = avro::binaryDecoder();
     d->init(*in);
 

--- a/lang/c++/examples/resolving.cc
+++ b/lang/c++/examples/resolving.cc
@@ -43,7 +43,7 @@ main()
     avro::ValidSchema cpxSchema = load("cpx.json");
     avro::ValidSchema imaginarySchema = load("imaginary.json");
 
-    std::auto_ptr<avro::OutputStream> out = avro::memoryOutputStream();
+    std::unique_ptr<avro::OutputStream> out = avro::memoryOutputStream();
     avro::EncoderPtr e = avro::binaryEncoder();
     e->init(*out);
     c::cpx c1;
@@ -51,7 +51,7 @@ main()
     c1.im = 105.77;
     avro::encode(*e, c1);
 
-    std::auto_ptr<avro::InputStream> in = avro::memoryInputStream(*out);
+    std::unique_ptr<avro::InputStream> in = avro::memoryInputStream(*out);
     avro::DecoderPtr d = avro::resolvingDecoder(cpxSchema, imaginarySchema,
         avro::binaryDecoder());
     d->init(*in);

--- a/lang/c++/examples/validating.cc
+++ b/lang/c++/examples/validating.cc
@@ -49,14 +49,14 @@ main()
     avro::ValidSchema cpxSchema;
     avro::compileJsonSchema(ifs, cpxSchema);
 
-    std::auto_ptr<avro::OutputStream> out = avro::memoryOutputStream();
+    std::unique_ptr<avro::OutputStream> out = avro::memoryOutputStream();
     avro::EncoderPtr e = avro::validatingEncoder(cpxSchema,
         avro::binaryEncoder());
     e->init(*out);
     std::complex<double> c1(1.0, 2.0);
     avro::encode(*e, c1);
 
-    std::auto_ptr<avro::InputStream> in = avro::memoryInputStream(*out);
+    std::unique_ptr<avro::InputStream> in = avro::memoryInputStream(*out);
     avro::DecoderPtr d = avro::validatingDecoder(cpxSchema,
         avro::binaryDecoder());
     d->init(*in);

--- a/lang/c++/impl/Compiler.cc
+++ b/lang/c++/impl/Compiler.cc
@@ -481,7 +481,7 @@ AVRO_DECL ValidSchema compileJsonSchemaFromStream(InputStream& is)
 
 AVRO_DECL ValidSchema compileJsonSchemaFromFile(const char* filename)
 {
-    std::auto_ptr<InputStream> s = fileInputStream(filename);
+    std::unique_ptr<InputStream> s = fileInputStream(filename);
     return compileJsonSchemaFromStream(*s);
 }
 
@@ -504,7 +504,7 @@ AVRO_DECL ValidSchema compileJsonSchemaFromString(const std::string& input)
 
 static ValidSchema compile(std::istream& is)
 {
-    std::auto_ptr<InputStream> in = istreamInputStream(is);
+    std::unique_ptr<InputStream> in = istreamInputStream(is);
     return compileJsonSchemaFromStream(*in);
 }
 

--- a/lang/c++/impl/DataFile.cc
+++ b/lang/c++/impl/DataFile.cc
@@ -28,7 +28,7 @@
 #include <boost/iostreams/filter/zlib.hpp>
 
 namespace avro {
-using std::auto_ptr;
+using std::unique_ptr;
 using std::ostringstream;
 using std::istringstream;
 using std::vector;
@@ -69,7 +69,7 @@ DataFileWriterBase::DataFileWriterBase(const char* filename,
     syncInterval_(syncInterval),
     codec_(codec),
     stream_(fileOutputStream(filename)),
-    buffer_(memoryOutputStream()),
+    buffer_(std::move(memoryOutputStream())),
     sync_(makeSync()), objectCount_(0)
 {
     if (syncInterval < minSyncInterval || syncInterval > maxSyncInterval) {
@@ -115,7 +115,7 @@ void DataFileWriterBase::sync()
         int64_t byteCount = buffer_->byteCount();
         avro::encode(*encoderPtr_, byteCount);
         encoderPtr_->flush();
-        std::auto_ptr<InputStream> in = memoryInputStream(*buffer_);
+        std::unique_ptr<InputStream> in = memoryInputStream(*buffer_);
         copy(*in, *stream_);
     } else {
         std::vector<char> buf;
@@ -128,12 +128,12 @@ void DataFileWriterBase::sync()
             const uint8_t* data;
             size_t len;
 
-            std::auto_ptr<InputStream> input = memoryInputStream(*buffer_);
+            std::unique_ptr<InputStream> input = memoryInputStream(*buffer_);
             while (input->next(&data, &len)) {
                 boost::iostreams::write(os, reinterpret_cast<const char*>(data), len);
             }
         } // make sure all is flushed
-        std::auto_ptr<InputStream> in = memoryInputStream(
+        std::unique_ptr<InputStream> in = memoryInputStream(
            reinterpret_cast<const uint8_t*>(&buf[0]), buf.size());
         int64_t byteCount = buf.size();
         avro::encode(*encoderPtr_, byteCount);
@@ -146,7 +146,7 @@ void DataFileWriterBase::sync()
     encoderPtr_->flush();
 
 
-    buffer_ = memoryOutputStream();
+    buffer_ = std::move(memoryOutputStream());
     encoderPtr_->init(*buffer_);
     objectCount_ = 0;
 }
@@ -296,9 +296,9 @@ public:
         in_(in), limit_(limit) { }
 };
 
-auto_ptr<InputStream> boundedInputStream(InputStream& in, size_t limit)
+unique_ptr<InputStream> boundedInputStream(InputStream& in, size_t limit)
 {
-    return auto_ptr<InputStream>(new BoundedInputStream(in, limit));
+    return unique_ptr<InputStream>(new BoundedInputStream(in, limit));
 }
 
 bool DataFileReaderBase::readDataBlock()
@@ -316,10 +316,10 @@ bool DataFileReaderBase::readDataBlock()
     avro::decode(*decoder_, byteCount);
     decoder_->init(*stream_);
 
-    auto_ptr<InputStream> st = boundedInputStream(*stream_, static_cast<size_t>(byteCount));
+    unique_ptr<InputStream> st = boundedInputStream(*stream_, static_cast<size_t>(byteCount));
     if (codec_ == NULL_CODEC) {
         dataDecoder_->init(*st);
-        dataStream_ = st;
+        dataStream_ = std::move(st);
     } else {
         compressed_.clear();
         const uint8_t* data;
@@ -337,9 +337,9 @@ bool DataFileReaderBase::readDataBlock()
         os_->push(boost::iostreams::basic_array_source<char>(
             &compressed_[0], compressed_.size()));
 
-        std::auto_ptr<InputStream> in = istreamInputStream(*os_);
+        std::unique_ptr<InputStream> in = istreamInputStream(*os_);
         dataDecoder_->init(*in);
-        dataStream_ = in;
+        dataStream_ = std::move(in);
     }
     return true;
 }

--- a/lang/c++/impl/FileStream.cc
+++ b/lang/c++/impl/FileStream.cc
@@ -34,7 +34,7 @@
 #endif
 #endif
 
-using std::auto_ptr;
+using std::unique_ptr;
 using std::istream;
 using std::ostream;
 
@@ -138,7 +138,7 @@ struct IStreamBufferCopyIn : public BufferCopyIn {
 class BufferCopyInInputStream : public InputStream {
     const size_t bufferSize_;
     uint8_t* const buffer_;
-    auto_ptr<BufferCopyIn> in_;
+    unique_ptr<BufferCopyIn> in_;
     size_t byteCount_;
     uint8_t* next_;
     size_t available_;
@@ -190,10 +190,10 @@ class BufferCopyInInputStream : public InputStream {
 
 
 public:
-    BufferCopyInInputStream(auto_ptr<BufferCopyIn>& in, size_t bufferSize) :
+    BufferCopyInInputStream(unique_ptr<BufferCopyIn> in, size_t bufferSize) :
         bufferSize_(bufferSize),
         buffer_(new uint8_t[bufferSize]),
-        in_(in),
+        in_(std::move(in)),
         byteCount_(0),
         next_(buffer_),
         available_(0) { }
@@ -276,7 +276,7 @@ struct OStreamBufferCopyOut : public BufferCopyOut {
 class BufferCopyOutputStream : public OutputStream {
     size_t bufferSize_;
     uint8_t* const buffer_;
-    auto_ptr<BufferCopyOut> out_;
+    unique_ptr<BufferCopyOut> out_;
     uint8_t* next_;
     size_t available_;
     size_t byteCount_;
@@ -311,10 +311,10 @@ class BufferCopyOutputStream : public OutputStream {
     }
 
 public:
-    BufferCopyOutputStream(auto_ptr<BufferCopyOut> out, size_t bufferSize) :
+    BufferCopyOutputStream(unique_ptr<BufferCopyOut> out, size_t bufferSize) :
         bufferSize_(bufferSize),
         buffer_(new uint8_t[bufferSize]),
-        out_(out),
+        out_(std::move(out)),
         next_(buffer_),
         available_(bufferSize_), byteCount_(0) { }
 
@@ -323,32 +323,32 @@ public:
     }
 };
 
-auto_ptr<InputStream> fileInputStream(const char* filename,
+unique_ptr<InputStream> fileInputStream(const char* filename,
     size_t bufferSize)
 {
-    auto_ptr<BufferCopyIn> in(new FileBufferCopyIn(filename));
-    return auto_ptr<InputStream>( new BufferCopyInInputStream(in, bufferSize));
+    unique_ptr<BufferCopyIn> in(new FileBufferCopyIn(filename));
+    return unique_ptr<InputStream>( new BufferCopyInInputStream(std::move(in), bufferSize));
 }
 
-auto_ptr<InputStream> istreamInputStream(istream& is,
+unique_ptr<InputStream> istreamInputStream(istream& is,
     size_t bufferSize)
 {
-    auto_ptr<BufferCopyIn> in(new IStreamBufferCopyIn(is));
-    return auto_ptr<InputStream>( new BufferCopyInInputStream(in, bufferSize));
+    unique_ptr<BufferCopyIn> in(new IStreamBufferCopyIn(is));
+    return unique_ptr<InputStream>( new BufferCopyInInputStream(std::move(in), bufferSize));
 }
 
-auto_ptr<OutputStream> fileOutputStream(const char* filename,
+unique_ptr<OutputStream> fileOutputStream(const char* filename,
     size_t bufferSize)
 {
-    auto_ptr<BufferCopyOut> out(new FileBufferCopyOut(filename));
-    return auto_ptr<OutputStream>(new BufferCopyOutputStream(out, bufferSize));
+    unique_ptr<BufferCopyOut> out(new FileBufferCopyOut(filename));
+    return unique_ptr<OutputStream>(new BufferCopyOutputStream(std::move(out), bufferSize));
 }
 
-auto_ptr<OutputStream> ostreamOutputStream(ostream& os,
+unique_ptr<OutputStream> ostreamOutputStream(ostream& os,
     size_t bufferSize)
 {
-    auto_ptr<BufferCopyOut> out(new OStreamBufferCopyOut(os));
-    return auto_ptr<OutputStream>(new BufferCopyOutputStream(out, bufferSize));
+    unique_ptr<BufferCopyOut> out(new OStreamBufferCopyOut(os));
+    return unique_ptr<OutputStream>(new BufferCopyOutputStream(std::move(out), bufferSize));
 }
 
 

--- a/lang/c++/impl/Stream.cc
+++ b/lang/c++/impl/Stream.cc
@@ -157,23 +157,23 @@ public:
     void flush() { }
 };
 
-std::auto_ptr<OutputStream> memoryOutputStream(size_t chunkSize)
+std::unique_ptr<OutputStream> memoryOutputStream(size_t chunkSize)
 {
-    return std::auto_ptr<OutputStream>(new MemoryOutputStream(chunkSize));
+    return std::unique_ptr<OutputStream>(new MemoryOutputStream(chunkSize));
 }
 
-std::auto_ptr<InputStream> memoryInputStream(const uint8_t* data, size_t len)
+std::unique_ptr<InputStream> memoryInputStream(const uint8_t* data, size_t len)
 {
-    return std::auto_ptr<InputStream>(new MemoryInputStream2(data, len));
+    return std::unique_ptr<InputStream>(new MemoryInputStream2(data, len));
 }
 
-std::auto_ptr<InputStream> memoryInputStream(const OutputStream& source)
+std::unique_ptr<InputStream> memoryInputStream(const OutputStream& source)
 {
     const MemoryOutputStream& mos =
         dynamic_cast<const MemoryOutputStream&>(source);
     return (mos.data_.empty()) ?
-        std::auto_ptr<InputStream>(new MemoryInputStream2(0, 0)) :
-        std::auto_ptr<InputStream>(new MemoryInputStream(mos.data_,
+        std::unique_ptr<InputStream>(new MemoryInputStream2(0, 0)) :
+        std::unique_ptr<InputStream>(new MemoryInputStream(mos.data_,
             mos.chunkSize_,
             (mos.chunkSize_ - mos.available_)));
 }

--- a/lang/c++/impl/json/JsonDom.cc
+++ b/lang/c++/impl/json/JsonDom.cc
@@ -106,7 +106,7 @@ Entity loadEntity(InputStream& in)
 
 Entity loadEntity(const uint8_t* text, size_t len)
 {
-    std::auto_ptr<InputStream> in = memoryInputStream(text, len);
+    std::unique_ptr<InputStream> in = memoryInputStream(text, len);
     return loadEntity(*in);
 }
 
@@ -165,12 +165,12 @@ void Entity::ensureType(EntityType type) const
 
 std::string Entity::toString() const
 {
-    std::auto_ptr<OutputStream> out = memoryOutputStream();
+    std::unique_ptr<OutputStream> out = memoryOutputStream();
     JsonGenerator<JsonNullFormatter> g;
     g.init(*out);
     writeEntity(g, *this);
     g.flush();
-    std::auto_ptr<InputStream> in = memoryInputStream(*out);
+    std::unique_ptr<InputStream> in = memoryInputStream(*out);
     const uint8_t *p = 0;
     size_t n = 0;
     size_t c = 0;
@@ -180,7 +180,7 @@ std::string Entity::toString() const
     std::string result;
     result.resize(c);
     c = 0;
-    std::auto_ptr<InputStream> in2 = memoryInputStream(*out);
+    std::unique_ptr<InputStream> in2 = memoryInputStream(*out);
     while (in2->next(&p, &n)) {
         ::memcpy(&result[c], p, n);
         c += n;

--- a/lang/c++/impl/parsing/ResolvingDecoder.cc
+++ b/lang/c++/impl/parsing/ResolvingDecoder.cc
@@ -49,7 +49,7 @@ using boost::shared_ptr;
 using boost::static_pointer_cast;
 using boost::make_shared;
 
-using std::auto_ptr;
+using std::unique_ptr;
 using std::map;
 using std::pair;
 using std::vector;
@@ -156,7 +156,7 @@ static shared_ptr<vector<uint8_t> > getAvroBinary(
     const GenericDatum& defaultValue)
 {
     EncoderPtr e = binaryEncoder();
-    auto_ptr<OutputStream> os = memoryOutputStream();
+    unique_ptr<OutputStream> os = memoryOutputStream();
     e->init(*os);
     GenericWriter::write(*e, defaultValue);
     e->flush();
@@ -447,7 +447,7 @@ ProductionPtr ResolvingGrammarGenerator::doGenerate2(
 
 class ResolvingDecoderHandler {
     shared_ptr<vector<uint8_t> > defaultData_;
-    auto_ptr<InputStream> inp_;
+    unique_ptr<InputStream> inp_;
     DecoderPtr backup_;
     DecoderPtr& base_;
     const DecoderPtr binDecoder;

--- a/lang/c++/test/AvrogencppTests.cc
+++ b/lang/c++/test/AvrogencppTests.cc
@@ -41,7 +41,7 @@
 #endif
 
 
-using std::auto_ptr;
+using std::unique_ptr;
 using std::map;
 using std::string;
 using std::vector;
@@ -143,7 +143,7 @@ void testEncoding()
     ValidSchema s;
     ifstream ifs("jsonschemas/bigrecord");
     compileJsonSchema(ifs, s);
-    auto_ptr<OutputStream> os = memoryOutputStream();
+    unique_ptr<OutputStream> os = memoryOutputStream();
     EncoderPtr e = validatingEncoder(s, binaryEncoder());
     e->init(*os);
     testgen::RootRecord t1;
@@ -152,7 +152,7 @@ void testEncoding()
     e->flush();
 
     DecoderPtr d = validatingDecoder(s, binaryDecoder());
-    auto_ptr<InputStream> is = memoryInputStream(*os);
+    unique_ptr<InputStream> is = memoryInputStream(*os);
     d->init(*is);
     testgen::RootRecord t2;
     avro::decode(*d, t2);
@@ -165,7 +165,7 @@ void testResolution()
     ValidSchema s_w;
     ifstream ifs_w("jsonschemas/bigrecord");
     compileJsonSchema(ifs_w, s_w);
-    auto_ptr<OutputStream> os = memoryOutputStream();
+    unique_ptr<OutputStream> os = memoryOutputStream();
     EncoderPtr e = validatingEncoder(s_w, binaryEncoder());
     e->init(*os);
     testgen::RootRecord t1;
@@ -177,7 +177,7 @@ void testResolution()
     ifstream ifs_r("jsonschemas/bigrecord_r");
     compileJsonSchema(ifs_r, s_r);
     DecoderPtr dd = binaryDecoder();
-    auto_ptr<InputStream> is = memoryInputStream(*os);
+    unique_ptr<InputStream> is = memoryInputStream(*os);
     dd->init(*is);
     DecoderPtr rd = resolvingDecoder(s_w, s_r, dd);
     testgen_r::RootRecord t2;
@@ -187,7 +187,7 @@ void testResolution()
     checkDefaultValues(t2);
 
     //Re-use the resolving decoder to decode again.
-    auto_ptr<InputStream> is1 = memoryInputStream(*os);
+    unique_ptr<InputStream> is1 = memoryInputStream(*os);
     rd->init(*is1);
     testgen_r::RootRecord t3;
     avro::decode(*rd, t3);
@@ -246,7 +246,7 @@ void testEncoding2()
     ifstream ifs(schemaFilename<T>::value);
     compileJsonSchema(ifs, s);
 
-    auto_ptr<OutputStream> os = memoryOutputStream();
+    unique_ptr<OutputStream> os = memoryOutputStream();
     EncoderPtr e = validatingEncoder(s, binaryEncoder());
     e->init(*os);
     T t1;
@@ -255,7 +255,7 @@ void testEncoding2()
     e->flush();
 
     DecoderPtr d = validatingDecoder(s, binaryDecoder());
-    auto_ptr<InputStream> is = memoryInputStream(*os);
+    unique_ptr<InputStream> is = memoryInputStream(*os);
     d->init(*is);
     T t2;
     avro::decode(*d, t2);

--- a/lang/c++/test/CodecTests.cc
+++ b/lang/c++/test/CodecTests.cc
@@ -43,7 +43,7 @@ namespace avro {
 /*
 void dump(const OutputStream& os)
 {
-    std::auto_ptr<InputStream> in = memoryInputStream(os);
+    std::unique_ptr<InputStream> in = memoryInputStream(os);
     const char *b;
     size_t n;
     std::cout << os.byteCount() << std::endl;
@@ -91,7 +91,7 @@ using std::istringstream;
 using std::ostringstream;
 using std::back_inserter;
 using std::copy;
-using std::auto_ptr;
+using std::unique_ptr;
 
 template <typename T>
 T from_string(const std::string& s)
@@ -230,12 +230,12 @@ static vector<string> randomValues(const char* calls)
     return result;
 }
 
-static auto_ptr<OutputStream> generate(Encoder& e, const char* calls,
+static unique_ptr<OutputStream> generate(Encoder& e, const char* calls,
     const vector<string>& values)
 {
     Scanner sc(calls);
     vector<string>::const_iterator it = values.begin();
-    auto_ptr<OutputStream> ob = memoryOutputStream();
+    unique_ptr<OutputStream> ob = memoryOutputStream();
     e.init(*ob);
 
     while (! sc.isDone()) {
@@ -537,7 +537,7 @@ ValidSchema makeValidSchema(const char* schema)
 }
 
 void testEncoder(const EncoderPtr& e, const char* writerCalls,
-    vector<string>& v, auto_ptr<OutputStream>& p)
+    vector<string>& v, unique_ptr<OutputStream>& p)
 {
     v = randomValues(writerCalls);
     p = generate(*e, writerCalls, v);
@@ -615,7 +615,7 @@ void testCodec(const TestData& td) {
 
     for (unsigned int i = 0; i < count; ++i) {
         vector<string> v;
-        auto_ptr<OutputStream> p;
+        unique_ptr<OutputStream> p;
         testEncoder(CodecFactory::newEncoder(vs), td.calls, v, p);
         // dump(*p);
 
@@ -631,7 +631,7 @@ void testCodec(const TestData& td) {
                 << " schema: " << td.schema
                 << " calls: " << td.calls
                 << " skip-level: " << skipLevel);
-            auto_ptr<InputStream> in = memoryInputStream(*p);
+            unique_ptr<InputStream> in = memoryInputStream(*p);
             testDecoder(CodecFactory::newDecoder(vs), v, *in,
                 td.calls, skipLevel);
         }
@@ -653,7 +653,7 @@ void testCodecResolving(const TestData3& td) {
 
     for (unsigned int i = 0; i < count; ++i) {
         vector<string> v;
-        auto_ptr<OutputStream> p;
+        unique_ptr<OutputStream> p;
         testEncoder(CodecFactory::newEncoder(vs), td.writerCalls, v, p);
         // dump(*p);
 
@@ -666,7 +666,7 @@ void testCodecResolving(const TestData3& td) {
                 << " reader schema: " << td.readerSchema
                 << " reader calls: " << td.readerCalls
                 << " skip-level: " << skipLevel);
-            auto_ptr<InputStream> in = memoryInputStream(*p);
+            unique_ptr<InputStream> in = memoryInputStream(*p);
             testDecoder(CodecFactory::newDecoder(vs, rvs), v, *in,
                 td.readerCalls, skipLevel);
         }
@@ -696,7 +696,7 @@ void testCodecResolving2(const TestData4& td) {
     ValidSchema vs = makeValidSchema(td.writerSchema);
 
     vector<string> wd = mkValues(td.writerValues);
-    auto_ptr<OutputStream> p =
+    unique_ptr<OutputStream> p =
         generate(*CodecFactory::newEncoder(vs), td.writerCalls, wd);
     // dump(*p);
 
@@ -710,7 +710,7 @@ void testCodecResolving2(const TestData4& td) {
             << " reader schema: " << td.readerSchema
             << " reader calls: " << td.readerCalls
             << " skip-level: " << skipLevel);
-        auto_ptr<InputStream> in = memoryInputStream(*p);
+        unique_ptr<InputStream> in = memoryInputStream(*p);
         testDecoder(CodecFactory::newDecoder(vs, rvs), rd, *in,
             td.readerCalls, skipLevel);
     }
@@ -728,9 +728,9 @@ void testReaderFail(const TestData2& td) {
     ValidSchema vs = makeValidSchema(td.schema);
 
     vector<string> v;
-    auto_ptr<OutputStream> p;
+    unique_ptr<OutputStream> p;
     testEncoder(CodecFactory::newEncoder(vs), td.correctCalls, v, p);
-    auto_ptr<InputStream> in = memoryInputStream(*p);
+    unique_ptr<InputStream> in = memoryInputStream(*p);
     BOOST_CHECK_THROW(
         testDecoder(CodecFactory::newDecoder(vs), v, *in,
             td.incorrectCalls, td.depth), Exception);
@@ -746,7 +746,7 @@ void testWriterFail(const TestData2& td) {
     ValidSchema vs = makeValidSchema(td.schema);
 
     vector<string> v;
-    auto_ptr<OutputStream> p;
+    unique_ptr<OutputStream> p;
     BOOST_CHECK_THROW(testEncoder(CodecFactory::newEncoder(vs),
         td.incorrectCalls, v, p), Exception);
 }
@@ -763,17 +763,17 @@ void testGeneric(const TestData& td) {
 
     for (unsigned int i = 0; i < count; ++i) {
         vector<string> v;
-        auto_ptr<OutputStream> p;
+        unique_ptr<OutputStream> p;
         testEncoder(CodecFactory::newEncoder(vs), td.calls, v, p);
         // dump(*p);
         DecoderPtr d1 = CodecFactory::newDecoder(vs);
-        auto_ptr<InputStream> in1 = memoryInputStream(*p);
+        unique_ptr<InputStream> in1 = memoryInputStream(*p);
         d1->init(*in1);
         GenericDatum datum(vs);
         avro::decode(*d1, datum);
 
         EncoderPtr e2 = CodecFactory::newEncoder(vs);
-        auto_ptr<OutputStream> ob = memoryOutputStream();
+        unique_ptr<OutputStream> ob = memoryOutputStream();
         e2->init(*ob);
 
         avro::encode(*e2, datum);
@@ -782,7 +782,7 @@ void testGeneric(const TestData& td) {
         BOOST_TEST_CHECKPOINT("Test: " << testNo << ' '
             << " schema: " << td.schema
             << " calls: " << td.calls);
-        auto_ptr<InputStream> in2 = memoryInputStream(*ob);
+        unique_ptr<InputStream> in2 = memoryInputStream(*ob);
         testDecoder(CodecFactory::newDecoder(vs), v, *in2,
             td.calls, td.depth);
     }
@@ -804,11 +804,11 @@ void testGenericResolving(const TestData3& td) {
 
     for (unsigned int i = 0; i < count; ++i) {
         vector<string> v;
-        auto_ptr<OutputStream> p;
+        unique_ptr<OutputStream> p;
         testEncoder(CodecFactory::newEncoder(wvs), td.writerCalls, v, p);
         // dump(*p);
         DecoderPtr d1 = CodecFactory::newDecoder(wvs);
-        auto_ptr<InputStream> in1 = memoryInputStream(*p);
+        unique_ptr<InputStream> in1 = memoryInputStream(*p);
         d1->init(*in1);
 
         GenericReader gr(wvs, rvs, d1);
@@ -816,7 +816,7 @@ void testGenericResolving(const TestData3& td) {
         gr.read(datum);
 
         EncoderPtr e2 = CodecFactory::newEncoder(rvs);
-        auto_ptr<OutputStream> ob = memoryOutputStream();
+        unique_ptr<OutputStream> ob = memoryOutputStream();
         e2->init(*ob);
         avro::encode(*e2, datum);
         e2->flush();
@@ -826,7 +826,7 @@ void testGenericResolving(const TestData3& td) {
             << " writer-calls: " << td.writerCalls 
             << " reader-schema: " << td.readerSchema
             << " calls: " << td.readerCalls);
-        auto_ptr<InputStream> in2 = memoryInputStream(*ob);
+        unique_ptr<InputStream> in2 = memoryInputStream(*ob);
         testDecoder(CodecFactory::newDecoder(rvs), v, *in2,
             td.readerCalls, td.depth);
     }
@@ -848,11 +848,11 @@ void testGenericResolving2(const TestData4& td) {
 
     const vector<string> wd = mkValues(td.writerValues);
 
-    auto_ptr<OutputStream> p = generate(*CodecFactory::newEncoder(wvs),
+    unique_ptr<OutputStream> p = generate(*CodecFactory::newEncoder(wvs),
         td.writerCalls, wd);
     // dump(*p);
     DecoderPtr d1 = CodecFactory::newDecoder(wvs);
-    auto_ptr<InputStream> in1 = memoryInputStream(*p);
+    unique_ptr<InputStream> in1 = memoryInputStream(*p);
     d1->init(*in1);
 
     GenericReader gr(wvs, rvs, d1);
@@ -860,7 +860,7 @@ void testGenericResolving2(const TestData4& td) {
     gr.read(datum);
 
     EncoderPtr e2 = CodecFactory::newEncoder(rvs);
-    auto_ptr<OutputStream> ob = memoryOutputStream();
+    unique_ptr<OutputStream> ob = memoryOutputStream();
     e2->init(*ob);
     avro::encode(*e2, datum);
     e2->flush();
@@ -1446,7 +1446,7 @@ static void testStreamLifetimes()
 {
     EncoderPtr e = binaryEncoder();
     {
-        std::auto_ptr<OutputStream> s1 = memoryOutputStream();
+        std::unique_ptr<OutputStream> s1 = memoryOutputStream();
         e->init(*s1);
         e->encodeInt(100);
         e->encodeDouble(4.73);
@@ -1454,7 +1454,7 @@ static void testStreamLifetimes()
     }
 
     {
-        std::auto_ptr<OutputStream> s2 = memoryOutputStream();
+        std::unique_ptr<OutputStream> s2 = memoryOutputStream();
         e->init(*s2);
         e->encodeDouble(3.14);
         e->flush();
@@ -1464,7 +1464,7 @@ static void testStreamLifetimes()
 
 static void testLimits(const EncoderPtr& e, const DecoderPtr& d)
 {
-    std::auto_ptr<OutputStream> s1 = memoryOutputStream();
+    std::unique_ptr<OutputStream> s1 = memoryOutputStream();
     {
         e->init(*s1);
         e->encodeDouble(std::numeric_limits<double>::infinity());
@@ -1477,7 +1477,7 @@ static void testLimits(const EncoderPtr& e, const DecoderPtr& d)
     }
 
     {
-        std::auto_ptr<InputStream> s2 = memoryInputStream(*s1);
+        std::unique_ptr<InputStream> s2 = memoryInputStream(*s1);
         d->init(*s2);
         BOOST_CHECK_EQUAL(d->decodeDouble(),
             std::numeric_limits<double>::infinity());

--- a/lang/c++/test/DataFileTests.cc
+++ b/lang/c++/test/DataFileTests.cc
@@ -27,7 +27,7 @@
 #include "Stream.hh"
 #include "Compiler.hh"
 
-using std::auto_ptr;
+using std::unique_ptr;
 using std::string;
 using std::pair;
 using std::vector;
@@ -360,9 +360,9 @@ public:
      * Constructs the DataFileReader in two steps.
      */
     void testReadDoubleTwoStep() {
-        auto_ptr<avro::DataFileReaderBase>
+        unique_ptr<avro::DataFileReaderBase>
             base(new avro::DataFileReaderBase(filename));
-        avro::DataFileReader<ComplexDouble> df(base);
+        avro::DataFileReader<ComplexDouble> df(std::move(base));
         BOOST_CHECK_EQUAL(toString(writerSchema), toString(df.readerSchema()));
         BOOST_CHECK_EQUAL(toString(writerSchema), toString(df.dataSchema()));
         int i = 0;
@@ -384,9 +384,9 @@ public:
      * reader schema.
      */
     void testReadDoubleTwoStepProject() {
-        auto_ptr<avro::DataFileReaderBase>
+        unique_ptr<avro::DataFileReaderBase>
             base(new avro::DataFileReaderBase(filename));
-        avro::DataFileReader<Double> df(base, readerSchema);
+        avro::DataFileReader<Double> df(std::move(base), readerSchema);
 
         BOOST_CHECK_EQUAL(toString(readerSchema), toString(df.readerSchema()));
         BOOST_CHECK_EQUAL(toString(writerSchema), toString(df.dataSchema()));

--- a/lang/c++/test/SpecificTests.cc
+++ b/lang/c++/test/SpecificTests.cc
@@ -22,7 +22,7 @@
 #include "Specific.hh"
 #include "Stream.hh"
 
-using std::auto_ptr;
+using std::unique_ptr;
 using std::string;
 using std::vector;
 using std::map;
@@ -61,7 +61,7 @@ template <> struct codec_traits<C> {
 namespace specific {
 
 class Test {
-    auto_ptr<OutputStream> os;
+    unique_ptr<OutputStream> os;
     EncoderPtr e;
     DecoderPtr d;
 public:
@@ -75,7 +75,7 @@ public:
     }
 
     template <typename T> void decode(T& t) {
-        auto_ptr<InputStream> is = memoryInputStream(*os);
+        unique_ptr<InputStream> is = memoryInputStream(*os);
         d->init(*is);
         avro::decode(*d, t);
     }

--- a/lang/c++/test/StreamTests.cc
+++ b/lang/c++/test/StreamTests.cc
@@ -105,18 +105,18 @@ struct Verify2 {
 
 template <typename V>
 void testEmpty_memoryStream() {
-    std::auto_ptr<OutputStream> os = memoryOutputStream();
-    std::auto_ptr<InputStream> is = memoryInputStream(*os);
+    std::unique_ptr<OutputStream> os = memoryOutputStream();
+    std::unique_ptr<InputStream> is = memoryInputStream(*os);
     V()(*is);
 }
 
 template <typename F, typename V>
 void testNonEmpty_memoryStream(const TestData& td)
 {
-    std::auto_ptr<OutputStream> os = memoryOutputStream(td.chunkSize);
+    std::unique_ptr<OutputStream> os = memoryOutputStream(td.chunkSize);
     F()(*os, td.dataSize);
 
-    std::auto_ptr<InputStream> is = memoryInputStream(*os);
+    std::unique_ptr<InputStream> is = memoryInputStream(*os);
     V()(*is, td.dataSize);
 }
 
@@ -127,7 +127,7 @@ void testNonEmpty2(const TestData& td) {
     }
 
     uint8_t v2 = 0;
-    std::auto_ptr<InputStream> is = memoryInputStream(v.empty() ? &v2 : &v[0], v.size());
+    std::unique_ptr<InputStream> is = memoryInputStream(v.empty() ? &v2 : &v[0], v.size());
     Verify1()(*is, td.dataSize);
 }
 
@@ -143,9 +143,9 @@ template <typename V>
 void testEmpty_fileStream() {
     FileRemover fr(filename);
     {
-        std::auto_ptr<OutputStream> os = fileOutputStream(filename);
+        std::unique_ptr<OutputStream> os = fileOutputStream(filename);
     }
-    std::auto_ptr<InputStream> is = fileInputStream(filename);
+    std::unique_ptr<InputStream> is = fileInputStream(filename);
     V()(*is);
 }
 
@@ -154,12 +154,12 @@ void testNonEmpty_fileStream(const TestData& td)
 {
     FileRemover fr(filename);
     {
-        std::auto_ptr<OutputStream> os = fileOutputStream(filename,
+        std::unique_ptr<OutputStream> os = fileOutputStream(filename,
             td.chunkSize);
         F()(*os, td.dataSize);
     }
 
-    std::auto_ptr<InputStream> is = fileInputStream(filename, td.chunkSize);
+    std::unique_ptr<InputStream> is = fileInputStream(filename, td.chunkSize);
     V()(*is, td.dataSize);
 }
 


### PR DESCRIPTION

Please verify 
1) addition of flags to CMakeLists.txt and 
2) one case where auto_ptr was being passed by reference but is now changed to pass unique_ptr by value in lang/c++/impl/FileStream.cc  : 193

all tests passed in my local build