### PR TITLE
AVRO-2001 Adding support for doc attribute [ruby]

### DIFF
--- a/lang/ruby/lib/avro/protocol.rb
+++ b/lang/ruby/lib/avro/protocol.rb
@@ -20,7 +20,7 @@ module Avro
     VALID_TYPE_SCHEMA_TYPES_SYM = Set.new(VALID_TYPE_SCHEMA_TYPES.map(&:to_sym))
     class ProtocolParseError < Avro::AvroError; end
 
-    attr_reader :name, :namespace, :types, :messages, :md5
+    attr_reader :name, :namespace, :types, :messages, :md5, :doc
     def self.parse(protocol_string)
       json_data = MultiJson.load(protocol_string)
 
@@ -29,13 +29,14 @@ module Avro
         namespace = json_data['namespace']
         types = json_data['types']
         messages = json_data['messages']
-        Protocol.new(name, namespace, types, messages)
+        doc = json_data['doc']
+        Protocol.new(name, namespace, types, messages, doc)
       else
         raise ProtocolParseError, "Not a JSON object: #{json_data}"
       end
     end
 
-    def initialize(name, namespace=nil, types=nil, messages=nil)
+    def initialize(name, namespace=nil, types=nil, messages=nil, doc=nil)
       # Ensure valid ctor args
       if !name
         raise ProtocolParseError, 'Protocols must have a non-empty name.'
@@ -55,6 +56,7 @@ module Avro
       @types = parse_types(types, type_names)
       @messages = parse_messages(messages, type_names)
       @md5 = Digest::MD5.digest(to_s)
+      @doc = doc
     end
 
     def to_s
@@ -92,7 +94,8 @@ module Avro
         request  = body['request']
         response = body['response']
         errors   = body['errors']
-        message_objects[name] = Message.new(name, request, response, errors, names, namespace)
+        doc      = body['doc']
+        message_objects[name] = Message.new(name, request, response, errors, names, namespace, doc)
       end
       message_objects
     end
@@ -111,14 +114,15 @@ module Avro
     end
 
     class Message
-      attr_reader :name, :request, :response, :errors, :default_namespace
+      attr_reader :name, :request, :response, :errors, :default_namespace, :doc
 
-      def initialize(name, request, response, errors=nil, names=nil, default_namespace=nil)
+      def initialize(name, request, response, errors=nil, names=nil, default_namespace=nil, doc=nil)
         @name = name
         @default_namespace = default_namespace
         @request = parse_request(request, names)
         @response = parse_response(response, names)
         @errors = parse_errors(errors, names) if errors
+        @doc = doc
       end
 
       def to_avro(names=Set.new)
@@ -127,6 +131,7 @@ module Avro
           'response' => response.to_avro(names)
         }.tap do |hash|
           hash['errors'] = errors.to_avro(names) if errors
+          hash['doc'] = @doc if @doc
         end
       end
 

--- a/lang/ruby/test/test_protocol.rb
+++ b/lang/ruby/test/test_protocol.rb
@@ -5,9 +5,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -139,7 +139,7 @@ EOS
 
 }
 EOS
-  ExampleProtocol.new(<<-EOS, true)
+  ExampleProtocol.new(<<-EOS, true),
 {"namespace": "org.apache.avro.test",
  "protocol": "BulkData",
 
@@ -159,6 +159,29 @@ EOS
 
  }
 
+}
+EOS
+  ExampleProtocol.new(<<-EOS, true),
+{
+  "namespace": "com.acme",
+  "protocol": "HelloWorld",
+  "doc": "protocol_documentation",
+
+  "types": [
+    {"name": "Greeting", "type": "record", "fields": [
+      {"name": "message", "type": "string"}]},
+    {"name": "Curse", "type": "error", "fields": [
+      {"name": "message", "type": "string"}]}
+  ],
+
+  "messages": {
+    "hello": {
+      "doc": "message_documentation",
+      "request": [{"name": "greeting", "type": "Greeting" }],
+      "response": "Greeting",
+      "errors": ["Curse"]
+    }
+  }
 }
 EOS
 ]
@@ -195,5 +218,15 @@ EOS
     protocol.types.each do |type|
       assert_equal type.namespace, 'com.acme'
     end
+  end
+
+  def test_protocol_doc_attribute
+    original = Protocol.parse(EXAMPLES.last.protocol_string)
+    assert_equal 'protocol_documentation', original.doc
+  end
+
+  def test_protocol_message_doc_attribute
+    original = Protocol.parse(EXAMPLES.last.protocol_string)
+    assert_equal 'message_documentation', original.messages['hello'].doc
   end
 end

--- a/lang/ruby/test/test_schema.rb
+++ b/lang/ruby/test/test_schema.rb
@@ -160,4 +160,102 @@ class TestSchema < Test::Unit::TestCase
       ]
     }
   end
+
+  def test_record_field_doc_attribute
+    field_schema_json = Avro::Schema.parse <<-SCHEMA
+      {
+        "type": "record",
+        "name": "Record",
+        "namespace": "my.name.space",
+        "fields": [
+          {
+            "name": "name",
+            "type": "boolean",
+            "doc": "documentation"
+          }
+        ]
+      }
+    SCHEMA
+
+    field_schema_hash =
+      {
+        'type' => 'record',
+        'name' => 'Record',
+        'namespace' => 'my.name.space',
+        'fields' => [
+          {
+            'name' => 'name',
+            'type' => 'boolean',
+            'doc' => 'documentation'
+          }
+        ]
+      }
+
+    assert_equal field_schema_hash, field_schema_json.to_avro
+  end
+
+  def test_record_doc_attribute
+    record_schema_json = Avro::Schema.parse <<-SCHEMA
+      {
+        "type": "record",
+        "name": "Record",
+        "namespace": "my.name.space",
+        "doc": "documentation",
+        "fields": [
+          {
+            "name": "name",
+            "type": "boolean"
+          }
+        ]
+      }
+    SCHEMA
+
+    record_schema_hash =
+      {
+        'type' => 'record',
+        'name' => 'Record',
+        'namespace' => 'my.name.space',
+        'doc' => 'documentation',
+        'fields' => [
+          {
+            'name' => 'name',
+            'type' => 'boolean'
+          }
+        ]
+      }
+
+    assert_equal record_schema_hash, record_schema_json.to_avro
+  end
+
+  def test_enum_doc_attribute
+    enum_schema_json = Avro::Schema.parse <<-SCHEMA
+      {
+        "type": "enum",
+        "name": "Enum",
+        "namespace": "my.name.space",
+        "doc": "documentation",
+        "symbols" : [
+          "SPADES",
+          "HEARTS",
+          "DIAMONDS",
+          "CLUBS"
+        ]
+      }
+    SCHEMA
+
+    enum_schema_hash =
+      {
+        'type' => 'enum',
+        'name' => 'Enum',
+        'namespace' => 'my.name.space',
+        'doc' => 'documentation',
+        'symbols' => [
+          'SPADES',
+          'HEARTS',
+          'DIAMONDS',
+          'CLUBS'
+        ]
+      }
+    assert_equal enum_schema_hash, enum_schema_json.to_avro
+  end
 end


### PR DESCRIPTION
**AVRO-2001**: https://issues.apache.org/jira/browse/AVRO-2001

The Avro schema and protocol specification(http://avro.apache.org/docs/current/spec.html) allows for an optional attribute `doc` defined as, "a JSON string describing this field for users." Users should be able to include a doc with each field for `records` (http://avro.apache.org/docs/current/spec.html#N10085), `record fields`, and `enums` (http://avro.apache.org/docs/current/spec.html#N10186). The `doc` attribute is also in the spec for `protocols` and `protocol messages` (http://avro.apache.org/docs/1.8.1/spec.html#N105C6 and http://avro.apache.org/docs/1.8.1/spec.html#N105F1).

This doc attribute should be stripped when transforming into "Parsing Canonical Form" (http://avro.apache.org/docs/current/spec.html#N10815).

Currently, the Ruby Avro library (https://github.com/apache/avro/tree/master/lang/ruby) does not support `doc`. It is supported in other languages libraries, for example PHP (https://github.com/apache/avro/blob/master/lang/php/lib/avro/schema.php#L46).