### PR TITLE
AVRO 2118+2119 Fix licensing issues

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -103,6 +103,8 @@ Trunk (not yet released)
     AVRO-2115: Java: Permit @Union annotations on fields of classes.
     (Miguel Martinez-Espronceda via cutting).
 
+    AVRO-2119: Run Apache Rat check on every java build (Niels Basjes)
+
   BUG FIXES
 
     AVRO-1741: Python3: Fix error when codec is not in the header.

--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/idl/ResolvingVisitor.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/idl/ResolvingVisitor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -11,11 +11,10 @@
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- * implied.  See the License for the specific language governing
- * permissions and limitations under the License.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.apache.avro.compiler.idl;
 
 import com.google.common.base.Function;

--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/idl/SchemaResolver.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/idl/SchemaResolver.java
@@ -1,11 +1,13 @@
-/*
- * Copyright 2015 The Apache Software Foundation.
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/schema/CloningVisitor.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/schema/CloningVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/schema/CloningVisitor.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/schema/CloningVisitor.java
@@ -1,4 +1,20 @@
-
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.avro.compiler.schema;
 
 import java.util.ArrayList;

--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/schema/SchemaVisitor.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/schema/SchemaVisitor.java
@@ -1,31 +1,33 @@
-/*
-* Copyright (c) 2001 - 2016, Zoltan Farkas All Rights Reserved.
-*
-* This library is free software; you can redistribute it and/or
-* modify it under the terms of the GNU Lesser General Public
-* License as published by the Free Software Foundation; either
-* version 2.1 of the License, or (at your option) any later version.
-*
-* This library is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
-*
-* You should have received a copy of the GNU Lesser General Public
-* License along with this program; if not, write to the Free Software
-* Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
-*/
+ /*
+ * Copyright (c) 2001 - 2016, Zoltan Farkas All Rights Reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
 package org.apache.avro.compiler.schema;
 
 import org.apache.avro.Schema;
 
+/**
+ * @author zoly
+ */
 public interface SchemaVisitor<T> {
 
   /**
    * Invoked for schemas that do not have "child" schemas (like string, int ...)
    * or for a previously encountered schema with children,
    * which will be treated as a terminal. (to avoid circular recursion)
-   *
    * @param terminal
    * @return
    */
@@ -33,7 +35,6 @@ public interface SchemaVisitor<T> {
 
   /**
    * Invoked for schema with children before proceeding to visit the children.
-   *
    * @param nonTerminal
    * @return
    */
@@ -41,7 +42,6 @@ public interface SchemaVisitor<T> {
 
   /**
    * Invoked for schemas with children after its children have been visited.
-   *
    * @param nonTerminal
    * @return
    */
@@ -50,7 +50,6 @@ public interface SchemaVisitor<T> {
 
   /**
    * Invoked when visiting is complete.
-   *
    * @return a value which will be returned by the visit method.
    */
   T get();

--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/schema/SchemaVisitor.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/schema/SchemaVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -19,9 +19,6 @@ package org.apache.avro.compiler.schema;
 
 import org.apache.avro.Schema;
 
-/**
- * @author zoly
- */
 public interface SchemaVisitor<T> {
 
   /**

--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/schema/SchemaVisitor.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/schema/SchemaVisitor.java
@@ -1,19 +1,19 @@
- /*
- * Copyright (c) 2001 - 2016, Zoltan Farkas All Rights Reserved.
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.apache.avro.compiler.schema;
 

--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/schema/SchemaVisitorAction.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/schema/SchemaVisitorAction.java
@@ -1,41 +1,44 @@
-/*
-* Copyright (c) 2001 - 2016, Zoltan Farkas All Rights Reserved.
-*
-* This library is free software; you can redistribute it and/or
-* modify it under the terms of the GNU Lesser General Public
-* License as published by the Free Software Foundation; either
-* version 2.1 of the License, or (at your option) any later version.
-*
-* This library is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
-*
-* You should have received a copy of the GNU Lesser General Public
-* License along with this program; if not, write to the Free Software
-* Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
-*/
+ /*
+ * Copyright (c) 2001 - 2016, Zoltan Farkas All Rights Reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
 
 package org.apache.avro.compiler.schema;
 
+/**
+ * @author zoly
+ */
 public enum SchemaVisitorAction {
 
-  /**
-   * continue visit.
-   */
-  CONTINUE,
-  /**
-   * terminate visit.
-   */
-  TERMINATE,
-  /**
-   * when returned from pre non terminal visit method the children of the non terminal are skipped.
-   * afterVisitNonTerminal for the current schema will not be invoked.
-   */
-  SKIP_SUBTREE,
-  /**
-   * Skip visiting the  siblings of this schema.
-   */
-  SKIP_SIBLINGS;
+    /**
+     * continue visit.
+     */
+    CONTINUE,
+    /**
+     * terminate visit.
+     */
+    TERMINATE,
+    /**
+     * when returned from pre non terminal visit method the children of the non terminal are skipped.
+     * afterVisitNonTerminal for the current schema will not be invoked.
+     */
+    SKIP_SUBTREE,
+    /**
+     * Skip visiting the  siblings of this schema.
+     */
+    SKIP_SIBLINGS;
 
 }

--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/schema/SchemaVisitorAction.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/schema/SchemaVisitorAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -18,9 +18,6 @@
 
 package org.apache.avro.compiler.schema;
 
-/**
- * @author zoly
- */
 public enum SchemaVisitorAction {
 
     /**

--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/schema/SchemaVisitorAction.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/schema/SchemaVisitorAction.java
@@ -1,19 +1,19 @@
- /*
- * Copyright (c) 2001 - 2016, Zoltan Farkas All Rights Reserved.
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.avro.compiler.schema;

--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/schema/Schemas.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/schema/Schemas.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/schema/Schemas.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/schema/Schemas.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.avro.compiler.schema;
 
 import com.google.common.base.Function;

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <!-- plugin versions -->
     <antrun-plugin.version>1.7</antrun-plugin.version>
     <enforcer-plugin.version>1.3.1</enforcer-plugin.version>
-    <rat.version>0.9</rat.version>
+    <rat.version>0.12</rat.version>
     <checkstyle-plugin.version>2.17</checkstyle-plugin.version>
   </properties>
 
@@ -214,6 +214,7 @@
             <groupId>org.apache.rat</groupId>
             <artifactId>apache-rat-plugin</artifactId>
             <version>${rat.version}</version>
+            <inherited>false</inherited>
             <executions>
               <execution>
                 <phase>test</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -205,6 +205,9 @@
     </profile>
     <profile>
       <id>rat</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>


### PR DESCRIPTION
I have combined the various actions from AVRO-2118 (licensing issues) and AVRO-2119 (Run rat always) into this set of commits.
I also updated Apache Rat to the latest version and fixed the problem that rat would not only be run at the top level (desired) but also in all subprojects (undesired and failing). 