### PR TITLE
its value is never used

### DIFF
--- a/lang/csharp/src/apache/main/CodeGen/CodeGen.cs
+++ b/lang/csharp/src/apache/main/CodeGen/CodeGen.cs
@@ -272,7 +272,6 @@ namespace Avro
             ctd.Members.Add(codeField);
 
             // Add Size property
-            var fieldRef = new CodeFieldReferenceExpression(new CodeThisReferenceExpression(), sizefname);
             var property = new CodeMemberProperty();
             property.Attributes = MemberAttributes.Public | MemberAttributes.Static;
             property.Name = "FixedSize";


### PR DESCRIPTION
warning CS0219: The variable `fieldRef' is assigned but its value is never used