### PR TITLE
AVRO-2022: Allow `schema` as identifier in IDL (1.7)

### DIFF
--- a/lang/java/compiler/src/main/javacc/org/apache/avro/compiler/idl/idl.jj
+++ b/lang/java/compiler/src/main/javacc/org/apache/avro/compiler/idl/idl.jj
@@ -1538,6 +1538,7 @@ Token AnyIdentifier():
    t = <LONG> |
    t = <MAP> |
    t = <BYTES> |
+   t = <SCHEMA> |
    t = <STRING> |
    t = <PROTOCOL> |
    t = <RECORD> |


### PR DESCRIPTION
Currently the word `schema` is not allowed as identifier in IDL, even not when it is escaped in backticks. This patch fixed that for the 1.7 branch.