### PR TITLE
[AVRO-2228] Bump Apache Velocity to 2.0

### DIFF
--- a/lang/java/compiler/pom.xml
+++ b/lang/java/compiler/pom.xml
@@ -163,7 +163,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.velocity</groupId>
-      <artifactId>velocity</artifactId>
+      <artifactId>velocity-engine-core</artifactId>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/enum.vm
+++ b/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/enum.vm
@@ -26,7 +26,7 @@ package $schema.getNamespace();
 #end
 @org.apache.avro.specific.AvroGenerated
 public enum ${this.mangle($schema.getName())} {
-  #foreach ($symbol in ${schema.getEnumSymbols()})${this.mangle($symbol)}#if ($velocityHasNext), #end#end
+  #foreach ($symbol in ${schema.getEnumSymbols()})${this.mangle($symbol)}#if ($foreach.hasNext), #end#end
   ;
   public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("${this.javaEscape($schema.toString())}");
   public static org.apache.avro.Schema getClassSchema() { return SCHEMA$; }

--- a/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/protocol.vm
+++ b/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/protocol.vm
@@ -47,7 +47,7 @@ public interface $this.mangle($protocol.getName()) {
   #if ($message.isOneWay())void#else${this.javaUnbox($response)}#end
  ${this.mangle($name)}(##
 #foreach ($p in $message.getRequest().getFields())##
-#*      *#${this.javaUnbox($p.schema())} ${this.mangle($p.name())}#if ($velocityHasNext), #end
+#*      *#${this.javaUnbox($p.schema())} ${this.mangle($p.name())}#if ($foreach.hasNext), #end
 #end
 )#if (! $message.isOneWay())
  throws org.apache.avro.AvroRemoteException##
@@ -84,7 +84,7 @@ public interface $this.mangle($protocol.getName()) {
      */
     void ${this.mangle($name)}(##
 #foreach ($p in $message.getRequest().getFields())##
-#*      *#${this.javaUnbox($p.schema())} ${this.mangle($p.name())}#if ($velocityHasNext), #end
+#*      *#${this.javaUnbox($p.schema())} ${this.mangle($p.name())}#if ($foreach.hasNext), #end
 #end
 #if ($message.getRequest().getFields().size() > 0), #end
 org.apache.avro.ipc.Callback<${this.javaType($response)}> callback) throws java.io.IOException;

--- a/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/record.vm
+++ b/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/record.vm
@@ -133,7 +133,7 @@ public class ${this.mangle($schema.getName())}#if ($schema.isError()) extends or
 #end
 #end
    */
-  public ${this.mangle($schema.getName())}(#foreach($field in $schema.getFields())${this.javaType($field.schema())} ${this.mangle($field.name())}#if($velocityCount < $schema.getFields().size()), #end#end) {
+  public ${this.mangle($schema.getName())}(#foreach($field in $schema.getFields())${this.javaType($field.schema())} ${this.mangle($field.name())}#if($foreach.count < $schema.getFields().size()), #end#end) {
 #foreach ($field in $schema.getFields())
     this.${this.mangle($field.name())} = ${this.mangle($field.name())};
 #end

--- a/lang/java/ipc/pom.xml
+++ b/lang/java/ipc/pom.xml
@@ -136,10 +136,9 @@
     </dependency>
     <dependency>
       <groupId>org.apache.velocity</groupId>
-      <artifactId>velocity</artifactId>
+      <artifactId>velocity-engine-core</artifactId>
     </dependency>
 
   </dependencies>
 
 </project>
-

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -49,7 +49,7 @@
     <thrift.version>0.9.3</thrift.version>
     <slf4j.version>1.7.25</slf4j.version>
     <snappy.version>1.1.7.2</snappy.version>
-    <velocity.version>1.7</velocity.version>
+    <velocity.version>2.0</velocity.version>
     <maven.version>2.0.11</maven.version>
     <ant.version>1.10.0</ant.version>
     <commons-cli.version>1.3.1</commons-cli.version>
@@ -423,7 +423,7 @@
       </dependency>
       <dependency>
         <groupId>org.apache.velocity</groupId>
-        <artifactId>velocity</artifactId>
+        <artifactId>velocity-engine-core</artifactId>
         <version>${velocity.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
- Remove `Slf4jLogChute` since 2.0 uses SLF4J itself: https://github.com/apache/velocity-engine#upgrading-from-velocity-17x-to-velocity-20
- Update $velocityHasNext to $foreach.hasNext because of deprecation, Update $velocityCount to $foreach.count because of deprecation: https://github.com/apache/velocity-engine#upgrading-from-velocity-16x-to-velocity-17x
- Velocity 2.0 does not depend on apache-common collections anymore which used to be an old version with known security issues:  CVE-2015-6420, CVE-2017-15708