### PR TITLE
AVRO-2119: Run Apache Rat check on every java build

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -96,6 +96,8 @@ Trunk (not yet released)
     AVRO-2080: Fix Javadoc Warnings in Generated Records
     (Bridger Howell via Niels Basjes)
 
+    AVRO-2119: Run Apache Rat check on every java build (Niels Basjes)
+
   BUG FIXES
 
     AVRO-1741: Python3: Fix error when codec is not in the header.

--- a/pom.xml
+++ b/pom.xml
@@ -205,6 +205,9 @@
     </profile>
     <profile>
       <id>rat</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>


### PR DESCRIPTION
This simply forces Apache Rat to run on every Java build.
Must be committed to branch-1.7 branch-1.8 and master.