### PR TITLE
AVRO-2040: Ruby 2.4 deprecation fixes

### DIFF
--- a/lang/ruby/lib/avro/schema_validator.rb
+++ b/lang/ruby/lib/avro/schema_validator.rb
@@ -165,7 +165,7 @@ module Avro
       private
 
       def actual_value_message(value)
-        avro_type = if value.class == Integer
+        avro_type = if value.is_a?(Integer)
                       ruby_integer_to_avro_type(value)
                     else
                       ruby_to_avro_type(value.class)
@@ -181,8 +181,6 @@ module Avro
         {
           NilClass => 'null',
           String => 'string',
-          Fixnum => 'int',
-          Bignum => 'long',
           Float => 'float',
           Hash => 'record'
         }.fetch(ruby_class, ruby_class)

--- a/lang/ruby/test/test_datafile.rb
+++ b/lang/ruby/test/test_datafile.rb
@@ -20,13 +20,13 @@ require 'test_help'
 class TestDataFile < Test::Unit::TestCase
   HERE = File.expand_path File.dirname(__FILE__)
   def setup
-    if File.exists?(HERE + '/data.avr')
+    if File.exist?(HERE + '/data.avr')
       File.unlink(HERE + '/data.avr')
     end
   end
 
   def teardown
-    if File.exists?(HERE + '/data.avr')
+    if File.exist?(HERE + '/data.avr')
       File.unlink(HERE + '/data.avr')
     end
   end


### PR DESCRIPTION
https://issues.apache.org/jira/browse/AVRO-2040

Remove references to `Fixnum` and `Bignum` as suggested by @sldblog [here](https://github.com/apache/avro/pull/191#pullrequestreview-23737308). Ruby 2.4 unified these in a single `Integer` class.

Also, replace `File.exists?` with `File.exist`. 

Changes tested with:
  - 1.9.3-p551
  - 2.0.0-p648
  - 2.1.10
  - 2.2.7
  - 2.3.4
  - 2.4.1