### PR TITLE
add ivy profile to generate ivy.xml desriptors for java artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -353,6 +353,50 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>ivy</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>${antrun-plugin.version}</version>
+            <executions>
+              <execution>
+                <id>generate-ivy</id>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <phase>package</phase>
+                <configuration>
+                  <target name="generate-ivy" xmlns:ivy="antlib:org.apache.ivy.ant">
+                    <ivy:convertpom pomFile="${project.basedir}/pom.xml" ivyFile="${project.build.directory}/ivy.xml" />
+                    <!-- publish to local ivy cache so downstream modules could find it -->
+                    <!-- (required for them to build their own ivy.xml files, so cannot be one during install phase) -->
+                    <ivy:publish
+                        resolver="local"
+                        organisation="${project.groupId}"
+                        module="${project.artifactId}"
+                        revision="${project.version}"
+                        overwrite="true"
+                    >
+                      <artifacts pattern="${project.build.directory}/ivy.xml" />
+                    </ivy:publish>
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+            <dependencies>
+              <dependency>
+                <groupId>org.apache.ivy</groupId>
+                <artifactId>ivy</artifactId>
+                <version>2.4.0</version>
+              </dependency>
+            </dependencies>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
 </project>


### PR DESCRIPTION
some orgs use ivy for builds.
manually constructing ivy.xml files for avro jars is complicated and error-prone.
this utility profile can be used to automatically generate them during build time from pom files