### PR TITLE
AVRO-2120: Fix NullPointerException thrown by Schema.Parser#parse("")

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -218,6 +218,8 @@ Trunk (not yet released)
     AVRO-1485: Specification says Record field type can be record name but implementation allows any named type.
     (Nandor Kollar via gabor)
 
+    AVRO-2120: Fix NullPointerException thrown by Schema.Parser#parse("")
+
 Avro 1.8.1 (14 May 2016)
 
   INCOMPATIBLE CHANGES

--- a/lang/java/avro/src/main/java/org/apache/avro/Schema.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Schema.java
@@ -1225,6 +1225,9 @@ public abstract class Schema extends JsonProperties {
 
   /** @see #parse(String) */
   static Schema parse(JsonNode schema, Names names) {
+    if (schema == null) {
+      throw new SchemaParseException("Cannot parse <null> schema");
+    }
     if (schema.isTextual()) {                     // name
       Schema result = names.get(schema.getTextValue());
       if (result == null)

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchema.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchema.java
@@ -83,6 +83,11 @@ public class TestSchema {
     assertNotNull(schemaString);
   }
 
+  @Test(expected = SchemaParseException.class)
+  public void testParseEmptySchema() {
+    Schema schema = new Schema.Parser().parse("");
+  }
+
   @Test
   public void testSchemaWithFields() {
     List<Field> fields = new ArrayList<Field>();


### PR DESCRIPTION
Fix for master for https://issues.apache.org/jira/browse/AVRO-2120 .
TODO: Also backport to branch 1.8