### PR TITLE
Remove warning in C++ generated code

### DIFF
--- a/lang/c++/impl/avrogencpp.cc
+++ b/lang/c++/impl/avrogencpp.cc
@@ -529,7 +529,7 @@ void CodeGen::generateEnumTraits(const NodePtr& n)
 		<< "    }\n"
 		<< "    static void decode(Decoder& d, " << fn << "& v) {\n"
 		<< "		size_t index = d.decodeEnum();\n"
-		<< "		if (index < " << first << " || index > " << last << ")\n"
+		<< "		if (index > " << last << ")\n"
 		<< "		{\n"
 		<< "			std::ostringstream error;\n"
 		<< "			error << \"enum value \" << index << \" is out of bound for " << fn << " and cannot be decoded\";\n"


### PR DESCRIPTION
The C++ code generator generates code that results in the following warning when compiled with -Wextra.

> comparison of unsigned expression < 0 is always false [-Werror=type-limits]