### PR TITLE
AVRO-2132: allow the dot character to be used in the name of an IDL property annotation

### DIFF
--- a/lang/java/compiler/src/main/javacc/org/apache/avro/compiler/idl/idl.jj
+++ b/lang/java/compiler/src/main/javacc/org/apache/avro/compiler/idl/idl.jj
@@ -1528,6 +1528,8 @@ String PropertyName():
 {
   t = <IDENTIFIER>   { name.append(t.image); }
   ( t = <DASH>       { name.append(t.image); }
+    t = <IDENTIFIER> { name.append(t.image); } |
+    t = <DOT>        { name.append(t.image); }
     t = <IDENTIFIER> { name.append(t.image); }
   ) *
   { return name.toString(); }

--- a/lang/java/compiler/src/test/idl/input/simple.avdl
+++ b/lang/java/compiler/src/test/idl/input/simple.avdl
@@ -49,6 +49,9 @@ protocol Simple {
     float average = -Infinity;
     date d = 0;
     time_ms t = 0;
+
+    @foo.bar("bar.foo") long l;
+    union {null, @foo.foo.bar(42) @foo.foo.foo("3foo") string} nested_properties;
   }
 
   error TestError {

--- a/lang/java/compiler/src/test/idl/output/simple.avpr
+++ b/lang/java/compiler/src/test/idl/output/simple.avpr
@@ -54,7 +54,13 @@
       "name": "t",
       "type": {"type": "int", "logicalType": "time-millis"},
       "default": 0
-    } ],
+    } , {
+      "name": "l",
+      "type": {"type": "long", "foo.bar": "bar.foo"}
+    } , {
+      "name": "nested_properties",
+      "type": [ "null" , {"type":"string", "foo.foo.bar": 42, "foo.foo.foo": "3foo"} ]
+    }],
     "my-property" : {
       "key" : 3
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/AVRO-2132