### PR TITLE
AVRO-1995: JSON Parser does not properly check current state

### DIFF
--- a/lang/c++/impl/json/JsonIO.cc
+++ b/lang/c++/impl/json/JsonIO.cc
@@ -76,7 +76,7 @@ JsonParser::Token JsonParser::doAdvance()
 {
     char ch = next();
     if (ch == ']') {
-        if (curState == stArray0 || stArrayN) {
+        if (curState == stArray0 || curState == stArrayN) {
             curState = stateStack.top();
             stateStack.pop();
             return tkArrayEnd;
@@ -84,7 +84,7 @@ JsonParser::Token JsonParser::doAdvance()
             throw unexpected(ch);
         }
     } else if (ch == '}') {
-        if (curState == stObject0 || stObjectN) {
+        if (curState == stObject0 || curState == stObjectN) {
             curState = stateStack.top();
             stateStack.pop();
             return tkObjectEnd;


### PR DESCRIPTION
Clang reports the else statements will never be executed since stArrayN and stObjectN are always none-zero.