### PR TITLE
AVRO-2162 Adds Zstandard compression to the Avro File Format (Java)

### DIFF
--- a/lang/java/avro/pom.xml
+++ b/lang/java/avro/pom.xml
@@ -199,6 +199,11 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>com.github.luben</groupId>
+      <artifactId>zstd-jni</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-all</artifactId>
       <scope>test</scope>

--- a/lang/java/avro/src/main/java/org/apache/avro/file/BZip2Codec.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/file/BZip2Codec.java
@@ -17,19 +17,17 @@
  */
 package org.apache.avro.file;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.ByteBuffer;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream;
 
 /** * Implements bzip2 compression and decompression. */
-public class BZip2Codec extends Codec {
+public class BZip2Codec extends OutputInputStreamCodec {
 
   public static final int DEFAULT_BUFFER_SIZE = 64 * 1024;
-  private ByteArrayOutputStream outputBuffer;
 
   static class Option extends CodecFactory {
     @Override
@@ -42,64 +40,20 @@ public class BZip2Codec extends Codec {
   public String getName() { return DataFileConstants.BZIP2_CODEC; }
 
   @Override
-  public ByteBuffer compress(ByteBuffer uncompressedData) throws IOException {
-
-    ByteArrayOutputStream baos = getOutputBuffer(uncompressedData.remaining());
-    BZip2CompressorOutputStream outputStream = new BZip2CompressorOutputStream(baos);
-
-    try {
-      outputStream.write(uncompressedData.array(),
-                         uncompressedData.position(),
-                         uncompressedData.remaining());
-    } finally {
-      outputStream.close();
-    }
-
-    ByteBuffer result = ByteBuffer.wrap(baos.toByteArray());
-    return result;
+  protected OutputStream compressedStream(OutputStream output)
+      throws IOException {
+    return new BZip2CompressorOutputStream(output);
   }
 
   @Override
-  public ByteBuffer decompress(ByteBuffer compressedData) throws IOException {
-    ByteArrayInputStream bais = new ByteArrayInputStream(compressedData.array());
-    BZip2CompressorInputStream inputStream = new BZip2CompressorInputStream(bais);
-    try {
-      ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-      byte[] buffer = new byte[DEFAULT_BUFFER_SIZE];
-
-      int readCount = -1;
-
-      while ( (readCount = inputStream.read(buffer, compressedData.position(), buffer.length))> 0) {
-        baos.write(buffer, 0, readCount);
-      }
-
-      ByteBuffer result = ByteBuffer.wrap(baos.toByteArray());
-      return result;
-    } finally {
-      inputStream.close();
-    }
+  protected InputStream uncompressedStream(InputStream input) throws IOException {
+    return new BZip2CompressorInputStream(input);
   }
 
   @Override public int hashCode() { return getName().hashCode(); }
 
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj)
-      return true;
-    if (getClass() != obj.getClass())
-      return false;
-    return true;
+  public boolean equals(Object other) {
+    return (this == other) || (this.getClass() == other.getClass());
   }
-
-  //get and initialize the output buffer for use.
-  private ByteArrayOutputStream getOutputBuffer(int suggestedLength) {
-    if (null == outputBuffer) {
-      outputBuffer = new ByteArrayOutputStream(suggestedLength);
-    }
-    outputBuffer.reset();
-    return outputBuffer;
-  }
-
-
 }

--- a/lang/java/avro/src/main/java/org/apache/avro/file/DataFileConstants.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/file/DataFileConstants.java
@@ -39,5 +39,6 @@ public class DataFileConstants {
   public static final String SNAPPY_CODEC = "snappy";
   public static final String BZIP2_CODEC = "bzip2";
   public static final String XZ_CODEC = "xz";
+  public static final String ZSTD_CODEC = "zstd";
 
 }

--- a/lang/java/avro/src/main/java/org/apache/avro/file/OutputInputStreamCodec.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/file/OutputInputStreamCodec.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.avro.file;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+
+import org.apache.commons.compress.utils.IOUtils;
+
+/** Private helper for creating codecs that have OutputStream implementations
+ * for compressing data and InputStream implementations for decompression. **/
+abstract class OutputInputStreamCodec extends OutputStreamCodec {
+  private static final int BUFFER_SIZE = 32 * 1024;
+
+  /** Return an InputStream that uncompresses the provided input.
+   * @throws IOException **/
+  protected abstract InputStream uncompressedStream(InputStream input)
+      throws IOException;
+
+  @Override
+  public ByteBuffer decompress(ByteBuffer data) throws IOException {
+
+    int compressedSize = data.remaining();
+    ByteArrayOutputStream baos = getOutputBuffer(compressedSize);
+    InputStream bytesIn = new ByteArrayInputStream(
+      data.array(),
+      data.arrayOffset() + data.position(),
+      compressedSize);
+    InputStream ios = uncompressedStream(bytesIn);
+    try {
+      IOUtils.copy(ios, baos, BUFFER_SIZE);
+    } finally {
+      ios.close();
+    }
+    return ByteBuffer.wrap(baos.toByteArray());
+  }
+}

--- a/lang/java/avro/src/main/java/org/apache/avro/file/OutputStreamCodec.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/file/OutputStreamCodec.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.avro.file;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+
+/** Private helper for creating codecs that have OutputStream
+ * implementations for compressing data **/
+abstract class OutputStreamCodec extends Codec {
+  private ByteArrayOutputStream outputBuffer;
+
+  @Override
+  public ByteBuffer compress(ByteBuffer data) throws IOException {
+    ByteArrayOutputStream baos = getOutputBuffer(compressBound(data.remaining()));
+    OutputStream ios = compressedStream(baos);
+    writeAndClose(data, ios);
+    return ByteBuffer.wrap(baos.toByteArray());
+  }
+
+  /** Best guess for the compression output buffer size
+   * given the uncompressed data size **/
+  protected int compressBound(int uncompressedSize) {
+    return uncompressedSize;
+  }
+
+  /** Return an OutputStream that compresses data to the provided output. **/
+  protected abstract OutputStream compressedStream(OutputStream output) throws IOException;
+
+  /** Write the data in the provided ByteBuffer to the OutputStream and close the stream.
+   * The ByteBuffer must not be direct.
+   */
+  void writeAndClose(ByteBuffer data, OutputStream to) throws IOException {
+    byte[] input = data.array();
+    int offset = data.arrayOffset() + data.position();
+    int length = data.remaining();
+    try {
+      to.write(input, offset, length);
+    } finally {
+      to.close();
+    }
+  }
+
+  /** Initializes the outputBuffer to the suggestedLength if it has not
+   * yet been initialized.  Otherwise, returns the existing buffer.
+   */
+  protected final ByteArrayOutputStream getOutputBuffer(int suggestedLength) {
+    if (null == outputBuffer) {
+      outputBuffer = new ByteArrayOutputStream(suggestedLength);
+    }
+    outputBuffer.reset();
+    return outputBuffer;
+  }
+}

--- a/lang/java/avro/src/main/java/org/apache/avro/file/ZstandardCodec.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/file/ZstandardCodec.java
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.avro.file;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import com.github.luben.zstd.Zstd;
+import com.github.luben.zstd.ZstdInputStream;
+import com.github.luben.zstd.ZstdOutputStream;
+
+/**
+ * Implements zstd (https://github.com/facebook/zstd) compression
+ * using the jni wrappers from https://github.com/luben/zstd-jni.
+ * <p/>
+ * Supports compression levels from 1 to 22, with level 1 similar
+ * to gzip/deflate in compression ratio, but significantly faster.
+ * High levels of compression get close to xz compression ratios
+ * with decompression speeds 10x faster than xz.
+ */
+public class ZstandardCodec extends OutputInputStreamCodec {
+
+  static class Option extends CodecFactory {
+    private final int compressionLevel;
+
+    Option(int compressionLevel) {
+      this.compressionLevel = compressionLevel;
+    }
+
+    @Override
+    protected Codec createInstance() {
+      return new ZstandardCodec(compressionLevel);
+    }
+  }
+
+  private final int compressionLevel;
+
+  public ZstandardCodec(int compressionLevel) {
+    this.compressionLevel = Math.max(Math.min(compressionLevel, 22), 1);
+  }
+
+  @Override
+  public String getName() {
+    return DataFileConstants.ZSTD_CODEC;
+  }
+
+  @Override
+  protected int compressBound(int uncompressedSize) {
+    return (int) Zstd.compressBound(uncompressedSize);
+  }
+
+  @Override
+  protected OutputStream compressedStream(OutputStream output)
+      throws IOException {
+    return new ZstdOutputStream(output, compressionLevel);
+  }
+
+  @Override
+  protected InputStream uncompressedStream(InputStream input)
+      throws IOException {
+    return new ZstdInputStream(input);
+  }
+
+  @Override public int hashCode() { return getName().hashCode(); }
+
+  @Override
+  public boolean equals(Object other) {
+    return (this == other) || (this.getClass() == other.getClass());
+  }
+
+  @Override
+  public String toString() {
+    return getName() + "-" + compressionLevel;
+  }
+}

--- a/lang/java/avro/src/test/java/org/apache/avro/file/TestCodecs.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/file/TestCodecs.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.avro.file;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Random;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+
+@RunWith(Parameterized.class)
+public class TestCodecs {
+
+  @Parameters(name = "Codec: {0}")
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][] {
+      { new NullCodec() },
+      { new DeflateCodec(3) },
+      { new BZip2Codec() },
+      { new SnappyCodec() },
+      { new XZCodec(3) },
+      { new ZstandardCodec(3) }
+    });
+  }
+
+  private final Codec codec;
+  private final byte[] zeroes = new byte[1024*1024];
+  private final byte[] random = new byte[1024*1024];
+
+  public TestCodecs(Codec codec) {
+    this.codec = codec;
+  }
+
+  {
+    new Random().nextBytes(random);
+  }
+
+  @Test
+  public void roundTripZeroes() throws IOException {
+    roundTrip(zeroes);
+  }
+
+  @Test
+  public void roundTripRandomData() throws IOException {
+    roundTrip(random);
+  }
+
+  public void roundTrip(byte[] bytes) throws IOException {
+    ByteBuffer compressed = codec.compress(ByteBuffer.wrap(bytes));
+    ByteBuffer uncompressed = codec.decompress(compressed);
+    Assert.assertArrayEquals(bytes, uncompressed.array());
+  }
+
+  @Test
+  public void testEquals() {
+    Codec fromFactory = CodecFactory.fromString(codec.getName()).createInstance();
+    Assert.assertEquals(codec, fromFactory);
+    Assert.assertEquals(codec.hashCode(), fromFactory.hashCode());
+  }
+}

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -517,6 +517,11 @@
         <version>${commons-compress.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.github.luben</groupId>
+        <artifactId>zstd-jni</artifactId>
+        <version>1.3.3-4</version>
+      </dependency>
+      <dependency>
         <groupId>joda-time</groupId>
         <artifactId>joda-time</artifactId>
         <version>${joda.version}</version>


### PR DESCRIPTION
      Adds TestCodecs to cover all file compression Codecs.
      Consolidates common code in Codecs into OutputStreamCodec
      and OutputInputStreamCodec abstractions.
      Fixes DataFileStream so that Codecs can return DirectByteBuffers
      or Heap ByteBuffers with non-zero offset.