### PR TITLE
AVRO 1191: Fix C++ JSON Encoder to use \u escape sequence

### DIFF
--- a/lang/c++/impl/json/JsonIO.hh
+++ b/lang/c++/impl/json/JsonIO.hh
@@ -213,7 +213,7 @@ class AVRO_DECL JsonGenerator {
 
     void escapeCtl(char c) {
         out_.write('\\');
-        out_.write('U');
+        out_.write('u');
         out_.write('0');
         out_.write('0');
         out_.write(toHex((static_cast<unsigned char>(c)) / 16));


### PR DESCRIPTION
Proposed fix to [1191](https://issues.apache.org/jira/browse/AVRO-1191).