### PR TITLE
AVRO-2155: Include documentation for named schemas in generated code

### DIFF
--- a/lang/csharp/src/apache/main/CodeGen/CodeGen.cs
+++ b/lang/csharp/src/apache/main/CodeGen/CodeGen.cs
@@ -260,6 +260,11 @@ namespace Avro
             ctd.Attributes = MemberAttributes.Public;
             ctd.BaseTypes.Add("SpecificFixed");
 
+            if (fixedSchema.Documentation != null)
+            {
+                ctd.Comments.Add(createDocComment(fixedSchema.Documentation));
+            }
+
             // create static schema field
             createSchemaField(schema, ctd, true);
 
@@ -305,6 +310,11 @@ namespace Avro
             CodeTypeDeclaration ctd = new CodeTypeDeclaration(CodeGenUtil.Instance.Mangle(enumschema.Name));
             ctd.IsEnum = true;
             ctd.Attributes = MemberAttributes.Public;
+
+            if (enumschema.Documentation != null)
+            {
+                ctd.Comments.Add(createDocComment(enumschema.Documentation));
+            }
 
             foreach (string symbol in enumschema.Symbols)
             {
@@ -525,6 +535,11 @@ namespace Avro
             ctd.Attributes = MemberAttributes.Public;
             ctd.IsClass = true;
             ctd.IsPartial = true;
+
+            if (recordSchema.Documentation != null)
+            {
+                ctd.Comments.Add(createDocComment(recordSchema.Documentation));
+            }
 
             createSchemaField(schema, ctd, isError);
 

--- a/lang/csharp/src/apache/main/Schema/EnumSchema.cs
+++ b/lang/csharp/src/apache/main/Schema/EnumSchema.cs
@@ -70,7 +70,8 @@ namespace Avro
                 symbolMap[s] = i++;
                 symbols.Add(s);
             }
-            return new EnumSchema(name, aliases, symbols, symbolMap, props, names);
+            return new EnumSchema(name, aliases, symbols, symbolMap, props, names,
+                JsonHelper.GetOptionalString(jtok, "doc"));
         }
 
         /// <summary>
@@ -80,10 +81,13 @@ namespace Avro
         /// <param name="aliases">list of aliases for the name</param>
         /// <param name="symbols">list of enum symbols</param>
         /// <param name="symbolMap">map of enum symbols and value</param>
+        /// <param name="props">custom properties on this schema</param>
         /// <param name="names">list of named schema already read</param>
+        /// <param name="doc">documentation for this named schema</param>
         private EnumSchema(SchemaName name, IList<SchemaName> aliases, List<string> symbols,
-                            IDictionary<String, int> symbolMap, PropertyMap props, SchemaNames names)
-                            : base(Type.Enumeration, name, aliases, props, names)
+                            IDictionary<String, int> symbolMap, PropertyMap props, SchemaNames names,
+                            string doc)
+                            : base(Type.Enumeration, name, aliases, props, names, doc)
         {
             if (null == name.Name) throw new SchemaParseException("name cannot be null for enum schema.");
             this.Symbols = symbols;

--- a/lang/csharp/src/apache/main/Schema/FixedSchema.cs
+++ b/lang/csharp/src/apache/main/Schema/FixedSchema.cs
@@ -44,7 +44,8 @@ namespace Avro
             SchemaName name = NamedSchema.GetName(jtok, encspace);
             var aliases = NamedSchema.GetAliases(jtok, name.Space, name.EncSpace);
 
-            return new FixedSchema(name, aliases, JsonHelper.GetRequiredInteger(jtok, "size"), props, names);
+            return new FixedSchema(name, aliases, JsonHelper.GetRequiredInteger(jtok, "size"), props, names,
+                JsonHelper.GetOptionalString(jtok, "doc"));
         }
 
         /// <summary>
@@ -53,9 +54,12 @@ namespace Avro
         /// <param name="name">name of the fixed schema</param>
         /// <param name="aliases">list of aliases for the name</param>
         /// <param name="size">fixed size</param>
+        /// <param name="props">custom properties on this schema</param>
         /// <param name="names">list of named schema already parsed in</param>
-        private FixedSchema(SchemaName name, IList<SchemaName> aliases, int size, PropertyMap props, SchemaNames names)
-                            : base(Type.Fixed, name, aliases, props, names)
+        /// <param name="doc">documentation for this named schema</param>
+        private FixedSchema(SchemaName name, IList<SchemaName> aliases, int size, PropertyMap props, SchemaNames names,
+            string doc)
+                            : base(Type.Fixed, name, aliases, props, names, doc)
         {
             if (null == name.Name) throw new SchemaParseException("name cannot be null for fixed schema.");
             if (size <= 0) throw new ArgumentOutOfRangeException("size", "size must be greater than zero.");

--- a/lang/csharp/src/apache/main/Schema/NamedSchema.cs
+++ b/lang/csharp/src/apache/main/Schema/NamedSchema.cs
@@ -58,6 +58,11 @@ namespace Avro
         }
 
         /// <summary>
+        /// Documentation for the schema, if any. Null if there is no documentation.
+        /// </summary>
+        public string Documentation { get; private set; }
+
+        /// <summary>
         /// List of aliases for this named schema
         /// </summary>
         private readonly IList<SchemaName> aliases;
@@ -95,11 +100,16 @@ namespace Avro
         /// </summary>
         /// <param name="type">schema type</param>
         /// <param name="name">name</param>
+        /// <param name="aliases">aliases for this named schema</param>
+        /// <param name="props">custom properties on this schema</param>
         /// <param name="names">list of named schemas already read</param>
-        protected NamedSchema(Type type, SchemaName name, IList<SchemaName> aliases, PropertyMap props, SchemaNames names)
+        /// <param name="doc">documentation for this named schema</param>
+        protected NamedSchema(Type type, SchemaName name, IList<SchemaName> aliases, PropertyMap props, SchemaNames names,
+            string doc)
                                 : base(type, props)
         {
             this.SchemaName = name;
+            this.Documentation = doc;
             this.aliases = aliases;
             if (null != name.Name)  // Added this check for anonymous records inside Message
                 if (!names.Add(name, this))

--- a/lang/csharp/src/apache/main/Schema/RecordSchema.cs
+++ b/lang/csharp/src/apache/main/Schema/RecordSchema.cs
@@ -75,7 +75,8 @@ namespace Avro
             var fields = new List<Field>();
             var fieldMap = new Dictionary<string, Field>();
             var fieldAliasMap = new Dictionary<string, Field>();
-            var result = new RecordSchema(type, name, aliases, props, fields, request, fieldMap, fieldAliasMap, names);
+            var result = new RecordSchema(type, name, aliases, props, fields, request, fieldMap, fieldAliasMap, names,
+                JsonHelper.GetOptionalString(jtok, "doc"));
 
             int fieldPos = 0;
             foreach (JObject jfield in jfields)
@@ -99,14 +100,17 @@ namespace Avro
         /// <param name="type">type of record schema, either record or error</param>
         /// <param name="name">name of the record schema</param>
         /// <param name="aliases">list of aliases for the record name</param>
+        /// <param name="props">custom properties on this schema</param>
         /// <param name="fields">list of fields for the record</param>
         /// <param name="request">true if this is an anonymous record with 'request' instead of 'fields'</param>
         /// <param name="fieldMap">map of field names and field objects</param>
+        /// <param name="fieldAliasMap">map of field aliases and field objects</param>
         /// <param name="names">list of named schema already read</param>
+        /// <param name="doc">documentation for this named schema</param>
         private RecordSchema(Type type, SchemaName name, IList<SchemaName> aliases,  PropertyMap props,
                                 List<Field> fields, bool request, IDictionary<string, Field> fieldMap,
-                                IDictionary<string, Field> fieldAliasMap, SchemaNames names)
-                                : base(type, name, aliases, props, names)
+                                IDictionary<string, Field> fieldAliasMap, SchemaNames names, string doc)
+                                : base(type, name, aliases, props, names, doc)
         {
             if (!request && null == name.Name) throw new SchemaParseException("name cannot be null for record schema.");
             this.Fields = fields;

--- a/lang/csharp/src/apache/test/Schema/SchemaTests.cs
+++ b/lang/csharp/src/apache/test/Schema/SchemaTests.cs
@@ -195,6 +195,25 @@ namespace Avro.Test
             testToString(sc);
         }
 
+        [TestCase("{\"type\":\"record\",\"name\":\"LongList\"," +
+            "\"fields\":[{\"name\":\"f1\",\"type\":\"long\"}," +
+            "{\"name\":\"f2\",\"type\": \"int\"}]}",
+            null)]
+        [TestCase("{\"type\":\"record\",\"name\":\"LongList\"," +
+            "\"fields\":[{\"name\":\"f1\",\"type\":\"long\", \"default\": \"100\"}," +
+            "{\"name\":\"f2\",\"type\": \"int\"}], \"doc\": \"\"}",
+            "")]
+        [TestCase("{\"type\":\"record\",\"name\":\"LongList\"," +
+            "\"fields\":[{\"name\":\"f1\",\"type\":\"long\", \"default\": \"100\"}," +
+            "{\"name\":\"f2\",\"type\": \"int\"}], \"doc\": \"this is a test\"}",
+            "this is a test")]
+        public void TestRecordDoc(string s, string expectedDoc)
+        {
+            var rs = Schema.Parse(s) as RecordSchema;
+            Assert.IsNotNull(rs);
+            Assert.AreEqual(expectedDoc, rs.Documentation);
+        }
+
         [TestCase("{\"type\": \"enum\", \"name\": \"Test\", \"symbols\": [\"A\", \"B\"]}",
             new string[] { "A", "B" })]
         public void TestEnum(string s, string[] symbols)
@@ -212,6 +231,16 @@ namespace Avro.Test
 
             testEquality(s, sc);
             testToString(sc);
+        }
+
+        [TestCase("{\"type\": \"enum\", \"name\": \"Test\", \"symbols\": [\"A\", \"B\"]}", null)]
+        [TestCase("{\"type\": \"enum\", \"name\": \"Test\", \"symbols\": [\"A\", \"B\"], \"doc\": \"\"}", "")]
+        [TestCase("{\"type\": \"enum\", \"name\": \"Test\", \"symbols\": [\"A\", \"B\"], \"doc\": \"this is a test\"}", "this is a test")]
+        public void TestEnumDoc(string s, string expectedDoc)
+        {
+            var es = Schema.Parse(s) as EnumSchema;
+            Assert.IsNotNull(es);
+            Assert.AreEqual(expectedDoc, es.Documentation);
         }
 
         [TestCase("{\"type\": \"array\", \"items\": \"long\"}", "long")]
@@ -263,6 +292,16 @@ namespace Avro.Test
             Assert.AreEqual(size, fs.Size);
             testEquality(s, sc);
             testToString(sc);
+        }
+
+        [TestCase("{ \"type\": \"fixed\", \"name\": \"Test\", \"size\": 1}", null)]
+        [TestCase("{ \"type\": \"fixed\", \"name\": \"Test\", \"size\": 1, \"doc\": \"\"}", "")]
+        [TestCase("{ \"type\": \"fixed\", \"name\": \"Test\", \"size\": 1, \"doc\": \"this is a test\"}", "this is a test")]
+        public void TestFixedDoc(string s, string expectedDoc)
+        {
+            var fs = Schema.Parse(s) as FixedSchema;
+            Assert.IsNotNull(fs);
+            Assert.AreEqual(expectedDoc, fs.Documentation);
         }
 
         [TestCase("a", "o.a.h", Result = "o.a.h.a")]


### PR DESCRIPTION
[AVRO-2155](https://issues.apache.org/jira/browse/AVRO-2155)

1. Added `Documentation` property to `NamedSchema`, as well as an argument in the constructor to accept the value for the property
2. Added unit tests for the `Documentation`: `TestEumDoc`, `TestFixedDoc` and `TestRecordDoc`
3. In `CodeGen.cs`, added comments to the generated fixed, enum and record code declarations.
4. Unrelated change: Added missing parameter documentation on `EnumSchema`, `FixedSchema`, `NamedSchema` and `RecordSchema` documentation

I didn't see a good way to unit test the documentation in the generated code. As an alternative, I've added [sample.zip](https://github.com/apache/avro/files/1799659/sample.zip) containing a sample protocol and before/after generated code for comparison.



