### PR TITLE
Fix unknown binaryWrite function

### DIFF
--- a/lang/js/lib/utils.js
+++ b/lang/js/lib/utils.js
@@ -487,7 +487,7 @@ Tap.prototype.writeBinary = function (str, len) {
   if (this.pos > this.buf.length) {
     return;
   }
-  this.buf.binaryWrite(str, pos, len);
+  this.buf.write(str, pos, len);
 };
 
 // Binary comparison methods.


### PR DESCRIPTION
Running ./build.sh test with NodeJS 6 or 8, I get:
TypeError: this.buf.binaryWrite is not a function

Changed binaryWrite() to write()