### PR TITLE
Fix an incorrect string comparison in avro-python3 leading to corrupted files

### DIFF
--- a/lang/py3/avro/datafile.py
+++ b/lang/py3/avro/datafile.py
@@ -283,7 +283,7 @@ class DataFileWriter(object):
     self.writer.write(compressed_data)
 
     # Write CRC32 checksum for Snappy
-    if self.GetMeta(CODEC_KEY) == 'snappy':
+    if codec == 'snappy':
       self.encoder.write_crc32(uncompressed_data)
 
     # write sync marker


### PR DESCRIPTION
The corrected code was trying to compare the bytes value returned by GetMeta against a string.
The if was never taken and this was leading to corrupted files when the snappy codes is used.

Here is a minimal test case that demonstrates the issue:

``` python
import avro.schema
from avro.datafile import DataFileReader, DataFileWriter
from avro.io import DatumReader, DatumWriter

schema_text = """
{

  "namespace": "example.avro",
  "type": "record",
  "name": "User",
  "fields": [
      {"name": "name", "type": "string"},
      {"name": "favorite_number",  "type": ["int", "null"]},
      {"name": "favorite_color", "type": ["string", "null"]}
  ]
 }
"""

schema = avro.schema.Parse(schema_text)

writer = DataFileWriter(open("users.avro", "wb"), DatumWriter(), schema, codec="snappy")

writer.append({"name": "Alyssa", "favorite_number": 256})
writer.append({"name": "Ben", "favorite_number": 7, "favorite_color": "red"})
writer.close()

reader = DataFileReader(open("users.avro", "rb"), DatumReader())
for user in reader:
    print(user)

reader.close()
```