### PR TITLE
Fixnum is deprecated in ruby2.4

### DIFF
--- a/lang/ruby/lib/avro/schema.rb
+++ b/lang/ruby/lib/avro/schema.rb
@@ -347,7 +347,7 @@ module Avro
       attr_reader :size
       def initialize(name, space, size, names=nil)
         # Ensure valid cto args
-        unless size.is_a?(Fixnum) || size.is_a?(Bignum)
+        unless size.is_a?(Integer)
           raise AvroError, 'Fixed Schema requires a valid integer for size property.'
         end
         super(:fixed, name, space, names)


### PR DESCRIPTION
Gets rid of this warning when used in ruby2.4 projects:
```
App 66 stderr: /usr/src/app/vendor/bundle/ruby/2.4.0/gems/avro-1.8.2/lib/avro/schema.rb:350: warning: constant ::Fixnum is deprecated
```