### PR TITLE
AVRO-2183 Provide name only for named schema

### DIFF
--- a/lang/py3/avro/schema.py
+++ b/lang/py3/avro/schema.py
@@ -184,18 +184,6 @@ class Schema(object, metaclass=abc.ABCMeta):
       self._props.update(other_props)
 
   @property
-  def name(self):
-    """Returns: the simple name of this schema."""
-    return self._props['name']
-
-  @property
-  def fullname(self):
-    """Returns: the fully qualified name of this schema."""
-    # By default, the full name is the simple name.
-    # Named schemas override this behavior to include the namespace.
-    return self.name
-
-  @property
   def namespace(self):
     """Returns: the namespace this schema belongs to, if any, or None."""
     return self._props.get('namespace', None)
@@ -624,6 +612,12 @@ class PrimitiveSchema(Schema):
     """Returns: the simple name of this schema."""
     # The name of a primitive type is the type itself.
     return self.type
+
+  @property
+  def fullname(self):
+    """Returns: the fully qualified name of this schema."""
+    # The full name is the simple name for primitive schema.
+    return self.name
 
   def to_json(self, names=None):
     if len(self.props) == 1:

--- a/lang/py3/avro/tests/test_schema.py
+++ b/lang/py3/avro/tests/test_schema.py
@@ -472,6 +472,19 @@ class TestSchema(unittest.TestCase):
     # it could be reparsed.
     self.assertEqual("X", t.fields[0].type.name)
 
+  def testNoName(self):
+    """Test that schema without a name
+    raise AttributeError when you try
+    to access their name."""
+    cases = [
+      '{"type": "array", "items": "int"}',
+      '{"type": "map", "values": "int"}',
+      '["null", "int"]',
+    ]
+    for case in (schema.Parse(case) for case in cases):
+      self.assertRaises(AttributeError, lambda: case.name)
+      self.assertEqual(getattr(case, "name", "default"), "default")
+
   def testParse(self):
     correct = 0
     for iexample, example in enumerate(EXAMPLES):


### PR DESCRIPTION
A schema object should raise an `AttributeError` when a user attempts to access a `name` property on a schema that does not have a name. The Python 2 implementation does this correctly:

```python
>>> from avro.schema import parse
>>> s = parse('{"type": "array", "items": "int"}')
>>> s.name
Traceback (most recent call last):
File "<stdin>", line 1, in <module>
AttributeError: 'ArraySchema' object has no attribute 'name'
```

In the Python 3 implementation, however, it raises a `KeyError`.

```python
>>> from avro.schema import Parse
>>> s=Parse('{"type":"array","items":"int"}')
>>> s.name
Traceback (most recent call last):
File "<stdin>", line 1, in <module>
File "/home/michaels/dev/avro/lang/py3/avro/schema.py", line 224, in name
return self._props['name']
KeyError: 'name'
```

This is not only unpythonic, it also breaks the python builtins `getattr` and `hasattr`:

```python
>>> getattr(s, "name", "default")
Traceback (most recent call last):
File "<stdin>", line 1, in <module>
File "/home/michaels/dev/avro/lang/py3/avro/schema.py", line 224, in name
return self._props['name']
KeyError: 'name'
```

I found that removing the implementation of `name` on the base `Schema` class fixes this. Since every named schema subclasses `NamedSchema`, it makes sense to let Python itself raise the exception for nameless schema.