### PR TITLE
schema.py: No sys traceback in parse exception

### DIFF
--- a/lang/py/src/avro/schema.py
+++ b/lang/py/src/avro/schema.py
@@ -775,8 +775,7 @@ def parse(json_string):
     json_data = json.loads(json_string)
   except Exception, e:
     import sys
-    raise SchemaParseException('Error parsing JSON: %s, error = %s'
-                               % (json_string, e)), None, sys.exc_info()[2]
+    raise SchemaParseException('Error parsing JSON: %s' % json_string)
 
   # Initialize the names object
   names = Names()


### PR DESCRIPTION
In the ``SchemaParseException``, do not provide sys traceback. 

For our project CWL Tool, we're using `avro/py` in our python 3 builds. More on this has been discussed here: https://issues.apache.org/jira/browse/AVRO-2046 

For doing this, we use `autotranslate` tool which converts `avro/py` code to python2and3 compatible code during runtime. 
The problem arises when it tries to convert this `raise Exception` command. There is no way to achieve this in a cross-compatible way without the use of external lib.
 
Thus, I've created this PR. This is a very minimal change and really solves our problem for the time being. We really hope you'll consider this or at least give your feedback on the same.