### PR TITLE
AVRO-2152: Fix JsonDecoder handling of aliases in unions.

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/io/parsing/ResolvingGrammarGenerator.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/parsing/ResolvingGrammarGenerator.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
@@ -195,6 +196,7 @@ public class ResolvingGrammarGenerator extends ValidatingGrammarGenerator {
     final int size = alts.size();
     Symbol[] symbols = new Symbol[size];
     String[] labels = new String[size];
+    Set<String>[] aliases = new Set[size];
 
     /**
      * We construct a symbol without filling the arrays. Please see
@@ -204,9 +206,10 @@ public class ResolvingGrammarGenerator extends ValidatingGrammarGenerator {
     for (Schema w : alts) {
       symbols[i] = generate(w, reader, seen);
       labels[i] = w.getFullName();
+      aliases[i] = generateAliases(w);
       i++;
     }
-    return Symbol.seq(Symbol.alt(symbols, labels),
+    return Symbol.seq(Symbol.alt(symbols, labels, aliases),
                       Symbol.writerUnionAction());
   }
 

--- a/lang/java/avro/src/main/java/org/apache/avro/io/parsing/Symbol.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/parsing/Symbol.java
@@ -111,8 +111,8 @@ public abstract class Symbol {
   /**
    *  A convenience method to construct a union.
    */
-  static Symbol alt(Symbol[] symbols, String[] labels) {
-    return new Alternative(symbols, labels);
+  static Symbol alt(Symbol[] symbols, String[] labels, Set<String>[] aliases) {
+    return new Alternative(symbols, labels, aliases);
   }
 
   /**
@@ -426,10 +426,13 @@ public abstract class Symbol {
   public static class Alternative extends Symbol {
     public final Symbol[] symbols;
     public final String[] labels;
-    private Alternative(Symbol[] symbols, String[] labels) {
+    public final Set<String>[] aliases;
+
+    private Alternative(Symbol[] symbols, String[] labels, Set<String>[] aliases) {
       super(Kind.ALTERNATIVE);
       this.symbols = symbols;
       this.labels = labels;
+      this.aliases = aliases;
     }
 
     public Symbol getSymbol(int index) {
@@ -450,6 +453,9 @@ public abstract class Symbol {
           if (label.equals(labels[i])) {
             return i;
           }
+          if (aliases[i].contains(label)) {
+            return i;
+          }
         }
       }
       return -1;
@@ -462,7 +468,7 @@ public abstract class Symbol {
       for (int i = 0; i < ss.length; i++) {
         ss[i] = symbols[i].flatten(map, map2);
       }
-      return new Alternative(ss, labels);
+      return new Alternative(ss, labels, aliases);
     }
   }
 


### PR DESCRIPTION
 - Determine aliases of any named types when generating
   the json grammer
 - When reading union, check aliases when exact match is not found.