### PR TITLE
Upgrade commons-compress dependency version to 1.14

### DIFF
--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -60,7 +60,7 @@
     <ant.version>1.10.0</ant.version>
     <commons-cli.version>1.3.1</commons-cli.version>
     <commons-codec.version>1.10</commons-codec.version>
-    <commons-compress.version>1.13</commons-compress.version>
+    <commons-compress.version>1.14</commons-compress.version>
     <commons-lang.version>2.6</commons-lang.version>
     <commons-logging.version>1.2</commons-logging.version>
     <tukaani.version>1.6</tukaani.version>


### PR DESCRIPTION
The most recent of commons-compress was published recently and includes many interesting improvements for snappy and other compression algorithms.
https://commons.apache.org/proper/commons-compress/changes-report.html#a1.13