### PR TITLE
AVRO-1702: Added support for logical types in the C++ client.

### DIFF
--- a/lang/c++/CMakeLists.txt
+++ b/lang/c++/CMakeLists.txt
@@ -78,7 +78,7 @@ add_definitions (${Boost_LIB_DIAGNOSTIC_DEFINITIONS})
 include_directories (api ${CMAKE_CURRENT_BINARY_DIR} ${Boost_INCLUDE_DIRS})
 
 set (AVRO_SOURCE_FILES
-        impl/Compiler.cc impl/Node.cc
+        impl/Compiler.cc impl/Node.cc impl/LogicalType.cc
         impl/NodeImpl.cc impl/ResolverSchema.cc impl/Schema.cc
         impl/Types.cc impl/ValidSchema.cc impl/Zigzag.cc
         impl/BinaryEncoder.cc impl/BinaryDecoder.cc

--- a/lang/c++/api/GenericDatum.hh
+++ b/lang/c++/api/GenericDatum.hh
@@ -58,6 +58,9 @@ class AVRO_DECL GenericDatum {
     LogicalType logicalType_;
     boost::any value_;
 
+    GenericDatum(Type t)
+        : type_(t), logicalType_(LogicalType::NONE) { }
+
     GenericDatum(Type t, LogicalType logicalType)
         : type_(t), logicalType_(logicalType) { }
 

--- a/lang/c++/api/LogicalType.hh
+++ b/lang/c++/api/LogicalType.hh
@@ -47,9 +47,9 @@ class AVRO_DECL LogicalType {
     // setters will throw an exception if they are called on any type other
     // than DECIMAL.
     void setPrecision(int precision);
-    int precision() const;
+    int precision() const { return precision_; }
     void setScale(int scale);
-    int scale() const;
+    int scale() const { return scale_; }
 
     void printJson(std::ostream& os) const;
 

--- a/lang/c++/api/LogicalType.hh
+++ b/lang/c++/api/LogicalType.hh
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef avro_LogicalType_hh__
+#define avro_LogicalType_hh__
+
+#include <iostream>
+
+#include "Config.hh"
+
+namespace avro {
+
+class AVRO_DECL LogicalType {
+  public:
+    enum Type {
+        NONE,
+        DECIMAL,
+        DATE,
+        TIME_MILLIS,
+        TIME_MICROS,
+        TIMESTAMP_MILLIS,
+        TIMESTAMP_MICROS,
+        DURATION
+    };
+
+    explicit LogicalType(Type type);
+
+    Type type() const;
+
+    // Precision and scale can only be set for the DECIMAL logical type.
+    // Precision must be positive and scale must be either positive or zero. The
+    // setters will throw an exception if they are called on any type other
+    // than DECIMAL.
+    void setPrecision(int precision);
+    int precision() const;
+    void setScale(int scale);
+    int scale() const;
+
+    void printJson(std::ostream& os) const;
+
+  private:
+    Type type_;
+    int precision_;
+    int scale_;
+};
+
+}  // namespace avro
+
+#endif

--- a/lang/c++/api/Node.hh
+++ b/lang/c++/api/Node.hh
@@ -26,6 +26,7 @@
 #include <boost/shared_ptr.hpp>
 
 #include "Exception.hh"
+#include "LogicalType.hh"
 #include "Types.hh"
 #include "SchemaResolution.hh"
 
@@ -91,6 +92,7 @@ class AVRO_DECL Node : private boost::noncopyable
 
     Node(Type type) :
         type_(type),
+        logicalType_(LogicalType::NONE),
         locked_(false)
     {}
 
@@ -99,6 +101,12 @@ class AVRO_DECL Node : private boost::noncopyable
     Type type() const {
         return type_;
     }
+
+    LogicalType logicalType() const {
+        return logicalType_;
+    }
+
+    void setLogicalType(LogicalType logicalType);
 
     void lock() {
         locked_ = true;
@@ -172,6 +180,7 @@ class AVRO_DECL Node : private boost::noncopyable
   private:
 
     const Type type_;
+    LogicalType logicalType_;
     bool locked_;
 };
 

--- a/lang/c++/impl/Compiler.cc
+++ b/lang/c++/impl/Compiler.cc
@@ -104,11 +104,7 @@ static NodePtr makeNode(const std::string& t, SymbolTable& st, const string& ns)
 // e.g.: can be false for non-mandatory fields
 bool containsField(const Entity& e, const Object& m, const string& fieldName) {
     Object::const_iterator it = m.find(fieldName);
-    if (it == m.end()) {
-       return false;
-    } else {
-       return true;
-    }
+    return (it != m.end());
 }
 
 const json::Object::const_iterator findField(const Entity& e,
@@ -359,27 +355,21 @@ static LogicalType makeLogicalType(const Entity& e, const Object& m) {
         }
         return decimalType;
     }
-    if (typeField == "date") {
-        return LogicalType(LogicalType::DATE);
-    }
-    if (typeField == "time-millis") {
-        return LogicalType(LogicalType::TIME_MILLIS);
-    }
-    if (typeField == "time-micros") {
-        return LogicalType(LogicalType::TIME_MICROS);
-    }
-    if (typeField == "timestamp-millis") {
-        return LogicalType(LogicalType::TIMESTAMP_MILLIS);
-    }
-    if (typeField == "timestamp-micros") {
-        return LogicalType(LogicalType::TIMESTAMP_MICROS);
-    }
-    if (typeField == "duration") {
-        return LogicalType(LogicalType::DURATION);
-    }
 
-    // Unrecognized logical type values are ignored.
-    return LogicalType(LogicalType::NONE);
+    LogicalType::Type t = LogicalType::NONE;
+    if (typeField == "date")
+        t = LogicalType::DATE;
+    else if (typeField == "time-millis")
+        t = LogicalType::TIME_MILLIS;
+    else if (typeField == "time-micros")
+        t = LogicalType::TIME_MICROS;
+    else if (typeField == "timestamp-millis")
+        t = LogicalType::TIMESTAMP_MILLIS;
+    else if (typeField == "timestamp-micros")
+        t = LogicalType::TIMESTAMP_MICROS;
+    else if (typeField == "duration")
+        t = LogicalType::DURATION;
+    return LogicalType(t);
 }
 
 static NodePtr makeEnumNode(const Entity& e,

--- a/lang/c++/impl/GenericDatum.cc
+++ b/lang/c++/impl/GenericDatum.cc
@@ -25,12 +25,15 @@ using std::vector;
 namespace avro {
 
 GenericDatum::GenericDatum(const ValidSchema& schema) :
-    type_(schema.root()->type())
+    type_(schema.root()->type()),
+    logicalType_(schema.root()->logicalType())
 {
     init(schema.root());
 }
 
-GenericDatum::GenericDatum(const NodePtr& schema) : type_(schema->type())
+GenericDatum::GenericDatum(const NodePtr& schema) :
+    type_(schema->type()),
+    logicalType_(schema->logicalType())
 {
     init(schema);
 }
@@ -41,6 +44,7 @@ void GenericDatum::init(const NodePtr& schema)
     if (type_ == AVRO_SYMBOLIC) {
         sc = resolveSymbol(schema);
         type_ = sc->type();
+        logicalType_ = sc->logicalType();
     }
     switch (type_) {
     case AVRO_NULL:

--- a/lang/c++/impl/LogicalType.cc
+++ b/lang/c++/impl/LogicalType.cc
@@ -38,10 +38,6 @@ void LogicalType::setPrecision(int precision) {
     precision_ = precision;
 }
 
-int LogicalType::precision() const {
-    return precision_;
-}
-
 void LogicalType::setScale(int scale) {
     if (type_ != DECIMAL) {
         throw Exception("Only logical type DECIMAL can have scale");
@@ -50,10 +46,6 @@ void LogicalType::setScale(int scale) {
         throw Exception(boost::format("Scale cannot be: %1%") % scale);
     }
     scale_ = scale;
-}
-
-int LogicalType::scale() const {
-    return scale_;
 }
 
 void LogicalType::printJson(std::ostream& os) const {

--- a/lang/c++/impl/LogicalType.cc
+++ b/lang/c++/impl/LogicalType.cc
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Exception.hh"
+#include "LogicalType.hh"
+
+namespace avro {
+
+LogicalType::LogicalType(Type type)
+    : type_(type), precision_(0), scale_(0) {}
+
+LogicalType::Type LogicalType::type() const {
+    return type_;
+}
+
+void LogicalType::setPrecision(int precision) {
+    if (type_ != DECIMAL) {
+        throw Exception("Only logical type DECIMAL can have precision");
+    }
+    if (precision <= 0) {
+        throw Exception(boost::format("Precision cannot be: %1%") % precision);
+    }
+    precision_ = precision;
+}
+
+int LogicalType::precision() const {
+    return precision_;
+}
+
+void LogicalType::setScale(int scale) {
+    if (type_ != DECIMAL) {
+        throw Exception("Only logical type DECIMAL can have scale");
+    }
+    if (scale < 0) {
+        throw Exception(boost::format("Scale cannot be: %1%") % scale);
+    }
+    scale_ = scale;
+}
+
+int LogicalType::scale() const {
+    return scale_;
+}
+
+void LogicalType::printJson(std::ostream& os) const {
+    switch (type_) {
+    case LogicalType::NONE:
+        break;
+    case LogicalType::DECIMAL:
+        os << "\"logicalType\": \"decimal\"";
+        os << ", \"precision\": " << precision_;
+        os << ", \"scale\": " << scale_;
+        break;
+    case DATE:
+        os << "\"logicalType\": \"date\"";
+        break;
+    case TIME_MILLIS:
+        os << "\"logicalType\": \"time-millis\"";
+        break;
+    case TIME_MICROS:
+        os << "\"logicalType\": \"time-micros\"";
+        break;
+    case TIMESTAMP_MILLIS:
+        os << "\"logicalType\": \"timestamp-millis\"";
+        break;
+    case TIMESTAMP_MICROS:
+        os << "\"logicalType\": \"timestamp-micros\"";
+        break;
+    case DURATION:
+        os << "\"logicalType\": \"duration\"";
+        break;
+    }
+}
+
+}  // namespace avro

--- a/lang/c++/impl/Node.cc
+++ b/lang/c++/impl/Node.cc
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+#include <cmath>
+
 #include "Node.hh"
 
 namespace avro {
@@ -78,6 +80,77 @@ void Name::check() const
 bool Name::operator == (const Name& n) const
 {
     return ns_ == n.ns_ && simpleName_ == n.simpleName_;
+}
+
+void Node::setLogicalType(LogicalType logicalType) {
+    checkLock();
+
+    // Check that the logical type is applicable to the node type.
+    switch (logicalType.type()) {
+    case LogicalType::NONE:
+        break;
+    case LogicalType::DECIMAL: {
+        if (type_ != AVRO_BYTES && type_ != AVRO_FIXED) {
+            throw Exception("DECIMAL logical type can annotate "
+                            "only BYTES or FIXED type");
+        }
+        if (type_ == AVRO_FIXED) {
+            // Max precision that can be supported by the current size of
+            // the FIXED type.
+            long maxPrecision =
+                floor(log10(pow(2.0, 8.0 * fixedSize() - 1) - 1));
+            if (logicalType.precision() > maxPrecision) {
+                throw Exception(
+                    boost::format(
+                        "DECIMAL precision %1% is too large for the "
+                        "FIXED type of size %2%, precision cannot be "
+                        "larget than %3%") % logicalType.precision() %
+                        fixedSize() % maxPrecision);
+            }
+        }
+        if (logicalType.scale() > logicalType.precision()) {
+            throw Exception("DECIMAL scale cannot exceed precision");
+        }
+        break;
+    }
+    case LogicalType::DATE:
+        if (type_ != AVRO_INT) {
+            throw Exception("DATE logical type can only annotate INT type");
+        }
+        break;
+    case LogicalType::TIME_MILLIS:
+        if (type_ != AVRO_INT) {
+            throw Exception("TIME-MILLIS logical type can only annotate "
+                            "INT type");
+        }
+        break;
+    case LogicalType::TIME_MICROS:
+        if (type_ != AVRO_LONG) {
+            throw Exception("TIME-MICROS logical type can only annotate "
+                            "LONG type");
+        }
+        break;
+    case LogicalType::TIMESTAMP_MILLIS:
+        if (type_ != AVRO_LONG) {
+            throw Exception("TIMESTAMP-MILLIS logical type can only annotate "
+                            "LONG type");
+        }
+        break;
+    case LogicalType::TIMESTAMP_MICROS:
+        if (type_ != AVRO_LONG) {
+            throw Exception("TIMESTAMP-MICROS logical type can only annotate "
+                            "LONG type");
+        }
+        break;
+    case LogicalType::DURATION:
+        if (type_ != AVRO_FIXED || fixedSize() != 12) {
+            throw Exception("DURATION logical type can only annotate "
+                            "FIXED type of size 12");
+        }
+        break;
+    }
+
+    logicalType_ = logicalType;
 }
 
 } // namespace avro

--- a/lang/c++/impl/NodeImpl.cc
+++ b/lang/c++/impl/NodeImpl.cc
@@ -166,7 +166,19 @@ std::ostream& operator <<(std::ostream &os, indent x)
 void 
 NodePrimitive::printJson(std::ostream &os, int depth) const
 {
+    bool hasLogicalType = logicalType().type() != LogicalType::NONE;
+
+    if (hasLogicalType) {
+        os << "{\n" << indent(depth) << "\"type\": ";
+    }
+
     os << '\"' << type() << '\"';
+
+    if (hasLogicalType) {
+        os << ",\n" << indent(depth);
+        logicalType().printJson(os);
+        os << "\n}";
+    }
 }
 
 void 
@@ -274,8 +286,14 @@ NodeFixed::printJson(std::ostream &os, int depth) const
     os << "{\n";
     os << indent(++depth) << "\"type\": \"fixed\",\n";
     printName(os, nameAttribute_.get(), depth);
-    os << indent(depth) << "\"size\": " << sizeAttribute_.get() << "\n";
-    os << indent(--depth) << '}';
+    os << indent(depth) << "\"size\": " << sizeAttribute_.get();
+
+    if (logicalType().type() != LogicalType::NONE) {
+      os << ",\n" << indent(depth);
+      logicalType().printJson(os);
+    }
+
+    os << "\n" << indent(--depth) << '}';
 }
 
 } // namespace avro


### PR DESCRIPTION
This change adds support for logical types in the schema for the C++ client.