### PR TITLE
AVRO-2063. C: VERSION, SOVERSION not set correctly for shared library

### DIFF
--- a/lang/c/CMakeLists.txt
+++ b/lang/c/CMakeLists.txt
@@ -47,6 +47,16 @@ if (UNIX)
     if(LIBAVRO_VERSION_RESULT)
         message(FATAL_ERROR "Cannot determine libavro version number")
     endif(LIBAVRO_VERSION_RESULT)
+
+    execute_process(COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/version.sh libcurrent
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        RESULT_VARIABLE LIBAVRO_SOVERSION_RESULT
+        OUTPUT_VARIABLE LIBAVRO_SOVERSION
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(LIBAVRO_SOVERSION_RESULT)
+        message(FATAL_ERROR "Cannot determine libavro version number")
+    endif(LIBAVRO_SOVERSION_RESULT)
+
 else(UNIX)
     # Hard code for win32 -- need to figure out how to port version.sh for
     # Windows.

--- a/lang/c/src/CMakeLists.txt
+++ b/lang/c/src/CMakeLists.txt
@@ -79,7 +79,7 @@ set(AVRO_SRC
 
 source_group(Avro FILES ${AVRO_SRC})
 
-# The version.sh script gives us a SOVERSION that uses colon as a
+# The version.sh script gives us a VERSION that uses colon as a
 # separator; we need periods.
 
 string(REPLACE ":" "." LIBAVRO_DOT_VERSION ${LIBAVRO_VERSION})
@@ -94,7 +94,8 @@ add_library(avro-shared SHARED ${AVRO_SRC})
 target_link_libraries(avro-shared ${JANSSON_LIBRARIES} ${CODEC_LIBRARIES} ${THREADS_LIBRARIES})
 set_target_properties(avro-shared PROPERTIES
         OUTPUT_NAME avro
-        SOVERSION ${LIBAVRO_DOT_VERSION})
+        VERSION ${LIBAVRO_DOT_VERSION}
+        SOVERSION ${LIBAVRO_SOVERSION})
 endif(NOT WIN32)
 
 install(FILES


### PR DESCRIPTION
Prior to this commit the `VERSION` and `SOVERSION` properties were not being set correctly for the Avro C shared library. Previously, `VERSION` was unset, and `SOVERSION` was set to the full dotted version string (e.g. "23.0.0"), which resulted in a `SONAME` of "libavro.so.23.0.0", which is incorrect.

This commit sets `SOVERSION` to the library's "current" version number (obtained by invoking `version.sh libcurrent`), and sets `VERSION` to the full dotted version string.

This should result in a proper `libavro.so` → `libavro.so.23` → `libavro.so.23.0.0` symlink chain with a `SONAME` of "libavro.so.23".

See Sune Vuorela's article on "CMake and library properties": http://pusling.com/blog/?p=352.