### PR TITLE
AVRO-2127 Make InvalidAvroMagicException thrown if stream header is corrupted

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/file/DataFileReader.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/file/DataFileReader.java
@@ -47,7 +47,7 @@ public class DataFileReader<D>
                                              DatumReader<D> reader)
     throws IOException {
     if (in.length() < MAGIC.length)
-      throw new IOException("Not an Avro data file");
+      throw new EOFException("Not an Avro data file");
 
     // read magic header
     byte[] magic = new byte[MAGIC.length];
@@ -60,7 +60,7 @@ public class DataFileReader<D>
     if (Arrays.equals(DataFileReader12.MAGIC, magic)) // 1.2 format
       return new DataFileReader12<D>(in, reader);
 
-    throw new IOException("Not an Avro data file");
+    throw new InvalidAvroMagicException("Not an Avro data file");
   }
 
   /**

--- a/lang/java/avro/src/main/java/org/apache/avro/file/DataFileStream.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/file/DataFileStream.java
@@ -102,7 +102,7 @@ public class DataFileStream<D> implements Iterator<D>, Iterable<D>, Closeable {
       throw new IOException("Not an Avro data file.", e);
     }
     if (!Arrays.equals(DataFileConstants.MAGIC, magic))
-      throw new IOException("Not an Avro data file.");
+      throw new InvalidAvroMagicException("Not an Avro data file.");
 
     long l = vin.readMapStart();                  // read meta data
     if (l > 0) {

--- a/lang/java/avro/src/main/java/org/apache/avro/file/InvalidAvroMagicException.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/file/InvalidAvroMagicException.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.avro.file;
 
 import java.io.IOException;

--- a/lang/java/avro/src/main/java/org/apache/avro/file/InvalidAvroMagicException.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/file/InvalidAvroMagicException.java
@@ -1,0 +1,7 @@
+package org.apache.avro.file;
+
+import java.io.IOException;
+
+public class InvalidAvroMagicException extends IOException {
+    public InvalidAvroMagicException(String message){ super(message); }
+}


### PR DESCRIPTION
This seems reasonable to throw a subclass of IOException in case if we have an invalid header (empty file for example) so such errors can be handled in user code.