### PR TITLE
PHP: Fix typo in error messages (Unknown instead of Uknown)

### DIFF
--- a/lang/php/lib/avro/data_file.php
+++ b/lang/php/lib/avro/data_file.php
@@ -242,7 +242,7 @@ class AvroDataIOReader
     $codec = AvroUtil::array_value($this->metadata, 
                                    AvroDataIO::METADATA_CODEC_ATTR);
     if ($codec && !AvroDataIO::is_valid_codec($codec))
-      throw new AvroDataIOException(sprintf('Uknown codec: %s', $codec));
+      throw new AvroDataIOException(sprintf('Unknown codec: %s', $codec));
 
     $this->block_count = 0;
     // FIXME: Seems unsanitary to set writers_schema here.

--- a/lang/php/lib/avro/datum.php
+++ b/lang/php/lib/avro/datum.php
@@ -132,7 +132,7 @@ class AvroIODatumWriter
       case AvroSchema::UNION_SCHEMA:
         return $this->write_union($writers_schema, $datum, $encoder);
       default:
-        throw new AvroException(sprintf('Uknown type: %s',
+        throw new AvroException(sprintf('Unknown type: %s',
                                         $writers_schema->type));
     }
   }
@@ -782,7 +782,7 @@ class AvroIODatumReader
       case AvroSchema::REQUEST_SCHEMA:
         return $decoder->skip_record($writers_schema, $decoder);
       default:
-        throw new AvroException(sprintf('Uknown schema type: %s',
+        throw new AvroException(sprintf('Unknown schema type: %s',
                                         $writers_schema->type()));
     }
   }


### PR DESCRIPTION
A typo was present in several error messages. This pull request fix them.