### PR TITLE
AVRO-2115

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectData.java
@@ -744,6 +744,10 @@ public class ReflectData extends SpecificData {
     if (explicit != null)                                   // explicit schema
       return Schema.parse(explicit.value());
 
+    Union union = field.getAnnotation(Union.class);
+    if (union != null)
+      return getAnnotatedUnion(union, names);
+
     Schema schema = createSchema(field.getGenericType(), names);
     if (field.isAnnotationPresent(Stringable.class)) {      // Stringable
       schema = Schema.create(Schema.Type.STRING);

--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/Union.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/Union.java
@@ -31,7 +31,7 @@ import java.lang.annotation.Target;
  * to a method, this determines its return type.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE, ElementType.PARAMETER, ElementType.METHOD})
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
 @Documented
 public @interface Union {
   /** The instantiable classes that compose this union. */

--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/Union.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/Union.java
@@ -28,7 +28,8 @@ import java.lang.annotation.Target;
  * May be used for base classes or interfaces whose instantiable subclasses can
  * be listed in the parameters to the @Union annotation.  If applied to method
  * parameters this determines the reflected message parameter type.  If applied
- * to a method, this determines its return type.
+ * to a method, this determines its return type. A null schema may be specified 
+ * with {@link java.lang.Void}.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})

--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/package.html
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/package.html
@@ -30,7 +30,7 @@ classes.
   that are not static or transient are used.  Fields are not permitted
   to be null unless annotated by {@link
   org.apache.avro.reflect.Nullable Nullable} or a {@link
-  org.apache.avro.reflect.Union Union} containing null.</li>
+  org.apache.avro.reflect.Union Union} containing {@link java.lang.Void}.</li>
 
 <li><b>Arrays</b> are mapped to Avro array schemas.  If an array's
   elements are a union defined by the {@link

--- a/lang/java/avro/src/test/java/org/apache/avro/reflect/TestReflect.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/reflect/TestReflect.java
@@ -297,6 +297,31 @@ public class TestReflect {
     checkReadWrite(r9, ReflectData.get().getSchema(R9.class));
   }
 
+  // test union in fields
+  public static class R9_1  {
+	@Union({R7.class, R8.class})
+    public Object value;
+    @Override
+    public boolean equals(Object o) {
+      if (!(o instanceof R9_1)) return false;
+      return this.value.equals(((R9_1)o).value);
+    }
+  }
+
+  @Test public void testR6_1() throws Exception {
+    R7 r7 = new R7();
+    r7.value = 1;
+    checkReadWrite(r7, ReflectData.get().getSchema(R6.class));
+    R8 r8 = new R8();
+    r8.value = 1;
+    checkReadWrite(r8, ReflectData.get().getSchema(R6.class));
+    R9_1 r9_1 = new R9_1();
+    r9_1.value = r7;
+    checkReadWrite(r9_1, ReflectData.get().getSchema(R9_1.class));
+    r9_1.value = r8;
+    checkReadWrite(r9_1, ReflectData.get().getSchema(R9_1.class));
+  }
+  
   // test union annotation on methods and parameters
   public static interface P0 {
     @Union({Void.class,String.class})

--- a/lang/java/avro/src/test/java/org/apache/avro/reflect/TestReflect.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/reflect/TestReflect.java
@@ -299,11 +299,12 @@ public class TestReflect {
 
   // test union in fields
   public static class R9_1  {
-	@Union({R7.class, R8.class})
+	@Union({Void.class, R7.class, R8.class})
     public Object value;
     @Override
     public boolean equals(Object o) {
       if (!(o instanceof R9_1)) return false;
+      if (this.value == null) return ((R9_1)o).value == null;
       return this.value.equals(((R9_1)o).value);
     }
   }
@@ -316,6 +317,8 @@ public class TestReflect {
     r8.value = 1;
     checkReadWrite(r8, ReflectData.get().getSchema(R6.class));
     R9_1 r9_1 = new R9_1();
+    r9_1.value = null;
+    checkReadWrite(r9_1, ReflectData.get().getSchema(R9_1.class));
     r9_1.value = r7;
     checkReadWrite(r9_1, ReflectData.get().getSchema(R9_1.class));
     r9_1.value = r8;


### PR DESCRIPTION
This patch is to allow defining unions in members when using the reflect API (which was supposed to be supported). This is an example (note the @Union used in a member):

```
class MyDatum {
   @Union({Void.class, String.class, Long.class, Other.class,...})
   Object o;
}
```

There are also a correction and some minor changes in the reflect API docs to make it more clear to understand. 
