### PR TITLE
Avro-1999: Java - Specify license in pom

### DIFF
--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -33,6 +33,13 @@
   <url>http://avro.apache.org</url>
   <description>Avro parent Java project</description>
 
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 


### PR DESCRIPTION
My company uses tools that automatically check the licenses of libraries we use as specified in their poms. This change would make it much easier for us to use Avro. The vast majority of libraries we use specify their licenses in the pom, but Avro has to go through a special approval process anytime we want to upgrade the version we use.