### PR TITLE
AVRO-2144: Documentation Url fix for csharp spec

### DIFF
--- a/doc/src/content/xdocs/site.xml
+++ b/doc/src/content/xdocs/site.xml
@@ -77,7 +77,7 @@ See http://forrest.apache.org/docs/linking.html for more info
 	<index href="html/index.html" />
       </cpp>
       <csharp href="csharp/">
-	<index href="index.html" />
+	<index href="html/index.html" />
       </csharp>
       <java href="java/">
 	<index href="index.html" />


### PR DESCRIPTION
CSharp documentation currently points to https://avro.apache.org/docs/current/api/csharp/index.html where as it should be https://avro.apache.org/docs/current/api/csharp/html/index.html