### PR TITLE
Add Single Object Encoding Support to Ruby library

### DIFF
--- a/lang/ruby/lib/avro/schema.rb
+++ b/lang/ruby/lib/avro/schema.rb
@@ -151,6 +151,19 @@ module Avro
       fp
     end
 
+    SINGLE_OBJECT_MAGIC_NUMBER = [0xC3, 0x01]
+    def single_object_encoding_header
+      [SINGLE_OBJECT_MAGIC_NUMBER, single_object_schema_fingerprint].flatten
+    end
+    def single_object_schema_fingerprint
+      working = crc_64_avro_fingerprint
+      bytes = Array.new(8)
+      8.times do |i|
+        bytes[7 - i] = (working & 0xff)
+        working = working >> 8
+      end
+      bytes
+    end
 
     def read?(writers_schema)
       SchemaCompatibility.can_read?(writers_schema, self)

--- a/lang/ruby/test/test_fingerprints.rb
+++ b/lang/ruby/test/test_fingerprints.rb
@@ -40,7 +40,17 @@ class TestFingerprints < Test::Unit::TestCase
       { "type": "int" }
     SCHEMA
 
-    assert_equal 8247732601305521295,
+    assert_equal 8247732601305521295, # hex: 0x7275d51a3f395c8f
       schema.crc_64_avro_fingerprint
+  end
+
+  # This definitely belongs somewhere else
+  def test_single_object_encoding_header
+    schema = Avro::Schema.parse <<-SCHEMA
+      { "type": "int" }
+    SCHEMA
+
+    assert_equal ["c3", "01", "72", "75", "d5", "1a", "3f", "39", "5c", "8f"].map{|e| e.to_i(16) },
+      schema.single_object_encoding_header
   end
 end

--- a/lang/ruby/test/test_fingerprints.rb
+++ b/lang/ruby/test/test_fingerprints.rb
@@ -34,4 +34,13 @@ class TestFingerprints < Test::Unit::TestCase
     assert_equal 28572620203319713300323544804233350633246234624932075150020181448463213378117,
       schema.sha256_fingerprint
   end
+
+  def test_crc_64_avro_fingerprint
+    schema = Avro::Schema.parse <<-SCHEMA
+      { "type": "int" }
+    SCHEMA
+
+    assert_equal 8247732601305521295,
+      schema.crc_64_avro_fingerprint
+  end
 end


### PR DESCRIPTION
This patch adds support for the [Single Object Encoding Spec](http://avro.apache.org/docs/current/spec.html#single_object_encoding_spec).

I translated the code from Java to Ruby.

I believe this is a performant implementation in Ruby.

I'm not sure this is the right place for this code, but I couldn't think of a better one. Definitely open to suggestions / feedback!

Hope this helps,