### PR TITLE
AVRO-1954 - Schema.Field.defaultVal() generates: Unknown datum type org.apache.avro.JsonProperties$Null

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -40,6 +40,9 @@ Trunk (not yet released)
     AVRO-2122: Cannot validate schemas with recursive definitions
     (Bart via Nandor Kollar)
 
+    AVRO-1954: Java: Schema.Field.defaultVal() generates: Unknown datum type
+    (Nandor Kollar via tomwhite)
+
 Avro 1.8.2 (10 April 2017)
 
   INCOMPATIBLE CHANGES

--- a/lang/java/avro/src/main/java/org/apache/avro/generic/GenericData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/generic/GenericData.java
@@ -36,6 +36,7 @@ import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Conversion;
 import org.apache.avro.Conversions;
+import org.apache.avro.JsonProperties;
 import org.apache.avro.LogicalType;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field;
@@ -744,7 +745,7 @@ public class GenericData {
   /** Return the schema full name for a datum.  Called by {@link
    * #resolveUnion(Schema,Object)}. */
   protected String getSchemaName(Object datum) {
-    if (datum == null)
+    if (datum == null || datum == JsonProperties.NULL_VALUE)
       return Type.NULL.getName();
     if (isRecord(datum))
       return getRecordSchema(datum).getFullName();


### PR DESCRIPTION
Backport the fix for AVRO-1954 to the 1.8 branch