### PR TITLE
 AVRO-2007: enable getting schema enum size (i.e. number of symbols at enum schema). 

### DIFF
--- a/lang/c/src/avro/schema.h
+++ b/lang/c/src/avro/schema.h
@@ -61,6 +61,7 @@ int avro_schema_enum_get_by_name(const avro_schema_t enump,
 				 const char *symbol_name);
 int avro_schema_enum_symbol_append(const avro_schema_t
 				   enump, const char *symbol);
+size_t avro_schema_enum_size(const avro_schema_t enump);
 
 avro_schema_t avro_schema_fixed(const char *name, const int64_t len);
 avro_schema_t avro_schema_fixed_ns(const char *name, const char *space,

--- a/lang/c/src/schema.c
+++ b/lang/c/src/schema.c
@@ -574,6 +574,11 @@ avro_schema_enum_symbol_append(const avro_schema_t enum_schema,
 	return 0;
 }
 
+size_t avro_schema_enum_size( const avro_schema_t enump )
+{
+	return avro_schema_to_enum(enump)->symbols->num_entries;
+}
+
 int
 avro_schema_record_field_append(const avro_schema_t record_schema,
 				const char *field_name,


### PR DESCRIPTION
enable getting enum size (i.e. number of symbols at enum schema). This is needed to enable validating that later when using the instance and setting a value we are not setting out of range value. this is needed as internally enum instance is keeps its value as int, without doing any check on it.
