### PR TITLE
AVRO-1970: Flaky test: TestInputBytes

### DIFF
--- a/lang/java/trevni/core/src/test/java/org/apache/trevni/TestInputBytes.java
+++ b/lang/java/trevni/core/src/test/java/org/apache/trevni/TestInputBytes.java
@@ -33,7 +33,7 @@ public class TestInputBytes {
 
   @Test public void testRandomReads() throws Exception {
     Random random = new Random();
-    int length = random.nextInt(SIZE);
+    int length = random.nextInt(SIZE) + 1;
     byte[] data = new byte[length];
     random.nextBytes(data);
 

--- a/lang/java/trevni/core/src/test/java/org/apache/trevni/TestInputBytes.java
+++ b/lang/java/trevni/core/src/test/java/org/apache/trevni/TestInputBytes.java
@@ -32,7 +32,7 @@ public class TestInputBytes {
   private static final int COUNT = 100;
 
   @Test public void testRandomReads() throws Exception {
-    Random random = new Random();
+    Random random = new Random(19820210);
     int length = random.nextInt(SIZE) + 1;
     byte[] data = new byte[length];
     random.nextBytes(data);


### PR DESCRIPTION
Root cause of flaky test (probability: 1/1000):
if `length` is`0` at _line 36_ then `random.nextInt(length)` will fail with exception at _line 43_.