### PR TITLE
AVRO-2208 Unneeded OSGi import generated for Guava dependency

### DIFF
--- a/lang/java/avro/pom.xml
+++ b/lang/java/avro/pom.xml
@@ -37,6 +37,7 @@
   <properties>
     <osgi.import>
       !org.apache.avro*,
+      !com.google.common*,
       com.thoughtworks.paranamer,
       org.codehaus.jackson*,
       org.xerial.snappy;resolution:=optional,


### PR DESCRIPTION
The classes from Guava used by Avro are shaded into the final jar, however the OSGi imports are calculated before shading, resulting in a com.google.common* dependency declared in Import-Package manifest header. As a consequence in an OSGi environment one has to install a version of Guava even though that version will not be used by Avro.

By adding !com.google.common* to the Import-Package directive of the maven-bundle-plugin the package(s) of Guava will no longer be declared on the Import-Package of the Avro OSGi bundle.