### PR TITLE
Allow alias annotation on fields

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/AvroAlias.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/AvroAlias.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
  * named by the alias.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE)
+@Target({ElementType.TYPE, ElementType.FIELD})
 public @interface AvroAlias {
   String NULL = "NOT A VALID NAMESPACE";
 

--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectData.java
@@ -629,6 +629,11 @@ public class ReflectData extends SpecificData {
                 if (f.name().equals(fieldName))
                   throw new AvroTypeException("double field entry: "+ fieldName);
               }
+
+              if (field.isAnnotationPresent(AvroAlias.class)) {
+                  recordField.addAlias(field.getAnnotation(AvroAlias.class).alias());
+              }
+
               fields.add(recordField);
             }
           if (error)                              // add Throwable message

--- a/lang/java/avro/src/test/java/org/apache/avro/reflect/TestReflect.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/reflect/TestReflect.java
@@ -39,6 +39,7 @@ import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Protocol;
 import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
 import org.apache.avro.Schema.Field;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.io.Decoder;
@@ -1029,10 +1030,25 @@ public class TestReflect {
   private static class AliasC { }
 
   @Test
-  public void testAvroAlias() {
+  public void testAvroAliasOnClass() {
     check(AliasA.class, "{\"type\":\"record\",\"name\":\"AliasA\",\"namespace\":\"org.apache.avro.reflect.TestReflect$\",\"fields\":[],\"aliases\":[\"b.a\"]}");
     check(AliasB.class, "{\"type\":\"record\",\"name\":\"AliasB\",\"namespace\":\"org.apache.avro.reflect.TestReflect$\",\"fields\":[],\"aliases\":[\"a\"]}");
     check(AliasC.class, "{\"type\":\"record\",\"name\":\"AliasC\",\"namespace\":\"org.apache.avro.reflect.TestReflect$\",\"fields\":[],\"aliases\":[\"a\"]}");
+  }
+
+  private static class ClassWithAliasOnField {
+    @AvroAlias(alias = "aliasName")
+    int primitiveField;
+  }
+
+  @Test
+  public void testAvroAliasOnField() {
+
+    Schema expectedSchema = SchemaBuilder.record(ClassWithAliasOnField.class.getSimpleName())
+        .namespace("org.apache.avro.reflect.TestReflect$").fields().name("primitiveField").aliases("aliasName")
+        .type(Schema.create(org.apache.avro.Schema.Type.INT)).noDefault().endRecord();
+
+    check(ClassWithAliasOnField.class, expectedSchema.toString());
   }
 
   private static class DefaultTest {


### PR DESCRIPTION
Open Questions:

- What to do with the unused namespace field of the annotation? Throw an error if specified or introduce an new annotation for field aliases?