### PR TITLE
AVRO-1982: Fix static code analyzer findings.

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/Schema.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Schema.java
@@ -464,6 +464,8 @@ public abstract class Schema extends JsonProperties {
     private boolean defaultValueEquals(JsonNode thatDefaultValue) {
       if (defaultValue == null)
         return thatDefaultValue == null;
+      if (thatDefaultValue == null)
+        return false;
       if (Double.isNaN(defaultValue.getDoubleValue()))
         return Double.isNaN(thatDefaultValue.getDoubleValue());
       return defaultValue.equals(thatDefaultValue);
@@ -587,6 +589,7 @@ public abstract class Schema extends JsonProperties {
     private Object s1; private Object s2;
     private SeenPair(Object s1, Object s2) { this.s1 = s1; this.s2 = s2; }
     public boolean equals(Object o) {
+      if (!(o instanceof SeenPair)) return false;
       return this.s1 == ((SeenPair)o).s1 && this.s2 == ((SeenPair)o).s2;
     }
     public int hashCode() {

--- a/lang/java/avro/src/main/java/org/apache/avro/file/BZip2Codec.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/file/BZip2Codec.java
@@ -87,7 +87,7 @@ public class BZip2Codec extends Codec {
   public boolean equals(Object obj) {
     if (this == obj)
       return true;
-    if (getClass() != obj.getClass())
+    if (obj == null || obj.getClass() != getClass())
       return false;
     return true;
   }

--- a/lang/java/avro/src/main/java/org/apache/avro/file/DeflateCodec.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/file/DeflateCodec.java
@@ -132,7 +132,7 @@ class DeflateCodec extends Codec {
   public boolean equals(Object obj) {
     if (this == obj)
       return true;
-    if (getClass() != obj.getClass())
+    if (obj == null || obj.getClass() != getClass())
       return false;
     DeflateCodec other = (DeflateCodec)obj;
     return (this.nowrap == other.nowrap);

--- a/lang/java/avro/src/main/java/org/apache/avro/file/NullCodec.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/file/NullCodec.java
@@ -54,7 +54,7 @@ final class NullCodec extends Codec {
   public boolean equals(Object other) {
     if (this == other)
       return true;
-    return (this.getClass() == other.getClass());
+    return (other != null && other.getClass() == getClass());
   }
 
   @Override

--- a/lang/java/avro/src/main/java/org/apache/avro/file/SnappyCodec.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/file/SnappyCodec.java
@@ -75,7 +75,7 @@ class SnappyCodec extends Codec {
   public boolean equals(Object obj) {
     if (this == obj)
       return true;
-    if (getClass() != obj.getClass())
+    if (obj == null || obj.getClass() != getClass())
       return false;
     return true;
   }

--- a/lang/java/avro/src/main/java/org/apache/avro/file/XZCodec.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/file/XZCodec.java
@@ -109,7 +109,7 @@ public class XZCodec extends Codec {
   public boolean equals(Object obj) {
     if (this == obj)
       return true;
-    if (getClass() != obj.getClass())
+    if (obj == null || obj.getClass() != getClass())
       return false;
     XZCodec other = (XZCodec)obj;
     return (this.compressionLevel == other.compressionLevel);

--- a/lang/java/avro/src/main/java/org/apache/avro/util/WeakIdentityHashMap.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/util/WeakIdentityHashMap.java
@@ -96,6 +96,9 @@ public class WeakIdentityHashMap<K, V> implements Map<K, V> {
   }
 
   public boolean equals(Object o) {
+    if (!(o instanceof WeakIdentityHashMap)) {
+      return false;
+    }
     return backingStore.equals(((WeakIdentityHashMap)o).backingStore);
   }
 
@@ -158,6 +161,9 @@ public class WeakIdentityHashMap<K, V> implements Map<K, V> {
     public boolean equals(Object o) {
       if (this == o) {
         return true;
+      }
+      if (!(o instanceof WeakIdentityHashMap.IdentityWeakReference)) {
+        return false;
       }
       IdentityWeakReference ref = (IdentityWeakReference)o;
       if (this.get() == ref.get()) {


### PR DESCRIPTION
Fixed several possible null pointer exceptions and unchecked casts.
These triggered security and code health warnings in our static code
analyzer tools.