### PR TITLE
[AVRO-2058] ReflectData#isNonStringMap returns true for Utf8 keys

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/util/Utf8.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/util/Utf8.java
@@ -21,10 +21,12 @@ import java.nio.charset.Charset;
 import java.io.UnsupportedEncodingException;
 
 import org.apache.avro.io.BinaryData;
+import org.apache.avro.reflect.Stringable;
 
 /** A Utf8 string.  Unlike {@link String}, instances are mutable.  This is more
  * efficient than {@link String} when reading or writing a sequence of values,
  * as a single instance may be reused. */
+@Stringable
 public class Utf8 implements Comparable<Utf8>, CharSequence {
   private static final byte[] EMPTY = new byte[0];
   private static final Charset UTF8 = Charset.forName("UTF-8");

--- a/lang/java/avro/src/test/java/org/apache/avro/reflect/TestReflect.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/reflect/TestReflect.java
@@ -47,6 +47,7 @@ import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.reflect.TestReflect.SampleRecord.AnotherSampleRecord;
+import org.apache.avro.util.Utf8;
 import org.codehaus.jackson.node.NullNode;
 import org.junit.Test;
 
@@ -121,6 +122,15 @@ public class TestReflect {
       ("[\"null\", {\"type\":\"map\",\"values\":\"float\"}]");
     GenericData data = ReflectData.get();
     assertEquals(1, data.resolveUnion(s, new HashMap<String,Float>()));
+  }
+
+  @Test public void testUnionWithMapWithUtf8Keys() {
+    Schema s = new Schema.Parser().parse
+      ("[\"null\", {\"type\":\"map\",\"values\":\"float\"}]");
+    GenericData data = ReflectData.get();
+    HashMap<Utf8,Float> map = new HashMap<Utf8,Float>();
+    map.put(new Utf8("foo"), 1.0f);
+    assertEquals(1, data.resolveUnion(s, map));
   }
 
   @Test public void testUnionWithFixed() {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/AVRO-2058

Since `Utf8` does not have an `Stringable` notation, and is not in `SpecificData#stringableClasses`, `ReflectData#isNonStringMap` returns true. This also causes `ReflectData#isArray` to return true for maps with Utf8 keys, and thus `GenericData#resolveUnion` fails as well. This ultimately causes `ReflectData#write` to fail for schemas that contain a union that contains a map, where the data uses Utf8 for strings.

This following test case reproduces the issue:

```java
  @Test public void testUnionWithMapWithUtf8Keys() {
    Schema s = new Schema.Parser().parse
      ("[\"null\", {\"type\":\"map\",\"values\":\"float\"}]");
    GenericData data = ReflectData.get();
    HashMap<Utf8,Float> map = new HashMap<Utf8,Float>();
    map.put(new Utf8("foo"), 1.0f);
    assertEquals(1, data.resolveUnion(s, map));
  }
```
