### PR TITLE
Python 2/3 unification a new approach (backport avro-python3)

### DIFF
--- a/lang/py3/.gitignore
+++ b/lang/py3/.gitignore
@@ -4,3 +4,7 @@ avro/VERSION.txt
 avro/tests/interop.avsc
 avro_python3.egg-info/
 dist/
+.tox
+build
+.cache
+.eggs

--- a/lang/py3/avro/__init__.py
+++ b/lang/py3/avro/__init__.py
@@ -18,6 +18,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import open
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 __all__ = ('schema', 'io', 'datafile', 'protocol', 'ipc')
 
 

--- a/lang/py3/avro/datafile.py
+++ b/lang/py3/avro/datafile.py
@@ -19,7 +19,18 @@
 # limitations under the License.
 
 """Read/Write Avro File Object Containers."""
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from builtins import bytes
+from builtins import super
+from builtins import next
+from builtins import str
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import io
 import logging
 import os
@@ -57,7 +68,7 @@ SYNC_SIZE = 16
 SYNC_INTERVAL = 1000 * SYNC_SIZE
 
 # Schema of the container header:
-META_SCHEMA = schema.Parse("""
+META_SCHEMA = schema.parse("""
 {
   "type": "record", "name": "org.apache.avro.file.Header",
   "fields": [{
@@ -164,7 +175,7 @@ class DataFileWriter(object):
       # get schema used to write existing file
       schema_from_file = dfr.GetMeta('avro.schema').decode('utf-8')
       self.SetMeta('avro.schema', schema_from_file)
-      self.datum_writer.writer_schema = schema.Parse(schema_from_file)
+      self.datum_writer.writer_schema = schema.parse(schema_from_file)
 
       # seek to the end of the file and prepare for writing
       writer.seek(0, 2)
@@ -364,7 +375,7 @@ class DataFileReader(object):
     # get ready to read
     self._block_count = 0
     self.datum_reader.writer_schema = (
-        schema.Parse(self.GetMeta(SCHEMA_KEY).decode('utf-8')))
+        schema.parse(self.GetMeta(SCHEMA_KEY).decode('utf-8')))
 
   def __enter__(self):
     return self

--- a/lang/py3/avro/io.py
+++ b/lang/py3/avro/io.py
@@ -40,7 +40,18 @@ following mapping:
  - Schema doubles are implemented as float.
  - Schema booleans are implemented as bool.
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from builtins import bytes
+from builtins import int
+from builtins import range
+from builtins import str
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import binascii
 import json
 import logging

--- a/lang/py3/avro/io.py
+++ b/lang/py3/avro/io.py
@@ -49,9 +49,9 @@ from builtins import bytes
 from builtins import int
 from builtins import range
 from builtins import str
+from past.builtins import unicode, long
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *
 import binascii
 import json
 import logging
@@ -832,7 +832,7 @@ class DatumWriter(object):
     elif writer_schema.type == 'int':
       encoder.write_int(datum)
     elif writer_schema.type == 'long':
-      encoder.write_long(datum)
+      encoder.write_int(datum)
     elif writer_schema.type == 'float':
       encoder.write_float(datum)
     elif writer_schema.type == 'double':

--- a/lang/py3/avro/ipc.py
+++ b/lang/py3/avro/ipc.py
@@ -19,7 +19,17 @@
 # limitations under the License.
 
 """RPC/IPC support."""
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from builtins import open
+from builtins import super
+from builtins import str
+from builtins import *
+from future import standard_library
+standard_library.install_aliases()
 import abc
 import http.client
 import http.server
@@ -48,19 +58,19 @@ def LoadResource(name):
 HANDSHAKE_REQUEST_SCHEMA_JSON = LoadResource('HandshakeRequest.avsc')
 HANDSHAKE_RESPONSE_SCHEMA_JSON = LoadResource('HandshakeResponse.avsc')
 
-HANDSHAKE_REQUEST_SCHEMA = schema.Parse(HANDSHAKE_REQUEST_SCHEMA_JSON)
-HANDSHAKE_RESPONSE_SCHEMA = schema.Parse(HANDSHAKE_RESPONSE_SCHEMA_JSON)
+HANDSHAKE_REQUEST_SCHEMA = schema.parse(HANDSHAKE_REQUEST_SCHEMA_JSON)
+HANDSHAKE_RESPONSE_SCHEMA = schema.parse(HANDSHAKE_RESPONSE_SCHEMA_JSON)
 
 HANDSHAKE_REQUESTOR_WRITER = avro_io.DatumWriter(HANDSHAKE_REQUEST_SCHEMA)
 HANDSHAKE_REQUESTOR_READER = avro_io.DatumReader(HANDSHAKE_RESPONSE_SCHEMA)
 HANDSHAKE_RESPONDER_WRITER = avro_io.DatumWriter(HANDSHAKE_RESPONSE_SCHEMA)
 HANDSHAKE_RESPONDER_READER = avro_io.DatumReader(HANDSHAKE_REQUEST_SCHEMA)
 
-META_SCHEMA = schema.Parse('{"type": "map", "values": "bytes"}')
+META_SCHEMA = schema.parse('{"type": "map", "values": "bytes"}')
 META_WRITER = avro_io.DatumWriter(META_SCHEMA)
 META_READER = avro_io.DatumReader(META_SCHEMA)
 
-SYSTEM_ERROR_SCHEMA = schema.Parse('["string"]')
+SYSTEM_ERROR_SCHEMA = schema.parse('["string"]')
 
 AVRO_RPC_MIME = 'avro/binary'
 

--- a/lang/py3/avro/ipc.py
+++ b/lang/py3/avro/ipc.py
@@ -19,7 +19,6 @@
 # limitations under the License.
 
 """RPC/IPC support."""
-from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
@@ -27,7 +26,6 @@ from __future__ import absolute_import
 from builtins import open
 from builtins import super
 from builtins import str
-from builtins import *
 from future import standard_library
 standard_library.install_aliases()
 from future.utils import with_metaclass
@@ -681,6 +679,7 @@ def _MakeHandlerClass(responder):
 class MultiThreadedHTTPServer(
     socketserver.ThreadingMixIn,
     http.server.HTTPServer,
+  object
 ):
   """Multi-threaded HTTP server."""
   pass
@@ -697,7 +696,7 @@ class AvroIpcHttpServer(MultiThreadedHTTPServer):
       port: TCP port the server listens on, eg. 8000.
       responder: Responder implementation to handle RPCs.
     """
-    super(AvroIpcHttpServer, self).__init__(
+    super().__init__(
         server_address=(interface, port),
         RequestHandlerClass=_MakeHandlerClass(responder),
     )

--- a/lang/py3/avro/ipc.py
+++ b/lang/py3/avro/ipc.py
@@ -30,6 +30,7 @@ from builtins import str
 from builtins import *
 from future import standard_library
 standard_library.install_aliases()
+from future.utils import with_metaclass
 import abc
 import http.client
 import http.server
@@ -105,7 +106,7 @@ class ConnectionClosedException(schema.AvroException):
 # Base IPC Classes (Requestor/Responder)
 
 
-class BaseRequestor(object, metaclass=abc.ABCMeta):
+class BaseRequestor(with_metaclass(abc.ABCMeta, object)):
   """Base class for the client side of a protocol interaction."""
 
   def __init__(self, local_protocol, transceiver):
@@ -321,7 +322,7 @@ class Requestor(BaseRequestor):
 # ------------------------------------------------------------------------------
 
 
-class Responder(object, metaclass=abc.ABCMeta):
+class Responder(with_metaclass(abc.ABCMeta, object)):
   """Base class for the server side of a protocol interaction."""
 
   def __init__(self, local_protocol):
@@ -563,7 +564,7 @@ class FramedWriter(object):
 # Transceiver (send/receive channel)
 
 
-class Transceiver(object, metaclass=abc.ABCMeta):
+class Transceiver(with_metaclass(abc.ABCMeta, object)):
   @abc.abstractproperty
   def remote_name(self):
     pass

--- a/lang/py3/avro/protocol.py
+++ b/lang/py3/avro/protocol.py
@@ -20,8 +20,18 @@
 """
 Protocol implementation.
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
 
+from builtins import map
+from builtins import dict
+from builtins import str
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import hashlib
 import json
 import logging

--- a/lang/py3/avro/protocol.py
+++ b/lang/py3/avro/protocol.py
@@ -27,14 +27,11 @@ from __future__ import absolute_import
 
 
 from builtins import map
-from builtins import dict
 from builtins import str
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *
 import hashlib
 import json
-import logging
 
 from avro import schema
 
@@ -359,6 +356,7 @@ def ProtocolFromJSONData(json_data):
     ProtocolParseException: if the descriptor is invalid.
   """
   if type(json_data) != dict:
+    print(type(json_data))
     raise ProtocolParseException(
         'Invalid JSON descriptor for an Avro protocol: %r' % json_data)
 

--- a/lang/py3/avro/schema.py
+++ b/lang/py3/avro/schema.py
@@ -37,22 +37,23 @@ A schema may be one of:
  - A boolean;
  - Null.
 """
-from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
+import sys
+if sys.version_info.major == 3:
+  unicode=str
 
 from builtins import super
-from builtins import dict
 from builtins import filter
-from builtins import str
 from builtins import map
-from builtins import *
+from builtins import str
+from builtins import int
 from future import standard_library
 standard_library.install_aliases()
+from future.utils import with_metaclass
 import abc
-import collections
 import json
 import logging
 import re
@@ -208,7 +209,7 @@ class ImmutableDict(dict):
 # ------------------------------------------------------------------------------
 
 
-class Schema(object, metaclass=abc.ABCMeta):
+class Schema(with_metaclass(abc.ABCMeta, object)):
   """Abstract base class for all Schema classes."""
 
   def __init__(self, type, other_props=None):
@@ -1242,6 +1243,8 @@ _JSONDataParserTypeMap = {
   str: _SchemaFromJSONString,
   list: _SchemaFromJSONArray,
   dict: _SchemaFromJSONObject,
+  unicode: _SchemaFromJSONString,
+  bytes: _SchemaFromJSONString,
 }
 
 
@@ -1262,6 +1265,7 @@ def SchemaFromJSONData(json_data, names=None):
   # Select the appropriate parser based on the JSON data type:
   parser = _JSONDataParserTypeMap.get(type(json_data))
   if parser is None:
+    print(type(json_data))
     raise SchemaParseException(
         'Invalid JSON descriptor for an Avro schema: %r.' % json_data)
   return parser(json_data, names=names)

--- a/lang/py3/avro/schema.py
+++ b/lang/py3/avro/schema.py
@@ -1258,7 +1258,7 @@ def SchemaFromJSONData(json_data, names=None):
 # ------------------------------------------------------------------------------
 
 
-def Parse(json_string):
+def parse(json_string):
   """Constructs a Schema from its JSON descriptor in text form.
 
   Args:

--- a/lang/py3/avro/schema.py
+++ b/lang/py3/avro/schema.py
@@ -1298,3 +1298,7 @@ def parse(json_string):
 
   # construct the Avro Schema object
   return SchemaFromJSONData(json_data, names)
+
+def Parse(json_string):
+  """Clone of lowercase method to ensure 2/3 compatibility"""
+  return parse(json_string)

--- a/lang/py3/avro/schema.py
+++ b/lang/py3/avro/schema.py
@@ -37,8 +37,20 @@ A schema may be one of:
  - A boolean;
  - Null.
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
 
+from builtins import super
+from builtins import dict
+from builtins import filter
+from builtins import str
+from builtins import map
+from builtins import *
+from future import standard_library
+standard_library.install_aliases()
 import abc
 import collections
 import json

--- a/lang/py3/avro/tests/av_bench.py
+++ b/lang/py3/avro/tests/av_bench.py
@@ -18,6 +18,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
+from builtins import int
+from builtins import open
+from builtins import range
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import logging
 import random
 import string
@@ -63,7 +73,7 @@ def Write(nrecords):
     ]
   }
   """
-  schema = avro.schema.Parse(schema_s)
+  schema = avro.schema.parse(schema_s)
   writer = avro.io.DatumWriter(schema)
 
   with open(FILENAME, 'wb') as out:

--- a/lang/py3/avro/tests/gen_interop_data.py
+++ b/lang/py3/avro/tests/gen_interop_data.py
@@ -18,6 +18,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import open
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import sys
 
 from avro import datafile
@@ -47,7 +55,7 @@ DATUM = {
 
 
 if __name__ == "__main__":
-  interop_schema = schema.Parse(open(sys.argv[1], 'r').read())
+  interop_schema = schema.parse(open(sys.argv[1], 'r').read())
   writer = open(sys.argv[2], 'wb')
   datum_writer = io.DatumWriter()
   # NB: not using compression

--- a/lang/py3/avro/tests/run_tests.py
+++ b/lang/py3/avro/tests/run_tests.py
@@ -41,10 +41,8 @@ Usage:
   ./run_tests.py -h
   ./run_tests.py discover -h
 """
-from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
-from __future__ import absolute_import
 
 from builtins import int
 from future import standard_library

--- a/lang/py3/avro/tests/run_tests.py
+++ b/lang/py3/avro/tests/run_tests.py
@@ -41,7 +41,15 @@ Usage:
   ./run_tests.py -h
   ./run_tests.py discover -h
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from builtins import int
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import logging
 import os
 import sys

--- a/lang/py3/avro/tests/sample_http_client.py
+++ b/lang/py3/avro/tests/sample_http_client.py
@@ -17,6 +17,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
+from builtins import range
+from builtins import int
+from builtins import dict
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import sys
 
 from avro import ipc

--- a/lang/py3/avro/tests/sample_http_server.py
+++ b/lang/py3/avro/tests/sample_http_server.py
@@ -17,7 +17,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from avro import ipc
 from avro import protocol
 

--- a/lang/py3/avro/tests/test_datafile.py
+++ b/lang/py3/avro/tests/test_datafile.py
@@ -29,7 +29,12 @@ standard_library.install_aliases()
 from builtins import *
 import logging
 import os
+import sys
 import tempfile
+if sys.version_info.major == 3:
+    from tempfile import TemporaryDirectory
+else:
+    from backports.tempfile import TemporaryDirectory
 import unittest
 
 from avro import datafile
@@ -103,7 +108,7 @@ class TestDataFile(unittest.TestCase):
   @classmethod
   def setUpClass(cls):
     cls._temp_dir = (
-        tempfile.TemporaryDirectory(prefix=cls.__name__, suffix='.tmp'))
+        TemporaryDirectory(prefix=cls.__name__, suffix='.tmp'))
     logging.debug('Created temporary directory: %s', cls._temp_dir.name)
 
   @classmethod

--- a/lang/py3/avro/tests/test_datafile.py
+++ b/lang/py3/avro/tests/test_datafile.py
@@ -18,6 +18,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import open
+from builtins import range
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import logging
 import os
 import tempfile
@@ -136,7 +145,7 @@ class TestDataFile(unittest.TestCase):
         logging.debug('Creating data file %r', file_path)
         with open(file_path, 'wb') as writer:
           datum_writer = io.DatumWriter()
-          schema_object = schema.Parse(writer_schema)
+          schema_object = schema.parse(writer_schema)
           with datafile.DataFileWriter(
               writer=writer,
               datum_writer=datum_writer,
@@ -185,7 +194,7 @@ class TestDataFile(unittest.TestCase):
         logging.debug('Creating data file %r', file_path)
         with open(file_path, 'wb') as writer:
           datum_writer = io.DatumWriter()
-          schema_object = schema.Parse(writer_schema)
+          schema_object = schema.parse(writer_schema)
           with datafile.DataFileWriter(
               writer=writer,
               datum_writer=datum_writer,
@@ -231,7 +240,7 @@ class TestDataFile(unittest.TestCase):
     with open(file_path, 'wb') as writer:
       datum_writer = io.DatumWriter()
       sample_schema, sample_datum = SCHEMAS_TO_VALIDATE[1]
-      schema_object = schema.Parse(sample_schema)
+      schema_object = schema.parse(sample_schema)
       with datafile.DataFileWriter(writer, datum_writer, schema_object) as dfw:
         dfw.append(sample_datum)
       self.assertTrue(writer.closed)
@@ -252,7 +261,7 @@ class TestDataFile(unittest.TestCase):
     with open(file_path, 'wb') as writer:
       datum_writer = io.DatumWriter()
       sample_schema, sample_datum = SCHEMAS_TO_VALIDATE[1]
-      schema_object = schema.Parse(sample_schema)
+      schema_object = schema.parse(sample_schema)
       with datafile.DataFileWriter(writer, datum_writer, schema_object) as dfw:
         dfw.SetMeta('test.string', 'foo')
         dfw.SetMeta('test.number', '1')

--- a/lang/py3/avro/tests/test_datafile_interop.py
+++ b/lang/py3/avro/tests/test_datafile_interop.py
@@ -18,6 +18,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import open
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import logging
 import os
 import tempfile
@@ -33,7 +41,7 @@ def GetInteropSchema():
   schema_json_path = os.path.join(test_dir, 'interop.avsc')
   with open(schema_json_path, 'r') as f:
     schema_json = f.read()
-  return schema.Parse(schema_json)
+  return schema.parse(schema_json)
 
 
 INTEROP_SCHEMA = GetInteropSchema()

--- a/lang/py3/avro/tests/test_enum.py
+++ b/lang/py3/avro/tests/test_enum.py
@@ -18,6 +18,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import unittest
 
 from avro import schema

--- a/lang/py3/avro/tests/test_io.py
+++ b/lang/py3/avro/tests/test_io.py
@@ -18,6 +18,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import binascii
 import io
 import logging
@@ -98,7 +105,7 @@ DEFAULT_VALUE_EXAMPLES = (
    '{"A": 5}', {'A': 5}),
 )
 
-LONG_RECORD_SCHEMA = schema.Parse("""
+LONG_RECORD_SCHEMA = schema.parse("""
 {
   "type": "record",
   "name": "Test",
@@ -150,7 +157,7 @@ def check_binary_encoding(number_type):
     logging.debug('Datum: %d', datum)
     logging.debug('Correct Encoding: %s', hex_encoding)
 
-    writer_schema = schema.Parse('"%s"' % number_type.lower())
+    writer_schema = schema.parse('"%s"' % number_type.lower())
     writer, encoder, datum_writer = write_datum(datum, writer_schema)
     writer.seek(0)
     hex_val = avro_hexlify(writer)
@@ -168,7 +175,7 @@ def check_skip_number(number_type):
     logging.debug('Value to Skip: %d', value_to_skip)
 
     # write the value to skip and a known value
-    writer_schema = schema.Parse('"%s"' % number_type.lower())
+    writer_schema = schema.parse('"%s"' % number_type.lower())
     writer, encoder, datum_writer = write_datum(value_to_skip, writer_schema)
     datum_writer.write(VALUE_TO_READ, encoder)
 
@@ -199,7 +206,7 @@ class TestIO(unittest.TestCase):
     for example_schema, datum in SCHEMAS_TO_VALIDATE:
       logging.debug('Schema: %r', example_schema)
       logging.debug('Datum: %r', datum)
-      validated = avro_io.Validate(schema.Parse(example_schema), datum)
+      validated = avro_io.Validate(schema.parse(example_schema), datum)
       logging.debug('Valid: %s', validated)
       if validated: passed += 1
     self.assertEqual(passed, len(SCHEMAS_TO_VALIDATE))
@@ -210,7 +217,7 @@ class TestIO(unittest.TestCase):
       logging.debug('Schema: %s', example_schema)
       logging.debug('Datum: %s', datum)
 
-      writer_schema = schema.Parse(example_schema)
+      writer_schema = schema.parse(example_schema)
       writer, encoder, datum_writer = write_datum(datum, writer_schema)
       round_trip_datum = read_datum(writer, writer_schema)
 
@@ -248,10 +255,10 @@ class TestIO(unittest.TestCase):
     promotable_schemas = ['"int"', '"long"', '"float"', '"double"']
     incorrect = 0
     for i, ws in enumerate(promotable_schemas):
-      writer_schema = schema.Parse(ws)
+      writer_schema = schema.parse(ws)
       datum_to_write = 219
       for rs in promotable_schemas[i + 1:]:
-        reader_schema = schema.Parse(rs)
+        reader_schema = schema.parse(rs)
         writer, enc, dw = write_datum(datum_to_write, writer_schema)
         datum_read = read_datum(writer, writer_schema, reader_schema)
         logging.debug('Writer: %s Reader: %s', writer_schema, reader_schema)
@@ -260,12 +267,12 @@ class TestIO(unittest.TestCase):
     self.assertEqual(incorrect, 0)
 
   def testUnknownSymbol(self):
-    writer_schema = schema.Parse("""\
+    writer_schema = schema.parse("""\
       {"type": "enum", "name": "Test",
        "symbols": ["FOO", "BAR"]}""")
     datum_to_write = 'FOO'
 
-    reader_schema = schema.Parse("""\
+    reader_schema = schema.parse("""\
       {"type": "enum", "name": "Test",
        "symbols": ["BAR", "BAZ"]}""")
 
@@ -281,7 +288,7 @@ class TestIO(unittest.TestCase):
 
     correct = 0
     for field_type, default_json, default_datum in DEFAULT_VALUE_EXAMPLES:
-      reader_schema = schema.Parse("""\
+      reader_schema = schema.parse("""\
         {"type": "record", "name": "Test",
          "fields": [{"name": "H", "type": %s, "default": %s}]}
         """ % (field_type, default_json))
@@ -297,7 +304,7 @@ class TestIO(unittest.TestCase):
     writer_schema = LONG_RECORD_SCHEMA
     datum_to_write = LONG_RECORD_DATUM
 
-    reader_schema = schema.Parse("""\
+    reader_schema = schema.parse("""\
       {"type": "record", "name": "Test",
        "fields": [{"name": "H", "type": "int"}]}""")
 
@@ -311,7 +318,7 @@ class TestIO(unittest.TestCase):
     writer_schema = LONG_RECORD_SCHEMA
     datum_to_write = LONG_RECORD_DATUM
 
-    reader_schema = schema.Parse("""\
+    reader_schema = schema.parse("""\
       {"type": "record", "name": "Test",
        "fields": [{"name": "E", "type": "int"},
                   {"name": "F", "type": "int"}]}""")
@@ -326,7 +333,7 @@ class TestIO(unittest.TestCase):
     writer_schema = LONG_RECORD_SCHEMA
     datum_to_write = LONG_RECORD_DATUM
 
-    reader_schema = schema.Parse("""\
+    reader_schema = schema.parse("""\
       {"type": "record", "name": "Test",
        "fields": [{"name": "F", "type": "int"},
                   {"name": "E", "type": "int"}]}""")
@@ -338,7 +345,7 @@ class TestIO(unittest.TestCase):
     self.assertEqual(datum_to_read, datum_read)
 
   def testTypeException(self):
-    writer_schema = schema.Parse("""\
+    writer_schema = schema.parse("""\
       {"type": "record", "name": "Test",
        "fields": [{"name": "F", "type": "int"},
                   {"name": "E", "type": "int"}]}""")

--- a/lang/py3/avro/tests/test_ipc.py
+++ b/lang/py3/avro/tests/test_ipc.py
@@ -21,7 +21,16 @@
 There are currently no IPC tests within python, in part because there are no
 servers yet available.
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from builtins import int
+from builtins import super
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import logging
 import threading
 import time

--- a/lang/py3/avro/tests/test_ipc.py
+++ b/lang/py3/avro/tests/test_ipc.py
@@ -21,12 +21,12 @@
 There are currently no IPC tests within python, in part because there are no
 servers yet available.
 """
-from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
 from builtins import int
+from past.builtins import long, unicode
 from builtins import super
 from future import standard_library
 standard_library.install_aliases()
@@ -91,7 +91,7 @@ ECHO_PROTOCOL = protocol.Parse(ECHO_PROTOCOL_JSON)
 
 class EchoResponder(ipc.Responder):
   def __init__(self):
-    super(EchoResponder, self).__init__(
+    super().__init__(
         local_protocol=ECHO_PROTOCOL,
     )
 
@@ -105,7 +105,7 @@ class EchoResponder(ipc.Responder):
 class TestIPC(unittest.TestCase):
 
   def __init__(self, *args, **kwargs):
-    super(TestIPC, self).__init__(*args, **kwargs)
+    super().__init__(*args, **kwargs)
     # Reference to an Echo RPC over HTTP server:
     self._server = None
 
@@ -147,13 +147,13 @@ class TestIPC(unittest.TestCase):
       )
       response = requestor.Request(
           message_name='ping',
-          request_datum={'ping': {'timestamp': 31415, 'text': 'hello ping'}},
+          request_datum={'ping': {'timestamp': long(31415), 'text': unicode('hello ping')}},
       )
       logging.info('Received echo response: %s', response)
 
       response = requestor.Request(
           message_name='ping',
-          request_datum={'ping': {'timestamp': 123456, 'text': 'hello again'}},
+          request_datum={'ping': {'timestamp': long(123456), 'text': unicode('hello again')}},
       )
       logging.info('Received echo response: %s', response)
 

--- a/lang/py3/avro/tests/test_protocol.py
+++ b/lang/py3/avro/tests/test_protocol.py
@@ -20,7 +20,15 @@
 """
 Test the protocol parsing logic.
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from builtins import str
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import logging
 import traceback
 import unittest

--- a/lang/py3/avro/tests/test_schema.py
+++ b/lang/py3/avro/tests/test_schema.py
@@ -20,7 +20,15 @@
 """
 Test the schema parsing logic.
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from builtins import str
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import logging
 import traceback
 import unittest
@@ -451,7 +459,7 @@ VALID_EXAMPLES = [e for e in EXAMPLES if e.valid]
 class TestSchema(unittest.TestCase):
 
   def testCorrectRecursiveExtraction(self):
-    parsed = schema.Parse("""
+    parsed = schema.parse("""
       {
         "type": "record",
         "name": "X",
@@ -467,7 +475,7 @@ class TestSchema(unittest.TestCase):
     """)
     logging.debug('Parsed schema:\n%s', parsed)
     logging.debug('Fields: %s', parsed.fields)
-    t = schema.Parse(str(parsed.fields[0].type))
+    t = schema.parse(str(parsed.fields[0].type))
     # If we've made it this far, the subschema was reasonably stringified;
     # it could be reparsed.
     self.assertEqual("X", t.fields[0].type.name)
@@ -477,7 +485,7 @@ class TestSchema(unittest.TestCase):
     for iexample, example in enumerate(EXAMPLES):
       logging.debug('Testing example #%d\n%s', iexample, example.schema_string)
       try:
-        schema.Parse(example.schema_string)
+        schema.parse(example.schema_string)
         if example.valid:
           correct += 1
         else:
@@ -508,8 +516,8 @@ class TestSchema(unittest.TestCase):
     """
     correct = 0
     for example in VALID_EXAMPLES:
-      schema_data = schema.Parse(example.schema_string)
-      schema.Parse(str(schema_data))
+      schema_data = schema.parse(example.schema_string)
+      schema.parse(str(schema_data))
       correct += 1
 
     fail_msg = "Cast to string success on %d out of %d schemas" % \
@@ -525,8 +533,8 @@ class TestSchema(unittest.TestCase):
     """
     correct = 0
     for example in VALID_EXAMPLES:
-      original_schema = schema.Parse(example.schema_string)
-      round_trip_schema = schema.Parse(str(original_schema))
+      original_schema = schema.parse(example.schema_string)
+      round_trip_schema = schema.parse(str(original_schema))
       if original_schema == round_trip_schema:
         correct += 1
         debug_msg = "%s: ROUND TRIP SUCCESS" % example.name
@@ -580,7 +588,7 @@ class TestSchema(unittest.TestCase):
   def testDocAttributes(self):
     correct = 0
     for example in DOC_EXAMPLES:
-      original_schema = schema.Parse(example.schema_string)
+      original_schema = schema.parse(example.schema_string)
       if original_schema.doc is not None:
         correct += 1
       if original_schema.type == 'record':
@@ -595,8 +603,8 @@ class TestSchema(unittest.TestCase):
     correct = 0
     props = {}
     for example in OTHER_PROP_EXAMPLES:
-      original_schema = schema.Parse(example.schema_string)
-      round_trip_schema = schema.Parse(str(original_schema))
+      original_schema = schema.parse(example.schema_string)
+      round_trip_schema = schema.parse(str(original_schema))
       self.assertEqual(original_schema.other_props,round_trip_schema.other_props)
       if original_schema.type == "record":
         field_props = 0

--- a/lang/py3/avro/tests/test_schema.py
+++ b/lang/py3/avro/tests/test_schema.py
@@ -28,7 +28,6 @@ from __future__ import absolute_import
 from builtins import str
 from future import standard_library
 standard_library.install_aliases()
-from builtins import *
 import logging
 import traceback
 import unittest

--- a/lang/py3/avro/tests/test_script.py
+++ b/lang/py3/avro/tests/test_script.py
@@ -18,6 +18,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import dict
+from builtins import next
+from builtins import map
+from builtins import str
+from builtins import open
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import csv
 import io
 import json
@@ -85,7 +97,9 @@ def GetScriptPath():
 SCRIPT_PATH = GetScriptPath()
 
 
-def RunScript(*args, stdin=None):
+def RunScript(*args, **_3to2kwargs):
+  if 'stdin' in _3to2kwargs: stdin = _3to2kwargs['stdin']; del _3to2kwargs['stdin']
+  else: stdin = None
   command = [SCRIPT_PATH]
   command.extend(args)
   env = dict(os.environ)
@@ -119,7 +133,7 @@ class TestCat(unittest.TestCase):
 
   @staticmethod
   def WriteAvroFile(file_path):
-    schema = avro.schema.Parse(SCHEMA)
+    schema = avro.schema.parse(SCHEMA)
     with open(file_path, 'wb') as writer:
       with avro.datafile.DataFileWriter(
           writer=writer,
@@ -139,7 +153,9 @@ class TestCat(unittest.TestCase):
   def tearDown(self):
     self._avro_file.close()
 
-  def _RunCat(self, *args, raw=False):
+  def _RunCat(self, *args, **_3to2kwargs):
+    if 'raw' in _3to2kwargs: raw = _3to2kwargs['raw']; del _3to2kwargs['raw']
+    else: raw = False
     """Runs the specified 'avro cat test-file ...' command.
 
     Args:
@@ -259,7 +275,9 @@ class TestWrite(unittest.TestCase):
     self._json_file.close()
     self._schema_file.close()
 
-  def _RunWrite(self, *args, stdin=None):
+  def _RunWrite(self, *args, **_3to2kwargs):
+    if 'stdin' in _3to2kwargs: stdin = _3to2kwargs['stdin']; del _3to2kwargs['stdin']
+    else: stdin = None
     """Runs the specified 'avro write ...' command.
 
     Args:

--- a/lang/py3/avro/tests/test_script.py
+++ b/lang/py3/avro/tests/test_script.py
@@ -19,17 +19,6 @@
 # limitations under the License.
 
 from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import dict
-from builtins import next
-from builtins import map
-from builtins import str
-from builtins import open
-from future import standard_library
-standard_library.install_aliases()
-from builtins import *
 import csv
 import io
 import json
@@ -97,9 +86,7 @@ def GetScriptPath():
 SCRIPT_PATH = GetScriptPath()
 
 
-def RunScript(*args, **_3to2kwargs):
-  if 'stdin' in _3to2kwargs: stdin = _3to2kwargs['stdin']; del _3to2kwargs['stdin']
-  else: stdin = None
+def RunScript(*args, **kwargs):
   command = [SCRIPT_PATH]
   command.extend(args)
   env = dict(os.environ)
@@ -108,7 +95,7 @@ def RunScript(*args, **_3to2kwargs):
   process = subprocess.Popen(
       args=command,
       env=env,
-      stdin=stdin,
+      stdin=kwargs.get('stdin', None),
       stdout=subprocess.PIPE,
       stderr=subprocess.PIPE,
   )
@@ -153,9 +140,7 @@ class TestCat(unittest.TestCase):
   def tearDown(self):
     self._avro_file.close()
 
-  def _RunCat(self, *args, **_3to2kwargs):
-    if 'raw' in _3to2kwargs: raw = _3to2kwargs['raw']; del _3to2kwargs['raw']
-    else: raw = False
+  def _RunCat(self, *args, **kwargs):
     """Runs the specified 'avro cat test-file ...' command.
 
     Args:
@@ -165,7 +150,7 @@ class TestCat(unittest.TestCase):
       The command stdout (as bytes if raw is set, or else as string).
     """
     out = RunScript('cat', self._avro_file.name, *args)
-    if raw:
+    if kwargs.get('raw'):
       return out
     else:
       return out.decode('utf-8')
@@ -275,9 +260,7 @@ class TestWrite(unittest.TestCase):
     self._json_file.close()
     self._schema_file.close()
 
-  def _RunWrite(self, *args, **_3to2kwargs):
-    if 'stdin' in _3to2kwargs: stdin = _3to2kwargs['stdin']; del _3to2kwargs['stdin']
-    else: stdin = None
+  def _RunWrite(self, *args, **kwargs):
     """Runs the specified 'avro write ...' command.
 
     Args:
@@ -288,7 +271,7 @@ class TestWrite(unittest.TestCase):
     """
     return RunScript(
         'write', '--schema', self._schema_file.name,
-        stdin=stdin, *args
+        stdin=kwargs.get('stdin'), *args
     )
 
   def LoadAvro(self, filename):

--- a/lang/py3/avro/tests/txsample_http_client.py
+++ b/lang/py3/avro/tests/txsample_http_client.py
@@ -17,6 +17,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
+from builtins import range
+from builtins import int
+from builtins import dict
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import sys
 
 from twisted.internet import reactor, defer

--- a/lang/py3/avro/tests/txsample_http_server.py
+++ b/lang/py3/avro/tests/txsample_http_server.py
@@ -17,6 +17,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 from twisted.web import server
 from twisted.internet import reactor
 

--- a/lang/py3/avro/tool.py
+++ b/lang/py3/avro/tool.py
@@ -22,11 +22,19 @@ Command-line tool
 
 NOTE: The API for the command-line tool is experimental.
 """
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
+from builtins import open
+from builtins import *
+from future import standard_library
+standard_library.install_aliases()
 import sys
 import urllib
 
-from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
+from http.server import HTTPServer, BaseHTTPRequestHandler
 
 from avro import io
 from avro import datafile

--- a/lang/py3/avro/txipc.py
+++ b/lang/py3/avro/txipc.py
@@ -18,6 +18,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import io
 
 from avro import io as avro_io

--- a/lang/py3/scripts/avro
+++ b/lang/py3/scripts/avro
@@ -213,7 +213,7 @@ def write(opts, files):
   try:
     with open(opts.schema, 'rt') as f:
       json_schema = f.read()
-    writer_schema = schema.Parse(json_schema)
+    writer_schema = schema.parse(json_schema)
     out = _open(opts.output, 'wb')
   except (IOError, OSError) as e:
     raise AvroError('Cannot open file - %s' % e)

--- a/lang/py3/setup.cfg
+++ b/lang/py3/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test=pytest

--- a/lang/py3/setup.py
+++ b/lang/py3/setup.py
@@ -18,6 +18,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import open
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import os
 import shutil
 import sys
@@ -94,8 +102,8 @@ def SetupSources():
 
   # Make sure the avro shell script is executable:
   os.chmod(
-      path=os.path.join(py3_dir, 'scripts', 'avro'),
-      mode=0o777,
+      os.path.join(py3_dir, 'scripts', 'avro'),
+      0o777,
   )
 
 
@@ -110,9 +118,6 @@ def ReadVersion():
 
 
 def Main():
-  assert (sys.version_info[0] >= 3), \
-      ('Python version >= 3 required, got %r' % sys.version_info)
-
   if not RunsFromSourceDist():
     SetupSources()
 
@@ -124,6 +129,7 @@ def Main():
       packages = ['avro'],
       package_dir = {'avro': 'avro'},
       scripts = ['scripts/avro'],
+      install_requires=['future'],
 
       package_data = {
           'avro': [

--- a/lang/py3/setup.py
+++ b/lang/py3/setup.py
@@ -133,7 +133,7 @@ def Main():
       },
       setup_requires=['pytest-runner'],
       test_suite='pytest',
-      tests_require=['pytest', 'future'],
+      tests_requires=['pytest', 'future', 'backports.tempfile'],
 
       # metadata for upload to PyPI
       author = 'Apache Avro',

--- a/lang/py3/setup.py
+++ b/lang/py3/setup.py
@@ -18,17 +18,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import open
-from future import standard_library
-standard_library.install_aliases()
-from builtins import *
 import os
 import shutil
-import sys
 
 from setuptools import setup
 
@@ -140,9 +131,9 @@ def Main():
               NOTICE_FILE_NAME,
           ],
       },
-
-      test_suite='avro.tests.run_tests',
-      tests_require=[],
+      setup_requires=['pytest-runner'],
+      test_suite='pytest',
+      tests_require=['pytest', 'future'],
 
       # metadata for upload to PyPI
       author = 'Apache Avro',

--- a/lang/py3/tox.ini
+++ b/lang/py3/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = py27,py36
+[testenv]
+deps=
+	pytest
+	future
+commands=pytest

--- a/lang/py3/tox.ini
+++ b/lang/py3/tox.ini
@@ -2,6 +2,7 @@
 envlist = py27,py36
 [testenv]
 deps=
+	backports.tempfile
 	pytest
 	future
 commands=pytest


### PR DESCRIPTION
Like #234 and #133 I am also interested in unifying python2/3 support so I have taken the opposite approach. Take python3 implementation and back port it to python2. This now supports python2 and 3 which is verifiable with Tox. I have added support for tox which is optional but viable. I have revived the lowercase method ```parse``` in schema.py to bring full backwards compatibility

So now recommended testing path for https://cwiki.apache.org/confluence/display/AVRO/How+To+Contribute is

```
cd lang/py3
tox
```

It would be advisable to follow up this pull with the creation of a symlink to lang/py so both packages can be created.

I hope this can help others like it will help me.