### PR TITLE
AVRO-2043: Remove pre JDK 1.8 surefire specific configuration

### DIFF
--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -218,8 +218,7 @@
                  rather than the console. -->
             <redirectTestOutputToFile>true</redirectTestOutputToFile>
             <failIfNoTests>false</failIfNoTests>
-            <!-- The correct argLine value depends on the JDK version -->
-            <argLine>${surefire.argline}</argLine>
+            <argLine>-Xmx1000m</argLine>
             <systemPropertyVariables>
               <test.dir>${project.basedir}/target/</test.dir>
             </systemPropertyVariables>
@@ -387,28 +386,6 @@
         </plugins>
       </build>
     </profile>
-
-    <!--In JDK 1.8 and newer the PermGem has been removed. -->
-    <!--These two profiles are to handle the differences between the before and after 1.8 -->
-    <profile>
-      <id>old-jdk</id>
-      <activation>
-        <jdk>(,1.8)</jdk>
-      </activation>
-      <properties>
-        <surefire.argline>-Xmx1000m -XX:MaxPermSize=200m</surefire.argline>
-      </properties>
-    </profile>
-    <profile>
-      <id>new-jdk</id>
-      <activation>
-        <jdk>[1.8,)</jdk>
-      </activation>
-      <properties>
-        <surefire.argline>-Xmx1000m</surefire.argline>
-      </properties>
-    </profile>
-
   </profiles>
 
   <!-- dependencyManagement can be used to define dependency versions, scopes, and


### PR DESCRIPTION
I found a few remnants of the transition from Java 1.7 to 1.8 that can be removed.