### PR TITLE
[AVRO-2226] Fixes UnionSchema specificity

### DIFF
--- a/lang/py3/avro/io.py
+++ b/lang/py3/avro/io.py
@@ -135,9 +135,17 @@ def Validate(expected_schema, datum):
     return any(Validate(union_branch, datum)
                for union_branch in expected_schema.schemas)
   elif schema_type in ['record', 'error', 'request']:
-    return (isinstance(datum, dict)
-        and all(Validate(field.type, datum.get(field.name))
-                for field in expected_schema.fields))
+    if not isinstance(datum, dict):
+        return False
+    expected_schema_field_names = set()
+    for field in expected_schema.fields:
+        expected_schema_field_names.add(field.name)
+        if not Validate(field.type, datum.get(field.name)):
+            return False
+    for datum_field in datum.keys():
+        if datum_field not in expected_schema_field_names:
+            return False
+    return True
   else:
     raise AvroTypeException('Unknown Avro schema type: %r' % schema_type)
 


### PR DESCRIPTION
Trouble arises in the python library when deducing the appropriate schema from a list of schemas given a particular datum.

When "null" values are allowed for fields in two separate schemas, there is no way to differentiate which schema should be used given of a list of schemas that are set as the type definition for a record.

This PR checks to ensure all fields defined on a given datum are _also_ defined in the schema being validated to use for that datum.

With this bugfix, datums such as `{"foo": "a"}` will not "cast" to schemas such as `{"name": "bar", "type": ["long", "null"]}`, which is currently the case.