### PR TITLE
AVRO-1813: Incorrect link to build instructions in Java Getting Started

### DIFF
--- a/doc/src/content/xdocs/gettingstartedjava.xml
+++ b/doc/src/content/xdocs/gettingstartedjava.xml
@@ -93,7 +93,7 @@
       <p>
         You may also build the required Avro jars from source.  Building Avro is
         beyond the scope of this guide; see the <a
-        href="https://cwiki.apache.org/AVRO/build-documentation.html">Build
+        href="https://cwiki.apache.org/confluence/display/AVRO/Build+Documentation">Build
         Documentation</a> page in the wiki for more information.
       </p>
     </section>

--- a/doc/src/content/xdocs/gettingstartedjava.xml
+++ b/doc/src/content/xdocs/gettingstartedjava.xml
@@ -93,7 +93,7 @@
       <p>
         You may also build the required Avro jars from source.  Building Avro is
         beyond the scope of this guide; see the <a
-        href="https://cwiki.apache.org/confluence/display/AVRO/Build+Documentation">Build
+        href="https://cwiki.apache.org/AVRO/Build+Documentation">Build
         Documentation</a> page in the wiki for more information.
       </p>
     </section>


### PR DESCRIPTION
Changed link at "doc/src/content/xdocs/gettingstartedjava.xml" which
pointed incorrect to
"https://cwiki.apache.org/AVRO/build-documentation.html" to link to
"https://cwiki.apache.org/confluence/display/AVRO/Build+Documentation"