### PR TITLE
jira avro 2157: add <SCHEMA> to AnyIdentifier() in idl.jj

### DIFF
--- a/lang/java/compiler/src/main/javacc/org/apache/avro/compiler/idl/idl.jj
+++ b/lang/java/compiler/src/main/javacc/org/apache/avro/compiler/idl/idl.jj
@@ -1567,6 +1567,7 @@ Token AnyIdentifier():
    t = <STRING> |
    t = <PROTOCOL> |
    t = <RECORD> |
+   t = <SCHEMA> |
    t = <THROWS> |
    t = <TRUE> |
    t = <UNION> |

--- a/lang/java/compiler/src/test/idl/input/baz.avsc
+++ b/lang/java/compiler/src/test/idl/input/baz.avsc
@@ -1,0 +1,3 @@
+{"type": "record", "name": "ns.other.schema.Baz",
+ "fields": [ {"name": "x", "type": "int"} ]
+}

--- a/lang/java/compiler/src/test/idl/input/import.avdl
+++ b/lang/java/compiler/src/test/idl/input/import.avdl
@@ -26,12 +26,15 @@ protocol Import {
   import protocol "OnTheClasspath.avpr";
   import schema "OnTheClasspath.avsc";
   
+  import schema "baz.avsc";
   import schema "foo.avsc";
   import protocol "bar.avpr";
   
   record Bar {
+    ns.other.schema.Baz baz;
     Foo foo;
   }
 
+  void bazm(ns.other.schema.Baz baz);
   Bar barf(Foo foo);
 }

--- a/lang/java/compiler/src/test/idl/output/import.avpr
+++ b/lang/java/compiler/src/test/idl/output/import.avpr
@@ -57,6 +57,14 @@
     "fields" : [ ]
   }, {
     "type" : "record",
+    "name" : "Baz",
+    "namespace" : "ns.other.schema",
+    "fields" : [ {
+      "name" : "x",
+      "type" : "int"
+    } ]
+  }, {
+    "type" : "record",
     "name" : "Foo",
     "fields" : [ {
       "name" : "x",
@@ -66,6 +74,9 @@
     "type" : "record",
     "name" : "Bar",
     "fields" : [ {
+      "name" : "baz",
+      "type" : "ns.other.schema.Baz"
+    }, {
       "name" : "foo",
       "type" : "Foo"
     } ]
@@ -81,6 +92,13 @@
     },
     "bar" : {
       "request" : [ ],
+      "response" : "null"
+    },
+    "bazm" : {
+      "request" : [ {
+        "name" : "baz",
+        "type" : "ns.other.schema.Baz"
+      } ],
       "response" : "null"
     },
     "barf" : {


### PR DESCRIPTION
This patch is an attempt to fix [AVRO-2157](https://issues.apache.org/jira/projects/AVRO/issues/AVRO-2157).

I tested this patch against `release-1.8.2`, and it seems to solve the problem without breaking any tests.

I also tested against `master`. There appear to be a few broken tests on `master` as of now (2018-03-09 01:31 America/New_York), but this patch appears to fix 2157 on master without breaking further tests.

I do not know why `<SCHEMA>` was not yet a part of `AnyIdentifier()`, and perhaps I'm trying to change something which ought not to be changed. If not, I hope you'll consider accepting this patch :).