### PR TITLE
Idl identifier `schema` (1.7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ target
 /build
 test-output
 /dist
+/.idea
+*.iml

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -16,6 +16,8 @@ Trunk (not yet released)
     AVRO-843. C#: Change Visual Studio project files to specify .NET 3.5.
     (Dmitry Kovalev via cutting)
 
+    AVRO-1585. Java: Deprecate Jackson classes in public API. (tomwhite)
+
   BUG FIXES
 
     AVRO-1553. Java: MapReduce never uses MapOutputValueSchema (tomwhite)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -20,6 +20,9 @@ Trunk (not yet released)
     AVRO-1544. Java: Fix GenericData#validate for unions with null.
     (Matthew Hayes via cutting)
 
+    AVRO-1489. Java: Avro fails to build with OpenJDK 8. (Ricardo Arguello via
+    tomwhite)
+
 Avro 1.7.7 (23 July 2014)
 
   NEW FEATURES

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,9 @@ Trunk (not yet released)
 
     AVRO-1555.  C#: Add support for RPC over HTTP. (Dmitry Kovalev via cutting)
 
+    AVRO-834. Java: Data File corruption recovery tool.
+    (scottcarey and tomwhite)
+
   OPTIMIZATIONS
 
   IMPROVEMENTS
@@ -22,6 +25,9 @@ Trunk (not yet released)
 
     AVRO-1489. Java: Avro fails to build with OpenJDK 8. (Ricardo Arguello via
     tomwhite)
+
+	AVRO-1596. Java: Cannot read past corrupted block in Avro data file.
+	(tomwhite)
 
 Avro 1.7.7 (23 July 2014)
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,6 +18,9 @@ Trunk (not yet released)
 
     AVRO-1585. Java: Deprecate Jackson classes in public API. (tomwhite)
 
+    AVRO-1681. Improve generated JavaDocs.
+    (Charles Gariépy-Ikeson via tomwhite)
+
   BUG FIXES
 
     AVRO-1553. Java: MapReduce never uses MapOutputValueSchema (tomwhite)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -34,6 +34,8 @@ Trunk (not yet released)
 	AVRO-1596. Java: Cannot read past corrupted block in Avro data file.
 	(tomwhite)
 
+    AVRO-1813: Incorrect link to build instructions in Java Getting Started (Pietro Menna via gabor)
+
 Avro 1.7.7 (23 July 2014)
 
   NEW FEATURES

--- a/doc/src/content/xdocs/gettingstartedjava.xml
+++ b/doc/src/content/xdocs/gettingstartedjava.xml
@@ -93,7 +93,7 @@
       <p>
         You may also build the required Avro jars from source.  Building Avro is
         beyond the scope of this guide; see the <a
-        href="https://cwiki.apache.org/AVRO/build-documentation.html">Build
+        href="https://cwiki.apache.org/AVRO/Build+Documentation">Build
         Documentation</a> page in the wiki for more information.
       </p>
     </section>

--- a/lang/java/avro/src/main/java/org/apache/avro/JsonProperties.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/JsonProperties.java
@@ -23,12 +23,97 @@ import java.util.Map;
 import java.util.Set;
 import java.io.IOException;
 
+import org.apache.avro.util.internal.JacksonUtils;
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.JsonGenerator;
 import org.codehaus.jackson.node.TextNode;
 
-/** Base class for objects that have Json-valued properties. */
+/**
+ * Base class for objects that have JSON-valued properties. Avro and JSON values are
+ * represented in Java using the following mapping:
+ * 
+ * <table>
+ *   <th>
+ *     <td>Avro type</td>
+ *     <td>JSON type</td>
+ *     <td>Java type</td>
+ *   </th>
+ *   <tr>
+ *     <td><code>null</code></td>
+ *     <td><code>null</code></td>
+ *     <td>{@link #NULL_VALUE}</td>
+ *   </tr>
+ *   <tr>
+ *     <td><code>boolean</code></td>
+ *     <td>Boolean</td>
+ *     <td><code>boolean</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td><code>int</code></td>
+ *     <td>Number</td>
+ *     <td><code>int</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td><code>long</code></td>
+ *     <td>Number</td>
+ *     <td><code>long</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td><code>float</code></td>
+ *     <td>Number</td>
+ *     <td><code>float</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td><code>double</code></td>
+ *     <td>Number</td>
+ *     <td><code>double</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td><code>bytes</code></td>
+ *     <td>String</td>
+ *     <td><code>byte[]</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td><code>string</code></td>
+ *     <td>String</td>
+ *     <td>{@link java.lang.String}</td>
+ *   </tr>
+ *   <tr>
+ *     <td><code>record</code></td>
+ *     <td>Object</td>
+ *     <td>{@link java.util.Map}</td>
+ *   </tr>
+ *   <tr>
+ *     <td><code>enum</code></td>
+ *     <td>String</td>
+ *     <td>{@link java.lang.String}</td>
+ *   </tr>
+ *   <tr>
+ *     <td><code>array</code></td>
+ *     <td>Array</td>
+ *     <td>{@link java.util.Collection}</td>
+ *   </tr>
+ *   <tr>
+ *     <td><code>map</code></td>
+ *     <td>Object</td>
+ *     <td>{@link java.util.Map}</td>
+ *   </tr>
+ *   <tr>
+ *     <td><code>fixed</code></td>
+ *     <td>String</td>
+ *     <td><code>byte[]</code></td>
+ *   </tr>
+ * </table>
+ *
+ * @see org.apache.avro.data.Json
+ */
 public abstract class JsonProperties {
+  public static class Null {
+    private Null() {}
+  }
+  /** A value representing a JSON <code>null</code>. */
+  public static final Null NULL_VALUE = new Null();
+
   Map<String,JsonNode> props = new LinkedHashMap<String,JsonNode>(1);
 
   private Set<String> reserved;
@@ -49,9 +134,19 @@ public abstract class JsonProperties {
   /**
    * Returns the value of the named property in this schema.
    * Returns <tt>null</tt> if there is no property with that name.
+   * @deprecated use {@link #getObjectProp(String)}
    */
+  @Deprecated
   public synchronized JsonNode getJsonProp(String name) {
     return props.get(name);
+  }
+
+  /**
+   * Returns the value of the named property in this schema.
+   * Returns <tt>null</tt> if there is no property with that name.
+   */
+  public synchronized Object getObjectProp(String name) {
+    return JacksonUtils.toObject(props.get(name));
   }
 
   /**
@@ -75,7 +170,9 @@ public abstract class JsonProperties {
    * 
    * @param name The name of the property to add
    * @param value The value for the property to add
+   * @deprecated use {@link #addProp(String, Object)}
    */
+  @Deprecated
   public synchronized void addProp(String name, JsonNode value) {
     if (reserved.contains(name))
       throw new AvroRuntimeException("Can't set reserved property: " + name);
@@ -88,6 +185,10 @@ public abstract class JsonProperties {
       props.put(name, value);
     else if (!old.equals(value))
       throw new AvroRuntimeException("Can't overwrite property: " + name);
+  }
+
+  public synchronized void addProp(String name, Object value) {
+    addProp(name, JacksonUtils.toJsonNode(value));
   }
 
   /** Return the defined properties that have string values. */
@@ -107,9 +208,21 @@ public abstract class JsonProperties {
     return result;
   }
 
-  /** Return the defined properties as an unmodifieable Map. */
+  /**
+   * Return the defined properties as an unmodifieable Map.
+   * @deprecated use {@link #getObjectProps()}
+   */
+  @Deprecated
   public Map<String,JsonNode> getJsonProps() {
     return Collections.unmodifiableMap(props);
+  }
+
+  /** Return the defined properties as an unmodifieable Map. */
+  public Map<String,Object> getObjectProps() {
+    Map<String,Object> result = new LinkedHashMap<String,Object>();
+    for (Map.Entry<String,JsonNode> e : props.entrySet())
+      result.put(e.getKey(), JacksonUtils.toObject(e.getValue()));
+    return result;
   }
 
   void writeProps(JsonGenerator gen) throws IOException {

--- a/lang/java/avro/src/main/java/org/apache/avro/Protocol.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Protocol.java
@@ -478,8 +478,12 @@ public class Protocol extends JsonProperties {
       if (fieldTypeNode == null)
         throw new SchemaParseException("No param type: "+field);
       String name = fieldNameNode.getTextValue();
+      String fieldDoc = null;
+      JsonNode fieldDocNode = field.get("doc");
+      if (fieldDocNode != null)
+        fieldDoc = fieldDocNode.getTextValue();
       fields.add(new Field(name, Schema.parse(fieldTypeNode,types),
-                           null /* message fields don't have docs */,
+                           fieldDoc,
                            field.get("default")));
     }
     Schema request = Schema.createRecord(fields);

--- a/lang/java/avro/src/main/java/org/apache/avro/Schema.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Schema.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.avro.util.internal.JacksonUtils;
 import org.codehaus.jackson.JsonFactory;
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.JsonParseException;
@@ -128,6 +129,11 @@ public abstract class Schema extends JsonProperties {
   int hashCode = NO_HASHCODE;
 
   @Override public void addProp(String name, JsonNode value) {
+    super.addProp(name, value);
+    hashCode = NO_HASHCODE;
+  }
+
+  @Override public void addProp(String name, Object value) {
     super.addProp(name, value);
     hashCode = NO_HASHCODE;
   }
@@ -362,10 +368,14 @@ public abstract class Schema extends JsonProperties {
     private final Order order;
     private Set<String> aliases;
 
+    /** @deprecated use {@link #Field(String, Schema, String, Object)} */
+    @Deprecated
     public Field(String name, Schema schema, String doc,
         JsonNode defaultValue) {
       this(name, schema, doc, defaultValue, Order.ASCENDING);
     }
+    /** @deprecated use {@link #Field(String, Schema, String, Object, Order)} */
+    @Deprecated
     public Field(String name, Schema schema, String doc,
         JsonNode defaultValue, Order order) {
       super(FIELD_RESERVED);
@@ -375,6 +385,22 @@ public abstract class Schema extends JsonProperties {
       this.defaultValue = validateDefault(name, schema, defaultValue);
       this.order = order;
     }
+    /**
+     * @param defaultValue the default value for this field specified using the mapping
+     *  in {@link JsonProperties}
+     */
+    public Field(String name, Schema schema, String doc,
+        Object defaultValue) {
+      this(name, schema, doc, defaultValue, Order.ASCENDING);
+    }
+    /**
+     * @param defaultValue the default value for this field specified using the mapping
+     *  in {@link JsonProperties}
+     */
+    public Field(String name, Schema schema, String doc,
+        Object defaultValue, Order order) {
+      this(name, schema, doc, JacksonUtils.toJsonNode(defaultValue), order);
+    }
     public String name() { return name; };
     /** The position of this field within the record. */
     public int pos() { return position; }
@@ -382,7 +408,13 @@ public abstract class Schema extends JsonProperties {
     public Schema schema() { return schema; }
     /** Field's documentation within the record, if set. May return null. */
     public String doc() { return doc; }
-    public JsonNode defaultValue() { return defaultValue; }
+    /** @deprecated use {@link #defaultVal() } */
+    @Deprecated public JsonNode defaultValue() { return defaultValue; }
+    /**
+     * @return the default value for this field specified using the mapping
+     *  in {@link JsonProperties}
+     */
+    public Object defaultVal() { return JacksonUtils.toObject(defaultValue); }
     public Order order() { return order; }
     @Deprecated public Map<String,String> props() { return getProps(); }
     public void addAlias(String alias) {
@@ -1313,7 +1345,11 @@ public abstract class Schema extends JsonProperties {
     return jsonNode != null ? jsonNode.getTextValue() : null;
   }
 
-  /** Parses a string as Json. */
+  /**
+   * Parses a string as Json.
+   * @deprecated use {@link org.apache.avro.data.Json#parseJson(String)}
+   */
+  @Deprecated
   public static JsonNode parseJson(String s) {
     try {
       return MAPPER.readTree(FACTORY.createJsonParser(new StringReader(s)));

--- a/lang/java/avro/src/main/java/org/apache/avro/file/DataFileStream.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/file/DataFileStream.java
@@ -251,6 +251,9 @@ public class DataFileStream<D> implements Iterator<D>, Iterable<D>, Closeable {
   /** Expert: Return the count of items in the current block. */
   public long getBlockCount() { return blockCount; }
 
+  /** Expert: Return the size in bytes (uncompressed) of the current block. */
+  public long getBlockSize() { return blockSize; }
+
   protected void blockFinished() throws IOException {
     // nothing for the stream impl
   }

--- a/lang/java/avro/src/main/java/org/apache/avro/file/DataFileStream.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/file/DataFileStream.java
@@ -289,9 +289,9 @@ public class DataFileStream<D> implements Iterator<D>, Iterable<D>, Closeable {
     // throws if it can't read the size requested
     vin.readFixed(reuse.data, 0, reuse.blockSize);
     vin.readFixed(syncBuffer);
+    availableBlock = false;
     if (!Arrays.equals(syncBuffer, header.sync))
       throw new IOException("Invalid sync!");
-    availableBlock = false;
     return reuse;
   }
 

--- a/lang/java/avro/src/main/java/org/apache/avro/io/EncoderFactory.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/EncoderFactory.java
@@ -320,7 +320,9 @@ public class EncoderFactory {
    *          The JsonGenerator to write with. Cannot be null.
    * @return A JsonEncoder configured with <i>gen</i> and <i>schema</i>
    * @throws IOException
+   * @deprecated internal method
    */
+  @Deprecated
   public JsonEncoder jsonEncoder(Schema schema, JsonGenerator gen)
       throws IOException {
     return new JsonEncoder(schema, gen);

--- a/lang/java/avro/src/main/java/org/apache/avro/io/JsonEncoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/JsonEncoder.java
@@ -131,7 +131,9 @@ public class JsonEncoder extends ParsingEncoder implements Parser.ActionHandler 
    *          The JsonGenerator to direct output to. Cannot be null.
    * @throws IOException
    * @return this JsonEncoder
+   * @deprecated internal method
    */
+  @Deprecated
   public JsonEncoder configure(JsonGenerator generator) throws IOException {
     if (null == generator)
       throw new NullPointerException("JsonGenerator cannot be null");

--- a/lang/java/avro/src/main/java/org/apache/avro/io/parsing/ResolvingGrammarGenerator.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/parsing/ResolvingGrammarGenerator.java
@@ -316,8 +316,9 @@ public class ResolvingGrammarGenerator extends ValidatingGrammarGenerator {
    * @param s The schema for the object being encoded.
    * @param n The Json node to encode.
    * @throws IOException
+   * @deprecated internal method
    */
-  
+  @Deprecated
   public static void encode(Encoder e, Schema s, JsonNode n)
     throws IOException {
     switch (s.getType()) {

--- a/lang/java/avro/src/main/java/org/apache/avro/util/internal/JacksonUtils.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/util/internal/JacksonUtils.java
@@ -1,0 +1,136 @@
+package org.apache.avro.util.internal;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.avro.AvroRuntimeException;
+import org.apache.avro.JsonProperties;
+import org.apache.avro.Schema;
+import org.codehaus.jackson.JsonGenerator;
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.util.TokenBuffer;
+
+public class JacksonUtils {
+  static final String BYTES_CHARSET = "ISO-8859-1";
+
+  private JacksonUtils() {
+  }
+
+  public static JsonNode toJsonNode(Object datum) {
+    if (datum == null) {
+      return null;
+    }
+    try {
+      TokenBuffer generator = new TokenBuffer(new ObjectMapper());
+      toJson(datum, generator);
+      return new ObjectMapper().readTree(generator.asParser());
+    } catch (IOException e) {
+      throw new AvroRuntimeException(e);
+    }
+  }
+
+  @SuppressWarnings(value="unchecked")
+  static void toJson(Object datum, JsonGenerator generator) throws IOException {
+    if (datum == JsonProperties.NULL_VALUE) { // null
+      generator.writeNull();
+    } else if (datum instanceof Map) { // record, map
+      generator.writeStartObject();
+      for (Map.Entry<Object,Object> entry : ((Map<Object,Object>) datum).entrySet()) {
+        generator.writeFieldName(entry.getKey().toString());
+        toJson(entry.getValue(), generator);
+      }
+      generator.writeEndObject();
+    } else if (datum instanceof Collection) { // array
+      generator.writeStartArray();
+      for (Object element : (Collection<?>) datum) {
+        toJson(element, generator);
+      }
+      generator.writeEndArray();
+    } else if (datum instanceof byte[]) { // bytes, fixed
+      generator.writeString(new String((byte[]) datum, BYTES_CHARSET));
+    } else if (datum instanceof CharSequence || datum instanceof Enum<?>) { // string, enum
+      generator.writeString(datum.toString());
+    } else if (datum instanceof Double) { // double
+      generator.writeNumber((Double) datum);
+    } else if (datum instanceof Float) { // float
+      generator.writeNumber((Float) datum);
+    } else if (datum instanceof Long) { // long
+      generator.writeNumber((Long) datum);
+    } else if (datum instanceof Integer) { // int
+      generator.writeNumber((Integer) datum);
+    } else if (datum instanceof Boolean) { // boolean
+      generator.writeBoolean((Boolean) datum);
+    }
+  }
+
+  public static Object toObject(JsonNode jsonNode) {
+    return toObject(jsonNode, null);
+  }
+
+  public static Object toObject(JsonNode jsonNode, Schema schema) {
+    if (schema != null && schema.getType().equals(Schema.Type.UNION)) {
+      return toObject(jsonNode, schema.getTypes().get(0));
+    }
+    if (jsonNode == null) {
+      return null;
+    } else if (jsonNode.isNull()) {
+      return JsonProperties.NULL_VALUE;
+    } else if (jsonNode.isBoolean()) {
+      return jsonNode.asBoolean();
+    } else if (jsonNode.isInt()) {
+      if (schema == null || schema.getType().equals(Schema.Type.INT)) {
+        return jsonNode.asInt();
+      } else if (schema.getType().equals(Schema.Type.LONG)) {
+        return jsonNode.asLong();
+      }
+    } else if (jsonNode.isLong()) {
+      return jsonNode.asLong();
+    } else if (jsonNode.isDouble()) {
+      if (schema == null || schema.getType().equals(Schema.Type.DOUBLE)) {
+        return jsonNode.asDouble();
+      } else if (schema.getType().equals(Schema.Type.FLOAT)) {
+        return (float) jsonNode.asDouble();
+      }
+    } else if (jsonNode.isTextual()) {
+      if (schema == null || schema.getType().equals(Schema.Type.STRING) ||
+          schema.getType().equals(Schema.Type.ENUM)) {
+        return jsonNode.asText();
+      } else if (schema.getType().equals(Schema.Type.BYTES)) {
+        try {
+          return jsonNode.getTextValue().getBytes(BYTES_CHARSET);
+        } catch (UnsupportedEncodingException e) {
+          throw new AvroRuntimeException(e);
+        }
+      }
+    } else if (jsonNode.isArray()) {
+      List l = new ArrayList();
+      for (JsonNode node : jsonNode) {
+        l.add(toObject(node, schema == null ? null : schema.getElementType()));
+      }
+      return l;
+    } else if (jsonNode.isObject()) {
+      Map m = new LinkedHashMap();
+      for (Iterator<String> it = jsonNode.getFieldNames(); it.hasNext(); ) {
+        String key = it.next();
+        Schema s = null;
+        if (schema == null) {
+          s = null;
+        } else if (schema.getType().equals(Schema.Type.MAP)) {
+          s = schema.getValueType();
+        } else if (schema.getType().equals(Schema.Type.RECORD)) {
+          s = schema.getField(key).schema();
+        }
+        Object value = toObject(jsonNode.get(key), s);
+        m.put(key, value);
+      }
+      return m;
+    }
+    return null;
+  }
+}

--- a/lang/java/avro/src/test/java/org/apache/avro/TestDataFileCorruption.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestDataFileCorruption.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.avro;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import org.apache.avro.Schema.Type;
+import org.apache.avro.file.DataFileConstants;
+import org.apache.avro.file.DataFileReader;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.util.Utf8;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+public class TestDataFileCorruption {
+
+  private static final File DIR
+      = new File(System.getProperty("test.dir", "/tmp"));
+
+  private File makeFile(String name) {
+    return new File(DIR, "test-" + name + ".avro");
+  }
+
+  @Test
+  public void testCorruptedFile() throws IOException {
+    Schema schema = Schema.create(Type.STRING);
+
+    // Write a data file
+    DataFileWriter<Utf8> w = new DataFileWriter<Utf8>(new GenericDatumWriter<Utf8>(schema));
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    w.create(schema, baos);
+    w.append(new Utf8("apple"));
+    w.append(new Utf8("banana"));
+    w.sync();
+    w.append(new Utf8("celery"));
+    w.append(new Utf8("date"));
+    long pos = w.sync();
+    w.append(new Utf8("endive"));
+    w.append(new Utf8("fig"));
+    w.close();
+
+    // Corrupt the input by inserting some zero bytes before the sync marker for the
+    // penultimate block
+    byte[] original = baos.toByteArray();
+    int corruptPosition = (int) pos - DataFileConstants.SYNC_SIZE;
+    int corruptedBytes = 3;
+    byte[] corrupted = new byte[original.length + corruptedBytes];
+    System.arraycopy(original, 0, corrupted, 0, corruptPosition);
+    System.arraycopy(original, corruptPosition,
+        corrupted, corruptPosition + corruptedBytes, original.length - corruptPosition);
+
+    File file = makeFile("corrupt");
+    file.deleteOnExit();
+    FileOutputStream out = new FileOutputStream(file);
+    out.write(corrupted);
+    out.close();
+
+    // Read the data file
+    DataFileReader r = new DataFileReader<Utf8>(file,
+        new GenericDatumReader<Utf8>(schema));
+    assertEquals("apple", r.next().toString());
+    assertEquals("banana", r.next().toString());
+    long prevSync = r.previousSync();
+    try {
+      r.next();
+      fail("Corrupt block should throw exception");
+    } catch (AvroRuntimeException e) {
+      assertEquals("Invalid sync!", e.getCause().getMessage());
+    }
+    r.sync(prevSync); // go to sync point after previous successful one
+    assertEquals("endive", r.next().toString());
+    assertEquals("fig", r.next().toString());
+    assertFalse(r.hasNext());
+  }
+}

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemaBuilder.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemaBuilder.java
@@ -33,7 +33,6 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecordBuilder;
-import org.codehaus.jackson.node.BooleanNode;
 import org.codehaus.jackson.node.NullNode;
 import org.junit.Assert;
 import org.junit.Test;
@@ -70,7 +69,7 @@ public class TestSchemaBuilder {
     types.add(Schema.create(Schema.Type.BOOLEAN));
     types.add(Schema.create(Schema.Type.NULL));
     Schema optional = Schema.createUnion(types);
-    Assert.assertEquals(new Schema.Field("f2", optional, null, BooleanNode.getTrue()),
+    Assert.assertEquals(new Schema.Field("f2", optional, null, true),
         fields.get(2));
   }
   

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemaCompatibility.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemaCompatibility.java
@@ -38,7 +38,6 @@ import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.util.Utf8;
-import org.codehaus.jackson.node.IntNode;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -118,13 +117,13 @@ public class TestSchemaCompatibility {
         new Field("a", INT_SCHEMA, null, null),
         new Field("b", INT_SCHEMA, null, null)));
     A_DINT_RECORD1.setFields(list(
-        new Field("a", INT_SCHEMA, null, new IntNode(0))));
+        new Field("a", INT_SCHEMA, null, 0)));
     A_INT_B_DINT_RECORD1.setFields(list(
         new Field("a", INT_SCHEMA, null, null),
-        new Field("b", INT_SCHEMA, null, new IntNode(0))));
+        new Field("b", INT_SCHEMA, null, 0)));
     A_DINT_B_DINT_RECORD1.setFields(list(
-        new Field("a", INT_SCHEMA, null, new IntNode(0)),
-        new Field("b", INT_SCHEMA, null, new IntNode(0))));
+        new Field("a", INT_SCHEMA, null, 0),
+        new Field("b", INT_SCHEMA, null, 0)));
   }
 
   // Recursive records
@@ -221,7 +220,7 @@ public class TestSchemaCompatibility {
   public void testValidateSchemaNewFieldWithDefault() throws Exception {
     final List<Schema.Field> readerFields = list(
         new Schema.Field("oldfield1", INT_SCHEMA, null, null),
-        new Schema.Field("newfield1", INT_SCHEMA, null, IntNode.valueOf(42)));
+        new Schema.Field("newfield1", INT_SCHEMA, null, 42));
     final Schema reader = Schema.createRecord(readerFields);
     final SchemaCompatibility.SchemaPairCompatibility expectedResult =
         new SchemaCompatibility.SchemaPairCompatibility(

--- a/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericRecordBuilder.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericRecordBuilder.java
@@ -26,8 +26,6 @@ import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field;
 import org.apache.avro.Schema.Type;
 import org.apache.avro.generic.GenericData.Record;
-import org.codehaus.jackson.node.TextNode;
-import org.codehaus.jackson.node.NullNode;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -100,13 +98,13 @@ public class TestGenericRecordBuilder {
   /** Creates a test record schema */
   private static Schema recordSchema() {
     List<Field> fields = new ArrayList<Field>();
-    fields.add(new Field("id", Schema.create(Type.STRING), null, new TextNode("0")));
+    fields.add(new Field("id", Schema.create(Type.STRING), null, "0"));
     fields.add(new Field("intField", Schema.create(Type.INT), null, null));
     fields.add(new Field("anArray", Schema.createArray(Schema.create(Type.STRING)), null, null));
     fields.add(new Field("optionalInt", Schema.createUnion
                          (Arrays.asList(Schema.create(Type.NULL),
                                         Schema.create(Type.INT))),
-                         null, NullNode.getInstance()));
+                         null, Schema.NULL_VALUE));
     Schema schema = Schema.createRecord("Foo", "test", "mytest", false);
     schema.setFields(fields);
     return schema;

--- a/lang/java/avro/src/test/java/org/apache/avro/util/internal/TestJacksonUtils.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/util/internal/TestJacksonUtils.java
@@ -1,0 +1,84 @@
+package org.apache.avro.util.internal;
+
+import java.util.Collections;
+import org.apache.avro.JsonProperties;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.codehaus.jackson.node.ArrayNode;
+import org.codehaus.jackson.node.BooleanNode;
+import org.codehaus.jackson.node.DoubleNode;
+import org.codehaus.jackson.node.IntNode;
+import org.codehaus.jackson.node.JsonNodeFactory;
+import org.codehaus.jackson.node.LongNode;
+import org.codehaus.jackson.node.NullNode;
+import org.codehaus.jackson.node.ObjectNode;
+import org.codehaus.jackson.node.TextNode;
+import org.junit.Test;
+
+import static org.apache.avro.util.internal.JacksonUtils.toJsonNode;
+import static org.apache.avro.util.internal.JacksonUtils.toObject;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class TestJacksonUtils {
+
+  enum Direction {
+    UP, DOWN;
+  }
+
+  @Test
+  public void testToJsonNode() {
+    assertEquals(null, toJsonNode(null));
+    assertEquals(NullNode.getInstance(), toJsonNode(JsonProperties.NULL_VALUE));
+    assertEquals(BooleanNode.TRUE, toJsonNode(true));
+    assertEquals(IntNode.valueOf(1), toJsonNode(1));
+    assertEquals(LongNode.valueOf(2), toJsonNode(2L));
+    assertEquals(DoubleNode.valueOf(1.0), toJsonNode(1.0f));
+    assertEquals(DoubleNode.valueOf(2.0), toJsonNode(2.0));
+    assertEquals(TextNode.valueOf("\u0001\u0002"), toJsonNode(new byte[] { 1, 2 }));
+    assertEquals(TextNode.valueOf("a"), toJsonNode("a"));
+    assertEquals(TextNode.valueOf("UP"), toJsonNode(Direction.UP));
+
+    ArrayNode an = JsonNodeFactory.instance.arrayNode();
+    an.add(1);
+    assertEquals(an, toJsonNode(Collections.singletonList(1)));
+
+    ObjectNode on = JsonNodeFactory.instance.objectNode();
+    on.put("a", 1);
+    assertEquals(on, toJsonNode(Collections.singletonMap("a", 1)));
+  }
+
+  @Test
+  public void testToObject() {
+    assertEquals(null, toObject(null));
+    assertEquals(JsonProperties.NULL_VALUE, toObject(NullNode.getInstance()));
+    assertEquals(true, toObject(BooleanNode.TRUE));
+    assertEquals(1, toObject(IntNode.valueOf(1)));
+    assertEquals(2L, toObject(IntNode.valueOf(2), Schema.create(Schema.Type.LONG)));
+    assertEquals(1.0f, toObject(DoubleNode.valueOf(1.0), Schema.create(Schema.Type.FLOAT)));
+    assertEquals(2.0, toObject(DoubleNode.valueOf(2.0)));
+    assertEquals(TextNode.valueOf("\u0001\u0002"), toJsonNode(new byte[]{1, 2}));
+    assertArrayEquals(new byte[]{1, 2},
+        (byte[]) toObject(TextNode.valueOf("\u0001\u0002"), Schema.create(Schema.Type.BYTES)));
+    assertEquals("a", toObject(TextNode.valueOf("a")));
+    assertEquals("UP", toObject(TextNode.valueOf("UP"),
+        SchemaBuilder.enumeration("Direction").symbols("UP", "DOWN")));
+
+    ArrayNode an = JsonNodeFactory.instance.arrayNode();
+    an.add(1);
+    assertEquals(Collections.singletonList(1), toObject(an));
+
+    ObjectNode on = JsonNodeFactory.instance.objectNode();
+    on.put("a", 1);
+    assertEquals(Collections.singletonMap("a", 1), toObject(on));
+    assertEquals(Collections.singletonMap("a", 1L), toObject(on,
+        SchemaBuilder.record("r").fields().requiredLong("a").endRecord()));
+
+    assertEquals(JsonProperties.NULL_VALUE, toObject(NullNode.getInstance(),
+        SchemaBuilder.unionOf().nullType().and().intType().endUnion()));
+
+    assertEquals("a", toObject(TextNode.valueOf("a"),
+        SchemaBuilder.unionOf().stringType().and().intType().endUnion()));
+  }
+
+}

--- a/lang/java/compiler/src/main/javacc/org/apache/avro/compiler/idl/idl.jj
+++ b/lang/java/compiler/src/main/javacc/org/apache/avro/compiler/idl/idl.jj
@@ -1538,6 +1538,7 @@ Token AnyIdentifier():
    t = <LONG> |
    t = <MAP> |
    t = <BYTES> |
+   t = <SCHEMA> |
    t = <STRING> |
    t = <PROTOCOL> |
    t = <RECORD> |

--- a/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/fixed.vm
+++ b/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/fixed.vm
@@ -36,7 +36,10 @@ public class ${this.mangle($schema.getName())} extends org.apache.avro.specific.
     super();
   }
   
-  /** Creates a new ${this.mangle($schema.getName())} with the given bytes */
+  /**
+   * Creates a new ${this.mangle($schema.getName())} with the given bytes.
+   * @param bytes The bytes to create the new ${this.mangle($schema.getName())}. 
+   */
   public ${this.mangle($schema.getName())}(byte[] bytes) {
     super(bytes);
   }

--- a/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/protocol.vm
+++ b/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/protocol.vm
@@ -33,9 +33,15 @@ public interface $this.mangle($protocol.getName()) {
 #set ($name = $e.getKey())
 #set ($message = $e.getValue())
 #set ($response = $message.getResponse())
+  /**
 #if ($message.getDoc())
-  /** $this.escapeForJavadoc($message.getDoc()) */
+   * $this.escapeForJavadoc($message.getDoc())
 #end
+#foreach ($p in $message.getRequest().getFields())##
+#if ($p.doc())   * @param ${this.mangle($p.name())} $p.doc()
+#end
+#end
+   */
 #foreach ($annotation in $this.javaAnnotations($message))
   @$annotation
 #end
@@ -67,9 +73,16 @@ public interface $this.mangle($protocol.getName()) {
 #set ($response = $message.getResponse())
 ## Generate callback method if the message is not one-way:
 #if (! $message.isOneWay())
+    /**
 #if ($message.getDoc())
-    /** $this.escapeForJavadoc($message.getDoc()) */
+     * $this.escapeForJavadoc($message.getDoc())
 #end
+#foreach ($p in $message.getRequest().getFields())##
+#if ($p.doc())     * @param ${this.mangle($p.name())} $p.doc()
+#end
+#end
+     * @throws java.io.IOException The async call could not be completed.
+     */
     void ${this.mangle($name)}(##
 #foreach ($p in $message.getRequest().getFields())##
 #*      *#${this.javaUnbox($p.schema())} ${this.mangle($p.name())}#if ($velocityHasNext), #end

--- a/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/record.vm
+++ b/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/record.vm
@@ -279,7 +279,7 @@ public class ${this.mangle($schema.getName())}#if ($schema.isError()) extends or
         record.${this.mangle($field.name(), $schema.isError())} = fieldSetFlags()[$field.pos()] ? this.${this.mangle($field.name(), $schema.isError())} : (${this.javaType($field.schema())}) defaultValue(fields()[$field.pos()]);
 #end
         return record;
-      } catch (Exception e) {
+      } catch (java.lang.Exception e) {
         throw new org.apache.avro.AvroRuntimeException(e);
       }
     }

--- a/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/record.vm
+++ b/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/record.vm
@@ -65,7 +65,7 @@ public class ${this.mangle($schema.getName())}#if ($schema.isError()) extends or
    * one should use <code>newBuilder()</code>. 
    */
   public ${this.mangle($schema.getName())}() {}
-
+#if ($this.isCreateAllArgsConstructor())
   /**
    * All-args constructor.
 #foreach ($field in $schema.getFields())
@@ -78,6 +78,14 @@ public class ${this.mangle($schema.getName())}#if ($schema.isError()) extends or
     this.${this.mangle($field.name())} = ${this.mangle($field.name())};
 #end
   }
+#else
+  /**
+   * This schema contains more than 254 fields which exceeds the maximum number
+   * of permitted constructor parameters in the JVM. An all-args constructor
+   * will not be generated. Please use <code>newBuilder()</code> to instantiate
+   * objects instead.
+   */
+#end
 #end
 
 #end

--- a/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/record.vm
+++ b/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/record.vm
@@ -68,6 +68,10 @@ public class ${this.mangle($schema.getName())}#if ($schema.isError()) extends or
 
   /**
    * All-args constructor.
+#foreach ($field in $schema.getFields())
+#if ($field.doc())   * @param ${this.mangle($field.name())} $field.doc()
+#end
+#end
    */
   public ${this.mangle($schema.getName())}(#foreach($field in $schema.getFields())${this.javaType($field.schema())} ${this.mangle($field.name())}#if($velocityCount < $schema.getFields().size()), #end#end) {
 #foreach ($field in $schema.getFields())
@@ -105,7 +109,8 @@ public class ${this.mangle($schema.getName())}#if ($schema.isError()) extends or
 #foreach ($field in $schema.getFields())
   /**
    * Gets the value of the '${this.mangle($field.name(), $schema.isError())}' field.
-#if ($field.doc())   * $field.doc()#end
+#if ($field.doc())   * @return $field.doc()
+#end
    */
   public ${this.javaType($field.schema())} ${this.generateGetMethod($schema, $field)}() {
     return ${this.mangle($field.name(), $schema.isError())};
@@ -114,7 +119,8 @@ public class ${this.mangle($schema.getName())}#if ($schema.isError()) extends or
 #if ($this.createSetters)
   /**
    * Sets the value of the '${this.mangle($field.name(), $schema.isError())}' field.
-#if ($field.doc())   * $field.doc()#end
+#if ($field.doc())   * $field.doc()
+#end
    * @param value the value to set.
    */
   public void ${this.generateSetMethod($schema, $field)}(${this.javaType($field.schema())} value) {
@@ -123,17 +129,28 @@ public class ${this.mangle($schema.getName())}#if ($schema.isError()) extends or
 #end
 
 #end
-  /** Creates a new ${this.mangle($schema.getName())} RecordBuilder */
+  /**
+   * Creates a new ${this.mangle($schema.getName())} RecordBuilder.
+   * @return A new ${this.mangle($schema.getName())} RecordBuilder
+   */
   public static #if ($schema.getNamespace())$schema.getNamespace().#end${this.mangle($schema.getName())}.Builder newBuilder() {
     return new #if ($schema.getNamespace())$schema.getNamespace().#end${this.mangle($schema.getName())}.Builder();
   }
   
-  /** Creates a new ${this.mangle($schema.getName())} RecordBuilder by copying an existing Builder */
+  /**
+   * Creates a new ${this.mangle($schema.getName())} RecordBuilder by copying an existing Builder.
+   * @param other The existing builder to copy.
+   * @return A new ${this.mangle($schema.getName())} RecordBuilder
+   */
   public static #if ($schema.getNamespace())$schema.getNamespace().#end${this.mangle($schema.getName())}.Builder newBuilder(#if ($schema.getNamespace())$schema.getNamespace().#end${this.mangle($schema.getName())}.Builder other) {
     return new #if ($schema.getNamespace())$schema.getNamespace().#end${this.mangle($schema.getName())}.Builder(other);
   }
   
-  /** Creates a new ${this.mangle($schema.getName())} RecordBuilder by copying an existing $this.mangle($schema.getName()) instance */
+  /**
+   * Creates a new ${this.mangle($schema.getName())} RecordBuilder by copying an existing $this.mangle($schema.getName()) instance.
+   * @param other The existing instance to copy.
+   * @return A new ${this.mangle($schema.getName())} RecordBuilder
+   */
   public static #if ($schema.getNamespace())$schema.getNamespace().#end${this.mangle($schema.getName())}.Builder newBuilder(#if ($schema.getNamespace())$schema.getNamespace().#end${this.mangle($schema.getName())} other) {
     return new #if ($schema.getNamespace())$schema.getNamespace().#end${this.mangle($schema.getName())}.Builder(other);
   }
@@ -146,6 +163,9 @@ public class ${this.mangle($schema.getName())}#if ($schema.isError()) extends or
     implements#if ($schema.isError()) org.apache.avro.data.ErrorBuilder<${this.mangle($schema.getName())}>#else org.apache.avro.data.RecordBuilder<${this.mangle($schema.getName())}>#end {
 
 #foreach ($field in $schema.getFields())
+#if ($field.doc())
+    /** $field.doc() */
+#end
     private ${this.javaUnbox($field.schema())} ${this.mangle($field.name(), $schema.isError())};
 #end
 
@@ -154,7 +174,10 @@ public class ${this.mangle($schema.getName())}#if ($schema.isError()) extends or
       super(#if ($schema.getNamespace())$schema.getNamespace().#end${this.mangle($schema.getName())}.SCHEMA$);
     }
     
-    /** Creates a Builder by copying an existing Builder */
+    /**
+     * Creates a Builder by copying an existing Builder.
+     * @param other The existing Builder to copy.
+     */
     private Builder(#if ($schema.getNamespace())$schema.getNamespace().#end${this.mangle($schema.getName())}.Builder other) {
       super(other);
 #foreach ($field in $schema.getFields())
@@ -165,7 +188,10 @@ public class ${this.mangle($schema.getName())}#if ($schema.isError()) extends or
 #end
     }
     
-    /** Creates a Builder by copying an existing $this.mangle($schema.getName()) instance */
+    /**
+     * Creates a Builder by copying an existing $this.mangle($schema.getName()) instance
+     * @param other The existing instance to copy.
+     */
     private Builder(#if ($schema.getNamespace())$schema.getNamespace().#end${this.mangle($schema.getName())} other) {
       #if ($schema.isError())super(other)#else
       super(#if ($schema.getNamespace())$schema.getNamespace().#end${this.mangle($schema.getName())}.SCHEMA$)#end;
@@ -204,12 +230,19 @@ public class ${this.mangle($schema.getName())}#if ($schema.isError()) extends or
 #end
 
 #foreach ($field in $schema.getFields())
-    /** Gets the value of the '${this.mangle($field.name(), $schema.isError())}' field */
+    /**
+     * Gets the value of the '${this.mangle($field.name(), $schema.isError())}' field.
+     * @return The value.
+     */
     public ${this.javaType($field.schema())} ${this.generateGetMethod($schema, $field)}() {
       return ${this.mangle($field.name(), $schema.isError())};
     }
     
-    /** Sets the value of the '${this.mangle($field.name(), $schema.isError())}' field */
+    /**
+     * Sets the value of the '${this.mangle($field.name(), $schema.isError())}' field.
+     * @param value The value of '${this.mangle($field.name(), $schema.isError())}'.
+     * @return This builder.
+     */
     public #if ($schema.getNamespace())$schema.getNamespace().#end${this.mangle($schema.getName())}.Builder ${this.generateSetMethod($schema, $field)}(${this.javaUnbox($field.schema())} value) {
       validate(fields()[$field.pos()], value);
       this.${this.mangle($field.name(), $schema.isError())} = value;
@@ -217,12 +250,18 @@ public class ${this.mangle($schema.getName())}#if ($schema.isError()) extends or
       return this; 
     }
     
-    /** Checks whether the '${this.mangle($field.name(), $schema.isError())}' field has been set */
+    /**
+     * Checks whether the '${this.mangle($field.name(), $schema.isError())}' field has been set.
+     * @return True if the '${this.mangle($field.name(), $schema.isError())}' field has been set, false otherwise.
+     */
     public boolean ${this.generateHasMethod($schema, $field)}() {
       return fieldSetFlags()[$field.pos()];
     }
     
-    /** Clears the value of the '${this.mangle($field.name(), $schema.isError())}' field */
+    /**
+     * Clears the value of the '${this.mangle($field.name(), $schema.isError())}' field.
+     * @return This builder.
+     */
     public #if ($schema.getNamespace())$schema.getNamespace().#end${this.mangle($schema.getName())}.Builder ${this.generateClearMethod($schema, $field)}() {
 #if (${this.isUnboxedJavaTypeNullable($field.schema())})
       ${this.mangle($field.name(), $schema.isError())} = null;

--- a/lang/java/compiler/src/test/java/org/apache/avro/compiler/TestSpecificCompiler.java
+++ b/lang/java/compiler/src/test/java/org/apache/avro/compiler/TestSpecificCompiler.java
@@ -56,6 +56,9 @@ public class TestSpecificCompiler {
     this.src = new File(this.schemaSrcPath);
     this.outputDir = AvroTestUtil.tempDirectory(getClass(), "specific-output");
     this.outputFile = new File(this.outputDir, "SimpleRecord.java");
+    if (outputFile.exists() && !outputFile.delete()) {
+      throw new IllegalStateException("unable to delete " + outputFile);
+    }
   }
 
   @After
@@ -100,6 +103,7 @@ public class TestSpecificCompiler {
       assertFalse("Line started with a deprecated field declaration: " + line,
         line.startsWith("@Deprecated public int value"));
     }
+    reader.close();
   }
 
   @Test
@@ -118,6 +122,7 @@ public class TestSpecificCompiler {
       assertFalse("Line started with a public field declaration: " + line,
         line.startsWith("public int value"));
     }
+    reader.close();
   }
 
   @Test
@@ -140,6 +145,7 @@ public class TestSpecificCompiler {
       assertFalse("Line started with a deprecated field declaration: " + line,
         line.startsWith("@Deprecated public int value"));
     }
+    reader.close();
   }
 
   @Test
@@ -158,6 +164,7 @@ public class TestSpecificCompiler {
         foundSetters++;
       }
     }
+    reader.close();
     assertEquals("Found the wrong number of setters", 1, foundSetters);
   }
 
@@ -176,6 +183,7 @@ public class TestSpecificCompiler {
       assertFalse("No line should include the setter: " + line,
         line.startsWith("public void setValue("));
     }
+    reader.close();
   }
 
   @Test
@@ -184,14 +192,20 @@ public class TestSpecificCompiler {
     // Generated file in default encoding
     compiler.compileToDestination(this.src, this.outputDir);
     byte[] fileInDefaultEncoding = new byte[(int) this.outputFile.length()];
-    new FileInputStream(this.outputFile).read(fileInDefaultEncoding);
-    this.outputFile.delete();
+    FileInputStream is = new FileInputStream(this.outputFile);
+    is.read(fileInDefaultEncoding);
+    is.close(); //close input stream otherwise delete might fail
+    if (!this.outputFile.delete()) {
+      throw new IllegalStateException("unable to delete " + this.outputFile); //delete otherwise compiler might not overwrite because src timestamp hasnt changed.
+    }
     // Generate file in another encoding (make sure it has different number of bytes per character)
     String differentEncoding = Charset.defaultCharset().equals(Charset.forName("UTF-16")) ? "UTF-32" : "UTF-16";
     compiler.setOutputCharacterEncoding(differentEncoding);
     compiler.compileToDestination(this.src, this.outputDir);
     byte[] fileInDifferentEncoding = new byte[(int) this.outputFile.length()];
-    new FileInputStream(this.outputFile).read(fileInDifferentEncoding);
+    is = new FileInputStream(this.outputFile);
+    is.read(fileInDifferentEncoding);
+    is.close();
     // Compare as bytes
     assertThat("Generated file should contain different bytes after setting non-default encoding",
       fileInDefaultEncoding, not(equalTo(fileInDifferentEncoding)));

--- a/lang/java/ipc/src/test/java/org/apache/avro/TestProtocolGeneric.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/TestProtocolGeneric.java
@@ -44,8 +44,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
-import org.codehaus.jackson.node.BooleanNode;
-
 public class TestProtocolGeneric {
   private static final Logger LOG
     = LoggerFactory.getLogger(TestProtocolGeneric.class);
@@ -222,7 +220,7 @@ public class TestProtocolGeneric {
     for (Field f : PROTOCOL.getType("TestRecord").getFields())
       fields.add(new Field(f.name(), f.schema(), null, null));
     fields.add(new Field("extra", Schema.create(Schema.Type.BOOLEAN),
-                         null, BooleanNode.TRUE));
+                         null, true));
     Schema record =
       Schema.createRecord("TestRecord", null, "org.apache.avro.test", false);
     record.setFields(fields);

--- a/lang/java/ipc/src/test/java/org/apache/avro/TestSchema.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/TestSchema.java
@@ -819,21 +819,21 @@ public class TestSchema {
   }
 
   public static void checkBinaryJson(String json) throws Exception {
-    JsonNode node = Schema.parseJson(json);
+    Object node = Json.parseJson(json);
     ByteArrayOutputStream out = new ByteArrayOutputStream();
-    DatumWriter<JsonNode> writer = new Json.Writer();
+    DatumWriter<Object> writer = new Json.ObjectWriter();
     Encoder encoder = EncoderFactory.get().binaryEncoder(out, null);
     encoder = EncoderFactory.get().validatingEncoder(Json.SCHEMA, encoder);
     writer.write(node, encoder);
     encoder.flush();
     byte[] bytes = out.toByteArray();
 
-    DatumReader<JsonNode> reader = new Json.Reader();
+    DatumReader<Object> reader = new Json.ObjectReader();
     Decoder decoder = DecoderFactory.get().binaryDecoder(bytes, null);
     decoder = DecoderFactory.get().validatingDecoder(Json.SCHEMA, decoder);
-    JsonNode decoded = reader.read(null, decoder);
+    Object decoded = reader.read(null, decoder);
 
-    assertEquals("Decoded json does not match.", node.toString(), decoded.toString());
+    assertEquals("Decoded json does not match.", Json.toString(node), Json.toString(decoded));
   }
 
   private static final Schema ACTUAL =            // an empty record schema

--- a/lang/java/ipc/src/test/java/org/apache/avro/compiler/specific/TestSpecificCompiler.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/compiler/specific/TestSpecificCompiler.java
@@ -217,7 +217,7 @@ public class TestSpecificCompiler {
       if (o.path.endsWith("Simple.java")) {
         count++;
         assertTrue(o.contents.contains("/** Protocol used for testing. */"));
-        assertTrue(o.contents.contains("/** Send a greeting */"));
+        assertTrue(o.contents.contains("* Send a greeting"));
       }
     }
     assertEquals("Missed generated protocol!", 1, count);

--- a/lang/java/mapred/src/test/java/org/apache/avro/mapred/TestGenericJob.java
+++ b/lang/java/mapred/src/test/java/org/apache/avro/mapred/TestGenericJob.java
@@ -47,7 +47,6 @@ import org.apache.hadoop.mapred.Mapper;
 import org.apache.hadoop.mapred.OutputCollector;
 import org.apache.hadoop.mapred.Reporter;
 import org.apache.hadoop.mapred.TextInputFormat;
-import org.codehaus.jackson.node.JsonNodeFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -61,8 +60,7 @@ public class TestGenericJob {
     List<Field> fields = new ArrayList<Schema.Field>();
 
       
-    fields.add(new Field("Optional", createArraySchema(), "",
-                         JsonNodeFactory.instance.arrayNode()));
+    fields.add(new Field("Optional", createArraySchema(), "", new ArrayList<Object>()));
 
     Schema recordSchema =
       Schema.createRecord("Container", "", "org.apache.avro.mapred", false);
@@ -83,8 +81,7 @@ public class TestGenericJob {
   private static Schema createInnerSchema(String name) {
     Schema innerrecord = Schema.createRecord(name, "", "", false);
     innerrecord.setFields
-      (Arrays.asList(new Field(name, Schema.create(Type.LONG), "",
-                               JsonNodeFactory.instance.numberNode(0l))));
+      (Arrays.asList(new Field(name, Schema.create(Type.LONG), "", 0L)));
     return innerrecord;
   }
 

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -248,6 +248,7 @@
                 <version>${plugin-tools-javadoc.version}</version>
               </tagletArtifact>
             </tagletArtifacts>
+            <excludePackageNames>org.apache.avro.compiler.idl,*.internal</excludePackageNames>
           </configuration>
         </plugin>
         <plugin>

--- a/lang/java/thrift/src/main/java/org/apache/avro/thrift/ThriftData.java
+++ b/lang/java/thrift/src/main/java/org/apache/avro/thrift/ThriftData.java
@@ -98,12 +98,14 @@ public class ThriftData extends GenericData {
     new ConcurrentHashMap<Schema,TFieldIdEnum[]>();
 
   @Override
+  @SuppressWarnings("unchecked")
   protected Object getRecordState(Object r, Schema s) {
     TFieldIdEnum[] fields = fieldCache.get(s);
     if (fields == null) {                           // cache miss
       fields = new TFieldIdEnum[s.getFields().size()];
       Class c = r.getClass();
-      for (TFieldIdEnum f : FieldMetaData.getStructMetaDataMap(c).keySet())
+      for (TFieldIdEnum f :
+          FieldMetaData.getStructMetaDataMap((Class<? extends TBase>) c).keySet())
         fields[s.getField(f.getFieldName()).pos()] = f;
       fieldCache.put(s, fields);                  // update cache
     }
@@ -166,6 +168,7 @@ public class ThriftData extends GenericData {
     = new ConcurrentHashMap<Class,Schema>();
 
   /** Return a record schema given a thrift generated class. */
+  @SuppressWarnings("unchecked")
   public Schema getSchema(Class c) {
     Schema schema = schemaCache.get(c);
 
@@ -181,7 +184,7 @@ public class ThriftData extends GenericData {
                                        Throwable.class.isAssignableFrom(c));
           List<Field> fields = new ArrayList<Field>();
           for (FieldMetaData f :
-                 FieldMetaData.getStructMetaDataMap(c).values()) {
+                 FieldMetaData.getStructMetaDataMap((Class<? extends TBase>) c).values()) {
             Schema s = getSchema(f.valueMetaData);
             if (f.requirementType == TFieldRequirementType.OPTIONAL
                 && (s.getType() != Schema.Type.UNION))

--- a/lang/java/tools/src/main/java/org/apache/avro/tool/DataFileRepairTool.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/DataFileRepairTool.java
@@ -1,0 +1,308 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.avro.tool;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.avro.Schema;
+import org.apache.avro.file.CodecFactory;
+import org.apache.avro.file.DataFileConstants;
+import org.apache.avro.file.DataFileReader;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericDatumWriter;
+
+/** Recovers data from a corrupt Avro Data file */
+public class DataFileRepairTool implements Tool {
+
+  @Override
+  public String getName() {
+    return "repair";
+  }
+
+  @Override
+  public String getShortDescription() {
+    return "Recovers data from a corrupt Avro Data file";
+  }
+  
+  private void printInfo(PrintStream output) {
+    output.println("Insufficient arguments.  Arguments:  [-o option] "
+        + "input_file output_file \n"
+        + "   Where option is one of the following: \n"
+        + "      " + ALL
+        + " (default) recover as many records as possible.\n"
+        + "      " + PRIOR
+        + "         recover only records prior to the first instance"
+        + " of corruption \n"
+        + "      " + AFTER
+        + "         recover only records after the first instance of"
+        + " corruption.\n"
+        + "      " + REPORT
+        + "        print the corruption report only, reporting the\n"
+        + "                    number of valid and corrupted blocks and records\n"
+        + "   input_file is the file to read from.  output_file is the file to\n"
+        + "   create and write recovered data to.  output_file is ignored if\n"
+        + "   using the report option.");
+  }
+
+  private static final Set<String> OPTIONS = new HashSet<String>();
+  private static final String ALL = "all";
+  private static final String PRIOR = "prior";
+  private static final String AFTER = "after";
+  private static final String REPORT = "report";
+  static {
+    OPTIONS.add(ALL);
+    OPTIONS.add(PRIOR);
+    OPTIONS.add(AFTER);
+    OPTIONS.add(REPORT);
+  }
+
+  @Override
+  public int run(InputStream stdin, PrintStream out, PrintStream err,
+      List<String> args) throws Exception {
+    if (args.size() < 2) {
+      printInfo(err);
+      return 1;
+    }
+    int index = 0;
+    String input = args.get(index);
+    String option = "all";
+    if ("-o".equals(input)) {
+      option = args.get(1);
+      index += 2;
+    }
+    if (!OPTIONS.contains(option) || (args.size() - index < 1)) {
+      printInfo(err);
+      return 1;
+    }
+    input = args.get(index++);
+    if (!REPORT.equals(option)) {
+      if (args.size() - index < 1) {
+        printInfo(err);
+        return 1;
+      } 
+    }
+    if (ALL.equals(option)) {
+      return recoverAll(input, args.get(index), out, err);
+    } else if (PRIOR.equals(option)) {
+      return recoverPrior(input, args.get(index), out, err);
+    } else if (AFTER.equals(option)) {
+      return recoverAfter(input, args.get(index), out, err);
+    } else if (REPORT.equals(option)) {
+      return reportOnly(input, out, err);
+    } else {
+      return 1;
+    }
+  }
+
+  private int recover(String input, String output, PrintStream out,
+      PrintStream err, boolean recoverPrior, boolean recoverAfter)
+      throws IOException {
+    File infile = new File(input);
+    if (!infile.canRead()) {
+      err.println("cannot read file: " + input);
+      return 1;
+    }
+    out.println("Recovering file: " + input);
+    GenericDatumReader<Object> reader = new GenericDatumReader<Object>();
+    DataFileReader<Object> fileReader = new DataFileReader<Object>(infile,
+        reader);
+    try {
+      Schema schema = fileReader.getSchema();
+      String codecStr = fileReader.getMetaString(DataFileConstants.CODEC);
+      CodecFactory codecFactory = CodecFactory.fromString("" + codecStr);
+      List<String> metas = fileReader.getMetaKeys();
+      if (recoverPrior || recoverAfter) {
+        GenericDatumWriter<Object> writer = new GenericDatumWriter<Object>();
+        DataFileWriter<Object> fileWriter = new DataFileWriter<Object>(writer);
+        try {
+          File outfile = new File(output);
+          for (String key : metas) {
+            if (!key.startsWith("avro.")) {
+              byte[] val = fileReader.getMeta(key);
+              fileWriter.setMeta(key, val);
+            }
+          }
+          fileWriter.setCodec(codecFactory);
+          int result = innerRecover(fileReader, fileWriter, out, err, recoverPrior,
+              recoverAfter, schema, outfile);
+          return result;
+        } catch (Exception e) {
+          e.printStackTrace(err);
+          return 1;
+        } 
+      } else {
+        return innerRecover(fileReader, null, out, err, recoverPrior,
+            recoverAfter, null, null);
+      }
+
+    } finally {
+      fileReader.close();
+    }
+  }
+
+  private int innerRecover(DataFileReader<Object> fileReader,
+      DataFileWriter<Object> fileWriter, PrintStream out, PrintStream err,
+      boolean recoverPrior, boolean recoverAfter, Schema schema, File outfile) {
+    int numBlocks = 0;
+    int numCorruptBlocks = 0;
+    int numRecords = 0;
+    int numCorruptRecords = 0;
+    int recordsWritten = 0;
+    long position = fileReader.previousSync();
+    long blockSize = 0;
+    long blockCount = 0;
+    boolean fileWritten = false;
+    try {
+      while (true) {
+        try {
+          if (!fileReader.hasNext()) {
+            out.println("File Summary: ");
+            out.println("  Number of blocks: " + numBlocks
+                + " Number of corrupt blocks: " + numCorruptBlocks);
+            out.println("  Number of records: " + numRecords
+                + " Number of corrupt records: " + numCorruptRecords);
+            if (recoverAfter || recoverPrior) {
+              out.println("  Number of records written " + recordsWritten);
+            }
+            out.println();
+            return 0;
+          }
+          position = fileReader.previousSync();
+          blockCount = fileReader.getBlockCount();
+          blockSize = fileReader.getBlockSize();
+          numRecords += blockCount;
+          long blockRemaining = blockCount;
+          numBlocks++;
+          boolean lastRecordWasBad = false;
+          long badRecordsInBlock = 0;
+          while (blockRemaining > 0) {
+            try {
+              Object datum = fileReader.next();
+              if ((recoverPrior && numCorruptBlocks == 0)
+                  || (recoverAfter && numCorruptBlocks > 0)) {
+                if (!fileWritten) {
+                  try {
+                    fileWriter.create(schema, outfile);
+                    fileWritten = true;
+                  } catch (Exception e) {
+                    e.printStackTrace(err);
+                    return 1;
+                  }
+                }
+                try {
+                  fileWriter.append(datum);
+                  recordsWritten++;
+                } catch (Exception e) {
+                  e.printStackTrace(err);
+                  throw e;
+                }
+              }
+              blockRemaining--;
+              lastRecordWasBad = false;
+            } catch (Exception e) {
+              long pos = blockCount - blockRemaining;
+              if (badRecordsInBlock == 0) {
+                // first corrupt record
+                numCorruptBlocks++;
+                err.println("Corrupt block: " + numBlocks + " Records in block: "
+                    + blockCount + " uncompressed block size: " + blockSize);
+                err.println("Corrupt record at position: "
+                    + (pos));
+              } else {
+                // second bad record in block, if consecutive skip block.
+                err.println("Corrupt record at position: "
+                    + (pos));
+                if (lastRecordWasBad) {
+                  // consecutive bad record
+                  err.println("Second consecutive bad record in block: " + numBlocks 
+                      + ". Skipping remainder of block. ");
+                  numCorruptRecords += blockRemaining;
+                  badRecordsInBlock += blockRemaining;
+                  try {
+                    fileReader.sync(position);
+                  } catch (Exception e2) {
+                    err.println("failed to sync to sync marker, aborting");
+                    e2.printStackTrace(err);
+                    return 1;
+                  }
+                  break;
+                }
+              }
+              blockRemaining --;
+              lastRecordWasBad = true;
+              numCorruptRecords++;
+              badRecordsInBlock++;
+            }
+          }
+          if (badRecordsInBlock != 0) {
+            err.println("** Number of unrecoverable records in block: "
+                + (badRecordsInBlock));
+          }
+          position = fileReader.previousSync();
+        } catch (Exception e) {
+          err.println("Failed to read block " + numBlocks + ". Unknown record "
+              + "count in block.  Skipping. Reason: " + e.getMessage());
+          numCorruptBlocks++;
+          try {
+            fileReader.sync(position);
+          } catch (Exception e2) {
+            err.println("failed to sync to sync marker, aborting");
+            e2.printStackTrace(err);
+            return 1;
+          }
+        } 
+      }
+    } finally {
+      if (fileWritten) {
+        try {
+          fileWriter.close();
+        } catch (Exception e) {
+          e.printStackTrace(err);
+          return 1;
+        }
+      }
+    }
+  }
+
+  private int reportOnly(String input, PrintStream out, PrintStream err)
+      throws IOException {
+    return recover(input, null, out, err, false, false);
+  }
+
+  private int recoverAfter(String input, String output, PrintStream out,
+      PrintStream err) throws IOException {
+    return recover(input, output, out, err, false, true);
+  }
+
+  private int recoverPrior(String input, String output, PrintStream out,
+      PrintStream err) throws IOException {
+    return recover(input, output, out, err, true, false);
+  }
+
+  private int recoverAll(String input, String output, PrintStream out,
+      PrintStream err) throws IOException {
+    return recover(input, output, out, err, true, true);
+  }
+}

--- a/lang/java/tools/src/main/java/org/apache/avro/tool/Main.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/Main.java
@@ -45,6 +45,7 @@ public class Main {
         new DataFileWriteTool(),
         new DataFileGetMetaTool(),
         new DataFileGetSchemaTool(),
+        new DataFileRepairTool(),
         new IdlTool(),
         new IdlToSchemataTool(),
         new RecodecTool(),

--- a/lang/java/tools/src/main/java/org/apache/avro/tool/RpcReceiveTool.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/RpcReceiveTool.java
@@ -38,9 +38,6 @@ import org.apache.avro.io.JsonEncoder;
 import org.apache.avro.ipc.Ipc;
 import org.apache.avro.ipc.Server;
 import org.apache.avro.ipc.generic.GenericResponder;
-import org.codehaus.jackson.JsonEncoding;
-import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.JsonGenerator;
 
 /**
  * Receives one RPC call and responds.  (The moral equivalent
@@ -82,14 +79,11 @@ public class RpcReceiveTool implements Tool {
       out.print(message.getName());
       out.print("\t");
       try {
-        JsonGenerator jsonGenerator = new JsonFactory().createJsonGenerator(
-            out, JsonEncoding.UTF8);
-        JsonEncoder jsonEncoder = EncoderFactory.get().jsonEncoder(message.getRequest(), jsonGenerator);
-
+        JsonEncoder jsonEncoder = EncoderFactory.get().jsonEncoder(message.getRequest(),
+            out);
         GenericDatumWriter<Object> writer = new GenericDatumWriter<Object>(
             message.getRequest());
         writer.write(request, jsonEncoder);
-        jsonGenerator.flush();
         jsonEncoder.flush();
         out.flush();
       } catch (IOException e) {

--- a/lang/java/tools/src/test/compiler/output-string/avro/examples/baseball/Player.java
+++ b/lang/java/tools/src/test/compiler/output-string/avro/examples/baseball/Player.java
@@ -114,17 +114,28 @@ public class Player extends org.apache.avro.specific.SpecificRecordBase implemen
     this.position = value;
   }
 
-  /** Creates a new Player RecordBuilder */
+  /**
+   * Creates a new Player RecordBuilder.
+   * @return A new Player RecordBuilder
+   */
   public static avro.examples.baseball.Player.Builder newBuilder() {
     return new avro.examples.baseball.Player.Builder();
   }
   
-  /** Creates a new Player RecordBuilder by copying an existing Builder */
+  /**
+   * Creates a new Player RecordBuilder by copying an existing Builder.
+   * @param other The existing builder to copy.
+   * @return A new Player RecordBuilder
+   */
   public static avro.examples.baseball.Player.Builder newBuilder(avro.examples.baseball.Player.Builder other) {
     return new avro.examples.baseball.Player.Builder(other);
   }
   
-  /** Creates a new Player RecordBuilder by copying an existing Player instance */
+  /**
+   * Creates a new Player RecordBuilder by copying an existing Player instance.
+   * @param other The existing instance to copy.
+   * @return A new Player RecordBuilder
+   */
   public static avro.examples.baseball.Player.Builder newBuilder(avro.examples.baseball.Player other) {
     return new avro.examples.baseball.Player.Builder(other);
   }
@@ -145,7 +156,10 @@ public class Player extends org.apache.avro.specific.SpecificRecordBase implemen
       super(avro.examples.baseball.Player.SCHEMA$);
     }
     
-    /** Creates a Builder by copying an existing Builder */
+    /**
+     * Creates a Builder by copying an existing Builder.
+     * @param other The existing Builder to copy.
+     */
     private Builder(avro.examples.baseball.Player.Builder other) {
       super(other);
       if (isValidValue(fields()[0], other.number)) {
@@ -166,7 +180,10 @@ public class Player extends org.apache.avro.specific.SpecificRecordBase implemen
       }
     }
     
-    /** Creates a Builder by copying an existing Player instance */
+    /**
+     * Creates a Builder by copying an existing Player instance
+     * @param other The existing instance to copy.
+     */
     private Builder(avro.examples.baseball.Player other) {
             super(avro.examples.baseball.Player.SCHEMA$);
       if (isValidValue(fields()[0], other.number)) {
@@ -187,12 +204,19 @@ public class Player extends org.apache.avro.specific.SpecificRecordBase implemen
       }
     }
 
-    /** Gets the value of the 'number' field */
+    /**
+     * Gets the value of the 'number' field.
+     * @return The value.
+     */
     public java.lang.Integer getNumber() {
       return number;
     }
     
-    /** Sets the value of the 'number' field */
+    /**
+     * Sets the value of the 'number' field.
+     * @param value The value of 'number'.
+     * @return This builder.
+     */
     public avro.examples.baseball.Player.Builder setNumber(int value) {
       validate(fields()[0], value);
       this.number = value;
@@ -200,23 +224,36 @@ public class Player extends org.apache.avro.specific.SpecificRecordBase implemen
       return this; 
     }
     
-    /** Checks whether the 'number' field has been set */
+    /**
+     * Checks whether the 'number' field has been set.
+     * @return True if the 'number' field has been set, false otherwise.
+     */
     public boolean hasNumber() {
       return fieldSetFlags()[0];
     }
     
-    /** Clears the value of the 'number' field */
+    /**
+     * Clears the value of the 'number' field.
+     * @return This builder.
+     */
     public avro.examples.baseball.Player.Builder clearNumber() {
       fieldSetFlags()[0] = false;
       return this;
     }
 
-    /** Gets the value of the 'first_name' field */
+    /**
+     * Gets the value of the 'first_name' field.
+     * @return The value.
+     */
     public java.lang.String getFirstName() {
       return first_name;
     }
     
-    /** Sets the value of the 'first_name' field */
+    /**
+     * Sets the value of the 'first_name' field.
+     * @param value The value of 'first_name'.
+     * @return This builder.
+     */
     public avro.examples.baseball.Player.Builder setFirstName(java.lang.String value) {
       validate(fields()[1], value);
       this.first_name = value;
@@ -224,24 +261,37 @@ public class Player extends org.apache.avro.specific.SpecificRecordBase implemen
       return this; 
     }
     
-    /** Checks whether the 'first_name' field has been set */
+    /**
+     * Checks whether the 'first_name' field has been set.
+     * @return True if the 'first_name' field has been set, false otherwise.
+     */
     public boolean hasFirstName() {
       return fieldSetFlags()[1];
     }
     
-    /** Clears the value of the 'first_name' field */
+    /**
+     * Clears the value of the 'first_name' field.
+     * @return This builder.
+     */
     public avro.examples.baseball.Player.Builder clearFirstName() {
       first_name = null;
       fieldSetFlags()[1] = false;
       return this;
     }
 
-    /** Gets the value of the 'last_name' field */
+    /**
+     * Gets the value of the 'last_name' field.
+     * @return The value.
+     */
     public java.lang.String getLastName() {
       return last_name;
     }
     
-    /** Sets the value of the 'last_name' field */
+    /**
+     * Sets the value of the 'last_name' field.
+     * @param value The value of 'last_name'.
+     * @return This builder.
+     */
     public avro.examples.baseball.Player.Builder setLastName(java.lang.String value) {
       validate(fields()[2], value);
       this.last_name = value;
@@ -249,24 +299,37 @@ public class Player extends org.apache.avro.specific.SpecificRecordBase implemen
       return this; 
     }
     
-    /** Checks whether the 'last_name' field has been set */
+    /**
+     * Checks whether the 'last_name' field has been set.
+     * @return True if the 'last_name' field has been set, false otherwise.
+     */
     public boolean hasLastName() {
       return fieldSetFlags()[2];
     }
     
-    /** Clears the value of the 'last_name' field */
+    /**
+     * Clears the value of the 'last_name' field.
+     * @return This builder.
+     */
     public avro.examples.baseball.Player.Builder clearLastName() {
       last_name = null;
       fieldSetFlags()[2] = false;
       return this;
     }
 
-    /** Gets the value of the 'position' field */
+    /**
+     * Gets the value of the 'position' field.
+     * @return The value.
+     */
     public java.util.List<avro.examples.baseball.Position> getPosition() {
       return position;
     }
     
-    /** Sets the value of the 'position' field */
+    /**
+     * Sets the value of the 'position' field.
+     * @param value The value of 'position'.
+     * @return This builder.
+     */
     public avro.examples.baseball.Player.Builder setPosition(java.util.List<avro.examples.baseball.Position> value) {
       validate(fields()[3], value);
       this.position = value;
@@ -274,12 +337,18 @@ public class Player extends org.apache.avro.specific.SpecificRecordBase implemen
       return this; 
     }
     
-    /** Checks whether the 'position' field has been set */
+    /**
+     * Checks whether the 'position' field has been set.
+     * @return True if the 'position' field has been set, false otherwise.
+     */
     public boolean hasPosition() {
       return fieldSetFlags()[3];
     }
     
-    /** Clears the value of the 'position' field */
+    /**
+     * Clears the value of the 'position' field.
+     * @return This builder.
+     */
     public avro.examples.baseball.Player.Builder clearPosition() {
       position = null;
       fieldSetFlags()[3] = false;

--- a/lang/java/tools/src/test/compiler/output-string/avro/examples/baseball/Player.java
+++ b/lang/java/tools/src/test/compiler/output-string/avro/examples/baseball/Player.java
@@ -364,7 +364,7 @@ public class Player extends org.apache.avro.specific.SpecificRecordBase implemen
         record.last_name = fieldSetFlags()[2] ? this.last_name : (java.lang.String) defaultValue(fields()[2]);
         record.position = fieldSetFlags()[3] ? this.position : (java.util.List<avro.examples.baseball.Position>) defaultValue(fields()[3]);
         return record;
-      } catch (Exception e) {
+      } catch (java.lang.Exception e) {
         throw new org.apache.avro.AvroRuntimeException(e);
       }
     }

--- a/lang/java/tools/src/test/compiler/output/Player.java
+++ b/lang/java/tools/src/test/compiler/output/Player.java
@@ -364,7 +364,7 @@ public class Player extends org.apache.avro.specific.SpecificRecordBase implemen
         record.last_name = fieldSetFlags()[2] ? this.last_name : (java.lang.CharSequence) defaultValue(fields()[2]);
         record.position = fieldSetFlags()[3] ? this.position : (java.util.List<avro.examples.baseball.Position>) defaultValue(fields()[3]);
         return record;
-      } catch (Exception e) {
+      } catch (java.lang.Exception e) {
         throw new org.apache.avro.AvroRuntimeException(e);
       }
     }

--- a/lang/java/tools/src/test/compiler/output/Player.java
+++ b/lang/java/tools/src/test/compiler/output/Player.java
@@ -114,17 +114,28 @@ public class Player extends org.apache.avro.specific.SpecificRecordBase implemen
     this.position = value;
   }
 
-  /** Creates a new Player RecordBuilder */
+  /**
+   * Creates a new Player RecordBuilder.
+   * @return A new Player RecordBuilder
+   */
   public static avro.examples.baseball.Player.Builder newBuilder() {
     return new avro.examples.baseball.Player.Builder();
   }
   
-  /** Creates a new Player RecordBuilder by copying an existing Builder */
+  /**
+   * Creates a new Player RecordBuilder by copying an existing Builder.
+   * @param other The existing builder to copy.
+   * @return A new Player RecordBuilder
+   */
   public static avro.examples.baseball.Player.Builder newBuilder(avro.examples.baseball.Player.Builder other) {
     return new avro.examples.baseball.Player.Builder(other);
   }
   
-  /** Creates a new Player RecordBuilder by copying an existing Player instance */
+  /**
+   * Creates a new Player RecordBuilder by copying an existing Player instance.
+   * @param other The existing instance to copy.
+   * @return A new Player RecordBuilder
+   */
   public static avro.examples.baseball.Player.Builder newBuilder(avro.examples.baseball.Player other) {
     return new avro.examples.baseball.Player.Builder(other);
   }
@@ -145,7 +156,10 @@ public class Player extends org.apache.avro.specific.SpecificRecordBase implemen
       super(avro.examples.baseball.Player.SCHEMA$);
     }
     
-    /** Creates a Builder by copying an existing Builder */
+    /**
+     * Creates a Builder by copying an existing Builder.
+     * @param other The existing Builder to copy.
+     */
     private Builder(avro.examples.baseball.Player.Builder other) {
       super(other);
       if (isValidValue(fields()[0], other.number)) {
@@ -166,7 +180,10 @@ public class Player extends org.apache.avro.specific.SpecificRecordBase implemen
       }
     }
     
-    /** Creates a Builder by copying an existing Player instance */
+    /**
+     * Creates a Builder by copying an existing Player instance
+     * @param other The existing instance to copy.
+     */
     private Builder(avro.examples.baseball.Player other) {
             super(avro.examples.baseball.Player.SCHEMA$);
       if (isValidValue(fields()[0], other.number)) {
@@ -187,12 +204,19 @@ public class Player extends org.apache.avro.specific.SpecificRecordBase implemen
       }
     }
 
-    /** Gets the value of the 'number' field */
+    /**
+     * Gets the value of the 'number' field.
+     * @return The value.
+     */
     public java.lang.Integer getNumber() {
       return number;
     }
     
-    /** Sets the value of the 'number' field */
+    /**
+     * Sets the value of the 'number' field.
+     * @param value The value of 'number'.
+     * @return This builder.
+     */
     public avro.examples.baseball.Player.Builder setNumber(int value) {
       validate(fields()[0], value);
       this.number = value;
@@ -200,23 +224,36 @@ public class Player extends org.apache.avro.specific.SpecificRecordBase implemen
       return this; 
     }
     
-    /** Checks whether the 'number' field has been set */
+    /**
+     * Checks whether the 'number' field has been set.
+     * @return True if the 'number' field has been set, false otherwise.
+     */
     public boolean hasNumber() {
       return fieldSetFlags()[0];
     }
     
-    /** Clears the value of the 'number' field */
+    /**
+     * Clears the value of the 'number' field.
+     * @return This builder.
+     */
     public avro.examples.baseball.Player.Builder clearNumber() {
       fieldSetFlags()[0] = false;
       return this;
     }
 
-    /** Gets the value of the 'first_name' field */
+    /**
+     * Gets the value of the 'first_name' field.
+     * @return The value.
+     */
     public java.lang.CharSequence getFirstName() {
       return first_name;
     }
     
-    /** Sets the value of the 'first_name' field */
+    /**
+     * Sets the value of the 'first_name' field.
+     * @param value The value of 'first_name'.
+     * @return This builder.
+     */
     public avro.examples.baseball.Player.Builder setFirstName(java.lang.CharSequence value) {
       validate(fields()[1], value);
       this.first_name = value;
@@ -224,24 +261,37 @@ public class Player extends org.apache.avro.specific.SpecificRecordBase implemen
       return this; 
     }
     
-    /** Checks whether the 'first_name' field has been set */
+    /**
+     * Checks whether the 'first_name' field has been set.
+     * @return True if the 'first_name' field has been set, false otherwise.
+     */
     public boolean hasFirstName() {
       return fieldSetFlags()[1];
     }
     
-    /** Clears the value of the 'first_name' field */
+    /**
+     * Clears the value of the 'first_name' field.
+     * @return This builder.
+     */
     public avro.examples.baseball.Player.Builder clearFirstName() {
       first_name = null;
       fieldSetFlags()[1] = false;
       return this;
     }
 
-    /** Gets the value of the 'last_name' field */
+    /**
+     * Gets the value of the 'last_name' field.
+     * @return The value.
+     */
     public java.lang.CharSequence getLastName() {
       return last_name;
     }
     
-    /** Sets the value of the 'last_name' field */
+    /**
+     * Sets the value of the 'last_name' field.
+     * @param value The value of 'last_name'.
+     * @return This builder.
+     */
     public avro.examples.baseball.Player.Builder setLastName(java.lang.CharSequence value) {
       validate(fields()[2], value);
       this.last_name = value;
@@ -249,24 +299,37 @@ public class Player extends org.apache.avro.specific.SpecificRecordBase implemen
       return this; 
     }
     
-    /** Checks whether the 'last_name' field has been set */
+    /**
+     * Checks whether the 'last_name' field has been set.
+     * @return True if the 'last_name' field has been set, false otherwise.
+     */
     public boolean hasLastName() {
       return fieldSetFlags()[2];
     }
     
-    /** Clears the value of the 'last_name' field */
+    /**
+     * Clears the value of the 'last_name' field.
+     * @return This builder.
+     */
     public avro.examples.baseball.Player.Builder clearLastName() {
       last_name = null;
       fieldSetFlags()[2] = false;
       return this;
     }
 
-    /** Gets the value of the 'position' field */
+    /**
+     * Gets the value of the 'position' field.
+     * @return The value.
+     */
     public java.util.List<avro.examples.baseball.Position> getPosition() {
       return position;
     }
     
-    /** Sets the value of the 'position' field */
+    /**
+     * Sets the value of the 'position' field.
+     * @param value The value of 'position'.
+     * @return This builder.
+     */
     public avro.examples.baseball.Player.Builder setPosition(java.util.List<avro.examples.baseball.Position> value) {
       validate(fields()[3], value);
       this.position = value;
@@ -274,12 +337,18 @@ public class Player extends org.apache.avro.specific.SpecificRecordBase implemen
       return this; 
     }
     
-    /** Checks whether the 'position' field has been set */
+    /**
+     * Checks whether the 'position' field has been set.
+     * @return True if the 'position' field has been set, false otherwise.
+     */
     public boolean hasPosition() {
       return fieldSetFlags()[3];
     }
     
-    /** Clears the value of the 'position' field */
+    /**
+     * Clears the value of the 'position' field.
+     * @return This builder.
+     */
     public avro.examples.baseball.Player.Builder clearPosition() {
       position = null;
       fieldSetFlags()[3] = false;

--- a/lang/java/tools/src/test/java/org/apache/avro/tool/TestDataFileRepairTool.java
+++ b/lang/java/tools/src/test/java/org/apache/avro/tool/TestDataFileRepairTool.java
@@ -1,0 +1,190 @@
+package org.apache.avro.tool;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.util.Arrays;
+import org.apache.avro.AvroTestUtil;
+import org.apache.avro.Schema;
+import org.apache.avro.file.DataFileConstants;
+import org.apache.avro.file.DataFileReader;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.io.BinaryData;
+import org.apache.avro.util.Utf8;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class TestDataFileRepairTool {
+
+  private static final Schema SCHEMA = Schema.create(Schema.Type.STRING);
+  private static File corruptBlockFile;
+  private static File corruptRecordFile;
+
+  private File repairedFile;
+
+  @BeforeClass
+  public static void writeCorruptFile() throws IOException {
+    // Write a data file
+    DataFileWriter<Utf8> w = new DataFileWriter<Utf8>(new GenericDatumWriter<Utf8>(SCHEMA));
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    w.create(SCHEMA, baos);
+    w.append(new Utf8("apple"));
+    w.append(new Utf8("banana"));
+    w.append(new Utf8("celery"));
+    w.sync();
+    w.append(new Utf8("date"));
+    w.append(new Utf8("endive"));
+    w.append(new Utf8("fig"));
+    long pos = w.sync();
+    w.append(new Utf8("guava"));
+    w.append(new Utf8("hazelnut"));
+    w.close();
+
+    byte[] original = baos.toByteArray();
+
+    // Corrupt the second block by inserting some zero bytes before the sync marker
+    int corruptPosition = (int) pos - DataFileConstants.SYNC_SIZE;
+    int corruptedBytes = 3;
+    byte[] corrupted = new byte[original.length + corruptedBytes];
+    System.arraycopy(original, 0, corrupted, 0, corruptPosition);
+    System.arraycopy(original, corruptPosition,
+        corrupted, corruptPosition + corruptedBytes, original.length - corruptPosition);
+
+    corruptBlockFile = AvroTestUtil.tempFile(TestDataFileRepairTool.class,
+        "corruptBlock.avro");
+    corruptBlockFile.deleteOnExit();
+    FileOutputStream out = new FileOutputStream(corruptBlockFile);
+    out.write(corrupted);
+    out.close();
+
+    // Corrupt the "endive" record by changing the length of the string to be negative
+    corruptPosition = (int) pos - DataFileConstants.SYNC_SIZE -
+        (1 + "fig".length() + 1 + "endive".length());
+    corrupted = new byte[original.length];
+    System.arraycopy(original, 0, corrupted, 0, original.length);
+    BinaryData.encodeLong(-1, corrupted, corruptPosition);
+
+    corruptRecordFile = AvroTestUtil.tempFile(TestDataFileRepairTool.class,
+        "corruptRecord.avro");
+    corruptRecordFile.deleteOnExit();
+    out = new FileOutputStream(corruptRecordFile);
+    out.write(corrupted);
+    out.close();
+  }
+
+  @Before
+  public void setUp() {
+    repairedFile = AvroTestUtil.tempFile(TestDataFileRepairTool.class, "repaired.avro");
+  }
+
+  @After
+  public void tearDown() {
+    repairedFile.delete();
+  }
+
+  private String run(Tool tool, String... args) throws Exception {
+    return run(tool, null, args);
+  }
+
+  private String run(Tool tool, InputStream stdin, String... args) throws Exception {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    PrintStream stdout = new PrintStream(out);
+    tool.run(
+        stdin,
+        stdout,
+        System.err,
+        Arrays.asList(args));
+    return out.toString("UTF-8").replace("\r", "");
+  }
+
+  @Test
+  public void testReportCorruptBlock() throws Exception {
+    String output = run(new DataFileRepairTool(), "-o", "report", corruptBlockFile.getPath());
+    assertTrue(output, output.contains("Number of blocks: 2 Number of corrupt blocks: 1"));
+    assertTrue(output, output.contains("Number of records: 5 Number of corrupt records: 0"));
+  }
+
+  @Test
+  public void testReportCorruptRecord() throws Exception {
+    String output = run(new DataFileRepairTool(), "-o", "report", corruptRecordFile.getPath());
+    assertTrue(output, output.contains("Number of blocks: 3 Number of corrupt blocks: 1"));
+    assertTrue(output, output.contains("Number of records: 8 Number of corrupt records: 2"));
+  }
+
+  @Test
+  public void testRepairAllCorruptBlock() throws Exception {
+    String output = run(new DataFileRepairTool(), "-o", "all",
+        corruptBlockFile.getPath(), repairedFile.getPath());
+    assertTrue(output, output.contains("Number of blocks: 2 Number of corrupt blocks: 1"));
+    assertTrue(output, output.contains("Number of records: 5 Number of corrupt records: 0"));
+    checkFileContains(repairedFile, "apple", "banana", "celery", "guava", "hazelnut");
+  }
+
+  @Test
+  public void testRepairAllCorruptRecord() throws Exception {
+    String output = run(new DataFileRepairTool(), "-o", "all",
+        corruptRecordFile.getPath(), repairedFile.getPath());
+    assertTrue(output, output.contains("Number of blocks: 3 Number of corrupt blocks: 1"));
+    assertTrue(output, output.contains("Number of records: 8 Number of corrupt records: 2"));
+    checkFileContains(repairedFile, "apple", "banana", "celery", "date", "guava",
+        "hazelnut");
+  }
+
+  @Test
+  public void testRepairPriorCorruptBlock() throws Exception {
+    String output = run(new DataFileRepairTool(), "-o", "prior",
+        corruptBlockFile.getPath(), repairedFile.getPath());
+    assertTrue(output, output.contains("Number of blocks: 2 Number of corrupt blocks: 1"));
+    assertTrue(output, output.contains("Number of records: 5 Number of corrupt records: 0"));
+    checkFileContains(repairedFile, "apple", "banana", "celery");
+  }
+
+  @Test
+  public void testRepairPriorCorruptRecord() throws Exception {
+    String output = run(new DataFileRepairTool(), "-o", "prior",
+        corruptRecordFile.getPath(), repairedFile.getPath());
+    assertTrue(output, output.contains("Number of blocks: 3 Number of corrupt blocks: 1"));
+    assertTrue(output, output.contains("Number of records: 8 Number of corrupt records: 2"));
+    checkFileContains(repairedFile, "apple", "banana", "celery", "date");
+  }
+
+  @Test
+  public void testRepairAfterCorruptBlock() throws Exception {
+    String output = run(new DataFileRepairTool(), "-o", "after",
+        corruptBlockFile.getPath(), repairedFile.getPath());
+    assertTrue(output, output.contains("Number of blocks: 2 Number of corrupt blocks: 1"));
+    assertTrue(output, output.contains("Number of records: 5 Number of corrupt records: 0"));
+    checkFileContains(repairedFile, "guava", "hazelnut");
+  }
+
+  @Test
+  public void testRepairAfterCorruptRecord() throws Exception {
+    String output = run(new DataFileRepairTool(), "-o", "after",
+        corruptRecordFile.getPath(), repairedFile.getPath());
+    assertTrue(output, output.contains("Number of blocks: 3 Number of corrupt blocks: 1"));
+    assertTrue(output, output.contains("Number of records: 8 Number of corrupt records: 2"));
+    checkFileContains(repairedFile, "guava", "hazelnut");
+  }
+
+  private void checkFileContains(File repairedFile, String... lines) throws IOException {
+    DataFileReader r = new DataFileReader<Utf8>(repairedFile,
+        new GenericDatumReader<Utf8>(SCHEMA));
+    for (String line : lines) {
+      assertEquals(line, r.next().toString());
+    }
+    assertFalse(r.hasNext());
+  }
+
+}

--- a/lang/js/Gruntfile.js
+++ b/lang/js/Gruntfile.js
@@ -17,7 +17,8 @@ module.exports = function(grunt) {
 
   // Project configuration.
   grunt.initConfig({
-    test: {
+    pkg: grunt.file.readJSON('package.json'),
+    nodeunit: {
       files: ['test/**/*.js']
     },
     lint: {
@@ -47,6 +48,11 @@ module.exports = function(grunt) {
     }
   });
 
-  grunt.registerTask('default', 'lint test');
+  grunt.loadNpmTasks('grunt-contrib-jshint');
+  grunt.loadNpmTasks('grunt-contrib-nodeunit');
+  grunt.loadNpmTasks('grunt-contrib-watch');
 
+  grunt.registerTask('default', ['jshint', 'nodeunit']);
+  grunt.registerTask('test', ['nodeunit']);
+  grunt.registerTask('lint', ['jshint']);
 };

--- a/lang/js/package.json
+++ b/lang/js/package.json
@@ -24,10 +24,17 @@
     "underscore"   :  "*"
   },
   "devDependencies" : {
-    "grunt"        :  "*"
+    "grunt-contrib-jshint": "^1.1.0",
+    "grunt-contrib-nodeunit": "^1.0.0",
+    "grunt-contrib-watch": "^1.0.0",
+    "coveralls": "^2.11.4",
+    "istanbul": "^0.3.19",
+    "mocha": "^2.3.2",
+    "tmp": "^0.0.28",
+    "grunt": "^1.0.1"
   },
   "noAnalyze": true,
-  "license": "Apache",
+  "license": "Apache-2.0",
   "engine": {
     "node": ">=0.4"
   }

--- a/lang/ruby/.gitignore
+++ b/lang/ruby/.gitignore
@@ -1,1 +1,3 @@
 tmp
+data.avr
+Gemfile.lock

--- a/lang/ruby/lib/avro/schema.rb
+++ b/lang/ruby/lib/avro/schema.rb
@@ -138,6 +138,18 @@ module Avro
     # Deprecated in favor of {#type_sym}.
     def type; @type_sym.to_s; end
 
+    # Returns the MD5 fingerprint of the schema as an Integer.
+    def md5_fingerprint
+      parsing_form = SchemaNormalization.to_parsing_form(self)
+      Digest::MD5.hexdigest(parsing_form).to_i(16)
+    end
+
+    # Returns the SHA-256 fingerprint of the schema as an Integer.
+    def sha256_fingerprint
+      parsing_form = SchemaNormalization.to_parsing_form(self)
+      Digest::SHA256.hexdigest(parsing_form).to_i(16)
+    end
+
     def ==(other, seen=nil)
       other.is_a?(Schema) && type_sym == other.type_sym
     end

--- a/lang/ruby/lib/avro/schema_normalization.rb
+++ b/lang/ruby/lib/avro/schema_normalization.rb
@@ -1,0 +1,83 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Avro
+  class SchemaNormalization
+    def self.to_parsing_form(schema)
+      new.to_parsing_form(schema)
+    end
+
+    def initialize
+      @processed_names = []
+    end
+
+    def to_parsing_form(schema)
+      JSON.dump(normalize_schema(schema))
+    end
+
+    private
+
+    def normalize_schema(schema)
+      type = schema.type_sym.to_s
+
+      if Schema::NAMED_TYPES.include?(type)
+        if @processed_names.include?(schema.name)
+          return schema.name
+        else
+          @processed_names << schema.name
+        end
+      end
+
+      case type
+      when *Schema::PRIMITIVE_TYPES
+        type
+      when "record"
+        fields = schema.fields.map {|field| normalize_field(field) }
+
+        normalize_named_type(schema, fields: fields)
+      when "enum"
+        normalize_named_type(schema, symbols: schema.symbols)
+      when "fixed"
+        normalize_named_type(schema, size: schema.size)
+      when "array"
+        { type: type, items: normalize_schema(schema.items) }
+      when "map"
+        { type: type, values: normalize_schema(schema.values) }
+      when "union"
+        if schema.schemas.nil?
+          []
+        else
+          schema.schemas.map {|s| normalize_schema(s) }
+        end
+      else
+        raise "unknown type #{type}"
+      end
+    end
+
+    def normalize_field(field)
+      {
+        name: field.name,
+        type: normalize_schema(field.type)
+      }
+    end
+
+    def normalize_named_type(schema, attributes = {})
+      name = Name.make_fullname(schema.name, schema.namespace)
+
+      { name: name, type: schema.type_sym.to_s }.merge(attributes)
+    end
+  end
+end

--- a/lang/ruby/test/case_finder.rb
+++ b/lang/ruby/test/case_finder.rb
@@ -1,0 +1,67 @@
+class CaseFinder
+  PATH = File.expand_path("../../../../share/test/data/schema-tests.txt", __FILE__)
+
+  Case = Struct.new(:id, :input, :canonical, :fingerprint)
+
+  def self.cases
+    new.cases
+  end
+
+  def initialize
+    @scanner = StringScanner.new(File.read(PATH))
+    @cases = []
+  end
+
+  def cases
+    until @scanner.eos?
+      test_case = scan_case
+      @cases << test_case if test_case
+    end
+
+    @cases
+  end
+
+  private
+
+  def scan_case
+    if id = @scanner.scan(/\/\/ \d+\n/)
+      while @scanner.skip(/\/\/ .*\n/); end
+
+      input = scan_input
+      canonical = scan_canonical
+      fingerprint = scan_fingerprint
+
+      Case.new(id, input, canonical, fingerprint)
+    else
+      @scanner.skip(/.*\n/)
+      nil
+    end
+  end
+
+  def scan_item(name)
+    if @scanner.scan(/<<#{name}\n/)
+      lines = []
+      while line = @scanner.scan(/.+\n/)
+        break if line.chomp == name
+        lines << line
+      end
+      lines.join
+    elsif @scanner.scan(/<<#{name} /)
+      input = @scanner.scan(/.+$/)
+      @scanner.skip(/\n/)
+      input
+    end
+  end
+
+  def scan_input
+    scan_item("INPUT")
+  end
+
+  def scan_canonical
+    scan_item("canonical")
+  end
+
+  def scan_fingerprint
+    scan_item("fingerprint")
+  end
+end

--- a/lang/ruby/test/test_fingerprints.rb
+++ b/lang/ruby/test/test_fingerprints.rb
@@ -14,29 +14,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'multi_json'
-require 'set'
-require 'digest/md5'
-require 'net/http'
-require 'stringio'
-require 'zlib'
+require 'test_help'
 
-module Avro
-  VERSION = "FIXME"
+class TestFingerprints < Test::Unit::TestCase
+  def test_md5_fingerprint
+    schema = Avro::Schema.parse <<-SCHEMA
+      { "type": "int" }
+    SCHEMA
 
-  class AvroError < StandardError; end
+    assert_equal 318112854175969537208795771590915775282,
+      schema.md5_fingerprint
+  end
 
-  class AvroTypeError < Avro::AvroError
-    def initialize(schm=nil, datum=nil, msg=nil)
-      msg ||= "Not a #{schm.to_s}: #{datum}"
-      super(msg)
-    end
+  def test_sha256_fingerprint
+    schema = Avro::Schema.parse <<-SCHEMA
+      { "type": "int" }
+    SCHEMA
+
+    assert_equal 28572620203319713300323544804233350633246234624932075150020181448463213378117,
+      schema.sha256_fingerprint
   end
 end
-
-require 'avro/schema'
-require 'avro/io'
-require 'avro/data_file'
-require 'avro/protocol'
-require 'avro/ipc'
-require 'avro/schema_normalization'

--- a/lang/ruby/test/test_schema_normalization.rb
+++ b/lang/ruby/test/test_schema_normalization.rb
@@ -1,0 +1,171 @@
+# -*- coding: utf-8 -*-
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'test_help'
+require 'case_finder'
+
+class TestSchemaNormalization < Test::Unit::TestCase
+  def test_primitives
+    %w[null boolean string bytes int long float double].each do |type|
+      schema = Avro::Schema.parse(<<-JSON)
+        { "type": "#{type}" }
+      JSON
+
+      canonical_form = Avro::SchemaNormalization.to_parsing_form(schema)
+
+      assert_equal %("#{type}"), canonical_form
+    end
+  end
+
+  def test_records
+    schema = Avro::Schema.parse(<<-JSON)
+      {
+        "type": "record",
+        "name": "test",
+        "namespace": "random",
+        "doc": "some record",
+        "fields": [
+          { "name": "height", "type": "int", "doc": "the height" }
+        ]
+      }
+    JSON
+
+    expected_type = <<-JSON.strip
+      {"name":"random.test","type":"record","fields":[{"name":"height","type":"int"}]}
+    JSON
+
+    canonical_form = Avro::SchemaNormalization.to_parsing_form(schema)
+
+    assert_equal expected_type, canonical_form
+  end
+
+  def test_recursive_records
+    schema = Avro::Schema.parse(<<-JSON)
+      {
+        "type": "record",
+        "name": "item",
+        "fields": [
+          { "name": "next", "type": "item" }
+        ]
+      }
+    JSON
+
+    expected_type = <<-JSON.strip
+      {"name":"item","type":"record","fields":[{"name":"next","type":"item"}]}
+    JSON
+
+    canonical_form = Avro::SchemaNormalization.to_parsing_form(schema)
+
+    assert_equal expected_type, canonical_form
+  end
+
+  def test_enums
+    schema = Avro::Schema.parse(<<-JSON)
+      {
+        "type": "enum",
+        "name": "suit",
+        "namespace": "cards",
+        "doc": "the different suits of cards",
+        "symbols": ["club", "hearts", "diamond", "spades"]
+      }
+    JSON
+
+    expected_type = <<-JSON.strip
+      {"name":"cards.suit","type":"enum","symbols":["club","hearts","diamond","spades"]}
+    JSON
+
+    canonical_form = Avro::SchemaNormalization.to_parsing_form(schema)
+
+    assert_equal expected_type, canonical_form
+  end
+
+  def test_fixed
+    schema = Avro::Schema.parse(<<-JSON)
+      {
+        "type": "fixed",
+        "name": "id",
+        "namespace": "db",
+        "size": 64
+      }
+    JSON
+
+    expected_type = <<-JSON.strip
+      {"name":"db.id","type":"fixed","size":64}
+    JSON
+
+    canonical_form = Avro::SchemaNormalization.to_parsing_form(schema)
+
+    assert_equal expected_type, canonical_form
+  end
+
+  def test_arrays
+    schema = Avro::Schema.parse(<<-JSON)
+      {
+        "type": "array",
+        "doc": "the items",
+        "items": "int"
+      }
+    JSON
+
+    expected_type = <<-JSON.strip
+      {"type":"array","items":"int"}
+    JSON
+
+    canonical_form = Avro::SchemaNormalization.to_parsing_form(schema)
+
+    assert_equal expected_type, canonical_form
+  end
+
+  def test_maps
+    schema = Avro::Schema.parse(<<-JSON)
+      {
+        "type": "map",
+        "doc": "the items",
+        "values": "int"
+      }
+    JSON
+
+    expected_type = <<-JSON.strip
+      {"type":"map","values":"int"}
+    JSON
+
+    canonical_form = Avro::SchemaNormalization.to_parsing_form(schema)
+
+    assert_equal expected_type, canonical_form
+  end
+
+  def test_unions
+    schema = Avro::Schema.parse(<<-JSON)
+      ["int", "string"]
+    JSON
+
+    expected_type = <<-JSON.strip
+      ["int","string"]
+    JSON
+
+    canonical_form = Avro::SchemaNormalization.to_parsing_form(schema)
+
+    assert_equal expected_type, canonical_form
+  end
+
+  def test_shared_dataset
+    CaseFinder.cases.each do |test_case|
+      schema = Avro::Schema.parse(test_case.input)
+      assert_equal test_case.canonical, Avro::SchemaNormalization.to_parsing_form(schema)
+    end
+  end
+end


### PR DESCRIPTION
Currently the word `schema` is not allowed as identifier, even not when it is escaped in backticks. This patch fixed that for the 1.7 branch.