### PR TITLE
AVRO-1987 Add @deprecated tag to getConverion method

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificRecordBase.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificRecordBase.java
@@ -56,6 +56,10 @@ public abstract class SpecificRecordBase
    */
   @Deprecated
   public Conversion<?> getConverion(String fieldName) {
+    return getConversion(fieldName);
+  }
+
+  public Conversion<?> getConversion(String fieldName) {
     return getConversion(getSchema().getField(fieldName).pos());
   }
 

--- a/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificRecordBase.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificRecordBase.java
@@ -50,6 +50,11 @@ public abstract class SpecificRecordBase
     return get(getSchema().getField(fieldName).pos());
   }
 
+  /**
+   * @deprecated As of Avro 1.8.2, this method has been moved to
+   * {@link #getConversion(String)} method from 1.9.0.
+   */
+  @Deprecated
   public Conversion<?> getConverion(String fieldName) {
     return getConversion(getSchema().getField(fieldName).pos());
   }


### PR DESCRIPTION
As part of AVRO-1972 a typo was fixed.
To inform the users of the same, a @Deprecated tag has been added to the incorrect function name.