### PR TITLE
Binary write buffer function gave a syntax error

### DIFF
--- a/lang/js/lib/utils.js
+++ b/lang/js/lib/utils.js
@@ -487,7 +487,7 @@ Tap.prototype.writeBinary = function (str, len) {
   if (this.pos > this.buf.length) {
     return;
   }
-  this.buf.binaryWrite(str, pos, len);
+  this.buf.write(str, pos, len, 'binary');
 };
 
 // Binary comparison methods.


### PR DESCRIPTION
Function gives the following error:

```bash
TypeError: this.buf.binaryWrite is not a function
```

Reason:
There is no `binaryWrite` function in the Node.JS Buffer module, only `write` with a binary encoding option.
https://nodejs.org/api/buffer.html#buffer_buf_write_string_offset_length_encoding