### PR TITLE
AVRO-1961: Java: Generate getters that return a Java 8 Optional.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -16,6 +16,8 @@ Trunk (not yet released)
     AVRO-1932: Java: Allow setting the SchemaStore on generated classes. 
     (Niels Basjes)
 
+    AVRO-1961: Java: Generate getters that return a Java 8 Optional. (Niels Basjes)
+
   OPTIMIZATIONS
 
   IMPROVEMENTS

--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
@@ -106,6 +106,7 @@ public class SpecificCompiler {
   private String templateDir;
   private FieldVisibility fieldVisibility = FieldVisibility.PUBLIC_DEPRECATED;
   private boolean createOptionalGetters = false;
+  private boolean gettersReturnOptional = false;
   private boolean createSetters = true;
   private boolean createAllArgsConstructor = true;
   private String outputCharacterEncoding;
@@ -227,6 +228,17 @@ public class SpecificCompiler {
    */
   public void setCreateOptionalGetters(boolean createOptionalGetters) {
     this.createOptionalGetters = createOptionalGetters;
+  }
+
+  public boolean isGettersReturnOptional() {
+    return this.gettersReturnOptional;
+  }
+
+  /**
+   * Set to false to not create the getters that return an Optional.
+   */
+  public void setGettersReturnOptional(boolean gettersReturnOptional) {
+    this.gettersReturnOptional = gettersReturnOptional;
   }
 
   /**

--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
@@ -105,6 +105,7 @@ public class SpecificCompiler {
   private VelocityEngine velocityEngine;
   private String templateDir;
   private FieldVisibility fieldVisibility = FieldVisibility.PUBLIC_DEPRECATED;
+  private boolean createOptionalGetters = false;
   private boolean createSetters = true;
   private boolean createAllArgsConstructor = true;
   private String outputCharacterEncoding;
@@ -215,6 +216,17 @@ public class SpecificCompiler {
    */
   public void setCreateSetters(boolean createSetters) {
     this.createSetters = createSetters;
+  }
+
+  public boolean isCreateOptionalGetters() {
+    return this.createOptionalGetters;
+  }
+
+  /**
+   * Set to false to not create the getters that return an Optional.
+   */
+  public void setCreateOptionalGetters(boolean createOptionalGetters) {
+    this.createOptionalGetters = createOptionalGetters;
   }
 
   /**
@@ -776,6 +788,16 @@ public class SpecificCompiler {
    */
   public static String generateGetMethod(Schema schema, Field field) {
     return generateMethodName(schema, field, "get", "");
+  }
+
+  /**
+   * Generates the name of a field accessor method that returns a Java 8 Optional.
+   * @param schema the schema in which the field is defined.
+   * @param field the field for which to generate the accessor name.
+   * @return the name of the accessor method for the given field.
+   */
+  public static String generateGetOptionalMethod(Schema schema, Field field) {
+    return generateMethodName(schema, field, "getOptional", "");
   }
 
   /**

--- a/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/record.vm
+++ b/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/record.vm
@@ -25,7 +25,7 @@ import org.apache.avro.message.BinaryMessageEncoder;
 import org.apache.avro.message.BinaryMessageDecoder;
 import org.apache.avro.message.SchemaStore;
 #end
-#if (${this.createOptionalGetters})import java.util.Optional;#end
+#if (${this.gettersReturnOptional} || ${this.createOptionalGetters})import java.util.Optional;#end
 
 @SuppressWarnings("all")
 #if ($schema.getDoc())
@@ -185,6 +185,17 @@ public class ${this.mangle($schema.getName())}#if ($schema.isError()) extends or
   }
 
 #foreach ($field in $schema.getFields())
+#if (${this.gettersReturnOptional})
+  /**
+   * Gets the value of the '${this.mangle($field.name(), $schema.isError())}' field as an Optional<${this.javaType($field.schema())}>.
+#if ($field.doc())      * $field.doc()
+#end
+   * @return The value wrapped in an Optional&lt;${this.javaType($field.schema())}&gt;.
+   */
+  public Optional<${this.javaType($field.schema())}> ${this.generateGetMethod($schema, $field)}() {
+    return Optional.<${this.javaType($field.schema())}>ofNullable(${this.mangle($field.name(), $schema.isError())});
+  }
+#else
   /**
    * Gets the value of the '${this.mangle($field.name(), $schema.isError())}' field.
 #if ($field.doc())   * @return $field.doc()
@@ -194,13 +205,14 @@ public class ${this.mangle($schema.getName())}#if ($schema.isError()) extends or
   public ${this.javaType($field.schema())} ${this.generateGetMethod($schema, $field)}() {
     return ${this.mangle($field.name(), $schema.isError())};
   }
+#end
 
 #if (${this.createOptionalGetters})
   /**
    * Gets the value of the '${this.mangle($field.name(), $schema.isError())}' field as an Optional<${this.javaType($field.schema())}>.
 #if ($field.doc())      * $field.doc()
 #end
-   * @return The Optional&lt;value&gt;.
+   * @return The value wrapped in an Optional&lt;${this.javaType($field.schema())}&gt;.
    */
   public Optional<${this.javaType($field.schema())}> ${this.generateGetOptionalMethod($schema, $field)}() {
     return Optional.<${this.javaType($field.schema())}>ofNullable(${this.mangle($field.name(), $schema.isError())});

--- a/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/record.vm
+++ b/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/record.vm
@@ -25,6 +25,7 @@ import org.apache.avro.message.BinaryMessageEncoder;
 import org.apache.avro.message.BinaryMessageDecoder;
 import org.apache.avro.message.SchemaStore;
 #end
+#if (${this.createOptionalGetters})import java.util.Optional;#end
 
 @SuppressWarnings("all")
 #if ($schema.getDoc())
@@ -194,6 +195,18 @@ public class ${this.mangle($schema.getName())}#if ($schema.isError()) extends or
     return ${this.mangle($field.name(), $schema.isError())};
   }
 
+#if (${this.createOptionalGetters})
+  /**
+   * Gets the value of the '${this.mangle($field.name(), $schema.isError())}' field as an Optional<${this.javaType($field.schema())}>.
+#if ($field.doc())      * $field.doc()
+#end
+   * @return The Optional&lt;value&gt;.
+   */
+  public Optional<${this.javaType($field.schema())}> ${this.generateGetOptionalMethod($schema, $field)}() {
+    return Optional.<${this.javaType($field.schema())}>ofNullable(${this.mangle($field.name(), $schema.isError())});
+  }
+#end
+
 #if ($this.createSetters)
   /**
    * Sets the value of the '${this.mangle($field.name(), $schema.isError())}' field.
@@ -328,6 +341,18 @@ public class ${this.mangle($schema.getName())}#if ($schema.isError()) extends or
     public ${this.javaType($field.schema())} ${this.generateGetMethod($schema, $field)}() {
       return ${this.mangle($field.name(), $schema.isError())};
     }
+
+#if (${this.createOptionalGetters})
+    /**
+      * Gets the value of the '${this.mangle($field.name(), $schema.isError())}' field as an Optional<${this.javaType($field.schema())}>.
+#if ($field.doc())      * $field.doc()
+#end
+      * @return The Optional&lt;value&gt;.
+      */
+    public Optional<${this.javaType($field.schema())}> ${this.generateGetOptionalMethod($schema, $field)}() {
+      return Optional.<${this.javaType($field.schema())}>ofNullable(${this.mangle($field.name(), $schema.isError())});
+    }
+#end
 
     /**
       * Sets the value of the '${this.mangle($field.name(), $schema.isError())}' field.

--- a/lang/java/ipc/pom.xml
+++ b/lang/java/ipc/pom.xml
@@ -74,6 +74,7 @@
               </excludes>
               <stringType>String</stringType>
               <createOptionalGetters>true</createOptionalGetters>
+              <!--<gettersReturnOptional>true</gettersReturnOptional>-->
               <sourceDirectory>${parent.project.basedir}/../../../../share/schemas/</sourceDirectory>
               <outputDirectory>${project.build.directory}/generated-sources/java</outputDirectory>
               <testSourceDirectory>${parent.project.basedir}/../../../../share/test/schemas/</testSourceDirectory>

--- a/lang/java/ipc/pom.xml
+++ b/lang/java/ipc/pom.xml
@@ -73,6 +73,7 @@
                 <exclude>org/apache/avro/data/Json.avsc</exclude>
               </excludes>
               <stringType>String</stringType>
+              <createOptionalGetters>true</createOptionalGetters>
               <sourceDirectory>${parent.project.basedir}/../../../../share/schemas/</sourceDirectory>
               <outputDirectory>${project.build.directory}/generated-sources/java</outputDirectory>
               <testSourceDirectory>${parent.project.basedir}/../../../../share/test/schemas/</testSourceDirectory>
@@ -80,6 +81,17 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>${jdkVersion}</source>
+          <target>${jdkVersion}</target>
+          <testSource>${jdk8Version}</testSource>
+          <testTarget>${jdk8Version}</testTarget>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/lang/java/ipc/src/test/java/org/apache/avro/specific/TestSpecificBuilderTree.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/specific/TestSpecificBuilderTree.java
@@ -21,8 +21,11 @@ import org.apache.avro.test.http.*;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Optional;
+import java.util.function.Consumer;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
 public class TestSpecificBuilderTree {
@@ -253,5 +256,54 @@ public class TestSpecificBuilderTree {
     assertEquals(HttpMethod.GET,    request.getHttpRequest().getURI().getMethod());
     assertEquals("/index.html",     request.getHttpRequest().getURI().getPath());
   }
+
+  @Test
+  public void validateBrowsingOptionals() {
+    Request.Builder requestBuilder = Request.newBuilder();
+    requestBuilder.setTimestamp(1234567890);
+
+    requestBuilder
+      .getHttpRequestBuilder()
+        .getUserAgentBuilder()
+          .setUseragent("Chrome 123");
+
+    requestBuilder
+      .getHttpRequestBuilder()
+        .getURIBuilder()
+          .setMethod(HttpMethod.GET)
+          .setPath("/index.html");
+
+    Request request = requestBuilder.build();
+
+    assertEquals("Chrome 123", Optional
+      .of(request)
+      .flatMap(Request::getOptionalHttpRequest)
+      .flatMap(HttpRequest::getOptionalUserAgent)
+      .flatMap(UserAgent::getOptionalUseragent)
+      .orElse("UNKNOWN"));
+
+    assertFalse(Optional
+      .of(request)
+      .flatMap(Request::getOptionalHttpRequest)
+      .flatMap(HttpRequest::getOptionalUserAgent)
+      .flatMap(UserAgent::getOptionalId)
+      .isPresent());
+
+    assertEquals(HttpMethod.GET, Optional
+      .of(request)
+      .flatMap(Request::getOptionalHttpRequest)
+      .flatMap(HttpRequest::getOptionalURI)
+      .flatMap(HttpURI::getOptionalMethod)
+      .orElse(null));
+
+    assertEquals("/index.html", Optional
+      .of(request)
+      .flatMap(Request::getOptionalHttpRequest)
+      .flatMap(HttpRequest::getOptionalURI)
+      .flatMap(HttpURI::getOptionalPath)
+      .orElse(null));
+
+  }
+
 
 }

--- a/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/AbstractAvroMojo.java
+++ b/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/AbstractAvroMojo.java
@@ -115,6 +115,15 @@ public abstract class AbstractAvroMojo extends AbstractMojo {
   protected String templateDirectory = "/org/apache/avro/compiler/specific/templates/java/classic/";
 
   /**
+   * The createOptionalGetters parameter enables generating the getOptional...
+   * methods that return an Optional of the requested type.
+   * This works ONLY on Java 8+
+   *
+   * @parameter property="createOptionalGetters"
+   */
+  protected boolean createOptionalGetters = false;
+
+  /**
    * Determines whether or not to create setters for the fields of the record.
    * The default is to create setters.
    *

--- a/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/AbstractAvroMojo.java
+++ b/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/AbstractAvroMojo.java
@@ -124,6 +124,16 @@ public abstract class AbstractAvroMojo extends AbstractMojo {
   protected boolean createOptionalGetters = false;
 
   /**
+   * The gettersReturnOptional parameter enables generating get...
+   * methods that return an Optional of the requested type.
+   * This will replace the
+   * This works ONLY on Java 8+
+   *
+   * @parameter property="gettersReturnOptional"
+   */
+  protected boolean gettersReturnOptional = false;
+
+  /**
    * Determines whether or not to create setters for the fields of the record.
    * The default is to create setters.
    *

--- a/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/IDLProtocolMojo.java
+++ b/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/IDLProtocolMojo.java
@@ -93,6 +93,7 @@ public class IDLProtocolMojo extends AbstractAvroMojo {
       compiler.setTemplateDir(templateDirectory);
       compiler.setFieldVisibility(getFieldVisibility());
       compiler.setCreateOptionalGetters(createOptionalGetters);
+      compiler.setGettersReturnOptional(gettersReturnOptional);
       compiler.setCreateSetters(createSetters);
       compiler.setEnableDecimalLogicalType(enableDecimalLogicalType);
       compiler.compileToDestination(null, outputDirectory);

--- a/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/IDLProtocolMojo.java
+++ b/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/IDLProtocolMojo.java
@@ -92,6 +92,7 @@ public class IDLProtocolMojo extends AbstractAvroMojo {
       compiler.setStringType(GenericData.StringType.valueOf(stringType));
       compiler.setTemplateDir(templateDirectory);
       compiler.setFieldVisibility(getFieldVisibility());
+      compiler.setCreateOptionalGetters(createOptionalGetters);
       compiler.setCreateSetters(createSetters);
       compiler.setEnableDecimalLogicalType(enableDecimalLogicalType);
       compiler.compileToDestination(null, outputDirectory);

--- a/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/ProtocolMojo.java
+++ b/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/ProtocolMojo.java
@@ -61,6 +61,7 @@ public class ProtocolMojo extends AbstractAvroMojo {
     compiler.setStringType(StringType.valueOf(stringType));
     compiler.setFieldVisibility(getFieldVisibility());
     compiler.setCreateOptionalGetters(createOptionalGetters);
+    compiler.setGettersReturnOptional(gettersReturnOptional);
     compiler.setCreateSetters(createSetters);
     compiler.setEnableDecimalLogicalType(enableDecimalLogicalType);
     compiler.compileToDestination(src, outputDirectory);

--- a/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/ProtocolMojo.java
+++ b/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/ProtocolMojo.java
@@ -60,6 +60,7 @@ public class ProtocolMojo extends AbstractAvroMojo {
     compiler.setTemplateDir(templateDirectory);
     compiler.setStringType(StringType.valueOf(stringType));
     compiler.setFieldVisibility(getFieldVisibility());
+    compiler.setCreateOptionalGetters(createOptionalGetters);
     compiler.setCreateSetters(createSetters);
     compiler.setEnableDecimalLogicalType(enableDecimalLogicalType);
     compiler.compileToDestination(src, outputDirectory);

--- a/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/SchemaMojo.java
+++ b/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/SchemaMojo.java
@@ -65,7 +65,7 @@ public class SchemaMojo extends AbstractAvroMojo {
 
     // This is necessary to maintain backward-compatibility. If there are
     // no imported files then isolate the schemas from each other, otherwise
-    // allow them to share a single schema so resuse and sharing of schema
+    // allow them to share a single schema so reuse and sharing of schema
     // is possible.
     if (imports == null) {
       schema = new Schema.Parser().parse(src);
@@ -77,6 +77,7 @@ public class SchemaMojo extends AbstractAvroMojo {
     compiler.setTemplateDir(templateDirectory);
     compiler.setStringType(StringType.valueOf(stringType));
     compiler.setFieldVisibility(getFieldVisibility());
+    compiler.setCreateOptionalGetters(createOptionalGetters);
     compiler.setCreateSetters(createSetters);
     compiler.setEnableDecimalLogicalType(enableDecimalLogicalType);
     compiler.setOutputCharacterEncoding(project.getProperties().getProperty("project.build.sourceEncoding"));

--- a/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/SchemaMojo.java
+++ b/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/SchemaMojo.java
@@ -78,6 +78,7 @@ public class SchemaMojo extends AbstractAvroMojo {
     compiler.setStringType(StringType.valueOf(stringType));
     compiler.setFieldVisibility(getFieldVisibility());
     compiler.setCreateOptionalGetters(createOptionalGetters);
+    compiler.setGettersReturnOptional(gettersReturnOptional);
     compiler.setCreateSetters(createSetters);
     compiler.setEnableDecimalLogicalType(enableDecimalLogicalType);
     compiler.setOutputCharacterEncoding(project.getProperties().getProperty("project.build.sourceEncoding"));

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -35,6 +35,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <jdkVersion>1.6</jdkVersion>
+    <jdk8Version>1.8</jdk8Version> <!-- Some tests need java 8 or newer -->
 
     <!-- version properties for dependencies -->
 
@@ -75,7 +77,7 @@
 
     <!-- version properties for plugins -->
     <bundle-plugin-version>2.5.3</bundle-plugin-version>
-    <compiler-plugin.version>3.1</compiler-plugin.version>
+    <compiler-plugin.version>3.6.0</compiler-plugin.version>
     <exec-plugin.version>1.3.2</exec-plugin.version>
     <jar-plugin.version>2.5</jar-plugin.version>
     <javacc-plugin.version>2.6</javacc-plugin.version>

--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -17,7 +17,7 @@
 # Dockerfile for installing the necessary dependencies for building Avro.
 # See BUILD.txt.
 
-FROM java:7-jdk
+FROM java:8-jdk
 
 WORKDIR /root
 

--- a/share/test/schemas/http.avdl
+++ b/share/test/schemas/http.avdl
@@ -59,7 +59,7 @@ protocol Http {
 
     record Request {
       long              timestamp;
-      NetworkConnection connection;
+      union { null, NetworkConnection } connection = null;
       HttpRequest       httpRequest;
     }
 


### PR DESCRIPTION
NOTE: This must wait until AFTER the release of Avro 1.8.2.

This is a first attempt at making the Java code generator have the option (default is off) to generate Java 8 Optional getters.

A few things about this that open and must be discussed before committing:

1. This will change the building of Avro to require JDK 8 to be installed. Building with JDK 7 will simply fail.
2. The main runtime is still compiled with the setting "JDK 6". So in theory that should remain backward compatible for systems that still rely in JDK 6.
3. This is my first time playing with Optionals so a thorough review is really needed.

Also a big question is: Do we want this? 
I think it is a good idea to use the new Java features that make it easier for downstream developers.
Yet the risk of breaking backward compatibility may be considered to be a problem.