### PR TITLE
AVRO-1996: compatibility with Ruby 2.4

### DIFF
--- a/lang/ruby/lib/avro/schema.rb
+++ b/lang/ruby/lib/avro/schema.rb
@@ -318,7 +318,7 @@ module Avro
       attr_reader :size
       def initialize(name, space, size, names=nil)
         # Ensure valid cto args
-        unless size.is_a?(Fixnum) || size.is_a?(Bignum)
+        unless size.is_a?(Integer)
           raise AvroError, 'Fixed Schema requires a valid integer for size property.'
         end
         super(:fixed, name, space, names)

--- a/lang/ruby/lib/avro/schema_validator.rb
+++ b/lang/ruby/lib/avro/schema_validator.rb
@@ -80,13 +80,13 @@ module Avro
         when :string, :bytes
           fail TypeMismatchError unless datum.is_a?(String)
         when :int
-          fail TypeMismatchError unless datum.is_a?(Fixnum) || datum.is_a?(Bignum)
+          fail TypeMismatchError unless datum.is_a?(Integer)
           result.add_error(path, "out of bound value #{datum}") unless INT_RANGE.cover?(datum)
         when :long
-          fail TypeMismatchError unless datum.is_a?(Fixnum) || datum.is_a?(Bignum)
+          fail TypeMismatchError unless datum.is_a?(Integer)
           result.add_error(path, "out of bound value #{datum}") unless LONG_RANGE.cover?(datum)
         when :float, :double
-          fail TypeMismatchError unless [Float, Fixnum, Bignum].any?(&datum.method(:is_a?))
+          fail TypeMismatchError unless [Float, Integer].any?(&datum.method(:is_a?))
         when :fixed
           if datum.is_a? String
             message = "expected fixed with size #{expected_schema.size}, got \"#{datum}\" with size #{datum.size}"
@@ -165,7 +165,11 @@ module Avro
       private
 
       def actual_value_message(value)
-        avro_type = ruby_to_avro_type(value.class)
+        avro_type = if value.class == Integer
+                      ruby_integer_to_avro_type(value)
+                    else
+                      ruby_to_avro_type(value.class)
+                    end
         if value.nil?
           avro_type
         else
@@ -182,6 +186,10 @@ module Avro
           Float => 'float',
           Hash => 'record'
         }.fetch(ruby_class, ruby_class)
+      end
+
+      def ruby_integer_to_avro_type(value)
+        INT_RANGE.cover?(value) ? 'int' : 'long'
       end
     end
   end


### PR DESCRIPTION
In Ruby 2.4, Fixnum and Bignum classes are deprecated and unified in the Integer class.

In earlier Ruby versions, Integer was an abstract parent of the Fixnum and Bignum classes, therefore conditions of the form `value.is_a?(Fixnum) || value.is_a?(Bignum)` can be replaced by `value.is_a?(Integer)` across versions.

Fixnum and Bignum still exist as aliases for Integer in Ruby 2.4

Tested against ruby versions:
  - 1.9.3-p551
  - 2.0.0-p648
  - 2.1.10
  - 2.2.6
  - 2.3.3
  - 2.4.0