### PR TITLE
[AVRO-1213] Update to latest release of Jetty

### DIFF
--- a/lang/java/ipc/pom.xml
+++ b/lang/java/ipc/pom.xml
@@ -40,7 +40,7 @@
       org.apache.avro*;version="${project.version}",
       org.jboss.netty*,
       javax.servlet*;resolution:=optional,
-      org.mortbay*;resolution:=optional,
+      org.eclipse*;resolution:=optional,
       org.apache.velocity*;resolution:=optional,
       *
     </osgi.import>
@@ -125,13 +125,12 @@
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.mortbay.jetty</groupId>
-      <artifactId>jetty</artifactId>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.mortbay.jetty</groupId>
-      <artifactId>jetty-util</artifactId>
-      <version>${jetty.version}</version>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-servlet</artifactId>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
@@ -140,11 +139,6 @@
     <dependency>
       <groupId>org.apache.velocity</groupId>
       <artifactId>velocity</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.mortbay.jetty</groupId>
-      <artifactId>servlet-api</artifactId>
-      <version>${jetty-servlet-api.version}</version>
     </dependency>
 
   </dependencies>

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/HttpServer.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/HttpServer.java
@@ -26,6 +26,7 @@ import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 
@@ -52,6 +53,8 @@ public class HttpServer implements Server {
   public HttpServer(ResponderServlet servlet, String bindAddress, int port) throws IOException {
     this.server = new org.eclipse.jetty.server.Server();
     ServerConnector connector = new ServerConnector(this.server);
+    connector.setAcceptQueueSize(128);
+    connector.setIdleTimeout(10000);
     if (bindAddress != null) {
       connector.setHost(bindAddress);
     }
@@ -59,8 +62,10 @@ public class HttpServer implements Server {
     server.addConnector(connector);
 
     ServletHandler handler = new ServletHandler();
-    server.setHandler(handler);
     handler.addServletWithMapping(new ServletHolder(servlet), "/*");
+    ServletContextHandler sch = new ServletContextHandler();
+    sch.setServletHandler(handler);
+    server.setHandler(sch);
   }
 
   /** Constructs a server to run with the given connector. */

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/HttpServer.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/HttpServer.java
@@ -19,6 +19,7 @@
 package org.apache.avro.ipc;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import org.apache.avro.AvroRuntimeException;
 import org.eclipse.jetty.server.ConnectionFactory;
@@ -85,6 +86,16 @@ public class HttpServer implements Server {
     connector.setPort(port);
 
     server.addConnector(connector);
+    ServletHandler handler = new ServletHandler();
+    server.setHandler(handler);
+    handler.addServletWithMapping(new ServletHolder(servlet), "/*");
+  }
+  
+  public HttpServer(ResponderServlet servlet, Connector connector) throws IOException {
+    this.server = connector.getServer();
+    if (server.getConnectors().length == 0 || Arrays.asList(server.getConnectors()).contains(connector)) {
+      server.addConnector(connector);
+    }
     ServletHandler handler = new ServletHandler();
     server.setHandler(handler);
     handler.addServletWithMapping(new ServletHolder(servlet), "/*");

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/HttpServer.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/HttpServer.java
@@ -69,12 +69,12 @@ public class HttpServer implements Server {
     server.setHandler(sch);
   }
 
-  /** Constructs a server to run with the given connector. */
+  /** Constructs a server to run with the given ConnectionFactory on the given address/port. */
   public HttpServer(Responder responder, ConnectionFactory connectionFactory, String bindAddress, int port) throws IOException {
     this(new ResponderServlet(responder), connectionFactory, bindAddress, port);
   }
 
-  /** Constructs a server to run with the given connector. */
+  /** Constructs a server to run with the given ConnectionFactory on the given address/port. */
   public HttpServer(ResponderServlet servlet, ConnectionFactory connectionFactory, String bindAddress, int port) throws IOException {
     this.server = new org.eclipse.jetty.server.Server();
     HttpConfiguration httpConfig = new HttpConfiguration();
@@ -90,7 +90,13 @@ public class HttpServer implements Server {
     server.setHandler(handler);
     handler.addServletWithMapping(new ServletHolder(servlet), "/*");
   }
-  
+
+  /**
+   * Constructs a server to run with the given connector.
+   *
+   *  @deprecated - use the Constructors that take a ConnectionFactory
+   */
+  @Deprecated
   public HttpServer(ResponderServlet servlet, Connector connector) throws IOException {
     this.server = connector.getServer();
     if (server.getConnectors().length == 0 || Arrays.asList(server.getConnectors()).contains(connector)) {
@@ -99,6 +105,15 @@ public class HttpServer implements Server {
     ServletHandler handler = new ServletHandler();
     server.setHandler(handler);
     handler.addServletWithMapping(new ServletHolder(servlet), "/*");
+  }
+  /**
+   * Constructs a server to run with the given connector.
+   *
+   *  @deprecated - use the Constructors that take a ConnectionFactory
+   */
+  @Deprecated
+  public HttpServer(Responder responder, Connector connector) throws IOException {
+    this(new ResponderServlet(responder), connector);
   }
 
   public void addConnector(Connector connector) {

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/stats/StaticServlet.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/stats/StaticServlet.java
@@ -18,11 +18,10 @@
 
 package org.apache.avro.ipc.stats;
 
-import java.io.IOException;
 import java.net.URL;
 
-import org.mortbay.jetty.servlet.DefaultServlet;
-import org.mortbay.resource.Resource;
+import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.util.resource.Resource;
 
 /**
  * Very simple servlet class capable of serving static files.
@@ -34,13 +33,9 @@ public class StaticServlet extends DefaultServlet {
     String[] parts = pathInContext.split("/");
     String filename =  parts[parts.length - 1];
 
-    try {
-      URL resource = getClass().getClassLoader().getResource(
-          "org/apache/avro/ipc/stats/static/" + filename);
-      if (resource == null) { return null; }
-      return Resource.newResource(resource);
-    } catch (IOException e) {
-      return null;
-    }
+    URL resource = getClass().getClassLoader().getResource(
+        "org/apache/avro/ipc/stats/static/" + filename);
+    if (resource == null) { return null; }
+    return Resource.newResource(resource);
   }
 }

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/stats/StatsServer.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/stats/StatsServer.java
@@ -16,9 +16,9 @@ package org.apache.avro.ipc.stats;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import org.mortbay.jetty.Server;
-import org.mortbay.jetty.servlet.Context;
-import org.mortbay.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
 
 /* This is a server that displays live information from a StatsPlugin.
  *
@@ -38,11 +38,11 @@ public class StatsServer {
     this.httpServer = new Server(port);
     this.plugin = plugin;
 
-    Context staticContext = new Context(httpServer, "/static");
-    staticContext.addServlet(new ServletHolder(new StaticServlet()), "/");
+    ServletHandler handler = new ServletHandler();
+    httpServer.setHandler(handler);
+    handler.addServletWithMapping(new ServletHolder(new StaticServlet()), "/");
 
-    Context context = new Context(httpServer, "/");
-    context.addServlet(new ServletHolder(new StatsServlet(plugin)), "/");
+    handler.addServletWithMapping(new ServletHolder(new StatsServlet(plugin)), "/");
 
     httpServer.start();
   }

--- a/lang/java/ipc/src/test/java/org/apache/avro/TestProtocolHttps.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/TestProtocolHttps.java
@@ -17,27 +17,17 @@
  */
 package org.apache.avro;
 
-import org.apache.avro.Schema;
-import org.apache.avro.Schema.Field;
 import org.apache.avro.ipc.Server;
 import org.apache.avro.ipc.Transceiver;
 import org.apache.avro.ipc.Responder;
 import org.apache.avro.ipc.HttpServer;
 import org.apache.avro.ipc.HttpTransceiver;
-import org.apache.avro.ipc.generic.GenericRequestor;
-import org.apache.avro.ipc.specific.SpecificRequestor;
-import org.apache.avro.generic.GenericData;
-import org.apache.avro.test.Simple;
+import org.eclipse.jetty.server.SslConnectionFactory;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
 
-import org.junit.Test;
 
-import org.mortbay.jetty.security.SslSocketConnector;
 
 import java.net.URL;
-import java.net.ServerSocket;
-import java.net.SocketTimeoutException;
-import java.lang.reflect.UndeclaredThrowableException;
-import java.util.ArrayList;
 
 public class TestProtocolHttps extends TestProtocolSpecific {
 
@@ -48,14 +38,14 @@ public class TestProtocolHttps extends TestProtocolSpecific {
     System.setProperty("javax.net.ssl.password", "avrotest");
     System.setProperty("javax.net.ssl.trustStore", "src/test/truststore");
     System.setProperty("javax.net.ssl.trustStorePassword", "avrotest");
-    SslSocketConnector connector = new SslSocketConnector();
-    connector.setPort(18443);
-    connector.setKeystore(System.getProperty("javax.net.ssl.keyStore"));
-    connector.setPassword(System.getProperty("javax.net.ssl.password"));
-    connector.setKeyPassword(System.getProperty("javax.net.ssl.keyStorePassword"));
-    connector.setHost("localhost");
-    connector.setNeedClientAuth(false);
-    return new HttpServer(testResponder, connector);
+    SslConnectionFactory connectionFactory = new SslConnectionFactory("HTTP/1.1");
+    SslContextFactory sslContextFactory = connectionFactory.getSslContextFactory();
+        
+    sslContextFactory.setKeyStorePath(System.getProperty("javax.net.ssl.keyStore"));
+    sslContextFactory.setKeyManagerPassword(System.getProperty("javax.net.ssl.password"));
+    sslContextFactory.setKeyStorePassword(System.getProperty("javax.net.ssl.keyStorePassword"));
+    sslContextFactory.setNeedClientAuth(false);
+    return new HttpServer(testResponder, connectionFactory, "localhost", 18443);
   }
 
   @Override

--- a/lang/java/ipc/src/test/java/org/apache/avro/ipc/stats/TestStatsPluginAndServlet.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/ipc/stats/TestStatsPluginAndServlet.java
@@ -42,7 +42,6 @@ import org.apache.avro.ipc.Transceiver;
 import org.apache.avro.ipc.generic.GenericRequestor;
 import org.apache.avro.ipc.generic.GenericResponder;
 import org.junit.Test;
-import org.mortbay.log.Log;
 
 public class TestStatsPluginAndServlet {
   Protocol protocol = Protocol.parse("" + "{\"protocol\": \"Minimal\", "
@@ -187,7 +186,6 @@ public class TestStatsPluginAndServlet {
         + "   \"request\": [{\"name\": \"millis\", \"type\": \"long\"}," +
           "{\"name\": \"data\", \"type\": \"bytes\"}], "
         + "   \"response\": \"null\"} } }");
-    Log.info("Using protocol: " + protocol.toString());
     Responder r = new SleepyResponder(protocol);
     StatsPlugin p = new StatsPlugin();
     r.addRPCPlugin(p);

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -40,8 +40,7 @@
 
     <hadoop2.version>2.7.3</hadoop2.version>
     <jackson.version>1.9.13</jackson.version>
-    <jetty.version>6.1.26</jetty.version>
-    <jetty-servlet-api.version>2.5-20081211</jetty-servlet-api.version>
+    <jetty.version>9.4.6.v20170531</jetty.version>
     <jopt-simple.version>5.0.3</jopt-simple.version>
     <junit.version>4.12</junit.version>
     <netty.version>3.10.6.Final</netty.version>
@@ -439,9 +438,14 @@
         <version>${velocity.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.mortbay.jetty</groupId>
-        <artifactId>jetty</artifactId>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-server</artifactId>
         <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-servlet</artifactId>
+          <version>${jetty.version}</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>


### PR DESCRIPTION
This updates the Jetty dependency to the latest Jetty release. 

Note: this does not address the Jetty vs. Netty thing or updates to the latest Netty.  I hope to tackle that soon, but the netty update is huge/hard with a much larger impact. 

The API signatures do change slightly, but that is obviously required due to the org.mortbay -> org.eclipse change.  However, getting onto the supported version of Jetty (with the latest security updates and fixes) is important.  


