### PR TITLE
Branch 1.8 - AVRO-1961 : [JAVA] Generate getters that return an Optional

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/Schema.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Schema.java
@@ -22,13 +22,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.io.StringWriter;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -38,10 +38,10 @@ import java.util.Set;
 
 import org.apache.avro.util.internal.JacksonUtils;
 import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.JsonGenerator;
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.JsonParseException;
 import org.codehaus.jackson.JsonParser;
+import org.codehaus.jackson.JsonGenerator;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.node.DoubleNode;
 

--- a/lang/java/avro/src/main/java/org/apache/avro/Schema.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Schema.java
@@ -371,16 +371,12 @@ public abstract class Schema extends JsonProperties {
                        "default","doc","name","order","type","aliases");
   }
 
-  /**
-   * Returns true if this record is an union type.
-   */
+  /** Returns true if this record is an union type. */
   public boolean isUnion(){
     return this instanceof UnionSchema;
   }
 
-  /**
-   * Returns true if this record is an union type containing null.
-   */
+  /** Returns true if this record is an union type containing null. */
   public boolean isNullable() {
     if (!isUnion()) {
       return getType().equals(Schema.Type.NULL);

--- a/lang/java/avro/src/main/java/org/apache/avro/Schema.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Schema.java
@@ -371,6 +371,24 @@ public abstract class Schema extends JsonProperties {
                        "default","doc","name","order","type","aliases");
   }
 
+  public boolean isUnion(){
+    return this instanceof UnionSchema;
+  }
+
+  public boolean isNullable() {
+    if (!isUnion()) {
+      return getType().equals(Schema.Type.NULL);
+    }
+
+    for (Schema schema : getTypes()) {
+      if (schema.isNullable()) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   /** A field within a record. */
   public static class Field extends JsonProperties {
 

--- a/lang/java/avro/src/main/java/org/apache/avro/Schema.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Schema.java
@@ -22,13 +22,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -38,10 +38,10 @@ import java.util.Set;
 
 import org.apache.avro.util.internal.JacksonUtils;
 import org.codehaus.jackson.JsonFactory;
+import org.codehaus.jackson.JsonGenerator;
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.JsonParseException;
 import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonGenerator;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.node.DoubleNode;
 
@@ -371,10 +371,16 @@ public abstract class Schema extends JsonProperties {
                        "default","doc","name","order","type","aliases");
   }
 
+  /**
+   * Returns true if this record is an union type.
+   */
   public boolean isUnion(){
     return this instanceof UnionSchema;
   }
 
+  /**
+   * Returns true if this record is an union type containing null.
+   */
   public boolean isNullable() {
     if (!isUnion()) {
       return getType().equals(Schema.Type.NULL);

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchema.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchema.java
@@ -18,11 +18,13 @@
 package org.apache.avro;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.avro.Schema.Field;
@@ -99,5 +101,68 @@ public class TestSchema {
     Schema.createRecord("foobar", null, null, false, null);
   }
 
+  @Test
+  public void testIsUnionOnUnionWithMultipleElements() {
+    Schema schema = Schema.createUnion(Schema.create(Type.NULL), Schema.create(Type.LONG));
+    assertTrue(schema.isUnion());
+  }
+
+  @Test
+  public void testIsUnionOnUnionWithOneElement() {
+    Schema schema = Schema.createUnion(Schema.create(Type.LONG));
+    assertTrue(schema.isUnion());
+  }
+
+  @Test
+  public void testIsUnionOnRecord() {
+    Schema schema = createDefaultRecord();
+    assertFalse(schema.isUnion());
+  }
+
+  @Test
+  public void testIsUnionOnArray() {
+    Schema schema = Schema.createArray(Schema.create(Type.LONG));
+    assertFalse(schema.isUnion());
+  }
+
+  @Test
+  public void testIsUnionOnEnum() {
+    Schema schema = Schema.createEnum("name", "doc", "namespace", Collections.singletonList("value"));
+    assertFalse(schema.isUnion());
+  }
+
+  @Test
+  public void testIsUnionOnFixed() {
+    Schema schema = Schema.createFixed("name", "doc", "space", 10);
+    assertFalse(schema.isUnion());
+  }
+
+  @Test
+  public void testIsUnionOnMap() {
+    Schema schema = Schema.createMap(Schema.create(Type.LONG));
+    assertFalse(schema.isUnion());
+  }
+
+  @Test
+  public void testIsNullableOnUnionWithNull() {
+    Schema schema = Schema.createUnion(Schema.create(Type.NULL), Schema.create(Type.LONG));
+    assertTrue(schema.isNullable());
+  }
+
+  @Test
+  public void testIsNullableOnUnionWithoutNull() {
+    Schema schema = Schema.createUnion(Schema.create(Type.LONG));
+    assertFalse(schema.isNullable());
+  }
+
+  @Test
+  public void testIsNullableOnRecord() {
+    Schema schema = createDefaultRecord();
+    assertFalse(schema.isNullable());
+  }
+
+  private Schema createDefaultRecord() {
+    return Schema.createRecord("name", "doc", "namespace", false);
+  }
 
 }

--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
@@ -106,6 +106,7 @@ public class SpecificCompiler {
   private String templateDir;
   private FieldVisibility fieldVisibility = FieldVisibility.PUBLIC_DEPRECATED;
   private boolean createSetters = true;
+  private boolean pojoWithOptional = false;
   private boolean createAllArgsConstructor = true;
   private String outputCharacterEncoding;
   private boolean enableDecimalLogicalType = false;
@@ -206,6 +207,9 @@ public class SpecificCompiler {
     this.fieldVisibility = fieldVisibility;
   }
 
+  /**
+   * @return true if the record fields should have setter methods.
+   */
   public boolean isCreateSetters() {
       return this.createSetters;
   }
@@ -215,6 +219,20 @@ public class SpecificCompiler {
    */
   public void setCreateSetters(boolean createSetters) {
     this.createSetters = createSetters;
+  }
+
+  /**
+   * @return true if the record nullable fields should have getter/setter/builder methods with Optional.
+   */
+  public boolean isPojoWithOptional() {
+    return this.pojoWithOptional;
+  }
+
+  /**
+   * Set to false to not create getter/setter methods with Optional for nullable fields of the record.
+   */
+  public void setPojoWithOptional(boolean pojoWithOptional) {
+    this.pojoWithOptional = pojoWithOptional;
   }
 
   /**
@@ -583,6 +601,16 @@ public class SpecificCompiler {
   /** Utility for template use.  Returns the java type for a Schema. */
   public String javaType(Schema schema) {
     return javaType(schema, true);
+  }
+
+  /** Utility for template use.  Returns true if any field of the current schema is nullable. */
+  public boolean containsNullableField(Schema schema) {
+    for (Field field : schema.getFields()) {
+      if (field.schema().isNullable()) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private String javaType(Schema schema, boolean checkConvertedLogicalType) {

--- a/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/record.vm
+++ b/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/record.vm
@@ -25,6 +25,7 @@ import org.apache.avro.message.BinaryMessageEncoder;
 import org.apache.avro.message.BinaryMessageDecoder;
 import org.apache.avro.message.SchemaStore;
 #end
+#if (${this.pojoWithOptional} && ${this.containsNullableField($schema)})import java.util.Optional;#end
 
 @SuppressWarnings("all")
 #if ($schema.getDoc())
@@ -184,6 +185,17 @@ public class ${this.mangle($schema.getName())}#if ($schema.isError()) extends or
   }
 
 #foreach ($field in $schema.getFields())
+#if (${this.pojoWithOptional} && ${field.schema().isNullable()})
+  /**
+   * Gets the value of the nullable '${this.mangle($field.name(), $schema.isError())}' field.
+#if ($field.doc())      * $field.doc()
+#end
+   * @return The value of the '${this.mangle($field.name(), $schema.isError())}' field.
+   */
+  public Optional<${this.javaType($field.schema())}> ${this.generateGetMethod($schema, $field)}() {
+    return Optional.ofNullable(${this.mangle($field.name(), $schema.isError())});
+  }
+#else
   /**
    * Gets the value of the '${this.mangle($field.name(), $schema.isError())}' field.
 #if ($field.doc())   * @return $field.doc()
@@ -193,8 +205,20 @@ public class ${this.mangle($schema.getName())}#if ($schema.isError()) extends or
   public ${this.javaType($field.schema())} ${this.generateGetMethod($schema, $field)}() {
     return ${this.mangle($field.name(), $schema.isError())};
   }
+#end
 
 #if ($this.createSetters)
+#if (${this.pojoWithOptional} && ${field.schema().isNullable()})
+/**
+* Sets the value of the nullable '${this.mangle($field.name(), $schema.isError())}' field.
+    #if ($field.doc())   * $field.doc()
+    #end
+* @param value the value to set.
+*/
+public void ${this.generateSetMethod($schema, $field)}(Optional<${this.javaType($field.schema())}> value) {
+this.${this.mangle($field.name(), $schema.isError())} = value.orElse(null);
+}
+#else
   /**
    * Sets the value of the '${this.mangle($field.name(), $schema.isError())}' field.
 #if ($field.doc())   * $field.doc()
@@ -204,6 +228,7 @@ public class ${this.mangle($schema.getName())}#if ($schema.isError()) extends or
   public void ${this.generateSetMethod($schema, $field)}(${this.javaType($field.schema())} value) {
     this.${this.mangle($field.name(), $schema.isError())} = value;
   }
+#end
 #end
 
 #end
@@ -319,10 +344,41 @@ public class ${this.mangle($schema.getName())}#if ($schema.isError()) extends or
 #end
 
 #foreach ($field in $schema.getFields())
+#if (${this.pojoWithOptional} && ${field.schema().isNullable()})
+
+    /**
+      * Gets the value of the nullable '${this.mangle($field.name(), $schema.isError())}' field.
+        #if ($field.doc())      * $field.doc()
+        #end
+      * @return The value.
+      */
+    public Optional<${this.javaType($field.schema())}> ${this.generateGetMethod($schema, $field)}() {
+      return Optional.ofNullable(${this.mangle($field.name(), $schema.isError())});
+    }
+
+    /**
+      * Sets the value of the nullable '${this.mangle($field.name(), $schema.isError())}' field.
+        #if ($field.doc())      * $field.doc()
+        #end
+      * @param value The value of '${this.mangle($field.name(), $schema.isError())}'.
+      * @return This builder.
+      */
+    public #if ($schema.getNamespace())$schema.getNamespace().#end${this.mangle($schema.getName())}.Builder ${this.generateSetMethod($schema, $field)}(Optional<${this.javaType($field.schema())}> value) {
+    ${this.javaType($field.schema())} effectiveValue = value.orElse(null);
+    validate(fields()[$field.pos()], effectiveValue);
+        #if (${this.hasBuilder($field.schema())})
+        this.${this.mangle($field.name(), $schema.isError())}Builder = null;
+        #end
+    this.${this.mangle($field.name(), $schema.isError())} = effectiveValue;
+    fieldSetFlags()[$field.pos()] = true;
+    return this;
+    }
+#else
+
     /**
       * Gets the value of the '${this.mangle($field.name(), $schema.isError())}' field.
-#if ($field.doc())      * $field.doc()
-#end
+        #if ($field.doc())      * $field.doc()
+        #end
       * @return The value.
       */
     public ${this.javaType($field.schema())} ${this.generateGetMethod($schema, $field)}() {
@@ -345,6 +401,7 @@ public class ${this.mangle($schema.getName())}#if ($schema.isError()) extends or
       fieldSetFlags()[$field.pos()] = true;
       return this;
     }
+#end
 
     /**
       * Checks whether the '${this.mangle($field.name(), $schema.isError())}' field has been set.

--- a/lang/java/compiler/src/test/java/org/apache/avro/compiler/specific/TestSpecificCompiler.java
+++ b/lang/java/compiler/src/test/java/org/apache/avro/compiler/specific/TestSpecificCompiler.java
@@ -532,7 +532,65 @@ public class TestSpecificCompiler {
         "null", compiler.conversionInstance(uuidSchema));
   }
 
-  public void testToFromByteBuffer() {
+  @Test
+  public void testPojoWithOptionalTurnedOffByDefault() throws IOException {
+    SpecificCompiler compiler = createCompiler();
+    assertFalse(compiler.isPojoWithOptional());
+    compiler.compileToDestination(this.src, this.outputDir);
+    assertTrue(this.outputFile.exists());
+    BufferedReader reader = null;
+    try {
+      reader = new BufferedReader(new FileReader(this.outputFile));
+      String line;
+      while ((line = reader.readLine()) != null) {
+        line = line.trim();
+        assertFalse(line.contains("Optional"));
+      }
+    } finally {
+      if (reader != null)
+        reader.close();
+    }
+  }
 
+  @Test
+  public void testPojoWithOptionalCreatedWhenOptionTurnedOn() throws IOException {
+    SpecificCompiler compiler = createCompiler();
+    compiler.setPojoWithOptional(true);
+    assertTrue(compiler.isPojoWithOptional());
+    compiler.compileToDestination(this.src, this.outputDir);
+    assertTrue(this.outputFile.exists());
+    int optionalFound = 0;
+    BufferedReader reader = null;
+    try {
+      reader = new BufferedReader(new FileReader(this.outputFile));
+
+      String line;
+      while ((line = reader.readLine()) != null) {
+        line = line.trim();
+        if (line.contains("Optional")) {
+          optionalFound++;
+        }
+      }
+    } finally {
+      if (reader != null)
+        reader.close();
+    }
+    assertEquals(7, optionalFound);
+  }
+
+  @Test
+  public void testContainsNullableFieldWorksOnRecordWithoutField(){
+    Schema recordWithoutFieldSchema = SchemaBuilder.builder().record("recordWithoutField").fields().endRecord();
+    assertFalse( new SpecificCompiler().containsNullableField(recordWithoutFieldSchema));
+  }
+
+  @Test
+  public void testContainsNullableFieldWorksOnSchemaWithoutNullableField(){
+    Schema recordWithoutNullableFieldSchema = SchemaBuilder.builder()
+        .record("recordWithoutNullableField")
+        .fields()
+        .name("value").type().intType().noDefault()
+        .endRecord();
+    assertFalse( new SpecificCompiler().containsNullableField(recordWithoutNullableFieldSchema));
   }
 }

--- a/lang/java/compiler/src/test/resources/simple_record.avsc
+++ b/lang/java/compiler/src/test/resources/simple_record.avsc
@@ -2,6 +2,7 @@
   "type": "record", 
   "name": "SimpleRecord",
   "fields" : [
-    {"name": "value", "type": "int"}
+    {"name": "value", "type": "int"},
+    {"name": "nullableValue", "type": ["null","int"], "doc" : "doc"}
   ]
 }

--- a/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/AbstractAvroMojo.java
+++ b/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/AbstractAvroMojo.java
@@ -123,6 +123,14 @@ public abstract class AbstractAvroMojo extends AbstractMojo {
   protected boolean createSetters;
 
   /**
+   * Determines whether or not to have getter/setter/builder methods with Optional for nullable fields of the record.
+   * The default is not to have getter/setter/builder methods with Optional.
+   *
+   * @parameter default-value="false"
+   */
+  protected boolean pojoWithOptional;
+
+  /**
    * Determines whether or not to use Java classes for decimal types
    *
    * @parameter default-value="false"

--- a/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/IDLProtocolMojo.java
+++ b/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/IDLProtocolMojo.java
@@ -93,6 +93,7 @@ public class IDLProtocolMojo extends AbstractAvroMojo {
       compiler.setTemplateDir(templateDirectory);
       compiler.setFieldVisibility(getFieldVisibility());
       compiler.setCreateSetters(createSetters);
+      compiler.setPojoWithOptional(pojoWithOptional);
       compiler.setEnableDecimalLogicalType(enableDecimalLogicalType);
       compiler.compileToDestination(null, outputDirectory);
     } catch (ParseException e) {

--- a/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/ProtocolMojo.java
+++ b/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/ProtocolMojo.java
@@ -61,6 +61,7 @@ public class ProtocolMojo extends AbstractAvroMojo {
     compiler.setStringType(StringType.valueOf(stringType));
     compiler.setFieldVisibility(getFieldVisibility());
     compiler.setCreateSetters(createSetters);
+    compiler.setPojoWithOptional(pojoWithOptional);
     compiler.setEnableDecimalLogicalType(enableDecimalLogicalType);
     compiler.compileToDestination(src, outputDirectory);
   }

--- a/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/SchemaMojo.java
+++ b/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/SchemaMojo.java
@@ -78,6 +78,7 @@ public class SchemaMojo extends AbstractAvroMojo {
     compiler.setStringType(StringType.valueOf(stringType));
     compiler.setFieldVisibility(getFieldVisibility());
     compiler.setCreateSetters(createSetters);
+    compiler.setPojoWithOptional(pojoWithOptional);
     compiler.setEnableDecimalLogicalType(enableDecimalLogicalType);
     compiler.setOutputCharacterEncoding(project.getProperties().getProperty("project.build.sourceEncoding"));
     compiler.compileToDestination(src, outputDirectory);


### PR DESCRIPTION
isUnion is needed since the class UnionSchema is private hence not accessible from outside code
isNullable is needed for doing nullable schema's specific actions in templates

Both methods add value whatever the outcome of AVRO-1961.

Any comment on the content or the "form" of the PR welcomed, I'm quite new to this all :)