### PR TITLE
[AVRO-2145] Cannot create Javadoc on JDK8+

### DIFF
--- a/lang/java/archetypes/avro-service-archetype/src/main/resources/archetype-resources/src/main/java/service/SimpleOrderService.java
+++ b/lang/java/archetypes/avro-service-archetype/src/main/resources/archetype-resources/src/main/java/service/SimpleOrderService.java
@@ -33,6 +33,14 @@ public class SimpleOrderService implements OrderProcessingService {
 
   private Logger log = LoggerFactory.getLogger(SimpleOrderService.class);
 
+  /**
+   * Submit order confirmation.
+   *
+   * @param order the order
+   * @return the confirmation
+   * @throws AvroRemoteException the avro remote exception
+   * @throws OrderFailure        the order failure
+   */
   @Override
   public Confirmation submitOrder(Order order) throws AvroRemoteException, OrderFailure {
     log.info("Received order for '{}' items from customer with id '{}'",

--- a/lang/java/archetypes/avro-service-archetype/src/main/resources/archetype-resources/src/main/java/transport/SimpleOrderServiceClient.java
+++ b/lang/java/archetypes/avro-service-archetype/src/main/resources/archetype-resources/src/main/java/transport/SimpleOrderServiceClient.java
@@ -50,10 +50,20 @@ public class SimpleOrderServiceClient implements OrderProcessingService {
 
   private OrderProcessingService service;
 
+  /**
+   * Instantiates a new Simple order service client.
+   *
+   * @param endpointAddress the endpoint address
+   */
   public SimpleOrderServiceClient(InetSocketAddress endpointAddress) {
     this.endpointAddress = endpointAddress;
   }
 
+  /**
+   * Start.
+   *
+   * @throws IOException the io exception
+   */
   public synchronized void start() throws IOException {
     if (log.isInfoEnabled()) {
       log.info("Starting Simple Ordering Netty client on '{}'", endpointAddress);
@@ -62,6 +72,11 @@ public class SimpleOrderServiceClient implements OrderProcessingService {
     service = SpecificRequestor.getClient(OrderProcessingService.class, transceiver);
   }
 
+  /**
+   * Stop.
+   *
+   * @throws IOException the io exception
+   */
   public void stop() throws IOException {
     if (log.isInfoEnabled()) {
       log.info("Stopping Simple Ordering Netty client on '{}'", endpointAddress);
@@ -71,6 +86,14 @@ public class SimpleOrderServiceClient implements OrderProcessingService {
     }
   }
 
+  /**
+   * Submit order confirmation.
+   *
+   * @param order the order
+   * @return the confirmation
+   * @throws AvroRemoteException the avro remote exception
+   * @throws OrderFailure        the order failure
+   */
   @Override
   public Confirmation submitOrder(Order order) throws AvroRemoteException, OrderFailure {
     return service.submitOrder(order);

--- a/lang/java/archetypes/avro-service-archetype/src/main/resources/archetype-resources/src/main/java/transport/SimpleOrderServiceEndpoint.java
+++ b/lang/java/archetypes/avro-service-archetype/src/main/resources/archetype-resources/src/main/java/transport/SimpleOrderServiceEndpoint.java
@@ -44,10 +44,20 @@ public class SimpleOrderServiceEndpoint {
 
   private Server service;
 
+  /**
+   * Instantiates a new Simple order service endpoint.
+   *
+   * @param endpointAddress the endpoint address
+   */
   public SimpleOrderServiceEndpoint(InetSocketAddress endpointAddress) {
     this.endpointAddress = endpointAddress;
   }
 
+  /**
+   * Start.
+   *
+   * @throws Exception the exception
+   */
   public synchronized void start() throws Exception {
     if (log.isInfoEnabled()) {
       log.info("Starting Simple Ordering Netty Server on '{}'", endpointAddress);
@@ -58,6 +68,11 @@ public class SimpleOrderServiceEndpoint {
     service.start();
   }
 
+  /**
+   * Stop.
+   *
+   * @throws Exception the exception
+   */
   public synchronized void stop() throws Exception {
     if (log.isInfoEnabled()) {
       log.info("Stopping Simple Ordering Server on '{}'", endpointAddress);

--- a/lang/java/archetypes/avro-service-archetype/src/main/resources/archetype-resources/src/test/java/integration/SimpleOrderServiceIntegrationTest.java
+++ b/lang/java/archetypes/avro-service-archetype/src/main/resources/archetype-resources/src/test/java/integration/SimpleOrderServiceIntegrationTest.java
@@ -47,6 +47,11 @@ public class SimpleOrderServiceIntegrationTest {
   private static SimpleOrderServiceEndpoint service;
   private static SimpleOrderServiceClient client;
 
+  /**
+   * Simple round trip test.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void simpleRoundTripTest() throws Exception {
     Order simpleOrder = createOrder();
@@ -57,6 +62,11 @@ public class SimpleOrderServiceIntegrationTest {
     assertTrue(c.getEstimatedCompletion() > 0);
   }
 
+  /**
+   * Sets transport.
+   *
+   * @throws Exception the exception
+   */
   @BeforeClass
   public static void setupTransport() throws Exception {
     InetSocketAddress endpointAddress = new InetSocketAddress("0.0.0.0", 12345);
@@ -67,16 +77,31 @@ public class SimpleOrderServiceIntegrationTest {
     client.start();
   }
 
+  /**
+   * Shutdown transport.
+   *
+   * @throws Exception the exception
+   */
   @AfterClass
   public static void shutdownTransport() throws Exception {
     client.stop();
     service.stop();
   }
 
+  /**
+   * Create order order.
+   *
+   * @return the order
+   */
   public Order createOrder() {
     return Order.newBuilder().setOrderId(1).setCustomerId(1).setOrderItems(createItems()).build();
   }
 
+  /**
+   * Create items list.
+   *
+   * @return the list
+   */
   public List<Item> createItems() {
     List<Item> items = new ArrayList<Item>();
     for (int x = 0; x < 5; x++)

--- a/lang/java/avro/src/main/java/org/apache/avro/Conversions.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Conversions.java
@@ -176,6 +176,7 @@ public class Conversions {
   /**
    * Convert a high level representation of a logical type (such as a BigDecimal)
    * to the its underlying representation object (such as a ByteBuffer)
+   * @param <T> The return type
    * @param datum The object to be converted.
    * @param schema The schema of datum. Cannot be null if datum is not null.
    * @param type The {@link org.apache.avro.LogicalType} of datum. Cannot

--- a/lang/java/avro/src/main/java/org/apache/avro/JsonProperties.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/JsonProperties.java
@@ -32,12 +32,12 @@ import org.codehaus.jackson.node.TextNode;
  * Base class for objects that have JSON-valued properties. Avro and JSON values are
  * represented in Java using the following mapping:
  *
- * <table>
- *   <th>
- *     <td>Avro type</td>
- *     <td>JSON type</td>
- *     <td>Java type</td>
- *   </th>
+ * <table summary="An overview of the different types in Avro, JSON and Java">
+ *   <tr>
+ *     <th>Avro type</th>
+ *     <th>JSON type</th>
+ *     <th>Java type</th>
+ *   </tr>
  *   <tr>
  *     <td><code>null</code></td>
  *     <td><code>null</code></td>
@@ -125,6 +125,9 @@ public abstract class JsonProperties {
   /**
    * Returns the value of the named, string-valued property in this schema.
    * Returns <tt>null</tt> if there is no string-valued property with that name.
+   *
+   * @param name The property name
+   * @return The property if exists, otherwise null
    */
   public String getProp(String name) {
     JsonNode value = getJsonProp(name);
@@ -134,6 +137,10 @@ public abstract class JsonProperties {
   /**
    * Returns the value of the named property in this schema.
    * Returns <tt>null</tt> if there is no property with that name.
+   *
+   * @param name The property name
+   * @return The JsonNode if exists, otherwise null
+   *
    * @deprecated use {@link #getObjectProp(String)}
    */
   @Deprecated
@@ -144,6 +151,9 @@ public abstract class JsonProperties {
   /**
    * Returns the value of the named property in this schema.
    * Returns <tt>null</tt> if there is no property with that name.
+   *
+   * @param name The property name
+   * @return The object if exists, otherwise null
    */
   public synchronized Object getObjectProp(String name) {
     return JacksonUtils.toObject(props.get(name));
@@ -191,7 +201,9 @@ public abstract class JsonProperties {
     addProp(name, JacksonUtils.toJsonNode(value));
   }
 
-  /** Return the defined properties that have string values. */
+  /**
+   * @return Return the defined properties that have string values.
+   */
   @Deprecated public Map<String,String> getProps() {
     Map<String,String> result = new LinkedHashMap<>();
     for (Map.Entry<String,JsonNode> e : props.entrySet())
@@ -200,24 +212,18 @@ public abstract class JsonProperties {
     return result;
   }
 
-  /** Convert a map of string-valued properties to Json properties. */
-  Map<String,JsonNode> jsonProps(Map<String,String> stringProps) {
-    Map<String,JsonNode> result = new LinkedHashMap<>();
-    for (Map.Entry<String,String> e : stringProps.entrySet())
-      result.put(e.getKey(), TextNode.valueOf(e.getValue()));
-    return result;
-  }
-
   /**
-   * Return the defined properties as an unmodifiable Map.
    * @deprecated use {@link #getObjectProps()}
+   * @return The defined properties as an unmodifiable Map.
    */
   @Deprecated
   public Map<String,JsonNode> getJsonProps() {
     return Collections.unmodifiableMap(props);
   }
 
-  /** Return the defined properties as an unmodifiable Map. */
+  /**
+   * @return The defined properties as an unmodifiable Map.
+   */
   public Map<String,Object> getObjectProps() {
     Map<String,Object> result = new LinkedHashMap<>();
     for (Map.Entry<String,JsonNode> e : props.entrySet())

--- a/lang/java/avro/src/main/java/org/apache/avro/LogicalTypes.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/LogicalTypes.java
@@ -46,12 +46,17 @@ public class LogicalTypes {
   }
 
   /**
-   * Returns the {@link LogicalType} from the schema, if one is present.
+   * @param schema The schema
+   * @return The {@link LogicalType} from the schema, if one is present.
    */
   public static LogicalType fromSchema(Schema schema) {
     return fromSchemaImpl(schema, true);
   }
 
+  /**
+   * @param schema The schema
+   * @return The {@link LogicalType} from the schema, if one is present.
+   */
   public static LogicalType fromSchemaIgnoreInvalid(Schema schema) {
     return fromSchemaImpl(schema, false);
   }
@@ -108,12 +113,19 @@ public class LogicalTypes {
   private static final String TIMESTAMP_MILLIS = "timestamp-millis";
   private static final String TIMESTAMP_MICROS = "timestamp-micros";
 
-  /** Create a Decimal LogicalType with the given precision and scale 0 */
+  /**
+   * @param precision The precision of the decimal
+   * @return Decimal LogicalType with the given precision and scale 0
+   */
   public static Decimal decimal(int precision) {
     return decimal(precision, 0);
   }
 
-  /** Create a Decimal LogicalType with the given precision and scale */
+  /**
+   * @param precision The precision of the decimal
+   * @param scale The scale of the param
+   * @return Decimal LogicalType with the given precision and scale
+   */
   public static Decimal decimal(int precision, int scale) {
     return new Decimal(precision, scale);
   }

--- a/lang/java/avro/src/main/java/org/apache/avro/Protocol.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Protocol.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.io.StringWriter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -100,20 +101,46 @@ public class Protocol extends JsonProperties {
         }
     }
 
-    /** The name of this message. */
+    /**
+     * The name of this message
+     *
+     * @return Name of the messages
+     */
     public String getName() { return name; }
-    /** The parameters of this message. */
+
+    /**
+     * The parameters of this message
+     *
+     * @return The schema of the message
+     */
     public Schema getRequest() { return request; }
-    /** The returned data. */
+
+    /**
+     * The returned data
+     *
+     * @return The schema of the response
+     */
     public Schema getResponse() { return Schema.create(Schema.Type.NULL); }
-    /** Errors that might be thrown. */
+
+    /**
+     * Errors that might be thrown
+     *
+     * @return The schema of the errors
+     */
     public Schema getErrors() {
       return Schema.createUnion(new ArrayList<>());
     }
 
-    /** Returns true if this is a one-way message, with no response or errors.*/
+    /**
+     * Returns true if this is a one-way message, with no response or errors
+     *
+     * @return Boolean indicating if it is a one way messages
+     */
     public boolean isOneWay() { return true; }
 
+    /**
+     * @return A JSON representation of the protocol
+     */
     public String toString() {
       try {
         StringWriter writer = new StringWriter();
@@ -125,6 +152,7 @@ public class Protocol extends JsonProperties {
         throw new AvroRuntimeException(e);
       }
     }
+
     void toJson(JsonGenerator gen) throws IOException {
       gen.writeStartObject();
       if (doc != null) gen.writeStringField("doc", doc);
@@ -240,50 +268,100 @@ public class Protocol extends JsonProperties {
     this(name, null, namespace);
   }
 
-  /** The name of this protocol. */
+  /**
+   * @return Name of this protocol
+   */
   public String getName() { return name; }
 
-  /** The namespace of this protocol.  Qualifies its name. */
+  /**
+   * @return Namespace of this protocol. Qualifies its name.
+   */
   public String getNamespace() { return namespace; }
 
-  /** Doc string for this protocol. */
+  /**
+   * @return Doc string for this protocol
+   */
   public String getDoc() { return doc; }
 
-  /** The types of this protocol. */
+  /**
+   * @return The types of this protocol
+   */
   public Collection<Schema> getTypes() { return types.values(); }
 
-  /** Returns the named type. */
+  /**
+   * @param name the name of the type
+   * @return The named type
+   */
   public Schema getType(String name) { return types.get(name); }
 
-  /** Set the types of this protocol. */
+  /**
+   * Set the types of this protocol
+   * @param newTypes Types of this protocol
+   */
   public void setTypes(Collection<Schema> newTypes) {
     types = new Schema.Names();
     for (Schema s : newTypes)
       types.add(s);
   }
 
-  /** The messages of this protocol. */
+  /**
+   * @return Messages of this protocol
+   */
   public Map<String,Message> getMessages() { return messages; }
 
-  /** Create a one-way message. */
+  /**
+   * Create a one-way message.
+   * @param name Name of the message
+   * @param doc Docstring of the message
+   * @param request Schema of the message
+   * @return One-way message
+   */
   @Deprecated
   public Message createMessage(String name, String doc, Schema request) {
     return createMessage(name, doc, new LinkedHashMap<String,String>(),request);
   }
-  /** Create a one-way message. */
+
+  /**
+   * Create a one-way message.
+   * @param <T> The type of the message to be created
+   * @param name Name of the message
+   * @param doc Docstring of the message
+   * @param propMap Properties of the message
+   * @param request Schema of the message
+   * @return One-way message
+   */
   public <T> Message createMessage(String name, String doc,
                                    Map<String,T> propMap, Schema request) {
     return new Message(name, doc, propMap, request);
   }
 
-  /** Create a two-way message. */
+  /**
+   * Create a two-way message.
+   * @param name Name of the message
+   * @param doc Docstring of the message
+   * @param request Schema of the request message
+   * @param response Schema of the response message
+   * @param errors Schema of the errors
+   * @return Two-way message
+   */
   @Deprecated
   public Message createMessage(String name, String doc, Schema request,
                                Schema response, Schema errors) {
     return createMessage(name, doc, new LinkedHashMap<String,String>(),
                          request, response, errors);
   }
-  /** Create a two-way message. */
+
+  /**
+   * Create a two-way message.
+   * @param <T> The type of the message to be created
+   * @param name Name of the message
+   * @param doc Docstring of the message
+   * @param propMap Properties of the message
+   * @param request Schema of the request message
+   * @param response Schema of the response message
+   * @param errors Schema of the errors
+   * @return Two-way message
+   */
   public <T> Message createMessage(String name, String doc,
                                    Map<String,T> propMap, Schema request,
                                    Schema response, Schema errors) {
@@ -306,12 +384,17 @@ public class Protocol extends JsonProperties {
       + types.hashCode() + messages.hashCode() + props.hashCode();
   }
 
-  /** Render this as <a href="http://json.org/">JSON</a>.*/
+  /**
+   * Render this as <a href="http://json.org/">JSON</a>.
+   * @return A JSON representation of the protocol
+   */
   @Override
   public String toString() { return toString(false); }
 
-  /** Render this as <a href="http://json.org/">JSON</a>.
+  /**
+   * Render this as <a href="http://json.org/">JSON</a>.
    * @param pretty if true, pretty-print JSON.
+   * @return JSON representation of the protocol
    */
   public String toString(boolean pretty) {
     try {
@@ -325,6 +408,7 @@ public class Protocol extends JsonProperties {
       throw new AvroRuntimeException(e);
     }
   }
+
   void toJson(JsonGenerator gen) throws IOException {
     types.space(namespace);
 
@@ -350,29 +434,47 @@ public class Protocol extends JsonProperties {
     gen.writeEndObject();
   }
 
-  /** Return the MD5 hash of the text of this protocol. */
+  /**
+   * Return the MD5 hash of the text of this protocol.
+   * @return The MD5 hash as a byte array
+   */
   public byte[] getMD5() {
     if (md5 == null)
       try {
         md5 = MessageDigest.getInstance("MD5")
-          .digest(this.toString().getBytes("UTF-8"));
+          .digest(this.toString().getBytes(StandardCharsets.UTF_8));
       } catch (Exception e) {
         throw new AvroRuntimeException(e);
       }
     return md5;
   }
 
-  /** Read a protocol from a Json file. */
+  /**
+   * Read a protocol from a JSON file
+   * @param file The file that contains the JSON to parse
+   * @throws IOException if the file cannot be read
+   * @return the parsed protocol
+   */
   public static Protocol parse(File file) throws IOException {
     return parse(Schema.FACTORY.createJsonParser(file));
   }
 
-  /** Read a protocol from a Json stream. */
+  /**
+   * Read a protocol from a JSON stream
+   * @param stream The InputStream providing JSON
+   * @throws IOException if the stream cannot be consumed
+   * @return the parsed protocol
+   */
   public static Protocol parse(InputStream stream) throws IOException {
     return parse(Schema.FACTORY.createJsonParser(stream));
   }
 
-  /** Read a protocol from one or more json strings */
+  /**
+   * Read a protocol from one or more JSON strings
+   * @param string One JSON string representing a protocol
+   * @param more Additional JSON strings representing one or more protocols
+   * @return the parsed protocol
+   */
   public static Protocol parse(String string, String... more) {
     StringBuilder b = new StringBuilder(string);
     for (String part : more)
@@ -380,11 +482,15 @@ public class Protocol extends JsonProperties {
     return parse(b.toString());
   }
 
-  /** Read a protocol from a Json string. */
+  /**
+   * Read a protocol from one JSON strings
+   * @param string JSON string containing a protocol
+   * @return the parsed protocol
+   */
   public static Protocol parse(String string) {
     try {
       return parse(Schema.FACTORY.createJsonParser
-                   (new ByteArrayInputStream(string.getBytes("UTF-8"))));
+                   (new ByteArrayInputStream(string.getBytes(StandardCharsets.UTF_8))));
     } catch (IOException e) {
       throw new AvroRuntimeException(e);
     }

--- a/lang/java/avro/src/main/java/org/apache/avro/Schema.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Schema.java
@@ -96,7 +96,7 @@ public abstract class Schema extends JsonProperties {
     private String name;
     private Type() { this.name = this.name().toLowerCase(Locale.ENGLISH); }
     public String getName() { return name; }
-  };
+  }
 
   private final Type type;
   private LogicalType logicalType = null;
@@ -106,7 +106,11 @@ public abstract class Schema extends JsonProperties {
     this.type = type;
   }
 
-  /** Create a schema for a primitive type. */
+  /**
+   * Create a schema for a primitive type.
+   * @param type The type of the schema to be created
+   * @return The created schema
+   */
   public static Schema create(Type type) {
     switch (type) {
     case STRING:  return new StringSchema();
@@ -153,72 +157,143 @@ public abstract class Schema extends JsonProperties {
     this.logicalType = logicalType;
   }
 
-  /** Create an anonymous record schema. */
+  /**
+   * Create an anonymous record schema
+   * @param fields A list of fields that will construct the record
+   * @return A new Schema
+   */
   public static Schema createRecord(List<Field> fields) {
     Schema result = createRecord(null, null, null, false);
     result.setFields(fields);
     return result;
   }
 
-  /** Create a named record schema. */
+  /**
+   * Create a named record schema
+   *
+   * @param name The name of the record
+   * @param doc Docstring of the record
+   * @param namespace The namespace of the record
+   * @param isError indicates if there is an error
+   * @return A new Schema
+   */
   public static Schema createRecord(String name, String doc, String namespace,
                                     boolean isError) {
     return new RecordSchema(new Name(name, namespace), doc, isError);
   }
 
-  /** Create a named record schema with fields already set. */
+
+  /**
+   * Create a named record schema with fields already set
+   *
+   * @param name The name of the record
+   * @param doc Docstring of the record
+   * @param namespace The namespace of the record
+   * @param isError Indicates if there is an error
+   * @param fields the preset fields
+   * @return A new Schema
+   */
   public static Schema createRecord(String name, String doc, String namespace,
                                     boolean isError, List<Field> fields) {
     return new RecordSchema(new Name(name, namespace), doc, isError, fields);
   }
 
-  /** Create an enum schema. */
+  /**
+   * Create an enum schema
+   *
+   * @param name The name of the record
+   * @param doc The docstring of the record
+   * @param namespace The namespace of the record
+   * @param values The enum values
+   * @return A new enum Schema
+   */
   public static Schema createEnum(String name, String doc, String namespace,
                                   List<String> values) {
     return new EnumSchema(new Name(name, namespace), doc,
       new LockableArrayList<>(values), null);
   }
 
-  /** Create an enum schema. */
+  /**
+   * Create an enum schema
+   *
+   * @param name The name of the record
+   * @param doc Docstring of the record
+   * @param namespace The namespace of the record
+   * @param values The enum values
+   * @param enumDefault The default enum value
+   * @return A new enum Schema
+   */
   public static Schema createEnum(String name, String doc, String namespace,
                                   List<String> values, String enumDefault) {
     return new EnumSchema(new Name(name, namespace), doc,
         new LockableArrayList<>(values), enumDefault);
   }
 
-  /** Create an array schema. */
+  /**
+   * Create an array schema
+   *
+   * @param elementType The type of element
+   * @return An array schema
+   */
   public static Schema createArray(Schema elementType) {
     return new ArraySchema(elementType);
   }
 
-  /** Create a map schema. */
+  /**
+   * Create a map schema
+   *
+   * @param valueType The value types of the map
+   * @return A map schema
+   */
   public static Schema createMap(Schema valueType) {
     return new MapSchema(valueType);
   }
 
-  /** Create a union schema. */
+  /**
+   * Create an union schema
+   *
+   * @param types The list of the schema types
+   * @return An union schema
+   */
   public static Schema createUnion(List<Schema> types) {
     return new UnionSchema(new LockableArrayList<>(types));
   }
 
-  /** Create a union schema. */
+  /**
+   * Create an union schema
+   *
+   * @param types One or more of the schema types
+   * @return An union schema
+   */
   public static Schema createUnion(Schema... types) {
     return createUnion(new LockableArrayList<>(types));
   }
 
-  /** Create a union schema. */
-  public static Schema createFixed(String name, String doc, String space,
-      int size) {
+  /**
+   * Create a map schema
+   *
+   * @param name The name of the schema
+   * @param doc The doc of the schema
+   * @param space The space
+   * @param size The capacity of the FixedSchema
+   * @return A fixed schema
+   */
+  public static Schema createFixed(String name, String doc, String space, int size) {
     return new FixedSchema(new Name(name, space), doc, size);
   }
 
-  /** Return the type of this schema. */
+  /**
+   * @return Type of this schema
+   */
   public Type getType() { return type; }
 
   /**
    * If this is a record, returns the Field with the
    * given name <tt>fieldName</tt>. If there is no field by that name, a
    * <tt>null</tt> is returned.
+   *
+   * @param fieldname The fieldname to look for
+   * @return The Field if set
    */
   public Field getField(String fieldname) {
     throw new AvroRuntimeException("Not a record: "+this);
@@ -227,6 +302,8 @@ public abstract class Schema extends JsonProperties {
   /**
    * If this is a record, returns the fields in it. The returned
    * list is in the order of their positions.
+   *
+   * @return A list of all the fields
    */
   public List<Field> getFields() {
     throw new AvroRuntimeException("Not a record: "+this);
@@ -235,103 +312,171 @@ public abstract class Schema extends JsonProperties {
   /**
    * If this is a record, set its fields. The fields can be set
    * only once in a schema.
+   *
+   * @param fields The fields to set
    */
   public void setFields(List<Field> fields) {
     throw new AvroRuntimeException("Not a record: "+this);
   }
 
-  /** If this is an enum, return its symbols. */
+  /**
+   * If this is an enum, return its symbols
+   *
+   * @return A list strings that represent the symbols of the enum
+   */
   public List<String> getEnumSymbols() {
     throw new AvroRuntimeException("Not an enum: "+this);
   }
 
-  /** If this is an enum, return its default value. */
+  /**
+   * If this is an enum, return its default value
+   *
+   * @return The default value of the enum
+   */
   public String getEnumDefault() {
     throw new AvroRuntimeException("Not an enum: "+this);
   }
 
-  /** If this is an enum, return a symbol's ordinal value. */
+  /**
+   * If this is an enum, return a symbol's ordinal value
+   *
+   * @param symbol The symbol to look for in the enum
+   * @return the ordinal value of the symbol
+   */
   public int getEnumOrdinal(String symbol) {
     throw new AvroRuntimeException("Not an enum: "+this);
   }
 
-  /** If this is an enum, returns true if it contains given symbol. */
+  /**
+   * If this is an enum, returns true if it contains given symbol
+   *
+   * @param symbol The symbol name
+   * @return Check if the symbol exists within the enum
+   */
   public boolean hasEnumSymbol(String symbol) {
     throw new AvroRuntimeException("Not an enum: "+this);
   }
 
-  /** If this is a record, enum or fixed, returns its name, otherwise the name
-   * of the primitive type. */
+  /**
+   * @return If this is a record, enum or fixed, returns its name, otherwise the name of the primitive type
+   */
   public String getName() { return type.name; }
 
-  /** If this is a record, enum, or fixed, returns its docstring,
-   * if available.  Otherwise, returns null. */
+  /**
+   * @return If this is a record, enum, or fixed, returns its docstring, if available.  Otherwise, returns null.
+   */
   public String getDoc() {
     return null;
   }
 
-  /** If this is a record, enum or fixed, returns its namespace, if any. */
+  /**
+   * @return If this is a record, enum or fixed, returns its namespace, if any.
+   */
   public String getNamespace() {
     throw new AvroRuntimeException("Not a named type: "+this);
   }
 
-  /** If this is a record, enum or fixed, returns its namespace-qualified name,
-   * otherwise returns the name of the primitive type. */
+  /**
+   * @return If this is a record, enum or fixed, returns its namespace-qualified name, otherwise returns the name of the primitive type.
+   */
   public String getFullName() {
     return getName();
   }
 
-  /** If this is a record, enum or fixed, add an alias. */
+  /**
+   * If this is a record, enum or fixed, add an alias
+   *
+   * @param alias The alias to be added
+   */
   public void addAlias(String alias) {
     throw new AvroRuntimeException("Not a named type: "+this);
   }
 
-  /** If this is a record, enum or fixed, add an alias. */
+  /**
+   * If this is a record, enum or fixed, add an alias
+   *
+   * @param alias The alias to be added
+   * @param space The space
+   */
   public void addAlias(String alias, String space) {
     throw new AvroRuntimeException("Not a named type: "+this);
   }
 
-  /** If this is a record, enum or fixed, return its aliases, if any. */
+  /**
+   * If this is a record, enum or fixed, return its aliases, if any.
+   *
+   * @return A set of all the known aliases
+   */
   public Set<String> getAliases() {
     throw new AvroRuntimeException("Not a named type: "+this);
   }
 
-  /** Returns true if this record is an error type. */
+  /**
+   * @return True if this record is an error type
+   */
   public boolean isError() {
     throw new AvroRuntimeException("Not a record: "+this);
   }
 
-  /** If this is an array, returns its element type. */
+  /**
+   * If this is an array, returns its element type
+   *
+   * @return The element type
+   */
   public Schema getElementType() {
     throw new AvroRuntimeException("Not an array: "+this);
   }
 
-  /** If this is a map, returns its value type. */
+  /**
+   * If this is a map, returns its value type
+   *
+   * @return Value type
+   */
   public Schema getValueType() {
     throw new AvroRuntimeException("Not a map: "+this);
   }
 
-  /** If this is a union, returns its types. */
+  /**
+   * If this is a union, returns its types
+   *
+   * @return Types
+   */
   public List<Schema> getTypes() {
     throw new AvroRuntimeException("Not a union: "+this);
   }
 
-  /** If this is a union, return the branch with the provided full name. */
+  /**
+   * If this is a union, return the branch with the provided full name
+   *
+   * @param name The lookup name
+   * @return The index of the given name
+   */
   public Integer getIndexNamed(String name) {
     throw new AvroRuntimeException("Not a union: "+this);
   }
 
-  /** If this is fixed, returns its size. */
+  /**
+   * If this is fixed, returns its size
+   *
+   * @return The fixed size of the schema
+   */
   public int getFixedSize() {
     throw new AvroRuntimeException("Not fixed: "+this);
   }
 
-  /** Render this as <a href="http://json.org/">JSON</a>.*/
+  /**
+   * Render this as <a href="http://json.org/">JSON</a>.
+   *
+   * @return the schema as a JSON representation
+   */
   @Override
   public String toString() { return toString(false); }
 
-  /** Render this as <a href="http://json.org/">JSON</a>.
+  /**
+   * Render this as <a href="http://json.org/">JSON</a>.
+   *
    * @param pretty if true, pretty-print JSON.
+   * @return JSON representation of the schema
    */
   public String toString(boolean pretty) {
     try {
@@ -406,18 +551,42 @@ public abstract class Schema extends JsonProperties {
     private final Order order;
     private Set<String> aliases;
 
-    /** @deprecated use {@link #Field(String, Schema, String, Object)} */
+    /**
+     * @deprecated use {@link #Field(String, Schema, String, Object)}
+     *
+     * @param name the name of the field
+     * @param schema the schema of the field
+     * @param doc the docstring of the field
+     * @param defaultValue The default value of the field
+     */
     @Deprecated
     public Field(String name, Schema schema, String doc,
         JsonNode defaultValue) {
       this(name, schema, doc, defaultValue, Order.ASCENDING);
     }
-    /** @deprecated use {@link #Field(String, Schema, String, Object, Order)} */
+
+    /**
+     * @deprecated use {@link #Field(String, Schema, String, Object, Order)}
+     * @param name the name of the field
+     * @param schema the schema of the field
+     * @param doc the docstring of the field
+     * @param defaultValue The default value of the field
+     * @param order The ordering of the field
+     */
     @Deprecated
     public Field(String name, Schema schema, String doc,
         JsonNode defaultValue, Order order) {
       this(name, schema, doc, defaultValue, true, order);
     }
+
+    /**
+     * @param name the name of the field
+     * @param schema the schema of the field
+     * @param doc the docstring of the field
+     * @param defaultValue the default value for this field specified using the mapping in {@link JsonProperties}
+     * @param validateDefault Validate the value by default
+     * @param order The ordering of the field
+     */
     public Field(String name, Schema schema, String doc,
                  JsonNode defaultValue, boolean validateDefault, Order order) {
       super(FIELD_RESERVED);
@@ -430,48 +599,96 @@ public abstract class Schema extends JsonProperties {
       this.order = order;
     }
     /**
-     * @param defaultValue the default value for this field specified using the mapping
-     *  in {@link JsonProperties}
+     *
+     * @param name the name of the field
+     * @param schema the schema of the field
+     * @param doc the docstring of the field
+     * @param defaultValue the default value for this field specified using the mapping in {@link JsonProperties}
      */
     public Field(String name, Schema schema, String doc,
         Object defaultValue) {
       this(name, schema, doc, defaultValue, Order.ASCENDING);
     }
+
+
     /**
-     * @param defaultValue the default value for this field specified using the mapping
-     *  in {@link JsonProperties}
+     * @param name the name of the field
+     * @param schema the schema of the field
+     * @param doc the docstring of the field
+     * @param defaultValue the default value for this field specified using the mapping in {@link JsonProperties}
+     * @param order The ordering of the field
      */
     public Field(String name, Schema schema, String doc,
         Object defaultValue, Order order) {
       this(name, schema, doc, JacksonUtils.toJsonNode(defaultValue), order);
     }
-    public String name() { return name; };
-    /** The position of this field within the record. */
+
+    /**
+     * @return The name of the field
+     */
+    public String name() { return name; }
+
+    /**
+     * @return position of this field within the record
+     */
     public int pos() { return position; }
-    /** This field's {@link Schema}. */
+
+    /**
+     * This field's {@link Schema}
+     *
+     * @return The schema of the field
+     */
     public Schema schema() { return schema; }
-    /** Field's documentation within the record, if set. May return null. */
+
+    /**
+     * Field's documentation within the record, if set. May return null
+     *
+     * @return The docstring of the field
+     */
     public String doc() { return doc; }
-    /** @deprecated use {@link #defaultVal() } */
+
+    /**
+     * @deprecated use {@link #defaultVal() }
+     * @return The default value of the field
+     */
     @Deprecated public JsonNode defaultValue() { return defaultValue; }
+
     /**
      * @return the default value for this field specified using the mapping
      *  in {@link JsonProperties}
      */
     public Object defaultVal() { return JacksonUtils.toObject(defaultValue, schema); }
+
+    /**
+     * This field's ordering {@link Order}
+     *
+     * @return The ordering of the field
+     */
     public Order order() { return order; }
+
+    /**
+     * @return The properties of the field
+     */
     @Deprecated public Map<String,String> props() { return getProps(); }
     public void addAlias(String alias) {
       if (aliases == null)
         this.aliases = new LinkedHashSet<>();
       aliases.add(alias);
     }
-    /** Return the defined aliases as an unmodifiable Set. */
+
+    /**
+     * @return the defined aliases as an unmodifiable Set
+     */
     public Set<String> aliases() {
       if (aliases == null)
         return Collections.emptySet();
       return Collections.unmodifiableSet(aliases);
     }
+
+    /**
+     * @param other The object to compare with
+     * @return If the objects are equal
+     */
     public boolean equals(Object other) {
       if (other == this) return true;
       if (!(other instanceof Field)) return false;
@@ -482,6 +699,10 @@ public abstract class Schema extends JsonProperties {
         (order == that.order) &&
         props.equals(that.props);
     }
+
+    /**
+     * @return returns the hashcode of the schema
+     */
     public int hashCode() { return name.hashCode() + schema.computeHash(); }
 
     private boolean defaultValueEquals(JsonNode thatDefaultValue) {
@@ -991,15 +1212,22 @@ public abstract class Schema extends JsonProperties {
     private boolean validate = true;
     private boolean validateDefaults = true;
 
-    /** Adds the provided types to the set of defined, named types known to
-     * this parser. */
+    /**
+     * Add the provided types to the set of defined, named types known to this parser.
+     *
+     * @param types Types to add to the current schema
+     * @return The schema with the appended types
+     */
     public Parser addTypes(Map<String,Schema> types) {
       for (Schema s : types.values())
         names.add(s);
       return this;
     }
 
-    /** Returns the set of defined, named types known to this parser. */
+    /**
+     * Returns the set of defined, named types known to this parser
+     * @return A map of all the names schema pair
+     */
     public Map<String,Schema> getTypes() {
       Map<String,Schema> result = new LinkedHashMap<>();
       for (Schema s : names.values())
@@ -1007,39 +1235,69 @@ public abstract class Schema extends JsonProperties {
       return result;
     }
 
-    /** Enable or disable name validation. */
+    /**
+     * @param validate Enable or disable name validation
+     * @return the parser
+     */
     public Parser setValidate(boolean validate) {
       this.validate = validate;
       return this;
     }
 
-    /** True iff names are validated.  True by default. */
+    /**
+     * True iff names are validated.  True by default.
+     * @return boolean if validation is on
+     */
     public boolean getValidate() { return this.validate; }
 
-    /** Enable or disable default value validation. */
+    /**
+     * Enable or disable default value validation
+     *
+     * @param validateDefaults Set validation on or of by default
+     * @return The current schema
+     */
     public Parser setValidateDefaults(boolean validateDefaults) {
       this.validateDefaults = validateDefaults;
       return this;
     }
 
-    /** True iff default values are validated.  False by default. */
+    /**
+     * @return True iff default values are validated. False by default.
+     */
     public boolean getValidateDefaults() { return this.validateDefaults; }
 
-    /** Parse a schema from the provided file.
-     * If named, the schema is added to the names known to this parser. */
+    /**
+     * Parse a schema from the provided file. If named, the schema is added to the names known to this parser.
+     *
+     * @param file The file which contains the schema
+     * @throws IOException Throws an exception if it cannot access the file
+     * @return the parsed schema
+     */
     public Schema parse(File file) throws IOException {
       return parse(FACTORY.createJsonParser(file));
     }
 
-    /** Parse a schema from the provided stream.
+    /**
+     * Parse a schema from the provided stream.
      * If named, the schema is added to the names known to this parser.
-     * The input stream stays open after the parsing. */
+     * The input stream stays open after the parsing.
+     *
+     * @param in the inputstream which provides the schema in json format
+     * @throws IOException Throws an exception if it cannot access the inputstream
+     * @return The parsed schema
+     */
     public Schema parse(InputStream in) throws IOException {
       return parse(FACTORY.createJsonParser(in).disable(
               JsonParser.Feature.AUTO_CLOSE_SOURCE));
     }
 
-    /** Read a schema from one or more json strings */
+    /**
+     * Read a schema from one or more json strings
+     *
+     * @param s The string containing the schema
+     * @param more one or more strings containing a schema
+     * @return The parsed schema based on the input string(s)
+     */
     public Schema parse(String s, String... more) {
       StringBuilder b = new StringBuilder(s);
       for (String part : more)
@@ -1047,8 +1305,13 @@ public abstract class Schema extends JsonProperties {
       return parse(b.toString());
     }
 
-    /** Parse a schema from the provided string.
-     * If named, the schema is added to the names known to this parser. */
+    /**
+     * Parse a schema from the provided string.
+     * If named, the schema is added to the names known to this parser.
+     *
+     * @param s The string to be parsed
+     * @return The parsed Schema
+     */
     public Schema parse(String s) {
       try {
         return parse(FACTORY.createJsonParser(new StringReader(s)));
@@ -1057,6 +1320,10 @@ public abstract class Schema extends JsonProperties {
       }
     }
 
+    /**
+     * @param parser The JsonParser which will provide the schema
+     * @return The parsed Schema
+     */
     private Schema parse(JsonParser parser) throws IOException {
       boolean saved = validateNames.get();
       boolean savedValidateDefaults = VALIDATE_DEFAULTS.get();
@@ -1100,16 +1367,22 @@ public abstract class Schema extends JsonProperties {
     return new Parser().parse(in);
   }
 
-  /** Construct a schema from <a href="http://json.org/">JSON</a> text.
+  /**
+   * Construct a schema from <a href="http://json.org/">JSON</a> text.
    * @deprecated use {@link Schema.Parser} instead.
+   * @param jsonSchema The JSON representing a schema
+   * @return the parsed schema based on the input JSON
    */
   public static Schema parse(String jsonSchema) {
     return new Parser().parse(jsonSchema);
   }
 
-  /** Construct a schema from <a href="http://json.org/">JSON</a> text.
-   * @param validate true if names should be validated, false if not.
+  /**
+   * Construct a schema from <a href="http://json.org/">JSON</a> text.
    * @deprecated use {@link Schema.Parser} instead.
+   * @param jsonSchema The JSON representing a schema
+   * @param validate true if names should be validated, false if not.
+   * @return the parsed schema based on the input JSON
    */
   public static Schema parse(String jsonSchema, boolean validate) {
     return new Parser().setValidate(validate).parse(jsonSchema);
@@ -1430,6 +1703,8 @@ public abstract class Schema extends JsonProperties {
   /**
    * Parses a string as Json.
    * @deprecated use {@link org.apache.avro.data.Json#parseJson(String)}
+   * @param s JSON representation as a string
+   * @return The parsed JsonNode
    */
   @Deprecated
   public static JsonNode parseJson(String s) {
@@ -1446,7 +1721,12 @@ public abstract class Schema extends JsonProperties {
    * permits reading records, enums and fixed schemas whose names have changed,
    * and records whose field names have changed.  The returned schema always
    * contains the same data elements in the same order, but with possibly
-   * different names. */
+   * different names.
+   *
+   * @param writer writer
+   * @param reader reader
+   * @return Schema
+   */
   public static Schema applyAliases(Schema writer, Schema reader) {
     if (writer == reader) return writer;          // same schema
 

--- a/lang/java/avro/src/main/java/org/apache/avro/SchemaBuilder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/SchemaBuilder.java
@@ -70,15 +70,15 @@ import org.codehaus.jackson.node.TextNode;
  *     .name("meta").type().nullable().map().values().bytesType().noDefault()
  *   .endRecord();
  * </pre>
- * <p/>
+ * <br>
  *
- * <h5>Usage Guide</h5>
+ * <h1>Usage Guide</h1>
  * SchemaBuilder chains together many smaller builders and maintains nested
  * context in order to mimic the Avro Schema specification. Every Avro type in
  * JSON has required and optional JSON properties, as well as user-defined
  * properties.
- * <p/>
- * <h6>Selecting and Building an Avro Type</h6>
+ * <br>
+ * <h2>Selecting and Building an Avro Type</h2>
  * The API analogy for the right hand side of the Avro Schema JSON
  * <pre>
  * "type":
@@ -86,8 +86,8 @@ import org.codehaus.jackson.node.TextNode;
  * is a {@link TypeBuilder}, {@link FieldTypeBuilder}, or
  * {@link UnionFieldTypeBuilder}, depending on the context. These types all
  * share a similar API for selecting and building types.
- * <p/>
- * <h5>Primitive Types</h5>
+ * <br>
+ * <h1>Primitive Types</h1>
  * All Avro primitive types are trivial to configure. A primitive type in
  * Avro JSON can be declared two ways, one that supports custom properties
  * and one that does not:
@@ -106,21 +106,25 @@ import org.codehaus.jackson.node.TextNode;
  * Every primitive type has a shortcut to create the trivial type, and
  * a builder when custom properties are required.  The first line above is
  * a shortcut for the second, analogous to the JSON case.
- * <h6>Named Types</h6>
+ * <h2>Named Types</h2>
  * Avro named types have names, namespace, aliases, and doc.  In this API
  * these share a common parent, {@link NamespacedBuilder}.
  * The builders for named types require a name to be constructed, and optional
  * configuration via:
+ * <ul>
  * <li>{@link NamespacedBuilder#doc()}</li>
  * <li>{@link NamespacedBuilder#namespace(String)}</li>
  * <li>{@link NamespacedBuilder#aliases(String...)}</li>
  * <li>{@link PropBuilder#prop(String, String)}</li>
- * <p/>
+ * </ul>
+ * <br>
  * Each named type completes configuration of the optional properties
  * with its own method:
+ * <ul>
  * <li>{@link FixedBuilder#size(int)}</li>
  * <li>{@link EnumBuilder#symbols(String...)}</li>
  * <li>{@link RecordBuilder#fields()}</li>
+ * </ul>
  * Example use of a named type with all optional parameters:
  * <pre>
  * .enumeration("Suit").namespace("org.apache.test")
@@ -139,31 +143,31 @@ import org.codehaus.jackson.node.TextNode;
  *   "symbols":["SPADES", "HEARTS", "DIAMONDS", "CLUBS"]
  * }
  * </pre>
- * <h6>Nested Types</h6>
+ * <h2>Nested Types</h2>
  * The Avro nested types, map and array, can have custom properties like
  * all avro types, are not named, and must specify a nested type.
  * After configuration of optional properties, an array or map
  * builds or selects its nested type with {@link ArrayBuilder#items()}
  * and {@link MapBuilder#values()}, respectively.
  *
- * <h6>Fields</h6>
+ * <h2>Fields</h2>
  * {@link RecordBuilder#fields()} returns a {@link FieldAssembler} for
  * defining the fields of the record and completing it.
  * Each field must have a name, specified via {@link FieldAssembler#name(String)},
  * which returns a {@link FieldBuilder} for defining aliases, custom properties,
  * and documentation of the field.  After configuring these optional values for
  * a field, the type is selected or built with {@link FieldBuilder#type()}.
- * <p/>
+ * <br>
  * Fields have default values that must be specified to complete the field.
  * {@link FieldDefault#noDefault()} is available for all field types, and
  * a specific method is available for each type to use a default, for example
  * {@link IntDefault#intDefault(int)}
- * <p/>
+ * <br>
  * There are field shortcut methods on {@link FieldAssembler} for primitive types.
  * These shortcuts create required, optional, and nullable fields, but do not
  * support field aliases, doc, or custom properties.
  *
- * <h6>Unions</h6>
+ * <h2>Unions</h2>
  * Union types are built via {@link TypeBuilder#unionOf()} or
  * {@link FieldTypeBuilder#unionOf()} in the context of type selection.
  * This chains together multiple types, in union order.  For example:
@@ -183,7 +187,7 @@ import org.codehaus.jackson.node.TextNode;
  * </pre>
  * In a field context, the first type of a union defines what default type
  * is allowed.
- * </p>
+ * <br>
  * Unions have two shortcuts for common cases.  nullable()
  * creates a union of a type and null.  In a field type context, optional()
  * is available and creates a union of null and a type, with a null default.
@@ -198,7 +202,7 @@ import org.codehaus.jackson.node.TextNode;
  *   .name("f").type().optional().longType()
  * </pre>
  *
- * <h6>Explicit Types and Types by Name</h6>
+ * <h2>Explicit Types and Types by Name</h2>
  * Types can also be specified explicitly by passing in a Schema, or by name:
  * <pre>
  *   .type(Schema.create(Schema.Type.INT)) // explicitly specified
@@ -210,7 +214,7 @@ import org.codehaus.jackson.node.TextNode;
  * propagate as a default to child fields, nested types, or later defined types
  * in a union.  To specify a name that has no namespace and ignore the inherited
  * namespace, set the namespace to "".
- * <p/>
+ * <br>
  * {@link SchemaBuilder#builder(String)} returns a type builder with a default
  * namespace.  {@link SchemaBuilder#builder()} returns a type builder with no
  * default namespace.
@@ -221,7 +225,7 @@ public class SchemaBuilder {
   }
 
   /**
-   * Create a builder for Avro schemas.
+   * @return A builder for Avro Schemas
    */
   public static TypeBuilder<Schema> builder() {
     return new TypeBuilder<>(new SchemaCompletion(), new NameContext());
@@ -230,6 +234,9 @@ public class SchemaBuilder {
   /**
    * Create a builder for Avro schemas with a default namespace. Types created
    * without namespaces will inherit the namespace provided.
+   *
+   * @param namespace The namespace of the Schema
+   * @return A new TypeBuilder
    */
   public static TypeBuilder<Schema> builder(String namespace) {
     return new TypeBuilder<>(new SchemaCompletion(),
@@ -243,6 +250,7 @@ public class SchemaBuilder {
    *   builder().record(name);
    * </pre>
    * @param name the record name
+   * @return A new RecordBuilder
    */
   public static RecordBuilder<Schema> record(String name) {
     return builder().record(name);
@@ -255,6 +263,7 @@ public class SchemaBuilder {
    *   builder().enumeration(name);
    * </pre>
    * @param name the enum name
+   * @return A new EnumBuilder
    */
   public static EnumBuilder<Schema> enumeration(String name) {
     return builder().enumeration(name);
@@ -267,6 +276,7 @@ public class SchemaBuilder {
    *   builder().fixed(name);
    * </pre>
    * @param name the fixed name
+   * @return A new FixedBuilder
    */
   public static FixedBuilder<Schema> fixed(String name) {
     return builder().fixed(name);
@@ -278,6 +288,7 @@ public class SchemaBuilder {
    * <pre>
    *   builder().array();
    * </pre>
+   * @return A new ArrayBuilder
    */
   public static ArrayBuilder<Schema> array() {
     return builder().array();
@@ -289,6 +300,7 @@ public class SchemaBuilder {
    * <pre>
    *   builder().map();
    * </pre>
+   * @return A new MapBuilder
    */
   public static MapBuilder<Schema> map() {
     return builder().map();
@@ -300,6 +312,7 @@ public class SchemaBuilder {
    * <pre>
    *   builder().unionOf();
    * </pre>
+   * @return A new BaseTypeBuilder
    */
   public static BaseTypeBuilder<UnionAccumulator<Schema>> unionOf() {
     return builder().unionOf();
@@ -318,6 +331,7 @@ public class SchemaBuilder {
    * <pre>
    *   unionOf().intType().and().nullType().endUnion();
    * </pre>
+   * @return A new BaseTypeBuilder
    */
   public static BaseTypeBuilder<Schema> nullable() {
     return builder().nullable();
@@ -327,6 +341,7 @@ public class SchemaBuilder {
   /**
    * An abstract builder for all Avro types.  All Avro types
    * can have arbitrary string key-value properties.
+   *
    */
   public static abstract class PropBuilder<S extends PropBuilder<S>> {
     private Map<String, JsonNode> props = null;
@@ -335,6 +350,10 @@ public class SchemaBuilder {
 
     /**
      * Set name-value pair properties for this type or field.
+     *
+     * @param name The name of the property
+     * @param val the value of the property
+     * @return the contructed property
      */
     public final S prop(String name, String val) {
       return prop(name, TextNode.valueOf(val));
@@ -342,6 +361,10 @@ public class SchemaBuilder {
 
     /**
      * Set name-value pair properties for this type or field.
+     *
+     * @param name The name of the property
+     * @param value the value of the property
+     * @return the contructed property
      */
     public final S prop(String name, Object value) {
       return prop(name, JacksonUtils.toJsonNode(value));
@@ -368,8 +391,12 @@ public class SchemaBuilder {
       }
       return jsonable;
     }
-    /** a self-type for chaining builder subclasses.  Concrete subclasses
-     * must return 'this' **/
+
+    /**
+     * A self-type for chaining builder subclasses. Concrete subclasses must return 'this'
+     *
+     * @return itself
+     */
     protected abstract S self();
   }
 
@@ -377,7 +404,7 @@ public class SchemaBuilder {
    * An abstract type that provides builder methods for configuring the name,
    * doc, and aliases of all Avro types that have names (fields, Fixed, Record,
    * and Enum).
-   * <p/>
+   * <br>
    * All Avro named types and fields have 'doc', 'aliases', and 'name'
    * components. 'name' is required, and provided to this builder. 'doc' and
    * 'aliases' are optional.
@@ -395,13 +422,23 @@ public class SchemaBuilder {
       this.name = name;
     }
 
-    /** configure this type's optional documentation string **/
+    /**
+     * Configure this type's optional documentation string
+     *
+     * @param doc The docstring
+     * @return {@link S}
+     */
     public final S doc(String doc) {
       this.doc = doc;
       return self();
     }
 
-    /** configure this type's optional name aliases **/
+    /**
+     * Configure this type's optional name aliases
+     *
+     * @param aliases Set one or more aliasses
+     * @return {@link S}
+     */
     public final S aliases(String... aliases) {
       this.aliases = aliases;
       return self();
@@ -456,10 +493,13 @@ public class SchemaBuilder {
 
     /**
      * Set the namespace of this type. To clear the namespace, set empty string.
-     * <p/>
+     * <br>
      * When the namespace is null or unset, the namespace of the type defaults
      * to the namespace of the enclosing context.
-     **/
+     *
+     * @param namespace The namespace of the schema
+     * @return {@link S}
+     */
     public final S namespace(String namespace) {
       this.namespace = namespace;
       return self();
@@ -511,7 +551,7 @@ public class SchemaBuilder {
   /**
    * Builds an Avro boolean type with optional properties. Set properties with
    * {@link #prop(String, String)}, and finalize with {@link #endBoolean()}
-   **/
+   */
   public static final class BooleanBuilder<R> extends
       PrimitiveBuilder<R, BooleanBuilder<R>> {
     private BooleanBuilder(Completion<R> context, NameContext names) {
@@ -528,7 +568,10 @@ public class SchemaBuilder {
       return this;
     }
 
-    /** complete building this type, return control to context **/
+    /**
+     * complete building this type, return control to context
+     * @return {@link R}
+     */
     public R endBoolean() {
       return super.end();
     }
@@ -537,7 +580,7 @@ public class SchemaBuilder {
   /**
    * Builds an Avro int type with optional properties. Set properties with
    * {@link #prop(String, String)}, and finalize with {@link #endInt()}
-   **/
+   */
   public static final class IntBuilder<R> extends
       PrimitiveBuilder<R, IntBuilder<R>> {
     private IntBuilder(Completion<R> context, NameContext names) {
@@ -554,7 +597,10 @@ public class SchemaBuilder {
       return this;
     }
 
-    /** complete building this type, return control to context **/
+    /**
+     * Complete building this type, return control to context
+     * @return {@link R}
+     */
     public R endInt() {
       return super.end();
     }
@@ -563,7 +609,7 @@ public class SchemaBuilder {
   /**
    * Builds an Avro long type with optional properties. Set properties with
    * {@link #prop(String, String)}, and finalize with {@link #endLong()}
-   **/
+   */
   public static final class LongBuilder<R> extends
       PrimitiveBuilder<R, LongBuilder<R>> {
     private LongBuilder(Completion<R> context, NameContext names) {
@@ -580,7 +626,10 @@ public class SchemaBuilder {
       return this;
     }
 
-    /** complete building this type, return control to context **/
+    /**
+     * Complete building this type, return control to context
+     * @return {@link R}
+     */
     public R endLong() {
       return super.end();
     }
@@ -589,7 +638,7 @@ public class SchemaBuilder {
   /**
    * Builds an Avro float type with optional properties. Set properties with
    * {@link #prop(String, String)}, and finalize with {@link #endFloat()}
-   **/
+   */
   public static final class FloatBuilder<R> extends
       PrimitiveBuilder<R, FloatBuilder<R>> {
     private FloatBuilder(Completion<R> context, NameContext names) {
@@ -606,7 +655,10 @@ public class SchemaBuilder {
       return this;
     }
 
-    /** complete building this type, return control to context **/
+    /**
+     * complete building this type, return control to context
+     * @return {@link R}
+     */
     public R endFloat() {
       return super.end();
     }
@@ -615,7 +667,7 @@ public class SchemaBuilder {
   /**
    * Builds an Avro double type with optional properties. Set properties with
    * {@link #prop(String, String)}, and finalize with {@link #endDouble()}
-   **/
+   */
   public static final class DoubleBuilder<R> extends
       PrimitiveBuilder<R, DoubleBuilder<R>> {
     private DoubleBuilder(Completion<R> context, NameContext names) {
@@ -632,7 +684,10 @@ public class SchemaBuilder {
       return this;
     }
 
-    /** complete building this type, return control to context **/
+    /**
+     * Complete building this type, return control to context
+     * @return {@link R}
+     */
     public R endDouble() {
       return super.end();
     }
@@ -641,7 +696,7 @@ public class SchemaBuilder {
   /**
    * Builds an Avro string type with optional properties. Set properties with
    * {@link #prop(String, String)}, and finalize with {@link #endString()}
-   **/
+   */
   public static final class StringBldr<R> extends
       PrimitiveBuilder<R, StringBldr<R>> {
     private StringBldr(Completion<R> context, NameContext names) {
@@ -658,7 +713,10 @@ public class SchemaBuilder {
       return this;
     }
 
-    /** complete building this type, return control to context **/
+    /**
+     * complete building this type, return control to context
+     * @return {@link R}
+     */
     public R endString() {
       return super.end();
     }
@@ -667,7 +725,7 @@ public class SchemaBuilder {
   /**
    * Builds an Avro bytes type with optional properties. Set properties with
    * {@link #prop(String, String)}, and finalize with {@link #endBytes()}
-   **/
+   */
   public static final class BytesBuilder<R> extends
       PrimitiveBuilder<R, BytesBuilder<R>> {
     private BytesBuilder(Completion<R> context, NameContext names) {
@@ -684,7 +742,10 @@ public class SchemaBuilder {
       return this;
     }
 
-    /** complete building this type, return control to context **/
+    /**
+     * Complete building this type, return control to context
+     * @return {@link R}
+     */
     public R endBytes() {
       return super.end();
     }
@@ -693,7 +754,7 @@ public class SchemaBuilder {
   /**
    * Builds an Avro null type with optional properties. Set properties with
    * {@link #prop(String, String)}, and finalize with {@link #endNull()}
-   **/
+   */
   public static final class NullBuilder<R> extends
       PrimitiveBuilder<R, NullBuilder<R>> {
     private NullBuilder(Completion<R> context, NameContext names) {
@@ -710,7 +771,10 @@ public class SchemaBuilder {
       return this;
     }
 
-    /** complete building this type, return control to context **/
+    /**
+     * Complete building this type, return control to context
+     * @return {@link R}
+     */
     public R endNull() {
       return super.end();
     }
@@ -719,14 +783,14 @@ public class SchemaBuilder {
   /**
    * Builds an Avro Fixed type with optional properties, namespace, doc, and
    * aliases.
-   * <p/>
+   * <br>
    * Set properties with {@link #prop(String, String)}, namespace with
    * {@link #namespace(String)}, doc with {@link #doc(String)}, and aliases with
    * {@link #aliases(String[])}.
-   * <p/>
+   * <br>
    * The Fixed schema is finalized when its required size is set via
    * {@link #size(int)}.
-   **/
+   */
   public static final class FixedBuilder<R> extends
       NamespacedBuilder<R, FixedBuilder<R>> {
     private FixedBuilder(Completion<R> context, NameContext names, String name) {
@@ -743,7 +807,12 @@ public class SchemaBuilder {
       return this;
     }
 
-    /** Configure this fixed type's size, and end its configuration. **/
+    /**
+     * Complete building this type, return control to context
+     *
+     * @param size The size of the {@link FixedBuilder}
+     * @return {@link R}
+     */
     public R size(int size) {
       Schema schema = Schema.createFixed(name(), super.doc(), space(), size);
       completeSchema(schema);
@@ -754,14 +823,14 @@ public class SchemaBuilder {
   /**
    * Builds an Avro Enum type with optional properties, namespace, doc, and
    * aliases.
-   * <p/>
+   * <br>
    * Set properties with {@link #prop(String, String)}, namespace with
    * {@link #namespace(String)}, doc with {@link #doc(String)}, and aliases with
    * {@link #aliases(String[])}.
-   * <p/>
+   * <br>
    * The Enum schema is finalized when its required symbols are set via
    * {@link #symbols(String[])}.
-   **/
+   */
   public static final class EnumBuilder<R> extends
       NamespacedBuilder<R, EnumBuilder<R>> {
     private EnumBuilder(Completion<R> context, NameContext names, String name) {
@@ -779,7 +848,12 @@ public class SchemaBuilder {
       return this;
     }
 
-    /** Configure this enum type's symbols, and end its configuration. Populates the default if it was set.**/
+    /**
+     * Configure this enum type's symbols, and end its configuration. Populates the default if it was set.
+     *
+     * @param symbols One or more symbols to construct the enum
+     * @return {@link R}
+     */
     public R symbols(String... symbols) {
       Schema schema = Schema.createEnum(name(), doc(), space(),
           Arrays.asList(symbols), this.enumDefault);
@@ -787,7 +861,11 @@ public class SchemaBuilder {
       return context().complete(schema);
     }
 
-    /** Set the default value of the enum. */
+    /**
+     * Set the default value of the enum.
+     * @param enumDefault The default symbol
+     * @return {@link R}
+     */
     public EnumBuilder<R> defaultSymbol(String enumDefault) {
       this.enumDefault = enumDefault;
       return self();
@@ -796,12 +874,12 @@ public class SchemaBuilder {
 
   /**
    * Builds an Avro Map type with optional properties.
-   * <p/>
+   * <br>
    * Set properties with {@link #prop(String, String)}.
-   * <p/>
+   * <br>
    * The Map schema's properties are finalized when {@link #values()} or
    * {@link #values(Schema)} is called.
-   **/
+   */
   public static final class MapBuilder<R> extends PropBuilder<MapBuilder<R>> {
     private final Completion<R> context;
     private final NameContext names;
@@ -825,7 +903,9 @@ public class SchemaBuilder {
      * Return a type builder for configuring the map's nested values schema.
      * This builder will return control to the map's enclosing context when
      * complete.
-     **/
+     *
+     * @return {@link TypeBuilder}
+     */
     public TypeBuilder<R> values() {
       return new TypeBuilder<>(new MapCompletion<>(this, context), names);
     }
@@ -833,7 +913,9 @@ public class SchemaBuilder {
     /**
      * Complete configuration of this map, setting the schema of the map values
      * to the schema provided. Returns control to the enclosing context.
-     **/
+     * @param valueSchema The schema to be set
+     * @return {@link R}
+     */
     public R values(Schema valueSchema) {
       return new MapCompletion<>(this, context).complete(valueSchema);
     }
@@ -841,12 +923,12 @@ public class SchemaBuilder {
 
   /**
    * Builds an Avro Array type with optional properties.
-   * <p/>
+   * <br>
    * Set properties with {@link #prop(String, String)}.
-   * <p/>
+   * <br>
    * The Array schema's properties are finalized when {@link #items()} or
    * {@link #items(Schema)} is called.
-   **/
+   */
   public static final class ArrayBuilder<R> extends
       PropBuilder<ArrayBuilder<R>> {
     private final Completion<R> context;
@@ -871,7 +953,9 @@ public class SchemaBuilder {
      * Return a type builder for configuring the array's nested items schema.
      * This builder will return control to the array's enclosing context when
      * complete.
-     **/
+     *
+     * @return The nested items of the schema
+     */
     public TypeBuilder<R> items() {
       return new TypeBuilder<>(new ArrayCompletion<>(this, context), names);
     }
@@ -879,7 +963,10 @@ public class SchemaBuilder {
     /**
      * Complete configuration of this array, setting the schema of the array
      * items to the schema provided. Returns control to the enclosing context.
-     **/
+     *
+     * @param itemsSchema Schema to complete the configuration
+     * @return The enclosing context control
+     */
     public R items(Schema itemsSchema) {
       return new ArrayCompletion<>(this, context).complete(itemsSchema);
     }
@@ -888,13 +975,12 @@ public class SchemaBuilder {
   /**
    * internal class for passing the naming context around. This allows for the
    * following:
-   * <li>Cache and re-use primitive schemas when they do not set
-   * properties.</li>
-   * <li>Provide a default namespace for nested contexts (as
-   * the JSON Schema spec does).</li>
-   * <li>Allow previously defined named types or primitive types
-   * to be referenced by name.</li>
-   **/
+   * <ul>
+   * <li>Cache and re-use primitive schemas when they do not set properties.</li>
+   * <li>Provide a default namespace for nested contexts (as the JSON Schema spec does).</li>
+   * <li>Allow previously defined named types or primitive types to be referenced by name.</li>
+   * </ul>
+   */
   private static class NameContext {
     private static final Set<String> PRIMITIVES = new HashSet<>();
     static {
@@ -973,15 +1059,17 @@ public class SchemaBuilder {
    * A common API for building types within a context. BaseTypeBuilder can build
    * all types other than Unions. {@link TypeBuilder} can additionally build
    * Unions.
-   * <p/>
+   * <br>
    * The builder has two contexts:
+   * <ul>
    * <li>A naming context provides a default namespace and allows for previously
    * defined named types to be referenced from {@link #type(String)}</li>
    * <li>A completion context representing the scope that the builder was
    * created in. A builder created in a nested context (for example,
    * {@link MapBuilder#values()} will have a completion context assigned by the
    * {@link MapBuilder}</li>
-   **/
+   * </ul>
+   */
   public static class BaseTypeBuilder<R> {
     private final Completion<R> context;
     private final NameContext names;
@@ -991,7 +1079,12 @@ public class SchemaBuilder {
       this.names = names;
     }
 
-    /** Use the schema provided as the type. **/
+    /**
+     * Use the schema provided as the type.
+     *
+     * @param schema The provided schema
+     * @return The completed record
+     */
     public final R type(Schema schema) {
       return context.complete(schema);
     }
@@ -999,11 +1092,14 @@ public class SchemaBuilder {
     /**
      * Look up the type by name. This type must be previously defined in the
      * context of this builder.
-     * <p/>
+     * <br>
      * The name may be fully qualified or a short name. If it is a short name,
      * the default namespace of the current context will additionally be
      * searched.
-     **/
+     *
+     * @param name The lookup name
+     * @return The completed record
+     */
     public final R type(String name) {
       return type(name, null);
     }
@@ -1011,12 +1107,16 @@ public class SchemaBuilder {
     /**
      * Look up the type by name and namespace. This type must be previously
      * defined in the context of this builder.
-     * <p/>
+     * <br>
      * The name may be fully qualified or a short name. If it is a fully
      * qualified name, the namespace provided is ignored. If it is a short name,
      * the namespace provided is used if not null, else the default namespace of
      * the current context will be used.
-     **/
+     *
+     * @param name The lookup name
+     * @param namespace The namespace to search in
+     * @return The completed record
+     */
     public final R type(String name, String namespace) {
       return type(names.get(name, namespace));
     }
@@ -1026,6 +1126,8 @@ public class SchemaBuilder {
      * <pre>
      * booleanBuilder().endBoolean();
      * </pre>
+     *
+     * @return Record
      */
     public final R booleanType() {
       return booleanBuilder().endBoolean();
@@ -1034,6 +1136,8 @@ public class SchemaBuilder {
     /**
      * Build a boolean type that can set custom properties. If custom properties
      * are not needed it is simpler to use {@link #booleanType()}.
+     *
+     * @return {@link BooleanBuilder}
      */
     public final BooleanBuilder<R> booleanBuilder() {
       return BooleanBuilder.create(context, names);
@@ -1044,6 +1148,8 @@ public class SchemaBuilder {
      * <pre>
      * intBuilder().endInt();
      * </pre>
+     *
+     * @return Record
      */
     public final R intType() {
       return intBuilder().endInt();
@@ -1052,6 +1158,8 @@ public class SchemaBuilder {
     /**
      * Build an int type that can set custom properties. If custom properties
      * are not needed it is simpler to use {@link #intType()}.
+     *
+     * @return {@link IntBuilder}
      */
     public final IntBuilder<R> intBuilder() {
       return IntBuilder.create(context, names);
@@ -1062,6 +1170,8 @@ public class SchemaBuilder {
      * <pre>
      * longBuilder().endLong();
      * </pre>
+     *
+     * @return Record
      */
     public final R longType() {
       return longBuilder().endLong();
@@ -1070,6 +1180,8 @@ public class SchemaBuilder {
     /**
      * Build a long type that can set custom properties. If custom properties
      * are not needed it is simpler to use {@link #longType()}.
+     *
+     * @return {@link LongBuilder}
      */
     public final LongBuilder<R> longBuilder() {
       return LongBuilder.create(context, names);
@@ -1080,6 +1192,8 @@ public class SchemaBuilder {
      * <pre>
      * floatBuilder().endFloat();
      * </pre>
+     *
+     * @return {@link R}
      */
     public final R floatType() {
       return floatBuilder().endFloat();
@@ -1088,6 +1202,8 @@ public class SchemaBuilder {
     /**
      * Build a float type that can set custom properties. If custom properties
      * are not needed it is simpler to use {@link #floatType()}.
+     *
+     * @return {@link FloatBuilder}
      */
     public final FloatBuilder<R> floatBuilder() {
       return FloatBuilder.create(context, names);
@@ -1098,6 +1214,8 @@ public class SchemaBuilder {
      * <pre>
      * doubleBuilder().endDouble();
      * </pre>
+     *
+     * @return Record
      */
     public final R doubleType() {
       return doubleBuilder().endDouble();
@@ -1106,6 +1224,8 @@ public class SchemaBuilder {
     /**
      * Build a double type that can set custom properties. If custom properties
      * are not needed it is simpler to use {@link #doubleType()}.
+     *
+     * @return {@link DoubleBuilder}
      */
     public final DoubleBuilder<R> doubleBuilder() {
       return DoubleBuilder.create(context, names);
@@ -1116,6 +1236,8 @@ public class SchemaBuilder {
      * <pre>
      * stringBuilder().endString();
      * </pre>
+     *
+     * @return Record
      */
     public final R stringType() {
       return stringBuilder().endString();
@@ -1124,6 +1246,8 @@ public class SchemaBuilder {
     /**
      * Build a string type that can set custom properties. If custom properties
      * are not needed it is simpler to use {@link #stringType()}.
+     *
+     * @return {@link StringBldr}
      */
     public final StringBldr<R> stringBuilder() {
       return StringBldr.create(context, names);
@@ -1134,6 +1258,8 @@ public class SchemaBuilder {
      * <pre>
      * bytesBuilder().endBytes();
      * </pre>
+     *
+     * @return Record
      */
     public final R bytesType() {
       return bytesBuilder().endBytes();
@@ -1142,6 +1268,8 @@ public class SchemaBuilder {
     /**
      * Build a bytes type that can set custom properties. If custom properties
      * are not needed it is simpler to use {@link #bytesType()}.
+     *
+     * @return {@link BytesBuilder}
      */
     public final BytesBuilder<R> bytesBuilder() {
       return BytesBuilder.create(context, names);
@@ -1152,6 +1280,8 @@ public class SchemaBuilder {
      * <pre>
      * nullBuilder().endNull();
      * </pre>
+     *
+     * @return Record
      */
     public final R nullType() {
       return nullBuilder().endNull();
@@ -1160,6 +1290,8 @@ public class SchemaBuilder {
     /**
      * Build a null type that can set custom properties. If custom properties
      * are not needed it is simpler to use {@link #nullType()}.
+     *
+     * @return {@link NullBuilder}
      */
     public final NullBuilder<R> nullBuilder() {
       return NullBuilder.create(context, names);
@@ -1173,12 +1305,15 @@ public class SchemaBuilder {
      * <pre>
      * {"type":"map", "values":"int"}
      * </pre>
-     **/
+     *
+     * @return {@link MapBuilder}
+     */
     public final MapBuilder<R> map() {
       return MapBuilder.create(context, names);
     }
 
-    /** Build an Avro array type  Example usage:
+    /**
+     * Build an Avro array type  Example usage:
      * <pre>
      * array().items().longType()
      * </pre>
@@ -1186,12 +1321,15 @@ public class SchemaBuilder {
      * <pre>
      * {"type":"array", "values":"long"}
      * </pre>
-     **/
+     *
+     * @return {@link ArrayBuilder}
+     */
     public final ArrayBuilder<R> array() {
       return ArrayBuilder.create(context, names);
     }
 
-    /** Build an Avro fixed type. Example usage:
+    /**
+     * Build an Avro fixed type. Example usage:
      * <pre>
      * fixed("com.foo.IPv4").size(4)
      * </pre>
@@ -1199,7 +1337,10 @@ public class SchemaBuilder {
      * <pre>
      * {"type":"fixed", "name":"com.foo.IPv4", "size":4}
      * </pre>
-     **/
+     *
+     * @param name The name of the field
+     * @return {@link FixedBuilder}
+     */
     public final FixedBuilder<R> fixed(String name) {
       return FixedBuilder.create(context, names, name);
     }
@@ -1215,7 +1356,10 @@ public class SchemaBuilder {
      *  "doc":"card suit names", "symbols":[
      *    "HEART", "SPADE", "DIAMOND", "CLUB"], "default":"HEART"}
      * </pre>
-     **/
+     *
+     * @param name The name of the field
+     * @return {@link EnumBuilder}
+     */
     public final EnumBuilder<R> enumeration(String name) {
       return EnumBuilder.create(context, names, name);
     }
@@ -1238,49 +1382,65 @@ public class SchemaBuilder {
      *     ]}
      *   ]}
      * </pre>
-     **/
+     *
+     * @param name The name of the field
+     * @return {@link RecordBuilder}
+     */
     public final RecordBuilder<R> record(String name) {
       return RecordBuilder.create(context, names, name);
     }
 
     /** Build an Avro union schema type. Example usage:
      * <pre>unionOf().stringType().and().bytesType().endUnion()</pre>
-     **/
+     *
+     * @return {@link BaseTypeBuilder}
+     */
     protected BaseTypeBuilder<UnionAccumulator<R>> unionOf() {
       return UnionBuilder.create(context, names);
     }
 
     /** A shortcut for building a union of a type and null.
-     * <p/>
+     * <br>
      * For example, the code snippets below are equivalent:
      * <pre>nullable().booleanType()</pre>
      * <pre>unionOf().booleanType().and().nullType().endUnion()</pre>
-     **/
+     *
+     * @return {@link BaseTypeBuilder}
+     */
     protected BaseTypeBuilder<R> nullable() {
       return new BaseTypeBuilder<>(new NullableCompletion<>(context), names);
     }
 
   }
 
-  /** A Builder for creating any Avro schema type.
-   **/
+  /**
+   * A Builder for creating any Avro schema type.
+   */
   public static final class TypeBuilder<R> extends BaseTypeBuilder<R> {
     private TypeBuilder(Completion<R> context, NameContext names) {
       super(context, names);
     }
 
+    /**
+     * @return {@link BaseTypeBuilder}
+     */
     @Override
     public BaseTypeBuilder<UnionAccumulator<R>> unionOf() {
       return super.unionOf();
     }
 
+    /**
+     * @return {@link BaseTypeBuilder}
+     */
     @Override
     public BaseTypeBuilder<R> nullable() {
       return super.nullable();
     }
   }
 
-  /** A special builder for unions.  Unions cannot nest unions directly **/
+  /**
+   * A special builder for unions.  Unions cannot nest unions directly
+   */
   private static final class UnionBuilder<R> extends
       BaseTypeBuilder<UnionAccumulator<R>> {
     private UnionBuilder(Completion<R> context, NameContext names) {
@@ -1300,11 +1460,11 @@ public class SchemaBuilder {
    * A special Builder for Record fields. The API is very similar to
    * {@link BaseTypeBuilder}. However, fields have their own names, properties,
    * and default values.
-   * <p/>
+   * <br>
    * The methods on this class create builder instances that return their
    * control to the {@link FieldAssembler} of the enclosing record context after
    * configuring a default for the field.
-   * <p/>
+   * <br>
    * For example, an int field with default value 1:
    * <pre>
    * intSimple().withDefault(1);
@@ -1330,6 +1490,8 @@ public class SchemaBuilder {
      * <pre>
      * booleanBuilder().endBoolean();
      * </pre>
+     *
+     * @return {@link BooleanDefault}
      */
     public final BooleanDefault<R> booleanType() {
       return booleanBuilder().endBoolean();
@@ -1338,6 +1500,8 @@ public class SchemaBuilder {
     /**
      * Build a boolean type that can set custom properties. If custom properties
      * are not needed it is simpler to use {@link #booleanType()}.
+     *
+     * @return {@link BooleanBuilder}
      */
     public final BooleanBuilder<BooleanDefault<R>> booleanBuilder() {
       return BooleanBuilder.create(wrap(new BooleanDefault<>(bldr)), names);
@@ -1348,6 +1512,8 @@ public class SchemaBuilder {
      * <pre>
      * intBuilder().endInt();
      * </pre>
+     *
+     * @return {@link IntDefault}
      */
     public final IntDefault<R> intType() {
       return intBuilder().endInt();
@@ -1356,6 +1522,8 @@ public class SchemaBuilder {
     /**
      * Build an int type that can set custom properties. If custom properties
      * are not needed it is simpler to use {@link #intType()}.
+     *
+     * @return {@link IntBuilder}
      */
     public final IntBuilder<IntDefault<R>> intBuilder() {
       return IntBuilder.create(wrap(new IntDefault<>(bldr)), names);
@@ -1366,6 +1534,8 @@ public class SchemaBuilder {
      * <pre>
      * longBuilder().endLong();
      * </pre>
+     *
+     * @return {@link LongDefault}
      */
     public final LongDefault<R> longType() {
       return longBuilder().endLong();
@@ -1374,6 +1544,8 @@ public class SchemaBuilder {
     /**
      * Build a long type that can set custom properties. If custom properties
      * are not needed it is simpler to use {@link #longType()}.
+     *
+     * @return {@link LongBuilder}
      */
     public final LongBuilder<LongDefault<R>> longBuilder() {
       return LongBuilder.create(wrap(new LongDefault<>(bldr)), names);
@@ -1384,6 +1556,8 @@ public class SchemaBuilder {
      * <pre>
      * floatBuilder().endFloat();
      * </pre>
+     *
+     * @return {@link FloatDefault}
      */
     public final FloatDefault<R> floatType() {
       return floatBuilder().endFloat();
@@ -1392,6 +1566,8 @@ public class SchemaBuilder {
     /**
      * Build a float type that can set custom properties. If custom properties
      * are not needed it is simpler to use {@link #floatType()}.
+     *
+     * @return {@link FloatBuilder}
      */
     public final FloatBuilder<FloatDefault<R>> floatBuilder() {
       return FloatBuilder.create(wrap(new FloatDefault<>(bldr)), names);
@@ -1402,6 +1578,8 @@ public class SchemaBuilder {
      * <pre>
      * doubleBuilder().endDouble();
      * </pre>
+     *
+     * @return {@link DoubleDefault}
      */
     public final DoubleDefault<R> doubleType() {
       return doubleBuilder().endDouble();
@@ -1410,6 +1588,8 @@ public class SchemaBuilder {
     /**
      * Build a double type that can set custom properties. If custom properties
      * are not needed it is simpler to use {@link #doubleType()}.
+     *
+     * @return {@link DoubleBuilder}
      */
     public final DoubleBuilder<DoubleDefault<R>> doubleBuilder() {
       return DoubleBuilder.create(wrap(new DoubleDefault<>(bldr)), names);
@@ -1420,6 +1600,8 @@ public class SchemaBuilder {
      * <pre>
      * stringBuilder().endString();
      * </pre>
+     *
+     * @return {@link StringDefault}
      */
     public final StringDefault<R> stringType() {
       return stringBuilder().endString();
@@ -1428,6 +1610,8 @@ public class SchemaBuilder {
     /**
      * Build a string type that can set custom properties. If custom properties
      * are not needed it is simpler to use {@link #stringType()}.
+     *
+     * @return {@link StringBldr}
      */
     public final StringBldr<StringDefault<R>> stringBuilder() {
       return StringBldr.create(wrap(new StringDefault<>(bldr)), names);
@@ -1438,6 +1622,8 @@ public class SchemaBuilder {
      * <pre>
      * bytesBuilder().endBytes();
      * </pre>
+     *
+     * @return {@link BytesDefault}
      */
     public final BytesDefault<R> bytesType() {
       return bytesBuilder().endBytes();
@@ -1446,6 +1632,8 @@ public class SchemaBuilder {
     /**
      * Build a bytes type that can set custom properties. If custom properties
      * are not needed it is simpler to use {@link #bytesType()}.
+     *
+     * @return {@link BytesBuilder}
      */
     public final BytesBuilder<BytesDefault<R>> bytesBuilder() {
       return BytesBuilder.create(wrap(new BytesDefault<>(bldr)), names);
@@ -1456,6 +1644,8 @@ public class SchemaBuilder {
      * <pre>
      * nullBuilder().endNull();
      * </pre>
+     *
+     * @return {@link NullDefault}
      */
     public final NullDefault<R> nullType() {
       return nullBuilder().endNull();
@@ -1464,32 +1654,57 @@ public class SchemaBuilder {
     /**
      * Build a null type that can set custom properties. If custom properties
      * are not needed it is simpler to use {@link #nullType()}.
+     *
+     * @return {@link NullBuilder}
      */
     public final NullBuilder<NullDefault<R>> nullBuilder() {
       return NullBuilder.create(wrap(new NullDefault<>(bldr)), names);
     }
 
-    /** Build an Avro map type **/
+    /**
+     * Build an Avro map type
+     *
+     * @return {@link MapBuilder}
+     */
     public final MapBuilder<MapDefault<R>> map() {
       return MapBuilder.create(wrap(new MapDefault<>(bldr)), names);
     }
 
-    /** Build an Avro array type **/
+    /**
+     * Build an Avro array type
+     *
+     * @return {@link ArrayBuilder}
+     */
     public final ArrayBuilder<ArrayDefault<R>> array() {
       return ArrayBuilder.create(wrap(new ArrayDefault<>(bldr)), names);
     }
 
-    /** Build an Avro fixed type. **/
+    /**
+     * Build an Avro fixed type
+     *
+     * @param name The name of the type
+     * @return {@link FixedBuilder}
+     */
     public final FixedBuilder<FixedDefault<R>> fixed(String name) {
       return FixedBuilder.create(wrap(new FixedDefault<>(bldr)), names, name);
     }
 
-    /** Build an Avro enum type. **/
+    /**
+     * Build an Avro enum type.
+     *
+     * @param name The name of the enumeration
+     * @return {@link EnumBuilder}
+     */
     public final EnumBuilder<EnumDefault<R>> enumeration(String name) {
       return EnumBuilder.create(wrap(new EnumDefault<>(bldr)), names, name);
     }
 
-    /** Build an Avro record type. **/
+    /**
+     * Build an Avro record type.
+     *
+     * @param name The name of the record
+     * @return {@link RecordBuilder}
+     */
     public final RecordBuilder<RecordDefault<R>> record(String name) {
       return RecordBuilder.create(wrap(new RecordDefault<>(bldr)), names, name);
     }
@@ -1503,14 +1718,20 @@ public class SchemaBuilder {
     }
   }
 
-  /** FieldTypeBuilder adds {@link #unionOf()}, {@link #nullable()}, and {@link #optional()}
-   * to BaseFieldTypeBuilder. **/
+  /**
+   * FieldTypeBuilder adds {@link #unionOf()}, {@link #nullable()}, and {@link #optional()}
+   * to BaseFieldTypeBuilder.
+   */
   public static final class FieldTypeBuilder<R> extends BaseFieldTypeBuilder<R> {
     private FieldTypeBuilder(FieldBuilder<R> bldr) {
       super(bldr, null);
     }
 
-    /** Build an Avro union schema type. **/
+    /**
+     * Build an Avro union schema type.
+     *
+     * @return UnionFieldTypeBuilder
+     */
     public UnionFieldTypeBuilder<R> unionOf() {
       return new UnionFieldTypeBuilder<>(bldr);
     }
@@ -1518,21 +1739,25 @@ public class SchemaBuilder {
     /**
      * A shortcut for building a union of a type and null, with an optional default
      * value of the non-null type.
-     * <p/>
+     * <br>
      * For example, the two code snippets below are equivalent:
      * <pre>nullable().booleanType().booleanDefault(true)</pre>
      * <pre>unionOf().booleanType().and().nullType().endUnion().booleanDefault(true)</pre>
-     **/
+     *
+     * @return BaseFieldTypeBuilder
+     */
     public BaseFieldTypeBuilder<R> nullable() {
       return new BaseFieldTypeBuilder<>(bldr, new NullableCompletionWrapper());
     }
 
     /**
      * A shortcut for building a union of null and a type, with a null default.
-     * <p/>
+     * <br>
      * For example, the two code snippets below are equivalent:
      * <pre>optional().booleanType()</pre>
      * <pre>unionOf().nullType().and().booleanType().endUnion().nullDefault()</pre>
+     *
+     * @return BaseTypeBuilder
      */
     public BaseTypeBuilder<FieldAssembler<R>> optional() {
       return new BaseTypeBuilder<>(
@@ -1557,6 +1782,8 @@ public class SchemaBuilder {
      * <pre>
      * booleanBuilder().endBoolean();
      * </pre>
+     *
+     * @return UnionAccumulator
      */
     public UnionAccumulator<BooleanDefault<R>> booleanType() {
       return booleanBuilder().endBoolean();
@@ -1565,6 +1792,8 @@ public class SchemaBuilder {
     /**
      * Build a boolean type that can set custom properties. If custom properties
      * are not needed it is simpler to use {@link #booleanType()}.
+     *
+     * @return BooleanBuilder
      */
     public BooleanBuilder<UnionAccumulator<BooleanDefault<R>>> booleanBuilder() {
       return BooleanBuilder.create(completion(new BooleanDefault<>(bldr)), names);
@@ -1575,6 +1804,8 @@ public class SchemaBuilder {
      * <pre>
      * intBuilder().endInt();
      * </pre>
+     *
+     * @return UnionAccumulator
      */
     public UnionAccumulator<IntDefault<R>> intType() {
       return intBuilder().endInt();
@@ -1583,6 +1814,8 @@ public class SchemaBuilder {
     /**
      * Build an int type that can set custom properties. If custom properties
      * are not needed it is simpler to use {@link #intType()}.
+     *
+     * @return IntBuilder
      */
     public IntBuilder<UnionAccumulator<IntDefault<R>>> intBuilder() {
       return IntBuilder.create(completion(new IntDefault<>(bldr)), names);
@@ -1593,6 +1826,8 @@ public class SchemaBuilder {
      * <pre>
      * longBuilder().endLong();
      * </pre>
+     *
+     * @return UnionAccumulator
      */
     public UnionAccumulator<LongDefault<R>> longType() {
       return longBuilder().endLong();
@@ -1601,6 +1836,8 @@ public class SchemaBuilder {
     /**
      * Build a long type that can set custom properties. If custom properties
      * are not needed it is simpler to use {@link #longType()}.
+     *
+     * @return LongBuilder
      */
     public LongBuilder<UnionAccumulator<LongDefault<R>>> longBuilder() {
       return LongBuilder.create(completion(new LongDefault<>(bldr)), names);
@@ -1611,6 +1848,8 @@ public class SchemaBuilder {
      * <pre>
      * floatBuilder().endFloat();
      * </pre>
+     *
+     * @return UnionAccumulator
      */
     public UnionAccumulator<FloatDefault<R>> floatType() {
       return floatBuilder().endFloat();
@@ -1619,6 +1858,8 @@ public class SchemaBuilder {
     /**
      * Build a float type that can set custom properties. If custom properties
      * are not needed it is simpler to use {@link #floatType()}.
+     *
+     * @return FloatBuilder
      */
     public FloatBuilder<UnionAccumulator<FloatDefault<R>>> floatBuilder() {
       return FloatBuilder.create(completion(new FloatDefault<>(bldr)), names);
@@ -1629,6 +1870,8 @@ public class SchemaBuilder {
      * <pre>
      * doubleBuilder().endDouble();
      * </pre>
+     *
+     * @return UnionAccumulator
      */
     public UnionAccumulator<DoubleDefault<R>> doubleType() {
       return doubleBuilder().endDouble();
@@ -1637,6 +1880,8 @@ public class SchemaBuilder {
     /**
      * Build a double type that can set custom properties. If custom properties
      * are not needed it is simpler to use {@link #doubleType()}.
+     *
+     * @return DoubleBuilder
      */
     public DoubleBuilder<UnionAccumulator<DoubleDefault<R>>> doubleBuilder() {
       return DoubleBuilder.create(completion(new DoubleDefault<>(bldr)), names);
@@ -1647,6 +1892,8 @@ public class SchemaBuilder {
      * <pre>
      * stringBuilder().endString();
      * </pre>
+     *
+     * @return UnionAccumulator
      */
     public UnionAccumulator<StringDefault<R>> stringType() {
       return stringBuilder().endString();
@@ -1655,6 +1902,8 @@ public class SchemaBuilder {
     /**
      * Build a string type that can set custom properties. If custom properties
      * are not needed it is simpler to use {@link #stringType()}.
+     *
+     * @return StringBldr
      */
     public StringBldr<UnionAccumulator<StringDefault<R>>> stringBuilder() {
       return StringBldr.create(completion(new StringDefault<>(bldr)), names);
@@ -1665,6 +1914,8 @@ public class SchemaBuilder {
      * <pre>
      * bytesBuilder().endBytes();
      * </pre>
+     *
+     * @return UnionAccumulator
      */
     public UnionAccumulator<BytesDefault<R>> bytesType() {
       return bytesBuilder().endBytes();
@@ -1673,6 +1924,8 @@ public class SchemaBuilder {
     /**
      * Build a bytes type that can set custom properties. If custom properties
      * are not needed it is simpler to use {@link #bytesType()}.
+     *
+     * @return BytesBuilder
      */
     public BytesBuilder<UnionAccumulator<BytesDefault<R>>> bytesBuilder() {
       return BytesBuilder.create(completion(new BytesDefault<>(bldr)), names);
@@ -1683,6 +1936,8 @@ public class SchemaBuilder {
      * <pre>
      * nullBuilder().endNull();
      * </pre>
+     *
+     * @return UnionAccumulator
      */
     public UnionAccumulator<NullDefault<R>> nullType() {
       return nullBuilder().endNull();
@@ -1691,36 +1946,65 @@ public class SchemaBuilder {
     /**
      * Build a null type that can set custom properties. If custom properties
      * are not needed it is simpler to use {@link #nullType()}.
+     *
+     * @return NullBuilder
      */
     public NullBuilder<UnionAccumulator<NullDefault<R>>> nullBuilder() {
       return NullBuilder.create(completion(new NullDefault<>(bldr)), names);
     }
 
-    /** Build an Avro map type **/
+    /**
+     * Build an Avro map type
+     *
+     * @return MapBuilder
+     */
     public MapBuilder<UnionAccumulator<MapDefault<R>>> map() {
       return MapBuilder.create(completion(new MapDefault<>(bldr)), names);
     }
 
-    /** Build an Avro array type **/
+    /**
+     * Build an Avro array type
+     *
+     * @return ArrayBuilder
+     */
     public ArrayBuilder<UnionAccumulator<ArrayDefault<R>>> array() {
       return ArrayBuilder.create(completion(new ArrayDefault<>(bldr)), names);
     }
 
-    /** Build an Avro fixed type. **/
+    /**
+     * Build an Avro fixed type.
+     *
+     * @param name The name of the type
+     * @return {@link FixedBuilder}
+     */
     public FixedBuilder<UnionAccumulator<FixedDefault<R>>> fixed(String name) {
       return FixedBuilder.create(completion(new FixedDefault<>(bldr)), names, name);
     }
 
-    /** Build an Avro enum type. **/
+    /**
+     * Build an Avro enum type.
+     *
+     * @param name The name of the type
+     * @return EnumBuilder
+     */
     public EnumBuilder<UnionAccumulator<EnumDefault<R>>> enumeration(String name) {
       return EnumBuilder.create(completion(new EnumDefault<>(bldr)), names, name);
     }
 
-    /** Build an Avro record type. **/
+    /**
+     * Build an Avro record type.
+     *
+     * @param name The name of the type
+     * @return RecordBuilder
+     */
     public RecordBuilder<UnionAccumulator<RecordDefault<R>>> record(String name) {
       return RecordBuilder.create(completion(new RecordDefault<>(bldr)), names, name);
     }
 
+    /**
+     * @param context The completion context
+     * @return A completed UnionCompletion
+     */
     private <C> UnionCompletion<C> completion(Completion<C> context) {
       return new UnionCompletion<>(context, names, new ArrayList<>());
     }
@@ -1742,6 +2026,9 @@ public class SchemaBuilder {
       return this;
     }
 
+    /**
+     * @return FieldAssembler
+     */
     public FieldAssembler<R> fields() {
       Schema record = Schema.createRecord(name(), doc(), space(), false);
       // place the record in the name context, fields yet to be set.
@@ -1765,6 +2052,7 @@ public class SchemaBuilder {
 
     /**
      * Add a field with the given name.
+     * @param fieldName The fieldname of the builder
      * @return A {@link FieldBuilder} for the given name.
      */
     public FieldBuilder<R> name(String fieldName) {
@@ -1773,10 +2061,12 @@ public class SchemaBuilder {
 
     /**
      * Shortcut for creating a boolean field with the given name and no default.
-     * <p/>This is equivalent to:
+     * <br>This is equivalent to:
      * <pre>
      *   name(fieldName).type().booleanType().noDefault()
      * </pre>
+     * @param fieldName The fieldname of the builder
+     * @return A {@link FieldAssembler} for the given name.
      */
     public FieldAssembler<R> requiredBoolean(String fieldName) {
       return name(fieldName).type().booleanType().noDefault();
@@ -1784,11 +2074,14 @@ public class SchemaBuilder {
 
     /**
      * Shortcut for creating an optional boolean field: a union of null and
-     * boolean with null default.<p/>
+     * boolean with null default.<br>
      * This is equivalent to:
      * <pre>
      *   name(fieldName).type().optional().booleanType()
      * </pre>
+     *
+     * @param fieldName The fieldname of the builder
+     * @return A {@link FieldAssembler} for the given name, if available
      */
     public FieldAssembler<R> optionalBoolean(String fieldName) {
       return name(fieldName).type().optional().booleanType();
@@ -1797,12 +2090,16 @@ public class SchemaBuilder {
     /**
      * Shortcut for creating a nullable boolean field: a union of boolean and
      * null with an boolean default.
-     * <p/>
+     * <br>
      * This is equivalent to:
      *
      * <pre>
      * name(fieldName).type().nullable().booleanType().booleanDefault(defaultVal)
      * </pre>
+     *
+     * @param fieldName The fieldname of the builder
+     * @param defaultVal The default value
+     * @return A {@link FieldAssembler} for the given name, if available
      */
     public FieldAssembler<R> nullableBoolean(String fieldName, boolean defaultVal) {
       return name(fieldName)
@@ -1811,10 +2108,13 @@ public class SchemaBuilder {
 
     /**
      * Shortcut for creating an int field with the given name and no default.
-     * <p/>This is equivalent to:
+     * <br>This is equivalent to:
      * <pre>
      *   name(fieldName).type().intType().noDefault()
      * </pre>
+     *
+     * @param fieldName The fieldname of the builder
+     * @return A {@link FieldAssembler} for the given name, if available
      */
     public FieldAssembler<R> requiredInt(String fieldName) {
       return name(fieldName).type().intType().noDefault();
@@ -1822,11 +2122,14 @@ public class SchemaBuilder {
 
     /**
      * Shortcut for creating an optional int field: a union of null and int
-     * with null default.<p/>
+     * with null default.<br>
      * This is equivalent to:
      * <pre>
      *   name(fieldName).type().optional().intType()
      * </pre>
+     *
+     * @param fieldName The fieldname of the builder
+     * @return A {@link FieldAssembler} for the given name, if available
      */
     public FieldAssembler<R> optionalInt(String fieldName) {
       return name(fieldName).type().optional().intType();
@@ -1834,11 +2137,15 @@ public class SchemaBuilder {
 
     /**
      * Shortcut for creating a nullable int field: a union of int and null
-     * with an int default.<p/>
+     * with an int default.<br>
      * This is equivalent to:
      * <pre>
      *   name(fieldName).type().nullable().intType().intDefault(defaultVal)
      * </pre>
+     *
+     * @param fieldName The fieldname of the builder
+     * @param defaultVal The default value
+     * @return A {@link FieldAssembler} for the given name, if available
      */
     public FieldAssembler<R> nullableInt(String fieldName, int defaultVal) {
       return name(fieldName).type().nullable().intType().intDefault(defaultVal);
@@ -1846,10 +2153,13 @@ public class SchemaBuilder {
 
     /**
      * Shortcut for creating a long field with the given name and no default.
-     * <p/>This is equivalent to:
+     * <br>This is equivalent to:
      * <pre>
      *   name(fieldName).type().longType().noDefault()
      * </pre>
+     *
+     * @param fieldName The fieldname of the builder
+     * @return A {@link FieldAssembler} for the given name, if available
      */
     public FieldAssembler<R> requiredLong(String fieldName) {
       return name(fieldName).type().longType().noDefault();
@@ -1857,11 +2167,14 @@ public class SchemaBuilder {
 
     /**
      * Shortcut for creating an optional long field: a union of null and long
-     * with null default.<p/>
+     * with null default.<br>
      * This is equivalent to:
      * <pre>
      *   name(fieldName).type().optional().longType()
      * </pre>
+     *
+     * @param fieldName The fieldname of the builder
+     * @return A {@link FieldAssembler} for the given name, if available
      */
     public FieldAssembler<R> optionalLong(String fieldName) {
       return name(fieldName).type().optional().longType();
@@ -1869,11 +2182,15 @@ public class SchemaBuilder {
 
     /**
      * Shortcut for creating a nullable long field: a union of long and null
-     * with a long default.<p/>
+     * with a long default.<br>
      * This is equivalent to:
      * <pre>
      *   name(fieldName).type().nullable().longType().longDefault(defaultVal)
      * </pre>
+     *
+     * @param fieldName The fieldname of the builder
+     * @param defaultVal The default value
+     * @return A {@link FieldAssembler} for the given name, if available
      */
     public FieldAssembler<R> nullableLong(String fieldName, long defaultVal) {
       return name(fieldName).type().nullable().longType().longDefault(defaultVal);
@@ -1881,10 +2198,13 @@ public class SchemaBuilder {
 
     /**
      * Shortcut for creating a float field with the given name and no default.
-     * <p/>This is equivalent to:
+     * <br>This is equivalent to:
      * <pre>
      *   name(fieldName).type().floatType().noDefault()
      * </pre>
+     *
+     * @param fieldName The fieldname of the builder
+     * @return A {@link FieldAssembler} for the given name, if available
      */
     public FieldAssembler<R> requiredFloat(String fieldName) {
       return name(fieldName).type().floatType().noDefault();
@@ -1892,11 +2212,14 @@ public class SchemaBuilder {
 
     /**
      * Shortcut for creating an optional float field: a union of null and float
-     * with null default.<p/>
+     * with null default.<br>
      * This is equivalent to:
      * <pre>
      *   name(fieldName).type().optional().floatType()
      * </pre>
+     *
+     * @param fieldName The fieldname of the builder
+     * @return A {@link FieldAssembler} for the given name, if available
      */
     public FieldAssembler<R> optionalFloat(String fieldName) {
       return name(fieldName).type().optional().floatType();
@@ -1904,11 +2227,15 @@ public class SchemaBuilder {
 
     /**
      * Shortcut for creating a nullable float field: a union of float and null
-     * with a float default.<p/>
+     * with a float default.<br>
      * This is equivalent to:
      * <pre>
      *   name(fieldName).type().nullable().floatType().floatDefault(defaultVal)
      * </pre>
+     *
+     * @param fieldName The fieldname of the builder
+     * @param defaultVal The default value
+     * @return A {@link FieldAssembler} for the given name, if available
      */
     public FieldAssembler<R> nullableFloat(String fieldName, float defaultVal) {
       return name(fieldName).type().nullable().floatType().floatDefault(defaultVal);
@@ -1916,10 +2243,13 @@ public class SchemaBuilder {
 
     /**
      * Shortcut for creating a double field with the given name and no default.
-     * <p/>This is equivalent to:
+     * <br>This is equivalent to:
      * <pre>
      *   name(fieldName).type().doubleType().noDefault()
      * </pre>
+     *
+     * @param fieldName The fieldname of the builder
+     * @return A {@link FieldAssembler} for the given name, if available
      */
     public FieldAssembler<R> requiredDouble(String fieldName) {
       return name(fieldName).type().doubleType().noDefault();
@@ -1927,11 +2257,14 @@ public class SchemaBuilder {
 
     /**
      * Shortcut for creating an optional double field: a union of null and double
-     * with null default.<p/>
+     * with null default.<br>
      * This is equivalent to:
      * <pre>
      *   name(fieldName).type().optional().doubleType()
      * </pre>
+     *
+     * @param fieldName The fieldname of the builder
+     * @return A {@link FieldAssembler} for the given name, if available
      */
     public FieldAssembler<R> optionalDouble(String fieldName) {
       return name(fieldName).type().optional().doubleType();
@@ -1939,11 +2272,15 @@ public class SchemaBuilder {
 
     /**
      * Shortcut for creating a nullable double field: a union of double and null
-     * with a double default.<p/>
+     * with a double default.<br>
      * This is equivalent to:
      * <pre>
      *   name(fieldName).type().nullable().doubleType().doubleDefault(defaultVal)
      * </pre>
+     *
+     * @param fieldName The fieldname of the builder
+     * @param defaultVal The default value
+     * @return A {@link FieldAssembler} for the given name, if available
      */
     public FieldAssembler<R> nullableDouble(String fieldName, double defaultVal) {
       return name(fieldName).type().nullable().doubleType().doubleDefault(defaultVal);
@@ -1951,10 +2288,13 @@ public class SchemaBuilder {
 
     /**
      * Shortcut for creating a string field with the given name and no default.
-     * <p/>This is equivalent to:
+     * <br>This is equivalent to:
      * <pre>
      *   name(fieldName).type().stringType().noDefault()
      * </pre>
+     *
+     * @param fieldName The fieldname of the builder
+     * @return A {@link FieldAssembler} for the given name, if available
      */
     public FieldAssembler<R> requiredString(String fieldName) {
       return name(fieldName).type().stringType().noDefault();
@@ -1962,11 +2302,14 @@ public class SchemaBuilder {
 
     /**
      * Shortcut for creating an optional string field: a union of null and string
-     * with null default.<p/>
+     * with null default.<br>
      * This is equivalent to:
      * <pre>
      *   name(fieldName).type().optional().stringType()
      * </pre>
+     *
+     * @param fieldName The fieldname of the builder
+     * @return A {@link FieldAssembler} for the given name, if available
      */
     public FieldAssembler<R> optionalString(String fieldName) {
       return name(fieldName).type().optional().stringType();
@@ -1974,11 +2317,15 @@ public class SchemaBuilder {
 
     /**
      * Shortcut for creating a nullable string field: a union of string and null
-     * with a string default.<p/>
+     * with a string default.<br>
      * This is equivalent to:
      * <pre>
      *   name(fieldName).type().nullable().stringType().stringDefault(defaultVal)
      * </pre>
+     *
+     * @param fieldName The fieldname of the builder
+     * @param defaultVal The default value
+     * @return A {@link FieldAssembler} for the given name, if available
      */
     public FieldAssembler<R> nullableString(String fieldName, String defaultVal) {
       return name(fieldName).type().nullable().stringType().stringDefault(defaultVal);
@@ -1986,10 +2333,13 @@ public class SchemaBuilder {
 
     /**
      * Shortcut for creating a bytes field with the given name and no default.
-     * <p/>This is equivalent to:
+     * <br>This is equivalent to:
      * <pre>
      *   name(fieldName).type().bytesType().noDefault()
      * </pre>
+     *
+     * @param fieldName The fieldname of the builder
+     * @return A {@link FieldAssembler} for the given name, if available
      */
     public FieldAssembler<R> requiredBytes(String fieldName) {
       return name(fieldName).type().bytesType().noDefault();
@@ -1997,11 +2347,14 @@ public class SchemaBuilder {
 
     /**
      * Shortcut for creating an optional bytes field: a union of null and bytes
-     * with null default.<p/>
+     * with null default.<br>
      * This is equivalent to:
      * <pre>
      *   name(fieldName).type().optional().bytesType()
      * </pre>
+     *
+     * @param fieldName The fieldname of the builder
+     * @return A {@link FieldAssembler} for the given name, if available
      */
     public FieldAssembler<R> optionalBytes(String fieldName) {
       return name(fieldName).type().optional().bytesType();
@@ -2009,11 +2362,15 @@ public class SchemaBuilder {
 
     /**
      * Shortcut for creating a nullable bytes field: a union of bytes and null
-     * with a bytes default.<p/>
+     * with a bytes default.<br>
      * This is equivalent to:
      * <pre>
      *   name(fieldName).type().nullable().bytesType().bytesDefault(defaultVal)
      * </pre>
+     *
+     * @param fieldName The fieldname of the builder
+     * @param defaultVal The default value
+     * @return A {@link FieldAssembler} for the given name, if available
      */
     public FieldAssembler<R> nullableBytes(String fieldName, byte[] defaultVal) {
       return name(fieldName).type().nullable().bytesType().bytesDefault(defaultVal);
@@ -2022,6 +2379,8 @@ public class SchemaBuilder {
     /**
      * End adding fields to this record, returning control
      * to the context that this record builder was created in.
+     *
+     * @return The closed record
      */
     public R endRecord() {
       record.setFields(fields);
@@ -2055,19 +2414,28 @@ public class SchemaBuilder {
       this.fields = fields;
     }
 
-    /** Set this field to have ascending order.  Ascending is the default **/
+    /**
+     * Set this field to have ascending order.  Ascending is the default
+     * @return {@link FieldBuilder}
+     */
     public FieldBuilder<R> orderAscending() {
       order = Schema.Field.Order.ASCENDING;
       return self();
     }
 
-    /** Set this field to have descending order.  Descending is the default **/
+    /**
+     * Set this field to have descending order.  Descending is the default
+     * @return {@link FieldBuilder}
+     */
     public FieldBuilder<R> orderDescending() {
       order = Schema.Field.Order.DESCENDING;
       return self();
     }
 
-    /** Set this field to ignore order.  **/
+    /**
+     * Set this field to ignore order.
+     * @return {@link FieldBuilder}
+     */
     public FieldBuilder<R> orderIgnore() {
       order = Schema.Field.Order.IGNORE;
       return self();
@@ -2086,6 +2454,9 @@ public class SchemaBuilder {
      * Final step in configuring this field, finalizing name, namespace, alias,
      * and order.  Sets the field's type to the provided schema, returns a
      * {@link GenericDefault}.
+     *
+     * @param type The type of the schema
+     * @return {@link GenericDefault}
      */
     public GenericDefault<R> type(Schema type) {
       return new GenericDefault<>(this, type);
@@ -2094,14 +2465,17 @@ public class SchemaBuilder {
     /**
      * Final step in configuring this field, finalizing name, namespace, alias,
      * and order. Sets the field's type to the schema by name reference.
-     * <p/>
+     * <br>
      * The name must correspond with a named schema that has already been
      * created in the context of this builder. The name may be a fully qualified
      * name, or a short name. If it is a short name, the namespace context of
      * this builder will be used.
-     * <p/>
+     * <br>
      * The name and namespace context rules are the same as the Avro schema JSON
      * specification.
+     *
+     * @param name The name of the schema
+     * @return {@link GenericDefault}
      */
     public GenericDefault<R> type(String name) {
       return type(name, null);
@@ -2110,15 +2484,19 @@ public class SchemaBuilder {
     /**
      * Final step in configuring this field, finalizing name, namespace, alias,
      * and order. Sets the field's type to the schema by name reference.
-     * <p/>
+     * <br>
      * The name must correspond with a named schema that has already been
      * created in the context of this builder. The name may be a fully qualified
      * name, or a short name. If it is a full name, the namespace is ignored. If
      * it is a short name, the namespace provided is used. If the namespace
      * provided is null, the namespace context of this builder will be used.
-     * <p/>
+     * <br>
      * The name and namespace context rules are the same as the Avro schema JSON
      * specification.
+     *
+     * @param name The name of the schema
+     * @param namespace The namespace of the schema
+     * @return {@link GenericDefault}
      */
     public GenericDefault<R> type(String name, String namespace) {
       Schema schema = names().get(name, namespace);
@@ -2147,7 +2525,7 @@ public class SchemaBuilder {
     }
   }
 
-  /** Abstract base class for field defaults. **/
+  /** Abstract base class for field defaults. */
   public static abstract class FieldDefault<R, S extends FieldDefault<R, S>> extends Completion<S> {
     private final FieldBuilder<R> field;
     private Schema schema;
@@ -2155,7 +2533,10 @@ public class SchemaBuilder {
       this.field = field;
     }
 
-    /** Completes this field with no default value **/
+    /**
+     * Completes this field with no default value
+     * @return {@link FieldAssembler}
+     */
     public final FieldAssembler<R> noDefault() {
       return field.completeField(schema);
     }
@@ -2173,13 +2554,17 @@ public class SchemaBuilder {
     abstract S self();
   }
 
-  /** Choose whether to use a default value for the field or not. **/
+  /** Choose whether to use a default value for the field or not. */
   public static class BooleanDefault<R> extends FieldDefault<R, BooleanDefault<R>> {
     private BooleanDefault(FieldBuilder<R> field) {
       super(field);
     }
 
-    /** Completes this field with the default value provided **/
+    /**
+     * Completes this field with the default value provided
+     * @param defaultVal Default value
+     * @return {@link FieldAssembler}
+     */
     public final FieldAssembler<R> booleanDefault(boolean defaultVal) {
       return super.usingDefault(defaultVal);
     }
@@ -2190,13 +2575,17 @@ public class SchemaBuilder {
     }
   }
 
-  /** Choose whether to use a default value for the field or not. **/
+  /** Choose whether to use a default value for the field or not. */
   public static class IntDefault<R> extends FieldDefault<R, IntDefault<R>> {
     private IntDefault(FieldBuilder<R> field) {
       super(field);
     }
 
-    /** Completes this field with the default value provided **/
+    /**
+     * Completes this field with the default value provided
+     * @param defaultVal Default value
+     * @return {@link FieldAssembler}
+     */
     public final FieldAssembler<R> intDefault(int defaultVal) {
       return super.usingDefault(defaultVal);
     }
@@ -2207,13 +2596,17 @@ public class SchemaBuilder {
     }
   }
 
-  /** Choose whether to use a default value for the field or not. **/
+  /** Choose whether to use a default value for the field or not. */
   public static class LongDefault<R> extends FieldDefault<R, LongDefault<R>> {
     private LongDefault(FieldBuilder<R> field) {
       super(field);
     }
 
-    /** Completes this field with the default value provided **/
+    /**
+     * Completes this field with the default value provided
+     * @param defaultVal Default value
+     * @return {@link FieldAssembler}
+     */
     public final FieldAssembler<R> longDefault(long defaultVal) {
       return super.usingDefault(defaultVal);
     }
@@ -2224,13 +2617,17 @@ public class SchemaBuilder {
     }
   }
 
-  /** Choose whether to use a default value for the field or not. **/
+  /** Choose whether to use a default value for the field or not. */
   public static class FloatDefault<R> extends FieldDefault<R, FloatDefault<R>> {
     private FloatDefault(FieldBuilder<R> field) {
       super(field);
     }
 
-    /** Completes this field with the default value provided **/
+    /**
+     * Completes this field with the default value provided
+     * @param defaultVal Default value
+     * @return {@link FieldAssembler}
+     */
     public final FieldAssembler<R> floatDefault(float defaultVal) {
       return super.usingDefault(defaultVal);
     }
@@ -2241,13 +2638,17 @@ public class SchemaBuilder {
     }
   }
 
-  /** Choose whether to use a default value for the field or not. **/
+  /** Choose whether to use a default value for the field or not. */
   public static class DoubleDefault<R> extends FieldDefault<R, DoubleDefault<R>> {
     private DoubleDefault(FieldBuilder<R> field) {
       super(field);
     }
 
-    /** Completes this field with the default value provided **/
+    /**
+     * Completes this field with the default value provided
+     * @param defaultVal Default value
+     * @return {@link FieldAssembler}
+     */
     public final FieldAssembler<R> doubleDefault(double defaultVal) {
       return super.usingDefault(defaultVal);
     }
@@ -2258,13 +2659,17 @@ public class SchemaBuilder {
     }
   }
 
-  /** Choose whether to use a default value for the field or not. **/
+  /** Choose whether to use a default value for the field or not. */
   public static class StringDefault<R> extends FieldDefault<R, StringDefault<R>> {
     private StringDefault(FieldBuilder<R> field) {
       super(field);
     }
 
-    /** Completes this field with the default value provided. Cannot be null. **/
+    /**
+     * Completes this field with the default value provided. Cannot be null.
+     * @param defaultVal Default value
+     * @return {@link FieldAssembler}
+     */
     public final FieldAssembler<R> stringDefault(String defaultVal) {
       return super.usingDefault(defaultVal);
     }
@@ -2275,25 +2680,37 @@ public class SchemaBuilder {
     }
   }
 
-  /** Choose whether to use a default value for the field or not. **/
+  /** Choose whether to use a default value for the field or not. */
   public static class BytesDefault<R> extends FieldDefault<R, BytesDefault<R>> {
     private BytesDefault(FieldBuilder<R> field) {
       super(field);
     }
 
-    /** Completes this field with the default value provided, cannot be null **/
+    /**
+     * Completes this field with the default value provided, cannot be null
+     * @param defaultVal Default value
+     * @return {@link FieldAssembler}
+     */
     public final FieldAssembler<R> bytesDefault(byte[] defaultVal) {
       return super.usingDefault(ByteBuffer.wrap(defaultVal));
     }
 
-    /** Completes this field with the default value provided, cannot be null **/
+    /**
+     * Completes this field with the default value provided, cannot be null
+     * @param defaultVal Default value
+     * @return {@link FieldAssembler}
+     */
     public final FieldAssembler<R> bytesDefault(ByteBuffer defaultVal) {
       return super.usingDefault(defaultVal);
     }
 
-    /** Completes this field with the default value provided, cannot be null.
+    /**
+     * Completes this field with the default value provided, cannot be null.
      * The string is interpreted as a byte[], with each character code point
-     * value equalling the byte value, as in the Avro spec JSON default. **/
+     * value equalling the byte value, as in the Avro spec JSON default.
+     * @param defaultVal Default value
+     * @return {@link FieldAssembler}
+     */
     public final FieldAssembler<R> bytesDefault(String defaultVal) {
       return super.usingDefault(defaultVal);
     }
@@ -2304,13 +2721,16 @@ public class SchemaBuilder {
     }
   }
 
-  /** Choose whether to use a default value for the field or not. **/
+  /** Choose whether to use a default value for the field or not. */
   public static class NullDefault<R> extends FieldDefault<R, NullDefault<R>> {
     private NullDefault(FieldBuilder<R> field) {
       super(field);
     }
 
-    /** Completes this field with a default value of null **/
+    /**
+     * Completes this field with a default value of null
+     * @return {@link FieldAssembler}
+     */
     public final FieldAssembler<R> nullDefault() {
       return super.usingDefault(null);
     }
@@ -2321,13 +2741,19 @@ public class SchemaBuilder {
     }
   }
 
-  /** Choose whether to use a default value for the field or not. **/
+  /** Choose whether to use a default value for the field or not. */
   public static class MapDefault<R> extends FieldDefault<R, MapDefault<R>> {
     private MapDefault(FieldBuilder<R> field) {
       super(field);
     }
 
-    /** Completes this field with the default value provided, cannot be null **/
+    /**
+     * Completes this field with the default value provided, cannot be null
+     * @param <K> The key type
+     * @param <V> The value type
+     * @param defaultVal The default value
+     * @return {@link FieldAssembler}
+     */
     public final <K, V> FieldAssembler<R> mapDefault(Map<K, V> defaultVal) {
       return super.usingDefault(defaultVal);
     }
@@ -2338,13 +2764,19 @@ public class SchemaBuilder {
     }
   }
 
-  /** Choose whether to use a default value for the field or not. **/
+  /** Choose whether to use a default value for the field or not. */
   public static class ArrayDefault<R> extends FieldDefault<R, ArrayDefault<R>> {
     private ArrayDefault(FieldBuilder<R> field) {
       super(field);
     }
 
-    /** Completes this field with the default value provided, cannot be null **/
+    /**
+     * Completes this field with the default value provided, cannot be null
+     *
+     * @param <V> The field to construct
+     * @param defaultVal The default value
+     * @return {@link FieldAssembler}
+     */
     public final <V> FieldAssembler<R> arrayDefault(List<V> defaultVal) {
       return super.usingDefault(defaultVal);
     }
@@ -2355,25 +2787,39 @@ public class SchemaBuilder {
     }
   }
 
-  /** Choose whether to use a default value for the field or not. **/
+  /** Choose whether to use a default value for the field or not. */
   public static class FixedDefault<R> extends FieldDefault<R, FixedDefault<R>> {
     private FixedDefault(FieldBuilder<R> field) {
       super(field);
     }
 
-    /** Completes this field with the default value provided, cannot be null **/
+    /**
+     * Completes this field with the default value provided, cannot be null
+     *
+     * @param defaultVal The default value
+     * @return {@link FieldAssembler}
+     */
     public final FieldAssembler<R> fixedDefault(byte[] defaultVal) {
       return super.usingDefault(ByteBuffer.wrap(defaultVal));
     }
 
-    /** Completes this field with the default value provided, cannot be null **/
+    /**
+     * Completes this field with the default value provided, cannot be null
+     *
+     * @param defaultVal The default value
+     * @return {@link FieldAssembler}
+     */
     public final FieldAssembler<R> fixedDefault(ByteBuffer defaultVal) {
       return super.usingDefault(defaultVal);
     }
 
     /** Completes this field with the default value provided, cannot be null.
      * The string is interpreted as a byte[], with each character code point
-     * value equalling the byte value, as in the Avro spec JSON default. **/
+     * value equalling the byte value, as in the Avro spec JSON default.
+     *
+     * @param defaultVal The default value
+     * @return {@link FieldAssembler}
+     */
     public final FieldAssembler<R> fixedDefault(String defaultVal) {
       return super.usingDefault(defaultVal);
     }
@@ -2384,30 +2830,43 @@ public class SchemaBuilder {
     }
   }
 
-  /** Choose whether to use a default value for the field or not. **/
+  /** Choose whether to use a default value for the field or not. */
   public static class EnumDefault<R> extends FieldDefault<R, EnumDefault<R>> {
     private EnumDefault(FieldBuilder<R> field) {
       super(field);
     }
 
-    /** Completes this field with the default value provided, cannot be null **/
+    /**
+     * Completes this field with the default value provided, cannot be null
+     *
+     * @param defaultVal The default value
+     * @return {@link FieldAssembler}
+     */
     public final FieldAssembler<R> enumDefault(String defaultVal) {
       return super.usingDefault(defaultVal);
     }
 
+    /**
+     * @return itself
+     */
     @Override
     final EnumDefault<R> self() {
       return this;
     }
   }
 
-  /** Choose whether to use a default value for the field or not. **/
+  /** Choose whether to use a default value for the field or not. */
   public static class RecordDefault<R> extends FieldDefault<R, RecordDefault<R>> {
     private RecordDefault(FieldBuilder<R> field) {
       super(field);
     }
 
-    /** Completes this field with the default value provided, cannot be null **/
+    /**
+     * Completes this field with the default value provided, cannot be null
+     *
+     * @param defaultVal The default value
+     * @return {@link FieldAssembler}
+     */
     public final FieldAssembler<R> recordDefault(GenericRecord defaultVal) {
       return super.usingDefault(defaultVal);
     }
@@ -2426,13 +2885,22 @@ public class SchemaBuilder {
       this.schema = schema;
     }
 
-    /** Do not use a default value for this field. **/
+    /**
+     * Do not use a default value for this field.
+     *
+     * @return {@link FieldAssembler}
+     */
     public FieldAssembler<R> noDefault() {
       return field.completeField(schema);
     }
 
-    /** Completes this field with the default value provided.
-     * The value must conform to the schema of the field. **/
+    /**
+     * Completes this field with the default value provided.
+     * The value must conform to the schema of the field.
+     *
+     * @param defaultVal The default value
+     * @return {@link FieldAssembler}
+     */
     public FieldAssembler<R> withDefault(Object defaultVal) {
       return field.completeField(schema, defaultVal);
     }
@@ -2471,9 +2939,11 @@ public class SchemaBuilder {
 
   private static class OptionalCompletion<R> extends Completion<FieldAssembler<R>> {
     private final FieldBuilder<R> bldr;
+
     public OptionalCompletion(FieldBuilder<R> bldr) {
       this.bldr = bldr;
     }
+
     @Override
     protected FieldAssembler<R> complete(Schema schema) {
       // wrap the schema as a union of null and the schema
@@ -2568,12 +3038,18 @@ public class SchemaBuilder {
       this.schemas = schemas;
     }
 
-    /** Add an additional type to this union **/
+    /**
+     * Add an additional type to this union
+     * @return {@link BaseTypeBuilder}
+     */
     public BaseTypeBuilder<UnionAccumulator<R>> and() {
       return new UnionBuilder<>(context, names, schemas);
     }
 
-    /** Complete this union **/
+    /**
+     * Complete this union
+     * @return {@link R}
+     */
     public R endUnion() {
       Schema schema = Schema.createUnion(schemas);
       return context.complete(schema);

--- a/lang/java/avro/src/main/java/org/apache/avro/SchemaCompatibility.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/SchemaCompatibility.java
@@ -578,6 +578,12 @@ public class SchemaCompatibility {
      * Returns a details object representing an incompatible schema pair, including error details.
      * @return a SchemaCompatibilityDetails object with INCOMPATIBLE SchemaCompatibilityType, and
      *         state representing the violating part.
+     *
+     * @param incompatibilityType {@link SchemaIncompatibilityType}
+     * @param readerFragment {@link Schema}
+     * @param writerFragment {@link Schema}
+     * @param message {@link String}
+     * @param location {@link List}
      */
     public static SchemaCompatibilityResult incompatible(
         SchemaIncompatibilityType incompatibilityType,

--- a/lang/java/avro/src/main/java/org/apache/avro/SchemaNormalization.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/SchemaNormalization.java
@@ -32,8 +32,11 @@ public class SchemaNormalization {
 
   private SchemaNormalization() {}
 
-  /** Returns "Parsing Canonical Form" of a schema as defined by Avro
-    * spec. */
+  /**
+   * Returns "Parsing Canonical Form" of a schema as defined by Avro spec.
+   * @param s The input schema
+   * @return The canonical form as a string
+   */
   public static String toParsingForm(Schema s) {
     try {
       Map<String,String> env = new HashMap<>();
@@ -44,20 +47,27 @@ public class SchemaNormalization {
     }
   }
 
-  /** Returns a fingerprint of a string of bytes.  This string is
-    * presumed to contain a canonical form of a schema.  The
-    * algorithm used to compute the fingerprint is selected by the
-    * argument <i>fpName</i>.  If <i>fpName</i> equals the string
-    * <code>"CRC-64-AVRO"</code>, then the result of {@link #fingerprint64} is
-    * returned in little-endian format.  Otherwise, <i>fpName</i> is
-    * used as an algorithm name for {@link
-    * MessageDigest#getInstance(String)}, which will throw
-    * <code>NoSuchAlgorithmException</code> if it doesn't recognize
-    * the name.
-    * <p> Recommended Avro practice dictates that
-    * <code>"CRC-64-AVRO"</code> is used for 64-bit fingerprints,
-    * <code>"MD5"</code> is used for 128-bit fingerprints, and
-    * <code>"SHA-256"</code> is used for 256-bit fingerprints. */
+  /**
+   *  Returns a fingerprint of a string of bytes.  This string is
+   * presumed to contain a canonical form of a schema.  The
+   * algorithm used to compute the fingerprint is selected by the
+   * argument <i>fpName</i>.  If <i>fpName</i> equals the string
+   * <code>"CRC-64-AVRO"</code>, then the result of {@link #fingerprint64} is
+   * returned in little-endian format.  Otherwise, <i>fpName</i> is
+   * used as an algorithm name for {@link
+   * MessageDigest#getInstance(String)}, which will throw
+   * <code>NoSuchAlgorithmException</code> if it doesn't recognize
+   * the name.
+   * <p>Recommended Avro practice dictates that</p>
+   * <code>"CRC-64-AVRO"</code> is used for 64-bit fingerprints,
+   * <code>"MD5"</code> is used for 128-bit fingerprints, and
+   * <code>"SHA-256"</code> is used for 256-bit fingerprints.
+   *
+   * @param fpName The fingerprint name
+   * @param data The Avro data as bytes
+   * @throws NoSuchAlgorithmException In case the algorithm isn't available
+   * @return The fingerprint as bytes
+   */
   public static byte[] fingerprint(String fpName, byte[] data)
     throws NoSuchAlgorithmException
   {
@@ -75,8 +85,10 @@ public class SchemaNormalization {
     return md.digest(data);
   }
 
-  /** Returns the 64-bit Rabin Fingerprint (as recommended in the Avro
-    * spec) of a byte string. */
+  /**
+   * @param data The data of the Avro message
+   * @return 64-bit Rabin Fingerprint (as recommended in the Avro spec) of a byte string.
+   */
   public static long fingerprint64(byte[] data) {
     long result = EMPTY64;
     for (byte b: data)
@@ -84,8 +96,13 @@ public class SchemaNormalization {
     return result;
   }
 
-  /** Returns {@link #fingerprint} applied to the parsing canonical form
-    * of the supplied schema. */
+  /**
+   * @param fpName The fingerprint name
+   * @param s Avro schema
+   *
+   * @throws NoSuchAlgorithmException In case the selected algoritm isn't available
+   * @return {@link #fingerprint} applied to the parsing canonical form of the supplied schema.
+   */
   public static byte[] parsingFingerprint(String fpName, Schema s)
     throws NoSuchAlgorithmException
   {
@@ -94,8 +111,10 @@ public class SchemaNormalization {
     } catch (UnsupportedEncodingException e) { throw new RuntimeException(e); }
   }
 
-  /** Returns {@link #fingerprint64} applied to the parsing canonical form
-    * of the supplied schema. */
+  /**
+   * @param s The Avro schema
+   * @return {@link #fingerprint64} applied to the parsing canonical form of the supplied schema.
+   */
   public static long parsingFingerprint64(Schema s) {
     try {
       return fingerprint64(toParsingForm(s).getBytes("UTF-8"));

--- a/lang/java/avro/src/main/java/org/apache/avro/SchemaValidationStrategy.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/SchemaValidationStrategy.java
@@ -23,13 +23,15 @@ package org.apache.avro;
  * another.
  * <p>
  * What makes one schema compatible with another is not defined by the contract.
- * <p/>
+ *
  */
 public interface SchemaValidationStrategy {
 
   /**
    * Validates that one schema is compatible with another.
    *
+   * @param toValidate The schema to be validated
+   * @param existing The current schema to check compatibility with
    * @throws SchemaValidationException if the schemas are not compatible.
    */
   void validate(Schema toValidate, Schema existing)

--- a/lang/java/avro/src/main/java/org/apache/avro/SchemaValidator.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/SchemaValidator.java
@@ -21,7 +21,7 @@ package org.apache.avro;
 /**
  * <p>
  * A SchemaValidator has one method, which validates that a {@link Schema} is
- * <b>compatible<b/> with the other schemas provided.
+ * <b>compatible</b> with the other schemas provided.
  * </p>
  * <p>
  * What makes one Schema compatible with another is not part of the interface

--- a/lang/java/avro/src/main/java/org/apache/avro/SchemaValidatorBuilder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/SchemaValidatorBuilder.java
@@ -34,6 +34,8 @@ public final class SchemaValidatorBuilder {
   /**
    * Use a strategy that validates that a schema can be used to read existing
    * schema(s) according to the Avro default schema resolution.
+   *
+   * @return {@link SchemaValidatorBuilder}
    */
   public SchemaValidatorBuilder canReadStrategy() {
     this.strategy = new ValidateCanRead();
@@ -43,6 +45,8 @@ public final class SchemaValidatorBuilder {
   /**
    * Use a strategy that validates that a schema can be read by existing
    * schema(s) according to the Avro default schema resolution.
+   *
+   * @return {@link SchemaValidatorBuilder}
    */
   public SchemaValidatorBuilder canBeReadStrategy() {
     this.strategy = new ValidateCanBeRead();
@@ -52,17 +56,25 @@ public final class SchemaValidatorBuilder {
   /**
    * Use a strategy that validates that a schema can read existing schema(s),
    * and vice-versa, according to the Avro default schema resolution.
+   *
+   * @return {@link SchemaValidatorBuilder}
    */
   public SchemaValidatorBuilder mutualReadStrategy() {
     this.strategy = new ValidateMutualRead();
     return this;
   }
 
+  /**
+   * @return {@link SchemaValidator}
+   */
   public SchemaValidator validateLatest() {
     valid();
     return new ValidateLatest(strategy);
   }
 
+  /**
+   * @return {@link SchemaValidator}
+   */
   public SchemaValidator validateAll() {
     valid();
     return new ValidateAll(strategy);

--- a/lang/java/avro/src/main/java/org/apache/avro/file/DataFileWriter.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/file/DataFileWriter.java
@@ -354,7 +354,7 @@ public class DataFileWriter<D> implements Closeable, Flushable {
    * of the two files are compatible, data blocks are copied directly without
    * decompression.  If the codecs are not compatible, blocks from otherFile
    * are uncompressed and then compressed using this file's codec.
-   * <p/>
+   *
    * If the recompress flag is set all blocks are decompressed and then compressed
    * using this file's codec.  This is useful when the two files have compatible
    * compression codecs but different codec options.  For example, one might

--- a/lang/java/avro/src/main/java/org/apache/avro/file/FileReader.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/file/FileReader.java
@@ -23,27 +23,39 @@ import java.util.Iterator;
 
 import org.apache.avro.Schema;
 
-/** Interface for reading data from a file. */
+/**
+ * Interface for reading data from a file.
+ */
 public interface FileReader<D> extends Iterator<D>, Iterable<D>, Closeable {
-  /** Return the schema for data in this file. */
+  /**
+   * Return the schema for data in this file.
+   */
   Schema getSchema();
 
-  /** Read the next datum from the file.
+  /**
+   * Read the next datum from the file.
+   *
    * @param reuse an instance to reuse.
-   * @throws NoSuchElementException if no more remain in the file.
+   * @throws java.util.NoSuchElementException if no more remain in the file.
    */
   D next(D reuse) throws IOException;
 
-  /** Move to the next synchronization point after a position. To process a
+  /**
+   * Move to the next synchronization point after a position. To process a
    * range of file entires, call this with the starting position, then check
    * {@link #pastSync(long)} with the end point before each call to {@link
-   * #next()}. */
+   * #next()}.
+   */
   void sync(long position) throws IOException;
 
-  /** Return true if past the next synchronization point after a position. */
+  /**
+   * Return true if past the next synchronization point after a position.
+   */
   boolean pastSync(long position) throws IOException;
 
-  /** Return the current position in the input. */
+  /**
+   * Return the current position in the input.
+   */
   long tell() throws IOException;
 
 }

--- a/lang/java/avro/src/main/java/org/apache/avro/generic/GenericData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/generic/GenericData.java
@@ -418,22 +418,42 @@ public class GenericData {
     }
   }
 
-  /** Returns a {@link DatumReader} for this kind of data. */
+  /**
+   * Returns a {@link DatumReader} for this kind of data.
+   *
+   * @param schema The schema to create the reader
+   * @return A compatible reader based on the schema
+   */
   public DatumReader createDatumReader(Schema schema) {
     return new GenericDatumReader(schema, schema, this);
   }
 
-  /** Returns a {@link DatumReader} for this kind of data. */
+  /** Returns a {@link DatumReader} for this kind of data.
+   *
+   * @param writer The writer schema of the reader
+   * @param writer The reader schema of the reader
+   * @return A compatible reader based on the schemas
+   */
   public DatumReader createDatumReader(Schema writer, Schema reader) {
     return new GenericDatumReader(writer, reader, this);
   }
 
-  /** Returns a {@link DatumWriter} for this kind of data. */
+  /**
+   * Returns a {@link DatumWriter} for this kind of data.
+   *
+   * @param schema The schema to create the writer
+   * @return The writer based on the schema
+   */
   public DatumWriter createDatumWriter(Schema schema) {
     return new GenericDatumWriter(schema, this);
   }
 
-  /** Returns true if a Java datum matches a schema. */
+  /**
+   * Returns true if a Java datum matches a schema.
+   * @param schema The schema to validate against
+   * @param datum The object that will be validated
+   * @return True if the object is compatible with the schema
+   */
   public boolean validate(Schema schema, Object datum) {
     switch (schema.getType()) {
     case RECORD:
@@ -482,7 +502,12 @@ public class GenericData {
     }
   }
 
-  /** Renders a Java datum as <a href="http://www.json.org/">JSON</a>. */
+  /**
+   * Renders a Java datum as <a href="http://www.json.org/">JSON</a>.
+   *
+   * @param datum The datum to convert to JSON
+   * @return A JSON representation of the Java datum
+   */
   public String toString(Object datum) {
     StringBuilder buffer = new StringBuilder();
     toString(datum, buffer, new IdentityHashMap<>(128) );
@@ -618,7 +643,12 @@ public class GenericData {
     }
   }
 
-  /** Create a schema given an example datum. */
+  /**
+   * Create a schema given an example datum.
+   *
+   * @param datum The object to reflect the schema from
+   * @return The extracted schema
+   */
   public Schema induce(Object datum) {
     if (isRecord(datum)) {
       return getRecordSchema(datum);
@@ -667,37 +697,74 @@ public class GenericData {
     else throw new AvroTypeException("Can't create schema for: "+datum);
   }
 
-  /** Called by {@link GenericDatumReader#readRecord} to set a record fields
+  /**
+   * Called by {@link GenericDatumReader#readRecord} to set a record fields
    * value to a record instance.  The default implementation is for {@link
-   * IndexedRecord}.*/
+   * IndexedRecord}.
+   *
+   * @param record The raw record
+   * @param name The name of the field
+   * @param position The position of the field
+   * @param o The object to map the value onto
+   */
   public void setField(Object record, String name, int position, Object o) {
     ((IndexedRecord)record).put(position, o);
   }
 
-  /** Called by {@link GenericDatumReader#readRecord} to retrieve a record
+  /**
+   * Called by {@link GenericDatumReader#readRecord} to retrieve a record
    * field value from a reused instance.  The default implementation is for
-   * {@link IndexedRecord}.*/
+   * {@link IndexedRecord}.
+   *
+   * @param record The raw record
+   * @param name The name of the field
+   * @param position The position of the field
+   * @return The extracted field
+   */
   public Object getField(Object record, String name, int position) {
     return ((IndexedRecord)record).get(position);
   }
 
-  /** Produce state for repeated calls to {@link
-   * #getField(Object,String,int,Object)} and {@link
-   * #setField(Object,String,int,Object,Object)} on the same record.*/
+  /**
+   * Produce state for repeated calls to {@link #getField(Object,String,int,Object)} and
+   * {@link #setField(Object,String,int,Object,Object)} on the same record.
+   *
+   * @param record The raw record
+   * @param schema The schema of the record
+   * @return Always null
+   */
   protected Object getRecordState(Object record, Schema schema) { return null; }
 
-  /** Version of {@link #setField} that has state. */
+  /**
+   * Version of {@link #setField} that has state.
+   *
+   * @param r The raw record
+   * @param n The name of the field
+   * @param p The position of the field
+   * @param state The state of the object
+   */
   protected void setField(Object r, String n, int p, Object o, Object state) {
     setField(r, n, p, o);
   }
 
-  /** Version of {@link #getField} that has state. */
+  /**
+   * Version of {@link #getField} that has state.
+   *
+   * @param record The raw record
+   * @param name The name of the field
+   * @param pos The position of the field
+   * @param state The state of the object
+   */
   protected Object getField(Object record, String name, int pos, Object state) {
     return getField(record, name, pos);
   }
 
-  /** Return the index for a datum within a union.  Implemented with {@link
-   * Schema#getIndexNamed(String)} and {@link #getSchemaName(Object)}.*/
+  /**
+   * Implemented with {@link Schema#getIndexNamed(String)} and {@link #getSchemaName(Object)}.
+   *
+   * @param union The schema that consists of an union
+   * @param datum The index for a datum within a union
+   */
   public int resolveUnion(Schema union, Object datum) {
     // if there is a logical type that works, use it first
     // this allows logical type concrete classes to overlap with supported ones
@@ -787,69 +854,119 @@ public class GenericData {
     }
   }
 
-  /** Called by the default implementation of {@link #instanceOf}.*/
+  /**
+   * Called by the default implementation of {@link #instanceOf}.
+   *
+   * @return True if it is an {@link Collection}
+   */
   protected boolean isArray(Object datum) {
     return datum instanceof Collection;
   }
 
-  /** Called to access an array as a collection. */
+  /**
+   * Called to access an array as a collection.
+   *
+   * @param datum The object which is a {@link Collection}
+   * @return The array as a collection
+   */
   protected Collection getArrayAsCollection(Object datum) {
     return (Collection)datum;
   }
 
-  /** Called by the default implementation of {@link #instanceOf}.*/
+  /**
+   * Called by the default implementation of {@link #instanceOf}.
+   *
+   * @return True if it is an {@link IndexedRecord}
+   */
   protected boolean isRecord(Object datum) {
     return datum instanceof IndexedRecord;
   }
 
-  /** Called to obtain the schema of a record.  By default calls
+  /**
+   * Called to obtain the schema of a record.  By default calls
    * {GenericContainer#getSchema().  May be overridden for alternate record
-   * representations. */
+   * representations.
+   *
+   * @param record The object which is a {@link GenericContainer}
+   * @return The record schema
+   */
   protected Schema getRecordSchema(Object record) {
     return ((GenericContainer)record).getSchema();
   }
 
-  /** Called by the default implementation of {@link #instanceOf}.*/
+  /**
+   * Called by the default implementation of {@link #instanceOf}.
+   *
+   * @return True if it is an Enum
+   */
   protected boolean isEnum(Object datum) {
     return datum instanceof GenericEnumSymbol;
   }
 
-  /** Called to obtain the schema of a enum.  By default calls
+  /**
+   * Called to obtain the schema of a enum.  By default calls
    * {GenericContainer#getSchema().  May be overridden for alternate enum
-   * representations. */
+   * representations.
+   *
+   * @param enu The object which is a {@link GenericContainer}
+   * @return The enum schema
+   */
   protected Schema getEnumSchema(Object enu) {
     return ((GenericContainer)enu).getSchema();
   }
 
-  /** Called by the default implementation of {@link #instanceOf}.*/
+  /**
+   * Called by the default implementation of {@link #instanceOf}.
+   *
+   * @return True if it is a Map
+   */
   protected boolean isMap(Object datum) {
     return datum instanceof Map;
   }
 
-  /** Called by the default implementation of {@link #instanceOf}.*/
+  /**
+   * Called by the default implementation of {@link #instanceOf}.
+   *
+   * @return True if it is a fixed schema
+   */
   protected boolean isFixed(Object datum) {
     return datum instanceof GenericFixed;
   }
 
-  /** Called to obtain the schema of a fixed.  By default calls
+  /**
+   * Called to obtain the schema of a fixed.  By default calls
    * {GenericContainer#getSchema().  May be overridden for alternate fixed
-   * representations. */
+   * representations.
+   *
+   * @param fixed The object which is a {@link GenericContainer}
+   * @return The fixed schmea
+   */
   protected Schema getFixedSchema(Object fixed) {
     return ((GenericContainer)fixed).getSchema();
   }
 
-  /** Called by the default implementation of {@link #instanceOf}.*/
+  /**
+   * Called by the default implementation of {@link #instanceOf}.
+   *
+   * @return True if it is a string
+   */
   protected boolean isString(Object datum) {
     return datum instanceof CharSequence;
   }
 
-  /** Called by the default implementation of {@link #instanceOf}.*/
+  /**
+   * Called by the default implementation of {@link #instanceOf}.
+   *
+   * @return True if it is a byte
+   */
   protected boolean isBytes(Object datum) {
     return datum instanceof ByteBuffer;
   }
 
-   /**
+  /**
    * Called by the default implementation of {@link #instanceOf}.
+   *
+   * @return True if it is a int
    */
   protected boolean isInteger(Object datum) {
     return datum instanceof Integer;
@@ -857,6 +974,8 @@ public class GenericData {
 
   /**
    * Called by the default implementation of {@link #instanceOf}.
+   *
+   * @return True if it is a long
    */
   protected boolean isLong(Object datum) {
     return datum instanceof Long;
@@ -864,6 +983,8 @@ public class GenericData {
 
   /**
    * Called by the default implementation of {@link #instanceOf}.
+   *
+   * @return True if it is a float
    */
   protected boolean isFloat(Object datum) {
     return datum instanceof Float;
@@ -871,6 +992,8 @@ public class GenericData {
 
   /**
    * Called by the default implementation of {@link #instanceOf}.
+   *
+   * @return True if it is a double
    */
   protected boolean isDouble(Object datum) {
     return datum instanceof Double;
@@ -878,6 +1001,8 @@ public class GenericData {
 
   /**
    * Called by the default implementation of {@link #instanceOf}.
+   *
+   * @return True if it is a boolean
    */
   protected boolean isBoolean(Object datum) {
     return datum instanceof Boolean;

--- a/lang/java/avro/src/main/java/org/apache/avro/io/BinaryDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/BinaryDecoder.java
@@ -26,9 +26,9 @@ import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.util.Utf8;
 
 /** An {@link Decoder} for binary-format data.
- * <p/>
+ *
  * Instances are created using {@link DecoderFactory}.
- * <p/>
+ *
  * This class may read-ahead and buffer bytes from the source beyond what is
  * required to serve its read methods.
  * The number of unused bytes in the buffer can be accessed by
@@ -101,7 +101,7 @@ public class BinaryDecoder extends Decoder {
    * it exists) from this Decoder. The old source's state no longer depends on
    * this Decoder and its InputStream interface will continue to drain the
    * remaining buffer and source data.
-   * <p/>
+   *
    * The decoder will read from the new source. The source will generally
    * replace the buffer with its own. If the source allocates a new buffer, it
    * will create it with size bufferSize.
@@ -442,7 +442,7 @@ public class BinaryDecoder extends Decoder {
    * Returns true if the current BinaryDecoder is at the end of its source data and
    * cannot read any further without throwing an EOFException or other
    * IOException.
-   * <p/>
+   *
    * Not all implementations of BinaryDecoder support isEnd(). Implementations that do
    * not support isEnd() will throw a
    * {@link java.lang.UnsupportedOperationException}.
@@ -471,12 +471,12 @@ public class BinaryDecoder extends Decoder {
    * Ensures that buf[pos + num - 1] is not out of the buffer array bounds.
    * However, buf[pos + num -1] may be >= limit if there is not enough data left
    * in the source to fill the array with num bytes.
-   * <p/>
+   *
    * This method allows readers to read ahead by num bytes safely without
    * checking for EOF at each byte. However, readers must ensure that their
    * reads are valid by checking that their read did not advance past the limit
    * before adjusting pos.
-   * <p/>
+   *
    * num must be less than the buffer size and greater than 0
    */
   private void ensureBounds(int num) throws IOException {
@@ -585,16 +585,16 @@ public class BinaryDecoder extends Decoder {
    * InputStream's API is a barrier to performance due to several quirks:
    * InputStream does not in general require that as many bytes as possible have
    * been read when filling a buffer.
-   * <p/>
+   *
    * InputStream's terminating conditions for a read are two-fold: EOFException
    * and '-1' on the return from read(). Implementations are supposed to return
    * '-1' on EOF but often do not. The extra terminating conditions cause extra
    * conditionals on both sides of the API, and slow performance significantly.
-   * <p/>
+   *
    * ByteSource implementations provide read() and skip() variants that have
    * stronger guarantees than InputStream, freeing client code to be simplified
    * and faster.
-   * <p/>
+   *
    * {@link skipSourceBytes} and {@link readRaw} are guaranteed to have read or
    * skipped as many bytes as possible, or throw EOFException.
    * {@link trySkipBytes} and {@link tryRead} are guaranteed to attempt to read
@@ -604,7 +604,7 @@ public class BinaryDecoder extends Decoder {
    * also be detected by a client if an EOFException is thrown from
    * {@link skipSourceBytes} or {@link readRaw}, or if {@link trySkipBytes} or
    * {@link tryRead} return 0;
-   * <p/>
+   *
    * A ByteSource also implements the InputStream contract for use by APIs that
    * require it. The InputStream interface must take into account buffering in
    * any decoder that this ByteSource is attached to. The other methods do not
@@ -678,7 +678,7 @@ public class BinaryDecoder extends Decoder {
      * Attempts to copy up to <i>len</i> bytes from the source into data,
      * starting at index <i>off</i>. Returns the actual number of bytes copied
      * which may be between 0 and <i>len</i>.
-     * <p/>
+     *
      * This method must attempt to read as much as possible from the source.
      * Returns 0 when at the end of stream/channel/file/etc.
      *

--- a/lang/java/avro/src/main/java/org/apache/avro/io/BinaryEncoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/BinaryEncoder.java
@@ -24,7 +24,7 @@ import org.apache.avro.util.Utf8;
 
 /**
  * An abstract {@link Encoder} for Avro's binary encoding.
- * <p/>
+ *
  * To construct and configure instances, use {@link EncoderFactory}
  *
  * @see EncoderFactory
@@ -118,7 +118,7 @@ public abstract class BinaryEncoder extends Encoder {
   /**
    * Returns the number of bytes currently buffered by this encoder. If this
    * Encoder does not buffer, this will always return zero.
-   * <p/>
+   *
    * Call {@link #flush()} to empty the buffer to the underlying output.
    */
   public abstract int bytesBuffered();

--- a/lang/java/avro/src/main/java/org/apache/avro/io/BlockingBinaryEncoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/BlockingBinaryEncoder.java
@@ -29,13 +29,13 @@ import org.apache.avro.Schema;
  * arbitrarily long arrays and maps may be written and subsequently read without
  * exhausting memory. Values are buffered until the specified block size would
  * be exceeded, minimizing block overhead.
- * <p/>
+ *
  * Use {@link EncoderFactory#blockingBinaryEncoder(OutputStream, BinaryEncoder)}
  * to construct and configure.
- * <p/>
+ *
  * BlockingBinaryEncoder buffers writes, data may not appear on the output until
  * {@link #flush()} is called.
- * <p/>
+ *
  * BlockingBinaryEncoder is not thread-safe
  *
  * @see BinaryEncoder

--- a/lang/java/avro/src/main/java/org/apache/avro/io/BufferedBinaryEncoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/BufferedBinaryEncoder.java
@@ -27,17 +27,17 @@ import org.apache.avro.AvroRuntimeException;
 
 /**
  * An {@link Encoder} for Avro's binary encoding.
- * <p/>
+ *
  * This implementation buffers output to enhance performance.
  * Output may not appear on the underlying output until flush() is called.
- * <p/>
+ *
  * {@link DirectBinaryEncoder} can be used in place of this implementation if
  * the buffering semantics are not desired, and the performance difference
  * is acceptable.
- * <p/>
+ *
  * To construct or reconfigure, use
  * {@link EncoderFactory#binaryEncoder(OutputStream, BinaryEncoder)}.
- * <p/>
+ *
  * To change the buffer size, configure the factory instance used to
  * create instances with {@link EncoderFactory#configureBufferSize(int)}
  *  @see Encoder
@@ -189,11 +189,11 @@ public class BufferedBinaryEncoder extends BinaryEncoder {
   /**
    * ByteSink abstracts the destination of written data from the core workings
    * of BinaryEncoder.
-   * <p/>
+   *
    * Currently the only destination option is an OutputStream, but we may later
    * want to handle other constructs or specialize for certain OutputStream
    * Implementations such as ByteBufferOutputStream.
-   * <p/>
+   *
    */
   private abstract static class ByteSink {
     protected ByteSink() {}

--- a/lang/java/avro/src/main/java/org/apache/avro/io/Decoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/Decoder.java
@@ -24,16 +24,16 @@ import org.apache.avro.util.Utf8;
 
 /**
  * Low-level support for de-serializing Avro values.
- * <p/>
+ *
  *  This class has two types of methods.  One type of methods support
  *  the reading of leaf values (for example, {@link #readLong} and
  *  {@link #readString}).
- *  <p/>
+ *
  *  The other type of methods support the reading of maps and arrays.
  *  These methods are {@link #readArrayStart}, {@link #arrayNext},
  *  and similar methods for maps).  See {@link #readArrayStart} for
  *  details on these methods.)
- *  <p/>
+ *
  *  {@link DecoderFactory} contains Decoder construction and configuration
  *  facilities.
  *  @see DecoderFactory
@@ -46,14 +46,14 @@ public abstract class Decoder {
    * "Reads" a null value.  (Doesn't actually read anything, but
    * advances the state of the parser if the implementation is
    * stateful.)
-   *  @throws AvroTypeException If this is a stateful reader and
+   *  @throws org.apache.avro.AvroTypeException If this is a stateful reader and
    *          null is not the type of the next value to be read
    */
   public abstract void readNull() throws IOException;
 
   /**
    * Reads a boolean value written by {@link Encoder#writeBoolean}.
-   * @throws AvroTypeException If this is a stateful reader and
+   * @throws org.apache.avro.AvroTypeException If this is a stateful reader and
    * boolean is not the type of the next value to be read
    */
 
@@ -61,51 +61,51 @@ public abstract class Decoder {
 
   /**
    * Reads an integer written by {@link Encoder#writeInt}.
-   * @throws AvroTypeException If encoded value is larger than
+   * @throws org.apache.avro.AvroTypeException If encoded value is larger than
    *          32-bits
-   * @throws AvroTypeException If this is a stateful reader and
+   * @throws org.apache.avro.AvroTypeException If this is a stateful reader and
    *          int is not the type of the next value to be read
    */
   public abstract int readInt() throws IOException;
 
   /**
    * Reads a long written by {@link Encoder#writeLong}.
-   * @throws AvroTypeException If this is a stateful reader and
+   * @throws org.apache.avro.AvroTypeException If this is a stateful reader and
    *          long is not the type of the next value to be read
    */
   public abstract long readLong() throws IOException;
 
   /**
    * Reads a float written by {@link Encoder#writeFloat}.
-   * @throws AvroTypeException If this is a stateful reader and
+   * @throws org.apache.avro.AvroTypeException If this is a stateful reader and
    * is not the type of the next value to be read
    */
   public abstract float readFloat() throws IOException;
 
   /**
    * Reads a double written by {@link Encoder#writeDouble}.
-   * @throws AvroTypeException If this is a stateful reader and
+   * @throws org.apache.avro.AvroTypeException If this is a stateful reader and
    *           is not the type of the next value to be read
    */
   public abstract double readDouble() throws IOException;
 
   /**
    * Reads a char-string written by {@link Encoder#writeString}.
-   * @throws AvroTypeException If this is a stateful reader and
+   * @throws org.apache.avro.AvroTypeException If this is a stateful reader and
    * char-string is not the type of the next value to be read
    */
   public abstract Utf8 readString(Utf8 old) throws IOException;
 
   /**
    * Reads a char-string written by {@link Encoder#writeString}.
-   * @throws AvroTypeException If this is a stateful reader and
+   * @throws org.apache.avro.AvroTypeException If this is a stateful reader and
    * char-string is not the type of the next value to be read
    */
   public abstract String readString() throws IOException;
 
   /**
    * Discards a char-string written by {@link Encoder#writeString}.
-   *  @throws AvroTypeException If this is a stateful reader and
+   *  @throws org.apache.avro.AvroTypeException If this is a stateful reader and
    *          char-string is not the type of the next value to be read
    */
   public abstract void skipString() throws IOException;
@@ -114,14 +114,14 @@ public abstract class Decoder {
    * Reads a byte-string written by {@link Encoder#writeBytes}.
    * if <tt>old</tt> is not null and has sufficient capacity to take in
    * the bytes being read, the bytes are returned in <tt>old</tt>.
-   * @throws AvroTypeException If this is a stateful reader and
+   * @throws org.apache.avro.AvroTypeException If this is a stateful reader and
    *          byte-string is not the type of the next value to be read
    */
   public abstract ByteBuffer readBytes(ByteBuffer old) throws IOException;
 
   /**
    * Discards a byte-string written by {@link Encoder#writeBytes}.
-   *  @throws AvroTypeException If this is a stateful reader and
+   *  @throws org.apache.avro.AvroTypeException If this is a stateful reader and
    *          byte-string is not the type of the next value to be read
    */
   public abstract void skipBytes() throws IOException;
@@ -131,7 +131,7 @@ public abstract class Decoder {
    * @param bytes The buffer to store the contents being read.
    * @param start The position where the data needs to be written.
    * @param length  The size of the binary object.
-   * @throws AvroTypeException If this is a stateful reader and
+   * @throws org.apache.avro.AvroTypeException If this is a stateful reader and
    *          fixed sized binary object is not the type of the next
    *          value to be read or the length is incorrect.
    * @throws IOException
@@ -141,7 +141,7 @@ public abstract class Decoder {
 
   /**
    * A shorthand for <tt>readFixed(bytes, 0, bytes.length)</tt>.
-   * @throws AvroTypeException If this is a stateful reader and
+   * @throws org.apache.avro.AvroTypeException If this is a stateful reader and
    *          fixed sized binary object is not the type of the next
    *          value to be read or the length is incorrect.
    * @throws IOException
@@ -153,7 +153,7 @@ public abstract class Decoder {
   /**
    * Discards fixed sized binary object.
    * @param length  The size of the binary object to be skipped.
-   * @throws AvroTypeException If this is a stateful reader and
+   * @throws org.apache.avro.AvroTypeException If this is a stateful reader and
    *          fixed sized binary object is not the type of the next
    *          value to be read or the length is incorrect.
    * @throws IOException
@@ -163,7 +163,7 @@ public abstract class Decoder {
   /**
    * Reads an enumeration.
    * @return The enumeration's value.
-   * @throws AvroTypeException If this is a stateful reader and
+   * @throws org.apache.avro.AvroTypeException If this is a stateful reader and
    *          enumeration is not the type of the next value to be read.
    * @throws IOException
    */
@@ -175,14 +175,14 @@ public abstract class Decoder {
    * indicated number of items, and then call {@link
    * #arrayNext} to find out the number of items in the next
    * block.  The typical pattern for consuming an array looks like:
-   * <pre>
+   * <pre>{@code
    *   for(long i = in.readArrayStart(); i != 0; i = in.arrayNext()) {
    *     for (long j = 0; j < i; j++) {
    *       read next element of the array;
    *     }
    *   }
-   * </pre>
-   *  @throws AvroTypeException If this is a stateful reader and
+   * }</pre>
+   * @throws org.apache.avro.AvroTypeException If this is a stateful reader and
    *          array is not the type of the next value to be read */
   public abstract long readArrayStart() throws IOException;
 
@@ -190,7 +190,7 @@ public abstract class Decoder {
    * Processes the next block of an array and returns the number of items in
    * the block and let's the caller
    * read those items.
-   * @throws AvroTypeException When called outside of an
+   * @throws org.apache.avro.AvroTypeException When called outside of an
    *         array context
    */
   public abstract long arrayNext() throws IOException;
@@ -205,19 +205,19 @@ public abstract class Decoder {
    * them if possible.  It will return zero if there are no more
    * items to skip through, or an item count if it needs the client's
    * help in skipping.  The typical usage pattern is:
-   * <pre>
-   *   for(long i = in.skipArray(); i != 0; i = i.skipArray()) {
-   *     for (long j = 0; j < i; j++) {
-   *       read and discard the next element of the array;
-   *     }
+   * <pre>{@code
+   * for(long i = in.skipArray(); i != 0; i = i.skipArray()) {
+   *   for (long j = 0; j < i; j++) {
+   *     read and discard the next element of the array;
    *   }
-   * </pre>
+   * }
+   * }</pre>
    * Note that this method can automatically skip through items if a
    * byte-count is found in the underlying data, or if a schema has
    * been provided to the implementation, but
    * otherwise the client will have to skip through items itself.
    *
-   *  @throws AvroTypeException If this is a stateful reader and
+   * @throws org.apache.avro.AvroTypeException If this is a stateful reader and
    *          array is not the type of the next value to be read
    */
   public abstract long skipArray() throws IOException;
@@ -226,10 +226,10 @@ public abstract class Decoder {
    * Reads and returns the size of the next block of map-entries.
    * Similar to {@link #readArrayStart}.
    *
-   *  As an example, let's say you want to read a map of records,
-   *  the record consisting of an Long field and a Boolean field.
-   *  Your code would look something like this:
-   * <pre>
+   * As an example, let's say you want to read a map of records,
+   * the record consisting of an Long field and a Boolean field.
+   * Your code would look something like this:
+   * <pre>{@code
    *   Map<String,Record> m = new HashMap<String,Record>();
    *   Record reuse = new Record();
    *   for(long i = in.readMapStart(); i != 0; i = in.readMapNext()) {
@@ -240,8 +240,9 @@ public abstract class Decoder {
    *       m.put(key, reuse);
    *     }
    *   }
-   * </pre>
-   * @throws AvroTypeException If this is a stateful reader and
+   * }</pre>
+   *
+   * @throws org.apache.avro.AvroTypeException If this is a stateful reader and
    *         map is not the type of the next value to be read
    */
   public abstract long readMapStart() throws IOException;
@@ -249,7 +250,7 @@ public abstract class Decoder {
   /**
    * Processes the next block of map entries and returns the count of them.
    * Similar to {@link #arrayNext}.  See {@link #readMapStart} for details.
-   * @throws AvroTypeException When called outside of a
+   * @throws org.apache.avro.AvroTypeException When called outside of a
    *         map context
    */
   public abstract long mapNext() throws IOException;
@@ -260,7 +261,7 @@ public abstract class Decoder {
    * As an example, let's say you want to skip a map of records,
    * the record consisting of an Long field and a Boolean field.
    * Your code would look something like this:
-   * <pre>
+   * <pre>{@code
    *   for(long i = in.skipMap(); i != 0; i = in.skipMap()) {
    *     for (long j = 0; j < i; j++) {
    *       in.skipString();  // Discard key
@@ -268,15 +269,16 @@ public abstract class Decoder {
    *       in.readBoolean(); // Discard boolean-field of value
    *     }
    *   }
-   * </pre>
-   *  @throws AvroTypeException If this is a stateful reader and
+   * }</pre>
+   *
+   * @throws org.apache.avro.AvroTypeException If this is a stateful reader and
    *          array is not the type of the next value to be read */
 
   public abstract long skipMap() throws IOException;
 
   /**
    * Reads the tag of a union written by {@link Encoder#writeIndex}.
-   * @throws AvroTypeException If this is a stateful reader and
+   * @throws org.apache.avro.AvroTypeException If this is a stateful reader and
    *         union is not the type of the next value to be read
    */
   public abstract int readIndex() throws IOException;

--- a/lang/java/avro/src/main/java/org/apache/avro/io/DecoderFactory.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/DecoderFactory.java
@@ -24,7 +24,7 @@ import org.apache.avro.Schema;
 
 /**
  * A factory for creating and configuring {@link Decoder}s.
- * <p/>
+ *
  * Factories are thread-safe, and are generally cached by applications for
  * performance reasons. Multiple instances are only required if multiple
  * concurrent configurations are needed.
@@ -103,13 +103,13 @@ public class DecoderFactory {
    * Creates or reinitializes a {@link BinaryDecoder} with the input stream
    * provided as the source of data. If <i>reuse</i> is provided, it will be
    * reinitialized to the given input stream.
-   * <p/>
+   *
    * {@link BinaryDecoder} instances returned by this method buffer their input,
    * reading up to {@link #getConfiguredBufferSize()} bytes past the minimum
    * required to satisfy read requests in order to achieve better performance.
    * If the buffering is not desired, use
    * {@link #directBinaryDecoder(InputStream, BinaryDecoder)}.
-   * <p/>
+   *
    * {@link BinaryDecoder#inputStream()} provides a view on the data that is
    * buffer-aware, for users that need to interleave access to data
    * with the Decoder API.
@@ -140,17 +140,17 @@ public class DecoderFactory {
    * Creates or reinitializes a {@link BinaryDecoder} with the input stream
    * provided as the source of data. If <i>reuse</i> is provided, it will be
    * reinitialized to the given input stream.
-   * <p/>
+   *
    * {@link BinaryDecoder} instances returned by this method do not buffer their input.
    * In most cases a buffering BinaryDecoder is sufficient in combination with
    * {@link BinaryDecoder#inputStream()} which provides a buffer-aware view on
    * the data.
-   * <p/>
+   *
    * A "direct" BinaryDecoder does not read ahead from an InputStream or other data source
    * that cannot be rewound.  From the perspective of a client, a "direct" decoder
    * must never read beyond the minimum necessary bytes to service a {@link BinaryDecoder}
    * API read request.
-   * <p/>
+   *
    * In the case that the improved performance of a buffering implementation does not outweigh the
    * inconvenience of its buffering semantics, a "direct" decoder can be
    * used.
@@ -193,7 +193,7 @@ public class DecoderFactory {
    * provided as the source of data. If <i>reuse</i> is provided, it will
    * attempt to reinitialize <i>reuse</i> to the new byte array. This instance
    * will use the provided byte array as its buffer.
-   * <p/>
+   *
    * {@link BinaryDecoder#inputStream()} provides a view on the data that is
    * buffer-aware and can provide a view of the data not yet read by Decoder API
    * methods.
@@ -237,7 +237,7 @@ public class DecoderFactory {
   /**
    * Creates a {@link JsonDecoder} using the InputStrim provided for reading
    * data that conforms to the Schema provided.
-   * <p/>
+   *
    *
    * @param schema
    *          The Schema for data read from this JsonEncoder. Cannot be null.
@@ -254,7 +254,7 @@ public class DecoderFactory {
   /**
    * Creates a {@link JsonDecoder} using the String provided for reading data
    * that conforms to the Schema provided.
-   * <p/>
+   *
    *
    * @param schema
    *          The Schema for data read from this JsonEncoder. Cannot be null.

--- a/lang/java/avro/src/main/java/org/apache/avro/io/DirectBinaryDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/DirectBinaryDecoder.java
@@ -27,7 +27,7 @@ import org.apache.avro.util.ByteBufferInputStream;
 
 /**
  *  A non-buffering version of {@link BinaryDecoder}.
- *  <p/>
+ *
  *  This implementation will not read-ahead from the provided InputStream
  *  beyond the minimum required to service the API requests.
  *

--- a/lang/java/avro/src/main/java/org/apache/avro/io/DirectBinaryEncoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/DirectBinaryEncoder.java
@@ -22,15 +22,15 @@ import java.io.OutputStream;
 
 /**
  * An {@link Encoder} for Avro's binary encoding that does not buffer output.
- * <p/>
+ *
  * This encoder does not buffer writes, and as a result is slower than
  * {@link BufferedBinaryEncoder}. However, it is lighter-weight and useful when the
  * buffering in BufferedBinaryEncoder is not desired and/or the Encoder is
  * very short lived.
- * <p/>
+ *
  * To construct, use
  * {@link EncoderFactory#directBinaryEncoder(OutputStream, BinaryEncoder)}
- *  <p/>
+ *
  * DirectBinaryEncoder is not thread-safe
  * @see BinaryEncoder
  * @see EncoderFactory

--- a/lang/java/avro/src/main/java/org/apache/avro/io/Encoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/Encoder.java
@@ -25,12 +25,12 @@ import org.apache.avro.util.Utf8;
 
 /**
  * Low-level support for serializing Avro values.
- * <p/>
+ *
  * This class has two types of methods.  One type of methods support
  * the writing of leaf values (for example, {@link #writeLong} and
  * {@link #writeString}).  These methods have analogs in {@link
  * Decoder}.
- * <p/>
+ *
  * The other type of methods support the writing of maps and arrays.
  * These methods are {@link #writeArrayStart}, {@link
  * #startItem}, and {@link #writeArrayEnd} (and similar methods for
@@ -38,7 +38,7 @@ import org.apache.avro.util.Utf8;
  * buffering required to break large maps and arrays into blocks,
  * which is necessary for applications that want to do streaming.
  * (See {@link #writeArrayStart} for details on these methods.)
- * <p/>
+ *
  * {@link EncoderFactory} contains Encoder construction and configuration
  * facilities.
  *  @see EncoderFactory
@@ -49,49 +49,49 @@ public abstract class Encoder implements Flushable {
   /**
    * "Writes" a null value.  (Doesn't actually write anything, but
    * advances the state of the parser if this class is stateful.)
-   * @throws AvroTypeException If this is a stateful writer and a
+   * @throws org.apache.avro.AvroTypeException If this is a stateful writer and a
    *         null is not expected
    */
   public abstract void writeNull() throws IOException;
 
   /**
    * Write a boolean value.
-   * @throws AvroTypeException If this is a stateful writer and a
+   * @throws org.apache.avro.AvroTypeException If this is a stateful writer and a
    * boolean is not expected
    */
   public abstract void writeBoolean(boolean b) throws IOException;
 
   /**
    * Writes a 32-bit integer.
-   * @throws AvroTypeException If this is a stateful writer and an
+   * @throws org.apache.avro.AvroTypeException If this is a stateful writer and an
    * integer is not expected
    */
   public abstract void writeInt(int n) throws IOException;
 
   /**
    * Write a 64-bit integer.
-   * @throws AvroTypeException If this is a stateful writer and a
+   * @throws org.apache.avro.AvroTypeException If this is a stateful writer and a
    * long is not expected
    */
   public abstract void writeLong(long n) throws IOException;
 
   /** Write a float.
    * @throws IOException
-   * @throws AvroTypeException If this is a stateful writer and a
+   * @throws org.apache.avro.AvroTypeException If this is a stateful writer and a
    * float is not expected
    */
   public abstract void writeFloat(float f) throws IOException;
 
   /**
    * Write a double.
-   * @throws AvroTypeException If this is a stateful writer and a
+   * @throws org.apache.avro.AvroTypeException If this is a stateful writer and a
    * double is not expected
    */
   public abstract void writeDouble(double d) throws IOException;
 
   /**
    * Write a Unicode character string.
-   * @throws AvroTypeException If this is a stateful writer and a
+   * @throws org.apache.avro.AvroTypeException If this is a stateful writer and a
    * char-string is not expected
    */
   public abstract void writeString(Utf8 utf8) throws IOException;
@@ -100,7 +100,7 @@ public abstract class Encoder implements Flushable {
    * Write a Unicode character string.  The default implementation converts
    * the String to a {@link org.apache.avro.util.Utf8}.  Some Encoder
    * implementations may want to do something different as a performance optimization.
-   * @throws AvroTypeException If this is a stateful writer and a
+   * @throws org.apache.avro.AvroTypeException If this is a stateful writer and a
    * char-string is not expected
    */
   public void writeString(String str) throws IOException {
@@ -111,7 +111,7 @@ public abstract class Encoder implements Flushable {
    * Write a Unicode character string.  If the CharSequence is an
    * {@link org.apache.avro.util.Utf8} it writes this directly, otherwise
    * the CharSequence is converted to a String via toString() and written.
-   * @throws AvroTypeException If this is a stateful writer and a
+   * @throws org.apache.avro.AvroTypeException If this is a stateful writer and a
    * char-string is not expected
    */
   public void writeString(CharSequence charSequence) throws IOException {
@@ -123,14 +123,14 @@ public abstract class Encoder implements Flushable {
 
   /**
    * Write a byte string.
-   * @throws AvroTypeException If this is a stateful writer and a
+   * @throws org.apache.avro.AvroTypeException If this is a stateful writer and a
    *         byte-string is not expected
    */
   public abstract void writeBytes(ByteBuffer bytes) throws IOException;
 
   /**
    * Write a byte string.
-   * @throws AvroTypeException If this is a stateful writer and a
+   * @throws org.apache.avro.AvroTypeException If this is a stateful writer and a
    * byte-string is not expected
    */
   public abstract void writeBytes(byte[] bytes, int start, int len) throws IOException;
@@ -139,7 +139,7 @@ public abstract class Encoder implements Flushable {
    * Writes a byte string.
    * Equivalent to <tt>writeBytes(bytes, 0, bytes.length)</tt>
    * @throws IOException
-   * @throws AvroTypeException If this is a stateful writer and a
+   * @throws org.apache.avro.AvroTypeException If this is a stateful writer and a
    * byte-string is not expected
    */
   public void writeBytes(byte[] bytes) throws IOException {
@@ -152,7 +152,7 @@ public abstract class Encoder implements Flushable {
    * @param start The position within <tt>bytes</tt> where the contents
    * start.
    * @param len The number of bytes to write.
-   * @throws AvroTypeException If this is a stateful writer and a
+   * @throws org.apache.avro.AvroTypeException If this is a stateful writer and a
    * byte-string is not expected
    * @throws IOException
    */
@@ -182,7 +182,7 @@ public abstract class Encoder implements Flushable {
   /**
    * Writes an enumeration.
    * @param e
-   * @throws AvroTypeException If this is a stateful writer and an enumeration
+   * @throws org.apache.avro.AvroTypeException If this is a stateful writer and an enumeration
    * is not expected or the <tt>e</tt> is out of range.
    * @throws IOException
    */
@@ -213,7 +213,7 @@ public abstract class Encoder implements Flushable {
    *  }
    *  out.writeArrayEnd();
    *  </pre>
-   *  @throws AvroTypeException If this is a stateful writer and an
+   *  @throws org.apache.avro.AvroTypeException If this is a stateful writer and an
    *          array is not expected
    */
   public abstract void writeArrayStart() throws IOException;
@@ -234,7 +234,7 @@ public abstract class Encoder implements Flushable {
   /**
    * Start a new item of an array or map.
    * See {@link #writeArrayStart} for usage information.
-   * @throws AvroTypeException If called outside of an array or map context
+   * @throws org.apache.avro.AvroTypeException If called outside of an array or map context
    */
   public abstract void startItem() throws IOException;
 
@@ -242,9 +242,9 @@ public abstract class Encoder implements Flushable {
    * Call this method to finish writing an array.
    * See {@link #writeArrayStart} for usage information.
    *
-   * @throws AvroTypeException If items written does not match count
+   * @throws org.apache.avro.AvroTypeException If items written does not match count
    *          provided to {@link #writeArrayStart}
-   * @throws AvroTypeException If not currently inside an array
+   * @throws org.apache.avro.AvroTypeException If not currently inside an array
    */
   public abstract void writeArrayEnd() throws IOException;
 
@@ -255,7 +255,8 @@ public abstract class Encoder implements Flushable {
    * As an example of usage, let's say you want to write a map of
    * records, the record consisting of an Long field and a Boolean
    * field.  Your code would look something like this:
-   * <pre>
+   *
+   * <pre>{@code
    * out.writeMapStart();
    * out.setItemCount(list.size());
    * for (Map.Entry<String,Record> entry : map.entrySet()) {
@@ -265,8 +266,9 @@ public abstract class Encoder implements Flushable {
    *   out.writeBoolean(entry.getValue().boolField);
    * }
    * out.writeMapEnd();
-   * </pre>
-   * @throws AvroTypeException If this is a stateful writer and a
+   * }</pre>
+   *
+   * @throws org.apache.avro.AvroTypeException If this is a stateful writer and a
    * map is not expected
    */
   public abstract void writeMapStart() throws IOException;
@@ -275,9 +277,9 @@ public abstract class Encoder implements Flushable {
    * Call this method to terminate the inner-most, currently-opened
    * map.  See {@link #writeArrayStart} for more details.
    *
-   * @throws AvroTypeException If items written does not match count
+   * @throws org.apache.avro.AvroTypeException If items written does not match count
    *          provided to {@link #writeMapStart}
-   * @throws AvroTypeException If not currently inside a map
+   * @throws org.apache.avro.AvroTypeException If not currently inside a map
    */
   public abstract void writeMapEnd() throws IOException;
 
@@ -291,7 +293,7 @@ public abstract class Encoder implements Flushable {
    * out.writeLong(record.longField);
    * out.writeBoolean(record.boolField);
    * </pre>
-   * @throws AvroTypeException If this is a stateful writer and a
+   * @throws org.apache.avro.AvroTypeException If this is a stateful writer and a
    * map is not expected
    */
   public abstract void writeIndex(int unionIndex) throws IOException;

--- a/lang/java/avro/src/main/java/org/apache/avro/io/EncoderFactory.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/EncoderFactory.java
@@ -26,7 +26,7 @@ import org.codehaus.jackson.JsonGenerator;
 
 /**
  * A factory for creating and configuring {@link Encoder} instances.
- * <p/>
+ *
  * Factory methods that create Encoder instances are thread-safe.
  * Multiple instances with different configurations can be cached
  * by an application.
@@ -128,7 +128,7 @@ public class EncoderFactory {
    * {@link BinaryEncoder} instances created with
    * #blockingBinaryEncoder(OutputStream, BinaryEncoder)
    * will have block buffers of this size.
-   * <p/>
+   *
    * @see #configureBlockSize(int)
    * @see #blockingBinaryEncoder(OutputStream, BinaryEncoder)
    * @return The preferred block size, in bytes.
@@ -142,14 +142,12 @@ public class EncoderFactory {
    * provided as the destination for written data. If <i>reuse</i> is provided,
    * an attempt will be made to reconfigure <i>reuse</i> rather than construct a
    * new instance, but this is not guaranteed, a new instance may be returned.
-   * <p/>
+   *
    * The {@link BinaryEncoder} implementation returned may buffer its output.
    * Data may not appear on the underlying OutputStream until
    * {@link Encoder#flush()} is called.  The buffer size is configured with
-   * {@link #configureBufferSize(int)}.
-   * </p>  If buffering is not desired, and lower performance is acceptable, use
+   * {@link #configureBufferSize(int)}. If buffering is not desired, and lower performance is acceptable, use
    * {@link #directBinaryEncoder(OutputStream, BinaryEncoder)}
-   * <p/>
    * {@link BinaryEncoder} instances returned by this method are not thread-safe
    *
    * @param out
@@ -163,7 +161,6 @@ public class EncoderFactory {
    *         <i>reuse</i> is null, this will be a new instance. If <i>reuse</i>
    *         is not null, then the returned instance may be a new instance or
    *         <i>reuse</i> reconfigured to use <i>out</i>.
-   * @throws IOException
    * @see BufferedBinaryEncoder
    * @see Encoder
    */
@@ -176,22 +173,22 @@ public class EncoderFactory {
   }
 
   /**
-   * Creates or reinitializes a {@link BinaryEncoder} with the OutputStream
+   * Creates or reinitialize a {@link BinaryEncoder} with the OutputStream
    * provided as the destination for written data. If <i>reuse</i> is provided,
    * an attempt will be made to reconfigure <i>reuse</i> rather than construct a
    * new instance, but this is not guaranteed, a new instance may be returned.
-   * <p/>
+   *
    * The {@link BinaryEncoder} implementation returned does not buffer its
    * output, calling {@link Encoder#flush()} will simply cause the wrapped
    * OutputStream to be flushed.
-   * <p/>
+   *
    * Performance of unbuffered writes can be significantly slower than buffered
    * writes.  {@link #binaryEncoder(OutputStream, BinaryEncoder)} returns
    * BinaryEncoder instances that are tuned for performance but may buffer output.
    * The unbuffered, 'direct' encoder may be desired when buffering semantics are
    * problematic, or if the lifetime of the encoder is so short that the buffer
    * would not be useful.
-   * <p/>
+   *
    * {@link BinaryEncoder} instances returned by this method are not thread-safe.
    *
    * @param out
@@ -221,17 +218,17 @@ public class EncoderFactory {
    * provided as the destination for written data. If <i>reuse</i> is provided,
    * an attempt will be made to reconfigure <i>reuse</i> rather than construct a
    * new instance, but this is not guaranteed, a new instance may be returned.
-   * <p/>
+   *
    * The {@link BinaryEncoder} implementation returned buffers its output,
    * calling {@link Encoder#flush()} is required for output to appear on the underlying
    * OutputStream.
-   * <p/>
+   *
    * The returned BinaryEncoder implements the Avro binary encoding using blocks
    * delimited with byte sizes for Arrays and Maps.  This allows for some decoders
    * to skip over large Arrays or Maps without decoding the contents, but adds
    * some overhead.  The default block size is configured with
    * {@link #configureBlockSize(int)}
-   * <p/>
+   *
    * {@link BinaryEncoder} instances returned by this method are not thread-safe.
    *
    * @param out
@@ -245,7 +242,6 @@ public class EncoderFactory {
    *         <i>reuse</i> is null, this will be a new instance. If <i>reuse</i>
    *         is not null, then the returned instance may be a new instance or
    *         <i>reuse</i> reconfigured to use <i>out</i>.
-   * @throws IOException
    * @see BlockingBinaryEncoder
    * @see Encoder
    */
@@ -264,10 +260,10 @@ public class EncoderFactory {
   /**
    * Creates a {@link JsonEncoder} using the OutputStream provided for writing
    * data conforming to the Schema provided.
-   * <p/>
+   *
    * {@link JsonEncoder} buffers its output. Data may not appear on the
    * underlying OutputStream until {@link Encoder#flush()} is called.
-   * <p/>
+   *
    * {@link JsonEncoder} is not thread-safe.
    *
    * @param schema
@@ -285,10 +281,10 @@ public class EncoderFactory {
   /**
    * Creates a {@link JsonEncoder} using the OutputStream provided for writing
    * data conforming to the Schema provided with optional pretty printing.
-   * <p/>
+   *
    * {@link JsonEncoder} buffers its output. Data may not appear on the
    * underlying OutputStream until {@link Encoder#flush()} is called.
-   * <p/>
+   *
    * {@link JsonEncoder} is not thread-safe.
    *
    * @param schema
@@ -308,10 +304,10 @@ public class EncoderFactory {
   /**
    * Creates a {@link JsonEncoder} using the {@link JsonGenerator} provided for
    * output of data conforming to the Schema provided.
-   * <p/>
+   *
    * {@link JsonEncoder} buffers its output. Data may not appear on the
    * underlying output until {@link Encoder#flush()} is called.
-   * <p/>
+   *
    * {@link JsonEncoder} is not thread-safe.
    *
    * @param schema
@@ -332,10 +328,10 @@ public class EncoderFactory {
    * Creates a {@link ValidatingEncoder} that wraps the Encoder provided.
    * This ValidatingEncoder will ensure that operations against it conform
    * to the schema provided.
-   * <p/>
+   *
    * Many {@link Encoder}s buffer their output. Data may not appear on the
    * underlying output until {@link Encoder#flush()} is called.
-   * <p/>
+   *
    * {@link ValidatingEncoder} is not thread-safe.
    *
    * @param schema

--- a/lang/java/avro/src/main/java/org/apache/avro/io/JsonDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/JsonDecoder.java
@@ -44,7 +44,7 @@ import org.codehaus.jackson.JsonToken;
 import org.codehaus.jackson.ObjectCodec;
 
 /** A {@link Decoder} for Avro's JSON data encoding.
- * </p>
+ * <p>
  * Construct using {@link DecoderFactory}.
  * </p>
  * JsonDecoder is not thread-safe.
@@ -90,9 +90,9 @@ public class JsonDecoder extends ParsingDecoder
 
   /**
    * Reconfigures this JsonDecoder to use the InputStream provided.
-   * <p/>
+   *
    * If the InputStream provided is null, a NullPointerException is thrown.
-   * <p/>
+   *
    * Otherwise, this JsonDecoder will reset its state and then
    * reconfigure its input.
    * @param in
@@ -114,9 +114,9 @@ public class JsonDecoder extends ParsingDecoder
 
   /**
    * Reconfigures this JsonDecoder to use the String provided for input.
-   * <p/>
+   *
    * If the String provided is null, a NullPointerException is thrown.
-   * <p/>
+   *
    * Otherwise, this JsonDecoder will reset its state and then
    * reconfigure its input.
    * @param in

--- a/lang/java/avro/src/main/java/org/apache/avro/io/JsonEncoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/JsonEncoder.java
@@ -35,12 +35,11 @@ import org.codehaus.jackson.util.DefaultPrettyPrinter;
 import org.codehaus.jackson.util.MinimalPrettyPrinter;
 
 /** An {@link Encoder} for Avro's JSON data encoding.
- * </p>
  * Construct using {@link EncoderFactory}.
- * </p>
+ *
  * JsonEncoder buffers output, and data may not appear on the output
  * until {@link Encoder#flush()} is called.
- * </p>
+ *
  * JsonEncoder is not thread-safe.
  * */
 public class JsonEncoder extends ParsingEncoder implements Parser.ActionHandler {
@@ -102,9 +101,9 @@ public class JsonEncoder extends ParsingEncoder implements Parser.ActionHandler 
 
   /**
    * Reconfigures this JsonEncoder to use the output stream provided.
-   * <p/>
+   *
    * If the OutputStream provided is null, a NullPointerException is thrown.
-   * <p/>
+   *
    * Otherwise, this JsonEncoder will flush its current output and then
    * reconfigure its output to use a default UTF8 JsonGenerator that writes
    * to the provided OutputStream.
@@ -121,9 +120,9 @@ public class JsonEncoder extends ParsingEncoder implements Parser.ActionHandler 
 
   /**
    * Reconfigures this JsonEncoder to output to the JsonGenerator provided.
-   * <p/>
+   *
    * If the JsonGenerator provided is null, a NullPointerException is thrown.
-   * <p/>
+   *
    * Otherwise, this JsonEncoder will flush its current output and then
    * reconfigure its output to use the provided JsonGenerator.
    *

--- a/lang/java/avro/src/main/java/org/apache/avro/io/ValidatingDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/ValidatingDecoder.java
@@ -30,10 +30,10 @@ import org.apache.avro.util.Utf8;
 /**
  * An implementation of {@link Decoder} that ensures that the sequence
  * of operations conforms to a schema.
- * <p/>
+ *
  * Use {@link DecoderFactory#validatingDecoder(Schema, Decoder)} to construct
  * and configure.
- * <p/>
+ *
  * ValidatingDecoder is not thread-safe.
  * @see Decoder
  * @see DecoderFactory

--- a/lang/java/avro/src/main/java/org/apache/avro/io/ValidatingEncoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/ValidatingEncoder.java
@@ -31,10 +31,10 @@ import org.apache.avro.util.Utf8;
 /**
  * An implementation of {@link Encoder} that wraps another Encoder and
  * ensures that the sequence of operations conforms to the provided schema.
- * <p/>
+ *
  * Use {@link EncoderFactory#validatingEncoder(Schema, Encoder)} to construct
  * and configure.
- * <p/>
+ *
  * ValidatingEncoder is not thread-safe.
  * @see Encoder
  * @see EncoderFactory

--- a/lang/java/avro/src/main/java/org/apache/avro/message/BinaryMessageEncoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/message/BinaryMessageEncoder.java
@@ -46,7 +46,7 @@ public class BinaryMessageEncoder<D> implements MessageEncoder<D> {
    * {@link GenericData data model} to deconstruct datum instances described by
    * the {@link Schema schema}.
    * <p>
-   * Buffers returned by {@link #encode(D)} are copied and will not be modified
+   * Buffers returned by {@link #encode(Object)} are copied and will not be modified
    * by future calls to {@code encode}.
    *
    * @param model the {@link GenericData data model} for datum instances
@@ -61,7 +61,7 @@ public class BinaryMessageEncoder<D> implements MessageEncoder<D> {
    * {@link GenericData data model} to deconstruct datum instances described by
    * the {@link Schema schema}.
    * <p>
-   * If {@code shouldCopy} is true, then buffers returned by {@link #encode(D)}
+   * If {@code shouldCopy} is true, then buffers returned by {@link #encode(Object)}
    * are copied and will not be modified by future calls to {@code encode}.
    * <p>
    * If {@code shouldCopy} is false, then buffers returned by {@code encode}

--- a/lang/java/avro/src/main/java/org/apache/avro/message/RawMessageEncoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/message/RawMessageEncoder.java
@@ -57,7 +57,7 @@ public class RawMessageEncoder<D> implements MessageEncoder<D> {
    * {@link GenericData data model} to deconstruct datum instances described by
    * the {@link Schema schema}.
    * <p>
-   * Buffers returned by {@link #encode(D)} are copied and will not be modified
+   * Buffers returned by {@link #encode(Object)} are copied and will not be modified
    * by future calls to {@code encode}.
    *
    * @param model the {@link GenericData data model} for datum instances
@@ -72,7 +72,7 @@ public class RawMessageEncoder<D> implements MessageEncoder<D> {
    * {@link GenericData data model} to deconstruct datum instances described by
    * the {@link Schema schema}.
    * <p>
-   * If {@code shouldCopy} is true, then buffers returned by {@link #encode(D)}
+   * If {@code shouldCopy} is true, then buffers returned by {@link #encode(Object)}
    * are copied and will not be modified by future calls to {@code encode}.
    * <p>
    * If {@code shouldCopy} is false, then buffers returned by {@code encode}

--- a/lang/java/avro/src/main/java/org/apache/avro/specific/FixedSize.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/specific/FixedSize.java
@@ -31,7 +31,10 @@ import java.lang.annotation.Target;
 @Target({ElementType.TYPE})
 @Documented
 public @interface FixedSize {
-  /** The declared size of instances of classes with this annotation. */
+  /**
+   * The declared size of instances of classes with this annotation.
+   * @return The size of the fixed size field
+   */
   int value();
 }
 

--- a/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificData.java
@@ -119,7 +119,9 @@ public class SpecificData extends GenericData {
     return new SpecificDatumWriter(schema, this);
   }
 
-  /** Return the singleton instance. */
+  /**
+   * @return the singleton instance.
+   */
   public static SpecificData get() { return INSTANCE; }
 
   @Override
@@ -148,7 +150,11 @@ public class SpecificData extends GenericData {
   private static final Class NO_CLASS = new Object(){}.getClass();
   private static final Schema NULL_SCHEMA = Schema.create(Schema.Type.NULL);
 
-  /** Return the class that implements a schema, or null if none exists. */
+  /**
+   * Return the class that implements a schema, or null if none exists.
+   * @param schema The schema of which we want to determine the class
+   * @return The class that belongs to the schema
+   */
   public Class getClass(Schema schema) {
     switch (schema.getType()) {
     case FIXED:
@@ -203,7 +209,10 @@ public class SpecificData extends GenericData {
     return getClass(schema);
   }
 
-  /** Returns the Java class name indicated by a schema's name and namespace. */
+  /**
+   * @param schema The schema of which we want to determine the class name
+   * @return Java class name indicated by a schema's name and namespace.
+   */
   public static String getClassName(Schema schema) {
     String namespace = schema.getNamespace();
     String name = schema.getName();
@@ -231,7 +240,11 @@ public class SpecificData extends GenericData {
             }
           });
 
-  /** Find the schema for a Java type. */
+  /**
+   * Find the schema for a Java type.
+   * @param type The type of which we want to determine the schema
+   * @return The schema for the given java type
+   */
   public Schema getSchema(java.lang.reflect.Type type) {
     try {
       return schemaCache.get(type);
@@ -241,7 +254,13 @@ public class SpecificData extends GenericData {
     }
   }
 
-  /** Create the schema for a Java type. */
+  /**
+   * Create the schema for a Java type.
+   *
+   * @param type The type of the schema
+   * @param names The names for the schema
+   * @return The generated schema
+   */
   @SuppressWarnings(value="unchecked")
   protected Schema createSchema(java.lang.reflect.Type type,
                                 Map<String,Schema> names) {
@@ -314,12 +333,21 @@ public class SpecificData extends GenericData {
     return super.getSchemaName(datum);
   }
 
-  /** True iff a class should be serialized with toString(). */
+  /**
+   * @param c If the class can be converted to a String
+   * @return True iff a class should be serialized with toString().
+   */
   protected boolean isStringable(Class<?> c) {
     return stringableClasses.contains(c);
   }
 
-  /** Return the protocol for a Java interface. */
+  /**
+   * Return the protocol for a Java interface.
+   *
+   * @param iface The class that is a protocol
+   * @throws NoSuchFieldException The class is not a protocol
+   * @return The protocol
+   */
   public Protocol getProtocol(Class iface) {
     try {
       Protocol p = (Protocol)(iface.getDeclaredField("PROTOCOL").get(null));

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/CallFuture.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/CallFuture.java
@@ -26,6 +26,8 @@ import java.util.concurrent.TimeoutException;
 
 /**
  * A Future implementation for RPCs.
+ *
+ * @param <T> the type parameter
  */
 public class CallFuture<T> implements Future<T>, Callback<T> {
   private final CountDownLatch latch = new CountDownLatch(1);
@@ -43,6 +45,7 @@ public class CallFuture<T> implements Future<T>, Callback<T> {
   /**
    * Creates a CallFuture with a chained Callback which will be invoked
    * when this CallFuture's Callback methods are invoked.
+   *
    * @param chainedCallback the chained Callback to set.
    */
   public CallFuture(Callback<T> chainedCallback) {
@@ -82,8 +85,8 @@ public class CallFuture<T> implements Future<T>, Callback<T> {
    * Using {@link #get()} or {@link #get(long, TimeUnit)} is usually
    * preferred because these methods block until the result is available or
    * an error occurs.
-   * @return the value of the response, or null if no result was returned or
-   * the RPC has not yet completed.
+   *
+   * @return the value of the response, or null if no result was returned or the RPC has not yet completed.
    */
   public T getResult() {
     return result;
@@ -93,8 +96,8 @@ public class CallFuture<T> implements Future<T>, Callback<T> {
    * Gets the error that was thrown during RPC execution.  Does not block.
    * Either {@link #get()} or {@link #get(long, TimeUnit)} should be called
    * first because these methods block until the RPC has completed.
-   * @return the RPC error that was thrown, or null if no error has occurred or
-   * if the RPC has not yet completed.
+   *
+   * @return the RPC error that was thrown, or null if no error has occurred or if the RPC has not yet completed.
    */
   public Throwable getError() {
     return error;
@@ -135,6 +138,7 @@ public class CallFuture<T> implements Future<T>, Callback<T> {
 
   /**
    * Waits for the CallFuture to complete without returning the result.
+   *
    * @throws InterruptedException if interrupted.
    */
   public void await() throws InterruptedException {
@@ -143,10 +147,11 @@ public class CallFuture<T> implements Future<T>, Callback<T> {
 
   /**
    * Waits for the CallFuture to complete without returning the result.
+   *
    * @param timeout the maximum time to wait.
-   * @param unit the time unit of the timeout argument.
+   * @param unit    the time unit of the timeout argument.
    * @throws InterruptedException if interrupted.
-   * @throws TimeoutException if the wait timed out.
+   * @throws TimeoutException     if the wait timed out.
    */
   public void await(long timeout, TimeUnit unit)
     throws InterruptedException, TimeoutException {

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/Callback.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/Callback.java
@@ -23,16 +23,20 @@ package org.apache.avro.ipc;
  * For each request with an asynchronous callback,
  * either {@link #handleResult(Object)} or {@link #handleError(Throwable)}
  * will be invoked.
+ *
+ * @param <T> the type parameter
  */
 public interface Callback<T> {
   /**
    * Receives a callback result.
+   *
    * @param result the result returned in the callback.
    */
   void handleResult(T result);
 
   /**
    * Receives an error.
+   *
    * @param error the error returned in the callback.
    */
   void handleError(Throwable error);

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/DatagramServer.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/DatagramServer.java
@@ -27,8 +27,10 @@ import java.nio.channels.DatagramChannel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** A datagram-based server implementation. This uses a simple, non-standard
- * wire protocol and is not intended for production services. */
+/**
+ * A datagram-based server implementation. This uses a simple, non-standard
+ * wire protocol and is not intended for production services.
+ */
 public class DatagramServer extends Thread implements Server {
   private static final Logger LOG =
     LoggerFactory.getLogger(DatagramServer.class);
@@ -37,6 +39,13 @@ public class DatagramServer extends Thread implements Server {
   private final DatagramChannel channel;
   private final Transceiver transceiver;
 
+  /**
+   * Instantiates a new Datagram server.
+   *
+   * @param responder the responder
+   * @param addr      the addr
+   * @throws IOException the io exception
+   */
   public DatagramServer(Responder responder, SocketAddress addr)
     throws IOException {
     String name = "DatagramServer on "+addr;
@@ -69,6 +78,12 @@ public class DatagramServer extends Thread implements Server {
 
   public void close() { this.interrupt(); }
 
+  /**
+   * The entry point of application.
+   *
+   * @param arg the input arguments
+   * @throws Exception the exception
+   */
   public static void main(String[] arg) throws Exception {
     DatagramServer server = new DatagramServer(null, new InetSocketAddress(0));
     server.start();

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/DatagramTransceiver.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/DatagramTransceiver.java
@@ -28,8 +28,10 @@ import java.nio.channels.DatagramChannel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** A datagram-based {@link Transceiver} implementation. This uses a simple,
- * non-standard wire protocol and is not intended for production services. */
+/**
+ * A datagram-based {@link Transceiver} implementation. This uses a simple,
+ * non-standard wire protocol and is not intended for production services.
+ */
 public class DatagramTransceiver extends Transceiver {
   private static final Logger LOG
     = LoggerFactory.getLogger(DatagramTransceiver.class);
@@ -42,11 +44,22 @@ public class DatagramTransceiver extends Transceiver {
 
   public String getRemoteName() { return remote.toString(); }
 
+  /**
+   * Instantiates a new Datagram transceiver.
+   *
+   * @param remote the remote
+   * @throws IOException the io exception
+   */
   public DatagramTransceiver(SocketAddress remote) throws IOException {
     this(DatagramChannel.open());
     this.remote = remote;
   }
 
+  /**
+   * Instantiates a new Datagram transceiver.
+   *
+   * @param channel the channel
+   */
   public DatagramTransceiver(DatagramChannel channel) {
     this.channel = channel;
   }

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/HttpServer.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/HttpServer.java
@@ -31,26 +31,50 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 
-/** An HTTP-based RPC {@link Server}. */
+/**
+ * An HTTP-based RPC {@link Server}.
+ */
 public class HttpServer implements Server {
   private org.eclipse.jetty.server.Server server;
 
-  /** Constructs a server to run on the named port. */
+  /**
+   * Constructs a server to run on the named port.  @param responder the responder
+   *
+   * @param port the port
+   * @throws IOException the io exception
+   */
   public HttpServer(Responder responder, int port) throws IOException {
     this(new ResponderServlet(responder), null, port);
   }
 
-  /** Constructs a server to run on the named port. */
+  /**
+   * Constructs a server to run on the named port.  @param servlet the servlet
+   *
+   * @param port the port
+   * @throws IOException the io exception
+   */
   public HttpServer(ResponderServlet servlet, int port) throws IOException {
     this(servlet, null, port);
   }
 
-  /** Constructs a server to run on the named port on the specified address. */
+  /**
+   * Constructs a server to run on the named port on the specified address.  @param responder the responder
+   *
+   * @param bindAddress the bind address
+   * @param port        the port
+   * @throws IOException the io exception
+   */
   public HttpServer(Responder responder, String bindAddress, int port) throws IOException {
     this(new ResponderServlet(responder), bindAddress, port);
   }
 
-  /** Constructs a server to run on the named port on the specified address. */
+  /**
+   * Constructs a server to run on the named port on the specified address.  @param servlet the servlet
+   *
+   * @param bindAddress the bind address
+   * @param port        the port
+   * @throws IOException the io exception
+   */
   public HttpServer(ResponderServlet servlet, String bindAddress, int port) throws IOException {
     this.server = new org.eclipse.jetty.server.Server();
     ServerConnector connector = new ServerConnector(this.server);
@@ -69,12 +93,26 @@ public class HttpServer implements Server {
     server.setHandler(sch);
   }
 
-  /** Constructs a server to run with the given ConnectionFactory on the given address/port. */
+  /**
+   * Constructs a server to run with the given ConnectionFactory on the given address/port.  @param responder the responder
+   *
+   * @param connectionFactory the connection factory
+   * @param bindAddress       the bind address
+   * @param port              the port
+   * @throws IOException the io exception
+   */
   public HttpServer(Responder responder, ConnectionFactory connectionFactory, String bindAddress, int port) throws IOException {
     this(new ResponderServlet(responder), connectionFactory, bindAddress, port);
   }
 
-  /** Constructs a server to run with the given ConnectionFactory on the given address/port. */
+  /**
+   * Constructs a server to run with the given ConnectionFactory on the given address/port.  @param servlet the servlet
+   *
+   * @param connectionFactory the connection factory
+   * @param bindAddress       the bind address
+   * @param port              the port
+   * @throws IOException the io exception
+   */
   public HttpServer(ResponderServlet servlet, ConnectionFactory connectionFactory, String bindAddress, int port) throws IOException {
     this.server = new org.eclipse.jetty.server.Server();
     HttpConfiguration httpConfig = new HttpConfiguration();
@@ -94,7 +132,10 @@ public class HttpServer implements Server {
   /**
    * Constructs a server to run with the given connector.
    *
-   *  @deprecated - use the Constructors that take a ConnectionFactory
+   * @param servlet   the servlet
+   * @param connector the connector
+   * @throws IOException the io exception
+   * @deprecated - use the Constructors that take a ConnectionFactory
    */
   @Deprecated
   public HttpServer(ResponderServlet servlet, Connector connector) throws IOException {
@@ -106,16 +147,25 @@ public class HttpServer implements Server {
     server.setHandler(handler);
     handler.addServletWithMapping(new ServletHolder(servlet), "/*");
   }
+
   /**
    * Constructs a server to run with the given connector.
    *
-   *  @deprecated - use the Constructors that take a ConnectionFactory
+   * @param responder the responder
+   * @param connector the connector
+   * @throws IOException the io exception
+   * @deprecated - use the Constructors that take a ConnectionFactory
    */
   @Deprecated
   public HttpServer(Responder responder, Connector connector) throws IOException {
     this(new ResponderServlet(responder), connector);
   }
 
+  /**
+   * Add connector.
+   *
+   * @param connector the connector
+   */
   public void addConnector(Connector connector) {
     server.addConnector(connector);
   }

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/HttpTransceiver.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/HttpTransceiver.java
@@ -29,8 +29,13 @@ import java.util.List;
 import java.net.URL;
 import java.net.HttpURLConnection;
 
-/** An HTTP-based {@link Transceiver} implementation. */
+/**
+ * An HTTP-based {@link Transceiver} implementation.
+ */
 public class HttpTransceiver extends Transceiver {
+  /**
+   * The Content type.
+   */
   static final String CONTENT_TYPE = "avro/binary";
 
   private URL url;
@@ -38,14 +43,27 @@ public class HttpTransceiver extends Transceiver {
   private HttpURLConnection connection;
   private int timeout;
 
+  /**
+   * Instantiates a new Http transceiver.
+   *
+   * @param url the url
+   */
   public HttpTransceiver(URL url) { this.url = url; }
 
+  /**
+   * Instantiates a new Http transceiver.
+   *
+   * @param url   the url
+   * @param proxy the proxy
+   */
   public HttpTransceiver(URL url, Proxy proxy) {
     this(url);
     this.proxy = proxy;
   }
 
-  /** Set the connect and read timeouts, in milliseconds. */
+  /**
+   * Set the connect and read timeouts, in milliseconds.  @param timeout the timeout
+   */
   public void setTimeout(int timeout) { this.timeout = timeout; }
 
   public String getRemoteName() { return this.url.toString(); }
@@ -82,6 +100,12 @@ public class HttpTransceiver extends Transceiver {
     }
   }
 
+  /**
+   * Gets length.
+   *
+   * @param buffers the buffers
+   * @return the length
+   */
   static int getLength(List<ByteBuffer> buffers) {
     int length = 0;
     for (ByteBuffer buffer : buffers) {
@@ -92,6 +116,13 @@ public class HttpTransceiver extends Transceiver {
     return length;
   }
 
+  /**
+   * Read buffers list.
+   *
+   * @param in the in
+   * @return the list
+   * @throws IOException the io exception
+   */
   static List<ByteBuffer> readBuffers(InputStream in)
     throws IOException {
     List<ByteBuffer> buffers = new ArrayList<>();
@@ -113,6 +144,13 @@ public class HttpTransceiver extends Transceiver {
     }
   }
 
+  /**
+   * Write buffers.
+   *
+   * @param buffers the buffers
+   * @param out     the out
+   * @throws IOException the io exception
+   */
   static void writeBuffers(List<ByteBuffer> buffers, OutputStream out)
     throws IOException {
     for (ByteBuffer buffer : buffers) {

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/Ipc.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/Ipc.java
@@ -22,11 +22,18 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URI;
 
-/** IPC utilities, including client and server factories. */
+/**
+ * IPC utilities, including client and server factories.
+ */
 public class Ipc {
   private Ipc() {}                                // no public ctor
 
-  /** Create a client {@link Transceiver} connecting to the provided URI. */
+  /**
+   * Create a client {@link Transceiver} connecting to the provided URI.  @param uri the uri
+   *
+   * @return the transceiver
+   * @throws IOException the io exception
+   */
   public static Transceiver createTransceiver(URI uri) throws IOException {
     if ("http".equals(uri.getScheme()))
        return new HttpTransceiver(uri.toURL());
@@ -37,8 +44,14 @@ public class Ipc {
       throw new IOException("unknown uri scheme: "+uri);
   }
 
-  /** Create a {@link Server} listening at the named URI using the provided
-   * responder. */
+  /**
+   * Create a {@link Server} listening at the named URI using the provided
+   * responder.  @param responder the responder
+   *
+   * @param uri the uri
+   * @return the server
+   * @throws IOException the io exception
+   */
   public static Server createServer(Responder responder,
                                     URI uri) throws IOException {
     if ("http".equals(uri.getScheme()))

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/LocalTransceiver.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/LocalTransceiver.java
@@ -21,10 +21,17 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
 
-/** Implementation of IPC that remains in process. */
+/**
+ * Implementation of IPC that remains in process.
+ */
 public class LocalTransceiver extends Transceiver {
   private Responder responder;
 
+  /**
+   * Instantiates a new Local transceiver.
+   *
+   * @param responder the responder
+   */
   public LocalTransceiver(Responder responder) {
     this.responder = responder;
   }

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/NettyServer.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/NettyServer.java
@@ -64,23 +64,37 @@ public class NettyServer implements Server {
   private final CountDownLatch closed = new CountDownLatch(1);
   private final ExecutionHandler executionHandler;
 
+  /**
+   * Instantiates a new Netty server.
+   *
+   * @param responder the responder
+   * @param addr      the addr
+   */
   public NettyServer(Responder responder, InetSocketAddress addr) {
     this(responder, addr, new NioServerSocketChannelFactory
          (Executors .newCachedThreadPool(), Executors.newCachedThreadPool()));
   }
 
+  /**
+   * Instantiates a new Netty server.
+   *
+   * @param responder      the responder
+   * @param addr           the addr
+   * @param channelFactory the channel factory
+   */
   public NettyServer(Responder responder, InetSocketAddress addr,
                      ChannelFactory channelFactory) {
       this(responder, addr, channelFactory, null);
   }
 
   /**
-   * @param executionHandler if not null, will be inserted into the Netty
-   *                         pipeline. Use this when your responder does
-   *                         long, non-cpu bound processing (see Netty's
-   *                         ExecutionHandler javadoc).
-   * @param pipelineFactory  Avro-related handlers will be added on top of
-   *                         what this factory creates
+   * Instantiates a new Netty server.
+   *
+   * @param responder        the responder
+   * @param addr             the addr
+   * @param channelFactory   the channel factory
+   * @param pipelineFactory  Avro-related handlers will be added on top of                         what this factory creates
+   * @param executionHandler if not null, will be inserted into the Netty                         pipeline. Use this when your responder does                         long, non-cpu bound processing (see Netty's                         ExecutionHandler javadoc).
    */
   public NettyServer(Responder responder, InetSocketAddress addr,
                      ChannelFactory channelFactory,
@@ -108,10 +122,12 @@ public class NettyServer implements Server {
   }
 
   /**
-   * @param executionHandler if not null, will be inserted into the Netty
-   *                         pipeline. Use this when your responder does
-   *                         long, non-cpu bound processing (see Netty's
-   *                         ExecutionHandler javadoc).
+   * Instantiates a new Netty server.
+   *
+   * @param responder        the responder
+   * @param addr             the addr
+   * @param channelFactory   the channel factory
+   * @param executionHandler if not null, will be inserted into the Netty                         pipeline. Use this when your responder does                         long, non-cpu bound processing (see Netty's                         ExecutionHandler javadoc).
    */
   public NettyServer(Responder responder, InetSocketAddress addr,
                      ChannelFactory channelFactory,
@@ -148,6 +164,7 @@ public class NettyServer implements Server {
   }
 
   /**
+   * Gets num active connections.
    *
    * @return The number of clients currently connected to this server.
    */

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/NettyTransceiver.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/NettyTransceiver.java
@@ -59,12 +59,26 @@ import org.slf4j.LoggerFactory;
  * A Netty-based {@link Transceiver} implementation.
  */
 public class NettyTransceiver extends Transceiver {
-  /** If not specified, the default connection timeout will be used (60 sec). */
+  /**
+   * If not specified, the default connection timeout will be used (60 sec).
+   */
   public static final long DEFAULT_CONNECTION_TIMEOUT_MILLIS = 60 * 1000L;
+  /**
+   * The constant NETTY_CONNECT_TIMEOUT_OPTION.
+   */
   public static final String NETTY_CONNECT_TIMEOUT_OPTION =
       "connectTimeoutMillis";
+  /**
+   * The constant NETTY_TCP_NODELAY_OPTION.
+   */
   public static final String NETTY_TCP_NODELAY_OPTION = "tcpNoDelay";
+  /**
+   * The constant NETTY_KEEPALIVE_OPTION.
+   */
   public static final String NETTY_KEEPALIVE_OPTION = "keepAlive";
+  /**
+   * The constant DEFAULT_TCP_NODELAY_VALUE.
+   */
   public static final boolean DEFAULT_TCP_NODELAY_VALUE = true;
 
   private static final Logger LOG = LoggerFactory.getLogger(NettyTransceiver.class
@@ -79,7 +93,13 @@ public class NettyTransceiver extends Transceiver {
   private final ClientBootstrap bootstrap;
   private final InetSocketAddress remoteAddr;
 
+  /**
+   * The Channel future.
+   */
   volatile ChannelFuture channelFuture;
+  /**
+   * The Stopping.
+   */
   volatile boolean stopping;
   private final Object channelFutureLock = new Object();
 
@@ -91,6 +111,9 @@ public class NettyTransceiver extends Transceiver {
   private Channel channel;       // Synchronized on stateLock
   private Protocol remote;       // Synchronized on stateLock
 
+  /**
+   * Instantiates a new Netty transceiver.
+   */
   NettyTransceiver() {
     channelFactory = null;
     connectTimeoutMillis = 0L;
@@ -103,6 +126,7 @@ public class NettyTransceiver extends Transceiver {
    * Creates a NettyTransceiver, and attempts to connect to the given address.
    * {@link #DEFAULT_CONNECTION_TIMEOUT_MILLIS} is used for the connection
    * timeout.
+   *
    * @param addr the address to connect to.
    * @throws IOException if an error occurs connecting to the given address.
    */
@@ -112,10 +136,9 @@ public class NettyTransceiver extends Transceiver {
 
   /**
    * Creates a NettyTransceiver, and attempts to connect to the given address.
-   * @param addr the address to connect to.
-   * @param connectTimeoutMillis maximum amount of time to wait for connection
-   * establishment in milliseconds, or null to use
-   * {@link #DEFAULT_CONNECTION_TIMEOUT_MILLIS}.
+   *
+   * @param addr                 the address to connect to.
+   * @param connectTimeoutMillis maximum amount of time to wait for connection establishment in milliseconds, or null to use {@link #DEFAULT_CONNECTION_TIMEOUT_MILLIS}.
    * @throws IOException if an error occurs connecting to the given address.
    */
   public NettyTransceiver(InetSocketAddress addr,
@@ -132,7 +155,8 @@ public class NettyTransceiver extends Transceiver {
    * Creates a NettyTransceiver, and attempts to connect to the given address.
    * {@link #DEFAULT_CONNECTION_TIMEOUT_MILLIS} is used for the connection
    * timeout.
-   * @param addr the address to connect to.
+   *
+   * @param addr           the address to connect to.
    * @param channelFactory the factory to use to create a new Netty Channel.
    * @throws IOException if an error occurs connecting to the given address.
    */
@@ -143,11 +167,10 @@ public class NettyTransceiver extends Transceiver {
 
   /**
    * Creates a NettyTransceiver, and attempts to connect to the given address.
-   * @param addr the address to connect to.
-   * @param channelFactory the factory to use to create a new Netty Channel.
-   * @param connectTimeoutMillis maximum amount of time to wait for connection
-   * establishment in milliseconds, or null to use
-   * {@link #DEFAULT_CONNECTION_TIMEOUT_MILLIS}.
+   *
+   * @param addr                 the address to connect to.
+   * @param channelFactory       the factory to use to create a new Netty Channel.
+   * @param connectTimeoutMillis maximum amount of time to wait for connection establishment in milliseconds, or null to use {@link #DEFAULT_CONNECTION_TIMEOUT_MILLIS}.
    * @throws IOException if an error occurs connecting to the given address.
    */
   public NettyTransceiver(InetSocketAddress addr, ChannelFactory channelFactory,
@@ -163,10 +186,10 @@ public class NettyTransceiver extends Transceiver {
    * to prevent connect/disconnect attempts from hanging indefinitely.  It is
    * also recommended that the {@link #NETTY_TCP_NODELAY_OPTION} option be set
    * to true to minimize RPC latency.
-   * @param addr the address to connect to.
-   * @param channelFactory the factory to use to create a new Netty Channel.
-   * @param nettyClientBootstrapOptions map of Netty ClientBootstrap options
-   * to use.
+   *
+   * @param addr                        the address to connect to.
+   * @param channelFactory              the factory to use to create a new Netty Channel.
+   * @param nettyClientBootstrapOptions map of Netty ClientBootstrap options to use.
    * @throws IOException if an error occurs connecting to the given address.
    */
   public NettyTransceiver(InetSocketAddress addr, ChannelFactory channelFactory,
@@ -224,6 +247,7 @@ public class NettyTransceiver extends Transceiver {
   /**
    * Creates a Netty ChannelUpstreamHandler for handling events on the
    * Netty client channel.
+   *
    * @return the ChannelUpstreamHandler to use.
    */
   protected ChannelUpstreamHandler createNettyClientAvroHandler() {
@@ -232,8 +256,8 @@ public class NettyTransceiver extends Transceiver {
 
   /**
    * Creates the default options map for the Netty ClientBootstrap.
-   * @param connectTimeoutMillis connection timeout in milliseconds, or null
-   * if no timeout is desired.
+   *
+   * @param connectTimeoutMillis connection timeout in milliseconds, or null if no timeout is desired.
    * @return the map of Netty bootstrap options.
    */
   protected static Map<String, Object> buildDefaultBootstrapOptions(
@@ -423,6 +447,7 @@ public class NettyTransceiver extends Transceiver {
   /**
    * Closes this transceiver and disconnects from the remote peer.
    * Cancels all pending RPCs and sends an IOException to all pending callbacks.
+   *
    * @param awaitCompletion if true, will block until the close has completed.
    */
   public void close(boolean awaitCompletion) {
@@ -555,11 +580,15 @@ public class NettyTransceiver extends Transceiver {
    * a {@link Callback} if an error occurs while writing to the channel.
    */
   protected class WriteFutureListener implements ChannelFutureListener {
+    /**
+     * The Callback.
+     */
     protected final Callback<List<ByteBuffer>> callback;
 
     /**
      * Creates a WriteFutureListener that notifies the given callback
      * if an error occurs writing data to the channel.
+     *
      * @param callback the callback to notify, or null to skip notification.
      */
     public WriteFutureListener(Callback<List<ByteBuffer>> callback) {
@@ -633,9 +662,8 @@ public class NettyTransceiver extends Transceiver {
     /**
      * Creates a NettyTransceiverThreadFactory that creates threads with the
      * specified name.
-     * @param prefix the name prefix to use for all threads created by this
-     * ThreadFactory.  A unique ID will be appended to this prefix to form the
-     * final thread name.
+     *
+     * @param prefix the name prefix to use for all threads created by this ThreadFactory.  A unique ID will be appended to this prefix to form the final thread name.
      */
     public NettyTransceiverThreadFactory(String prefix) {
       this.prefix = prefix;

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/NettyTransportCodec.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/NettyTransportCodec.java
@@ -41,25 +41,54 @@ public class NettyTransportCodec {
     private int serial; // to track each call in client side
     private List<ByteBuffer> datas;
 
+    /**
+     * Instantiates a new Netty data pack.
+     */
     public NettyDataPack() {}
 
+    /**
+     * Instantiates a new Netty data pack.
+     *
+     * @param serial the serial
+     * @param datas  the datas
+     */
     public NettyDataPack(int serial, List<ByteBuffer> datas) {
       this.serial = serial;
       this.datas = datas;
     }
 
+    /**
+     * Sets serial.
+     *
+     * @param serial the serial
+     */
     public void setSerial(int serial) {
       this.serial = serial;
     }
 
+    /**
+     * Gets serial.
+     *
+     * @return the serial
+     */
     public int getSerial() {
       return serial;
     }
 
+    /**
+     * Sets datas.
+     *
+     * @param datas the datas
+     */
     public void setDatas(List<ByteBuffer> datas) {
       this.datas = datas;
     }
 
+    /**
+     * Gets datas.
+     *
+     * @return the datas
+     */
     public List<ByteBuffer> getDatas() {
       return datas;
     }
@@ -124,6 +153,9 @@ public class NettyTransportCodec {
     private static final long SIZEOF_REF = 8L; // mem usage of 64-bit pointer
 
 
+    /**
+     * Instantiates a new Netty frame decoder.
+     */
     public NettyFrameDecoder() {
       maxMem = Runtime.getRuntime().maxMemory();
     }

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/RPCContext.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/RPCContext.java
@@ -31,37 +31,62 @@ import org.apache.avro.Protocol.Message;
  * including handshake and call metadata. Note: this data includes
  * full copies of the RPC payload, so plugins which store RPCContexts
  * beyond the life of each call should be conscious of memory use.
- *
  */
 public class RPCContext {
 
   private HandshakeRequest handshakeRequest;
   private HandshakeResponse handshakeResponse;
 
-  protected Map<String,ByteBuffer> requestCallMeta, responseCallMeta;
+  /**
+   * The Request call meta.
+   */
+  protected Map<String,ByteBuffer> requestCallMeta, /**
+   * The Response call meta.
+   */
+  responseCallMeta;
 
+  /**
+   * The Response.
+   */
   protected Object response;
+  /**
+   * The Error.
+   */
   protected Exception error;
   private Message message;
+  /**
+   * The Request payload.
+   */
   List<ByteBuffer> requestPayload;
+  /**
+   * The Response payload.
+   */
   List<ByteBuffer> responsePayload;
 
-  /** Set the handshake request of this RPC. */
+  /**
+   * Set the handshake request of this RPC.  @param handshakeRequest the handshake request
+   */
   public void setHandshakeRequest(HandshakeRequest handshakeRequest) {
     this.handshakeRequest = handshakeRequest;
   }
 
-  /** Get the handshake request of this RPC. */
+  /**
+   * Get the handshake request of this RPC.  @return the handshake request
+   */
   public HandshakeRequest getHandshakeRequest() {
     return this.handshakeRequest;
   }
 
-  /** Set the handshake response of this RPC. */
+  /**
+   * Set the handshake response of this RPC.  @param handshakeResponse the handshake response
+   */
   public void setHandshakeResponse(HandshakeResponse handshakeResponse) {
     this.handshakeResponse = handshakeResponse;
   }
 
-  /** Get the handshake response of this RPC. */
+  /**
+   * Get the handshake response of this RPC.  @return the handshake response
+   */
   public HandshakeResponse getHandshakeResponse() {
     return this.handshakeResponse;
   }
@@ -69,8 +94,8 @@ public class RPCContext {
   /**
    * This is an access method for the handshake state
    * provided by the client to the server.
-   * @return a map representing handshake state from
-   * the client to the server
+   *
+   * @return a map representing handshake state from the client to the server
    */
   public Map<String,ByteBuffer> requestHandshakeMeta() {
     if (handshakeRequest.meta == null)
@@ -78,6 +103,11 @@ public class RPCContext {
     return handshakeRequest.meta;
   }
 
+  /**
+   * Sets request handshake meta.
+   *
+   * @param newmeta the newmeta
+   */
   void setRequestHandshakeMeta(Map<String,ByteBuffer> newmeta) {
     handshakeRequest.meta = newmeta;
   }
@@ -85,8 +115,8 @@ public class RPCContext {
   /**
    * This is an access method for the handshake state
    * provided by the server back to the client
-   * @return a map representing handshake state from
-   * the server to the client
+   *
+   * @return a map representing handshake state from the server to the client
    */
   public Map<String,ByteBuffer> responseHandshakeMeta() {
     if (handshakeResponse.meta == null)
@@ -94,6 +124,11 @@ public class RPCContext {
     return handshakeResponse.meta;
   }
 
+  /**
+   * Sets response handshake meta.
+   *
+   * @param newmeta the newmeta
+   */
   void setResponseHandshakeMeta(Map<String,ByteBuffer> newmeta) {
     handshakeResponse.meta = newmeta;
   }
@@ -101,8 +136,8 @@ public class RPCContext {
   /**
    * This is an access method for the per-call state
    * provided by the client to the server.
-   * @return a map representing per-call state from
-   * the client to the server
+   *
+   * @return a map representing per-call state from the client to the server
    */
   public Map<String,ByteBuffer> requestCallMeta() {
     if (requestCallMeta == null) {
@@ -111,6 +146,11 @@ public class RPCContext {
     return requestCallMeta;
   }
 
+  /**
+   * Sets request call meta.
+   *
+   * @param newmeta the newmeta
+   */
   void setRequestCallMeta(Map<String,ByteBuffer> newmeta) {
     requestCallMeta = newmeta;
   }
@@ -118,8 +158,8 @@ public class RPCContext {
   /**
    * This is an access method for the per-call state
    * provided by the server back to the client.
-   * @return a map representing per-call state from
-   * the server to the client
+   *
+   * @return a map representing per-call state from the server to the client
    */
   public Map<String,ByteBuffer> responseCallMeta() {
     if (responseCallMeta == null) {
@@ -128,10 +168,20 @@ public class RPCContext {
     return responseCallMeta;
   }
 
+  /**
+   * Sets response call meta.
+   *
+   * @param newmeta the newmeta
+   */
   void setResponseCallMeta(Map<String,ByteBuffer> newmeta) {
     responseCallMeta = newmeta;
   }
 
+  /**
+   * Sets response.
+   *
+   * @param response the response
+   */
   void setResponse(Object response) {
     this.response = response;
     this.error = null;
@@ -141,13 +191,18 @@ public class RPCContext {
    * The response object generated at the server,
    * if it exists.  If an exception was generated,
    * this will be null.
-   * @return the response created by this RPC, no
-   * null if an exception was generated
+   *
+   * @return the response created by this RPC, no null if an exception was generated
    */
   public Object response() {
     return response;
   }
 
+  /**
+   * Sets error.
+   *
+   * @param error the error
+   */
   void setError(Exception error) {
     this.response = null;
     this.error = error;
@@ -156,8 +211,8 @@ public class RPCContext {
   /**
    * The exception generated at the server,
    * or null if no such exception has occurred
-   * @return the exception generated at the server, or
-   * null if no such exception
+   *
+   * @return the exception generated at the server, or null if no such exception
    */
   public Exception error() {
     return error;
@@ -166,49 +221,61 @@ public class RPCContext {
   /**
    * Indicates whether an exception was generated
    * at the server
-   * @return true is an exception was generated at
-   * the server, or false if not
+   *
+   * @return true is an exception was generated at the server, or false if not
    */
   public boolean isError() {
     return error != null;
   }
 
-  /** Sets the {@link Message} corresponding to this RPC */
+  /**
+   * Sets the {@link Message} corresponding to this RPC  @param message the message
+   */
   public void setMessage(Message message) {
     this.message = message;
   }
 
-  /** Returns the {@link Message} corresponding to this RPC
+  /**
+   * Returns the {@link Message} corresponding to this RPC
+   *
    * @return this RPC's {@link Message}
    */
   public Message getMessage() { return message; }
 
-  /** Sets the serialized payload of the request in this RPC. Will
-   * not include handshake or meta-data. */
+  /**
+   * Sets the serialized payload of the request in this RPC. Will
+   * not include handshake or meta-data.  @param payload the payload
+   */
   public void setRequestPayload(List<ByteBuffer> payload) {
     this.requestPayload = payload;
   }
 
-  /** Returns the serialized payload of the request in this RPC. Will only be
+  /**
+   * Returns the serialized payload of the request in this RPC. Will only be
    * generated from a Requestor and will not include handshake or meta-data.
    * If the request payload has not been set yet, returns null.
    *
-   * @return this RPC's request payload.*/
+   * @return this RPC's request payload.
+   */
   public List<ByteBuffer> getRequestPayload() {
     return this.requestPayload;
   }
 
-  /** Returns the serialized payload of the response in this RPC. Will only be
+  /**
+   * Returns the serialized payload of the response in this RPC. Will only be
    * generated from a Responder and will not include handshake or meta-data.
    * If the response payload has not been set yet, returns null.
    *
-   * @return this RPC's response payload.*/
+   * @return this RPC's response payload.
+   */
   public List<ByteBuffer> getResponsePayload() {
     return this.responsePayload;
   }
 
-  /** Sets the serialized payload of the response in this RPC. Will
-   * not include handshake or meta-data. */
+  /**
+   * Sets the serialized payload of the response in this RPC. Will
+   * not include handshake or meta-data.  @param payload the payload
+   */
   public void setResponsePayload(List<ByteBuffer> payload) {
     this.responsePayload = payload;
   }

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/RPCPlugin.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/RPCPlugin.java
@@ -28,24 +28,28 @@ public class RPCPlugin {
   /**
    * Called on the client before the initial RPC handshake to
    * setup any handshake metadata for this plugin
+   *
    * @param context the handshake rpc context
    */
   public void clientStartConnect(RPCContext context) { }
 
   /**
    * Called on the server during the RPC handshake
+   *
    * @param context the handshake rpc context
    */
   public void serverConnecting(RPCContext context) { }
 
   /**
    * Called on the client after the initial RPC handshake
+   *
    * @param context the handshake rpc context
    */
   public void clientFinishConnect(RPCContext context) { }
 
   /**
    * This method is invoked at the client before it issues the RPC call.
+   *
    * @param context the per-call rpc context (in/out parameter)
    */
   public void clientSendRequest(RPCContext context) { }
@@ -54,6 +58,7 @@ public class RPCPlugin {
   /**
    * This method is invoked at the RPC server when the request is received,
    * but before the call itself is executed
+   *
    * @param context the per-call rpc context (in/out parameter)
    */
   public void serverReceiveRequest(RPCContext context) { }
@@ -61,6 +66,7 @@ public class RPCPlugin {
   /**
    * This method is invoked at the server before the response is executed,
    * but before the response has been formulated
+   *
    * @param context the per-call rpc context (in/out parameter)
    */
   public void serverSendResponse(RPCContext context) { }
@@ -68,6 +74,7 @@ public class RPCPlugin {
   /**
    * This method is invoked at the client after the call is executed,
    * and after the client receives the response
+   *
    * @param context the per-call rpc context
    */
   public void clientReceiveResponse(RPCContext context) { }

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/Requestor.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/Requestor.java
@@ -48,7 +48,9 @@ import org.apache.avro.util.ByteBufferOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Base class for the client side of a protocol interaction. */
+/**
+ * Base class for the client side of a protocol interaction.
+ */
 public abstract class Requestor {
   private static final Logger LOG = LoggerFactory.getLogger(Requestor.class);
 
@@ -65,11 +67,32 @@ public abstract class Requestor {
   private final Transceiver transceiver;
   private final ReentrantLock handshakeLock = new ReentrantLock();
 
+  /**
+   * The Rpc meta plugins.
+   */
   protected final List<RPCPlugin> rpcMetaPlugins;
 
+  /**
+   * Gets local.
+   *
+   * @return the local
+   */
   public Protocol getLocal() { return local; }
+
+  /**
+   * Gets transceiver.
+   *
+   * @return the transceiver
+   */
   public Transceiver getTransceiver() { return transceiver; }
 
+  /**
+   * Instantiates a new Requestor.
+   *
+   * @param local       the local
+   * @param transceiver the transceiver
+   * @throws IOException the io exception
+   */
   protected Requestor(Protocol local, Transceiver transceiver)
     throws IOException {
     this.local = local;
@@ -81,6 +104,7 @@ public abstract class Requestor {
   /**
    * Adds a new plugin to manipulate RPC metadata.  Plugins
    * are executed in the order that they are added.
+   *
    * @param plugin a plugin that will manipulate RPC metadata
    */
   public void addRPCPlugin(RPCPlugin plugin) {
@@ -89,7 +113,13 @@ public abstract class Requestor {
 
   private static final EncoderFactory ENCODER_FACTORY = new EncoderFactory();
 
-  /** Writes a request message and reads a response or error message. */
+  /**
+   * Writes a request message and reads a response or error message.  @param messageName the message name
+   *
+   * @param request the request
+   * @return the object
+   * @throws Exception the exception
+   */
   public Object request(String messageName, Object request)
     throws Exception {
     // Initialize request
@@ -117,11 +147,11 @@ public abstract class Requestor {
    * Writes a request message and returns the result through a Callback.
    * Clients can also use a Future interface by creating a new CallFuture<T>,
    * passing it in as the Callback parameter, and then waiting on that Future.
-   * @param <T> the return type of the message.
+   *
+   * @param <T>         the return type of the message.
    * @param messageName the name of the message to invoke.
-   * @param request the request data to send.
-   * @param callback the callback which will be invoked when the response is returned
-   * or an error occurs.
+   * @param request     the request data to send.
+   * @param callback    the callback which will be invoked when the response is returned or an error occurs.
    * @throws Exception if an error occurs sending the message.
    */
   public <T> void request(String messageName, Object request, Callback<T> callback)
@@ -129,7 +159,13 @@ public abstract class Requestor {
     request(new Request(messageName, request, new RPCContext()), callback);
   }
 
-  /** Writes a request message and returns the result through a Callback. */
+  /**
+   * Writes a request message and returns the result through a Callback.  @param <T>  the type parameter
+   *
+   * @param request  the request
+   * @param callback the callback
+   * @throws Exception the exception
+   */
   <T> void request(Request request, Callback<T> callback)
     throws Exception {
     Transceiver t = getTransceiver();
@@ -264,7 +300,11 @@ public abstract class Requestor {
     REMOTE_PROTOCOLS.putIfAbsent(remoteHash, remote);
   }
 
-  /** Return the remote protocol.  Force a handshake if required. */
+  /**
+   * Return the remote protocol.  Force a handshake if required.  @return the remote
+   *
+   * @throws IOException the io exception
+   */
   public Protocol getRemote() throws IOException {
     if (remote != null) return remote;            // already have it
     MD5 remoteHash = REMOTE_HASHES.get(transceiver.getRemoteName());
@@ -294,30 +334,68 @@ public abstract class Requestor {
   }
 
 
-  /** Writes a request message. */
+  /**
+   * Writes a request message.  @param schema the schema
+   *
+   * @param request the request
+   * @param out     the out
+   * @throws IOException the io exception
+   */
   public abstract void writeRequest(Schema schema, Object request,
                                     Encoder out) throws IOException;
 
+  /**
+   * Read response object.
+   *
+   * @param schema the schema
+   * @param in     the in
+   * @return the object
+   * @throws IOException the io exception
+   */
   @Deprecated                                     // for compatibility in 1.5
   public Object readResponse(Schema schema, Decoder in) throws IOException {
     return readResponse(schema, schema, in);
   }
 
-  /** Reads a response message. */
+  /**
+   * Reads a response message.  @param writer the writer
+   *
+   * @param reader the reader
+   * @param in     the in
+   * @return the object
+   * @throws IOException the io exception
+   */
   public abstract Object readResponse(Schema writer, Schema reader, Decoder in)
     throws IOException;
 
+  /**
+   * Read error object.
+   *
+   * @param schema the schema
+   * @param in     the in
+   * @return the object
+   * @throws IOException the io exception
+   */
   @Deprecated                                     // for compatibility in 1.5
   public Object readError(Schema schema, Decoder in) throws IOException {
     return readError(schema, schema, in);
   }
 
-  /** Reads an error message. */
+  /**
+   * Reads an error message.  @param writer the writer
+   *
+   * @param reader the reader
+   * @param in     the in
+   * @return the exception
+   * @throws IOException the io exception
+   */
   public abstract Exception readError(Schema writer, Schema reader, Decoder in)
     throws IOException;
 
   /**
    * Handles callbacks from transceiver invocations.
+   *
+   * @param <T> the type parameter
    */
   protected class TransceiverCallback<T> implements Callback<List<ByteBuffer>> {
     private final Request request;
@@ -325,7 +403,8 @@ public abstract class Requestor {
 
     /**
      * Creates a TransceiverCallback.
-     * @param request the request to set.
+     *
+     * @param request  the request to set.
      * @param callback the callback to set.
      */
     public TransceiverCallback(Request request, Callback<T> callback) {
@@ -390,9 +469,10 @@ public abstract class Requestor {
 
     /**
      * Creates a Request.
+     *
      * @param messageName the name of the message to invoke.
-     * @param request the request data to send.
-     * @param context the RPC context to use.
+     * @param request     the request data to send.
+     * @param context     the RPC context to use.
      */
     public Request(String messageName, Object request, RPCContext context) {
       this(messageName, request, context, null);
@@ -400,10 +480,11 @@ public abstract class Requestor {
 
     /**
      * Creates a Request.
+     *
      * @param messageName the name of the message to invoke.
-     * @param request the request data to send.
-     * @param context the RPC context to use.
-     * @param encoder the BinaryEncoder to use to serialize the request.
+     * @param request     the request data to send.
+     * @param context     the RPC context to use.
+     * @param encoder     the BinaryEncoder to use to serialize the request.
      */
     public Request(String messageName, Object request, RPCContext context,
                    BinaryEncoder encoder) {
@@ -416,6 +497,7 @@ public abstract class Requestor {
 
     /**
      * Copy constructor.
+     *
      * @param other Request from which to copy fields.
      */
     public Request(Request other) {
@@ -427,6 +509,7 @@ public abstract class Requestor {
 
     /**
      * Gets the message name.
+     *
      * @return the message name.
      */
     public String getMessageName() {
@@ -435,6 +518,7 @@ public abstract class Requestor {
 
     /**
      * Gets the RPC context.
+     *
      * @return the RPC context.
      */
     public RPCContext getContext() {
@@ -443,6 +527,7 @@ public abstract class Requestor {
 
     /**
      * Gets the Message associated with this request.
+     *
      * @return this request's message.
      */
     public Message getMessage() {
@@ -457,6 +542,7 @@ public abstract class Requestor {
 
     /**
      * Gets the request data, generating it first if necessary.
+     *
      * @return the request data.
      * @throws Exception if an error occurs generating the request data.
      */
@@ -503,6 +589,7 @@ public abstract class Requestor {
 
     /**
      * Creates a Response.
+     *
      * @param request the Request associated with this response.
      */
     public Response(Request request) {
@@ -511,8 +598,9 @@ public abstract class Requestor {
 
     /**
      * Creates a Creates a Response.
+     *
      * @param request the Request associated with this response.
-     * @param in the BinaryDecoder to use to deserialize the response.
+     * @param in      the BinaryDecoder to use to deserialize the response.
      */
     public Response(Request request, BinaryDecoder in) {
       this.request = request;
@@ -521,6 +609,7 @@ public abstract class Requestor {
 
     /**
      * Gets the RPC response, reading/deserializing it first if necessary.
+     *
      * @return the RPC response.
      * @throws Exception if an error occurs reading/deserializing the response.
      */

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/Responder.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/Responder.java
@@ -47,7 +47,9 @@ import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.specific.SpecificDatumReader;
 import org.apache.avro.specific.SpecificDatumWriter;
 
-/** Base class for the server side of a protocol interaction. */
+/**
+ * Base class for the server side of a protocol interaction.
+ */
 public abstract class Responder {
   private static final Logger LOG = LoggerFactory.getLogger(Responder.class);
 
@@ -66,8 +68,16 @@ public abstract class Responder {
 
   private final Protocol local;
   private final MD5 localHash;
+  /**
+   * The Rpc meta plugins.
+   */
   protected final List<RPCPlugin> rpcMetaPlugins;
 
+  /**
+   * Instantiates a new Responder.
+   *
+   * @param local the local
+   */
   protected Responder(Protocol local) {
     this.local = local;
     this.localHash = new MD5();
@@ -77,31 +87,47 @@ public abstract class Responder {
       new CopyOnWriteArrayList<>();
   }
 
-  /** Return the remote protocol.  Accesses a {@link ThreadLocal} that's set
-   * around calls to {@link #respond(Protocol.Message, Object)}. */
+  /**
+   * Return the remote protocol.  Accesses a {@link ThreadLocal} that's set
+   * around calls to {@link #respond(Protocol.Message, Object)}.  @return the remote
+   */
   public static Protocol getRemote() { return REMOTE.get(); }
 
-  /** Return the local protocol. */
+  /**
+   * Return the local protocol.  @return the local
+   */
   public Protocol getLocal() { return local; }
 
   /**
    * Adds a new plugin to manipulate per-call metadata.  Plugins
    * are executed in the order that they are added.
+   *
    * @param plugin a plugin that will manipulate RPC metadata
    */
   public void addRPCPlugin(RPCPlugin plugin) {
     rpcMetaPlugins.add(plugin);
   }
 
-  /** Called by a server to deserialize a request, compute and serialize
-   * a response or error. */
+  /**
+   * Called by a server to deserialize a request, compute and serialize
+   * a response or error.  @param buffers the buffers
+   *
+   * @return the list
+   * @throws IOException the io exception
+   */
   public List<ByteBuffer> respond(List<ByteBuffer> buffers) throws IOException {
     return respond(buffers, null);
   }
 
-  /** Called by a server to deserialize a request, compute and serialize a
+  /**
+   * Called by a server to deserialize a request, compute and serialize a
    * response or error.  Transceiver is used by connection-based servers to
-   * track handshake status of connection. */
+   * track handshake status of connection.  @param buffers the buffers
+   *
+   * @param connection the connection
+   * @return the list
+   * @throws IOException the io exception
+   */
   public List<ByteBuffer> respond(List<ByteBuffer> buffers,
                                   Transceiver connection) throws IOException {
     Decoder in = DecoderFactory.get().binaryDecoder(
@@ -240,19 +266,44 @@ public abstract class Responder {
     return remote;
   }
 
-  /** Computes the response for a message. */
+  /**
+   * Computes the response for a message.  @param message the message
+   *
+   * @param request the request
+   * @return the object
+   * @throws Exception the exception
+   */
   public abstract Object respond(Message message, Object request)
     throws Exception;
 
-  /** Reads a request message. */
+  /**
+   * Reads a request message.  @param actual the actual
+   *
+   * @param expected the expected
+   * @param in       the in
+   * @return the object
+   * @throws IOException the io exception
+   */
   public abstract Object readRequest(Schema actual, Schema expected, Decoder in)
     throws IOException;
 
-  /** Writes a response message. */
+  /**
+   * Writes a response message.  @param schema the schema
+   *
+   * @param response the response
+   * @param out      the out
+   * @throws IOException the io exception
+   */
   public abstract void writeResponse(Schema schema, Object response,
                                      Encoder out) throws IOException;
 
-  /** Writes an error message. */
+  /**
+   * Writes an error message.  @param schema the schema
+   *
+   * @param error the error
+   * @param out   the out
+   * @throws IOException the io exception
+   */
   public abstract void writeError(Schema schema, Object error,
                                   Encoder out) throws IOException;
 

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/ResponderServlet.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/ResponderServlet.java
@@ -29,10 +29,18 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.avro.AvroRuntimeException;
 
-/** An {@link HttpServlet} that responds to Avro RPC requests. */
+/**
+ * An {@link HttpServlet} that responds to Avro RPC requests.
+ */
 public class ResponderServlet extends HttpServlet {
   private Responder responder;
 
+  /**
+   * Instantiates a new Responder servlet.
+   *
+   * @param responder the responder
+   * @throws IOException the io exception
+   */
   public ResponderServlet(Responder responder) throws IOException {
     this.responder = responder;
   }

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/SaslSocketServer.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/SaslSocketServer.java
@@ -30,19 +30,32 @@ import javax.security.auth.callback.CallbackHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** A {@link Server} that uses {@link javax.security.sasl} for authentication
- * and encryption. */
+/**
+ * A {@link Server} that uses {@link javax.security.sasl} for authentication
+ * and encryption.
+ */
 public class SaslSocketServer extends SocketServer {
   private static final Logger LOG = LoggerFactory.getLogger(SaslServer.class);
 
   private static abstract class SaslServerFactory {
+    /**
+     * Gets server.
+     *
+     * @return the server
+     * @throws SaslException the sasl exception
+     */
     protected abstract SaslServer getServer() throws SaslException;
   }
 
   private SaslServerFactory factory;
 
-  /** Create using SASL's anonymous (<a
-   * href="http://www.ietf.org/rfc/rfc2245.txt">RFC 2245) mechanism. */
+  /**
+   * Create using SASL's anonymous (<a
+   * href="http://www.ietf.org/rfc/rfc2245.txt">RFC 2245) mechanism.  @param responder the responder
+   *
+   * @param addr the addr
+   * @throws IOException the io exception
+   */
   public SaslSocketServer(Responder responder, SocketAddress addr)
     throws IOException {
     this(responder, addr,
@@ -51,7 +64,17 @@ public class SaslSocketServer extends SocketServer {
          });
   }
 
-  /** Create using the specified {@link SaslServer} parameters. */
+  /**
+   * Create using the specified {@link SaslServer} parameters.  @param responder the responder
+   *
+   * @param addr       the addr
+   * @param mechanism  the mechanism
+   * @param protocol   the protocol
+   * @param serverName the server name
+   * @param props      the props
+   * @param cbh        the cbh
+   * @throws IOException the io exception
+   */
   public SaslSocketServer(Responder responder, SocketAddress addr,
                           final String mechanism, final String protocol,
                           final String serverName, final Map<String,?> props,

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/SaslSocketTransceiver.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/SaslSocketTransceiver.java
@@ -39,15 +39,33 @@ import org.apache.avro.util.ByteBufferOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** A {@link Transceiver} that uses {@link javax.security.sasl} for
- * authentication and encryption. */
+/**
+ * A {@link Transceiver} that uses {@link javax.security.sasl} for
+ * authentication and encryption.
+ */
 public class SaslSocketTransceiver extends Transceiver {
   private static final Logger LOG =
     LoggerFactory.getLogger(SaslSocketTransceiver.class);
 
   private static final ByteBuffer EMPTY = ByteBuffer.allocate(0);
 
-  private static enum Status { START, CONTINUE, FAIL, COMPLETE }
+  private static enum Status {
+    /**
+     * Start status.
+     */
+    START,
+    /**
+     * Continue status.
+     */
+    CONTINUE,
+    /**
+     * Fail status.
+     */
+    FAIL,
+    /**
+     * Complete status.
+     */
+    COMPLETE }
 
   private SaslParticipant sasl;
   private SocketChannel channel;
@@ -60,13 +78,24 @@ public class SaslSocketTransceiver extends Transceiver {
   private ByteBuffer writeHeader = ByteBuffer.allocate(4);
   private ByteBuffer zeroHeader = ByteBuffer.allocate(4).putInt(0);
 
-  /** Create using SASL's anonymous (<a
-   * href="http://www.ietf.org/rfc/rfc2245.txt">RFC 2245) mechanism. */
+  /**
+   * Create using SASL's anonymous RFC 2245 mechanism.
+   *
+   * @param address The socket to connect to
+   * @throws IOException the io exception
+   * @see <a href="http://www.ietf.org/rfc/rfc2245.txt">RFC 2245</a>
+   */
   public SaslSocketTransceiver(SocketAddress address) throws IOException {
     this(address, new AnonymousClient());
   }
 
-  /** Create using the specified {@link SaslClient}. */
+  /**
+   * Create using the specified {@link SaslClient}.
+   *
+   * @param address    The socket to connect to
+   * @param saslClient The sasl client that you want to use
+   * @throws IOException the io exception
+   */
   public SaslSocketTransceiver(SocketAddress address, SaslClient saslClient)
     throws IOException {
     this.sasl = new SaslParticipant(saslClient);
@@ -76,7 +105,13 @@ public class SaslSocketTransceiver extends Transceiver {
     open(true);
   }
 
-  /** Create using the specified {@link SaslServer}. */
+  /**
+   * Create using the specified {@link SaslServer}.
+   *
+   * @param channel    The channel to use to connect
+   * @param saslServer The sasl server that you want to connect to
+   * @throws IOException the io exception
+   */
   public SaslSocketTransceiver(SocketChannel channel, SaslServer saslServer)
     throws IOException {
     this.sasl = new SaslParticipant(saslServer);
@@ -313,18 +348,39 @@ public class SaslSocketTransceiver extends Transceiver {
    * unfortunately don't share a common superclass.
    */
   private static class SaslParticipant {
-    // One of these will always be null.
+    /**
+     * The Server.
+     */
+// One of these will always be null.
     public SaslServer server;
+    /**
+     * The Client.
+     */
     public SaslClient client;
 
+    /**
+     * Instantiates a new Sasl participant.
+     *
+     * @param server the server
+     */
     public SaslParticipant(SaslServer server) {
       this.server = server;
     }
 
+    /**
+     * Instantiates a new Sasl participant.
+     *
+     * @param client the client
+     */
     public SaslParticipant(SaslClient client) {
       this.client = client;
     }
 
+    /**
+     * Gets mechanism name.
+     *
+     * @return the mechanism name
+     */
     public String getMechanismName() {
       if (client != null)
         return client.getMechanismName();
@@ -332,6 +388,11 @@ public class SaslSocketTransceiver extends Transceiver {
         return server.getMechanismName();
     }
 
+    /**
+     * Is complete boolean.
+     *
+     * @return the boolean
+     */
     public boolean isComplete() {
       if (client != null)
         return client.isComplete();
@@ -339,6 +400,11 @@ public class SaslSocketTransceiver extends Transceiver {
         return server.isComplete();
     }
 
+    /**
+     * Dispose.
+     *
+     * @throws SaslException the sasl exception
+     */
     public void dispose() throws SaslException {
       if (client != null)
         client.dispose();
@@ -346,6 +412,13 @@ public class SaslSocketTransceiver extends Transceiver {
         server.dispose();
     }
 
+    /**
+     * Unwrap byte [ ].
+     *
+     * @param buf the buf
+     * @return the byte [ ]
+     * @throws SaslException the sasl exception
+     */
     public byte[] unwrap(byte[] buf) throws SaslException {
       if (client != null)
         return client.unwrap(buf, 0, buf.length);
@@ -353,10 +426,26 @@ public class SaslSocketTransceiver extends Transceiver {
         return server.unwrap(buf, 0, buf.length);
     }
 
+    /**
+     * Wrap byte [ ].
+     *
+     * @param buf the buf
+     * @return the byte [ ]
+     * @throws SaslException the sasl exception
+     */
     public byte[] wrap(byte[] buf) throws SaslException {
       return wrap(buf, 0, buf.length);
     }
 
+    /**
+     * Wrap byte [ ].
+     *
+     * @param buf   the buf
+     * @param start the start
+     * @param len   the len
+     * @return the byte [ ]
+     * @throws SaslException the sasl exception
+     */
     public byte[] wrap(byte[] buf, int start, int len) throws SaslException {
       if (client != null)
         return client.wrap(buf, start, len);
@@ -364,6 +453,12 @@ public class SaslSocketTransceiver extends Transceiver {
         return server.wrap(buf, start, len);
     }
 
+    /**
+     * Gets negotiated property.
+     *
+     * @param propName the prop name
+     * @return the negotiated property
+     */
     public Object getNegotiatedProperty(String propName) {
       if (client != null)
         return client.getNegotiatedProperty(propName);
@@ -371,6 +466,13 @@ public class SaslSocketTransceiver extends Transceiver {
         return server.getNegotiatedProperty(propName);
     }
 
+    /**
+     * Evaluate byte [ ].
+     *
+     * @param buf the buf
+     * @return the byte [ ]
+     * @throws SaslException the sasl exception
+     */
     public byte[] evaluate(byte[] buf) throws SaslException {
       if (client != null)
         return client.evaluateChallenge(buf);

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/Server.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/Server.java
@@ -18,18 +18,28 @@
 
 package org.apache.avro.ipc;
 
-/** A server listening on a port. */
+/**
+ * A server listening on a port.
+ */
 public interface Server {
-  /** The port this server runs on. */
+  /**
+   * The port this server runs on.  @return the port
+   */
   int getPort();
 
-  /** Start this server. */
+  /**
+   * Start this server.
+   */
   void start();
 
-  /** Stop this server. */
+  /**
+   * Stop this server.
+   */
   void close();
 
-  /** Wait for this server to exit. */
+  /**
+   * Wait for this server to exit.  @throws InterruptedException the interrupted exception
+   */
   void join() throws InterruptedException;
 
 }

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/SocketServer.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/SocketServer.java
@@ -33,8 +33,10 @@ import org.apache.avro.Protocol;
 import org.apache.avro.Protocol.Message;
 import org.apache.avro.ipc.generic.GenericResponder;
 
-/** A socket-based server implementation. This uses a simple, non-standard wire
+/**
+ * A socket-based server implementation. This uses a simple, non-standard wire
  * protocol and is not intended for production services.
+ *
  * @deprecated use {@link SaslSocketServer} instead.
  */
 public class SocketServer extends Thread implements Server {
@@ -44,6 +46,13 @@ public class SocketServer extends Thread implements Server {
   private ServerSocketChannel channel;
   private ThreadGroup group;
 
+  /**
+   * Instantiates a new Socket server.
+   *
+   * @param responder the responder
+   * @param addr      the addr
+   * @throws IOException the io exception
+   */
   public SocketServer(Responder responder, SocketAddress addr)
     throws IOException {
     String name = "SocketServer on "+addr;
@@ -87,8 +96,13 @@ public class SocketServer extends Thread implements Server {
     group.interrupt();
   }
 
-  /** Creates an appropriate {@link Transceiver} for this server.
-   * Returns a {@link SocketTransceiver} by default. */
+  /**
+   * Creates an appropriate {@link Transceiver} for this server.
+   * Returns a {@link SocketTransceiver} by default.  @param channel the channel
+   *
+   * @return the transceiver
+   * @throws IOException the io exception
+   */
   protected Transceiver getTransceiver(SocketChannel channel)
     throws IOException {
     return new SocketTransceiver(channel);
@@ -96,9 +110,21 @@ public class SocketServer extends Thread implements Server {
 
   private class Connection implements Runnable {
 
+    /**
+     * The Channel.
+     */
     SocketChannel channel;
+    /**
+     * The Xc.
+     */
     Transceiver xc;
 
+    /**
+     * Instantiates a new Connection.
+     *
+     * @param channel the channel
+     * @throws IOException the io exception
+     */
     public Connection(SocketChannel channel) throws IOException {
       this.channel = channel;
 
@@ -129,6 +155,12 @@ public class SocketServer extends Thread implements Server {
 
   }
 
+  /**
+   * The entry point of application.
+   *
+   * @param arg the input arguments
+   * @throws Exception the exception
+   */
   public static void main(String[] arg) throws Exception {
     Responder responder =
       new GenericResponder(Protocol.parse("{\"protocol\": \"X\"}")) {

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/SocketTransceiver.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/SocketTransceiver.java
@@ -31,8 +31,10 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.avro.Protocol;
 
-/** A socket-based {@link Transceiver} implementation.  This uses a simple,
+/**
+ * A socket-based {@link Transceiver} implementation.  This uses a simple,
  * non-standard wire protocol and is not intended for production services.
+ *
  * @deprecated use {@link SaslSocketTransceiver} instead.
  */
 public class SocketTransceiver extends Transceiver {
@@ -44,10 +46,22 @@ public class SocketTransceiver extends Transceiver {
 
   private Protocol remote;
 
+  /**
+   * Instantiates a new Socket transceiver.
+   *
+   * @param address the address
+   * @throws IOException the io exception
+   */
   public SocketTransceiver(SocketAddress address) throws IOException {
     this(SocketChannel.open(address));
   }
 
+  /**
+   * Instantiates a new Socket transceiver.
+   *
+   * @param channel the channel
+   * @throws IOException the io exception
+   */
   public SocketTransceiver(SocketChannel channel) throws IOException {
     this.channel = channel;
     this.channel.socket().setTcpNoDelay(true);

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/Transceiver.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/Transceiver.java
@@ -26,10 +26,18 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.avro.Protocol;
 
-/** Base transport class used by {@link Requestor}. */
+/**
+ * Base transport class used by {@link Requestor}.
+ */
 public abstract class Transceiver implements Closeable {
   private final ReentrantLock channelLock = new ReentrantLock();
 
+  /**
+   * Gets remote name.
+   *
+   * @return the remote name
+   * @throws IOException the io exception
+   */
   public abstract String getRemoteName() throws IOException;
 
   /**
@@ -48,9 +56,14 @@ public abstract class Transceiver implements Closeable {
     }
   }
 
-  /** Called by {@link Requestor#request(String,Object)} for two-way messages.
+  /**
+   * Called by {@link Requestor#request(String, Object)} for two-way messages.
    * By default calls {@link #writeBuffers(List)} followed by
-   * {@link #readBuffers()}. */
+   * {@link #readBuffers()}.  @param request the request
+   *
+   * @return the list
+   * @throws IOException the io exception
+   */
   public List<ByteBuffer> transceive(List<ByteBuffer> request)
     throws IOException {
     lockChannel();
@@ -63,7 +76,11 @@ public abstract class Transceiver implements Closeable {
   }
 
   /**
-   * Called by {@link Requestor#request(String,Object,Callback)} for two-way messages using callbacks.
+   * Called by {@link Requestor#request(String, Object, Callback)} for two-way messages using callbacks.
+   *
+   * @param request  the request
+   * @param callback the callback
+   * @throws IOException the io exception
    */
   public void transceive(List<ByteBuffer> request, Callback<List<ByteBuffer>> callback)
     throws IOException {
@@ -76,30 +93,44 @@ public abstract class Transceiver implements Closeable {
     }
   }
 
-  /** Called by the default definition of {@link #transceive(List)}.*/
+  /**
+   * Called by the default definition of {@link #transceive(List)}. @return the list
+   *
+   * @throws IOException the io exception
+   */
   public abstract List<ByteBuffer> readBuffers() throws IOException;
 
-  /** Called by {@link Requestor#request(String,Object)} for one-way messages.*/
+  /**
+   * Called by {@link Requestor#request(String, Object)} for one-way messages. @param buffers the buffers
+   *
+   * @throws IOException the io exception
+   */
   public abstract void writeBuffers(List<ByteBuffer> buffers)
     throws IOException;
 
-  /** True if a handshake has been completed for this connection.  Used to
+  /**
+   * True if a handshake has been completed for this connection.  Used to
    * determine whether a handshake need be completed prior to a one-way
    * message.  Requests and responses are always prefixed by handshakes, but
    * one-way messages.  If the first request sent over a connection is one-way,
    * then a handshake-only response is returned.  Subsequent one-way messages
    * over the connection will have no response data sent.  Returns false by
-   * default. */
+   * default.  @return the boolean
+   */
   public boolean isConnected() { return false; }
 
-  /** Called with the remote protocol when a handshake has been completed.
+  /**
+   * Called with the remote protocol when a handshake has been completed.
    * After this has been called and while a connection is maintained, {@link
-   * #isConnected()} should return true and #getRemote() should return this
-   * protocol.  Does nothing by default. */
+   * #isConnected()}* should return true and #getRemote() should return this
+   * protocol.  Does nothing by default.  @param protocol the protocol
+   */
   public void setRemote(Protocol protocol) {}
 
-  /** Returns the protocol passed to {@link #setRemote(Protocol)}.  Throws
-   * IllegalStateException by default. */
+  /**
+   * Returns the protocol passed to {@link #setRemote(Protocol)}.  Throws
+   * IllegalStateException by default.  @return the remote
+   */
   public Protocol getRemote() {
     throw new IllegalStateException("Not connected.");
   }

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/generic/GenericRequestor.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/generic/GenericRequestor.java
@@ -33,15 +33,35 @@ import org.apache.avro.ipc.Callback;
 import org.apache.avro.ipc.Requestor;
 import org.apache.avro.ipc.Transceiver;
 
-/** {@link Requestor} implementation for generic Java data. */
+/**
+ * {@link Requestor} implementation for generic Java data.
+ */
 public class GenericRequestor extends Requestor {
+  /**
+   * The Data.
+   */
   GenericData data;
 
+  /**
+   * Instantiates a new Generic requestor.
+   *
+   * @param protocol    the protocol
+   * @param transceiver the transceiver
+   * @throws IOException the io exception
+   */
   public GenericRequestor(Protocol protocol, Transceiver transceiver)
     throws IOException {
     this(protocol, transceiver, GenericData.get());
   }
 
+  /**
+   * Instantiates a new Generic requestor.
+   *
+   * @param protocol    the protocol
+   * @param transceiver the transceiver
+   * @param data        the data
+   * @throws IOException the io exception
+   */
   public GenericRequestor(Protocol protocol, Transceiver transceiver,
                           GenericData data)
     throws IOException {
@@ -49,6 +69,11 @@ public class GenericRequestor extends Requestor {
     this.data = data;
   }
 
+  /**
+   * Gets generic data.
+   *
+   * @return the generic data
+   */
   public GenericData getGenericData() { return data; }
 
   @Override

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/generic/GenericResponder.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/generic/GenericResponder.java
@@ -32,26 +32,57 @@ import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.DatumWriter;
 import org.apache.avro.ipc.Responder;
 
-/** {@link Responder} implementation for generic Java data. */
+/**
+ * {@link Responder} implementation for generic Java data.
+ */
 public abstract class GenericResponder extends Responder {
   private GenericData data;
 
+  /**
+   * Instantiates a new Generic responder.
+   *
+   * @param local the local
+   */
   public GenericResponder(Protocol local) {
     this(local, GenericData.get());
 
   }
 
+  /**
+   * Instantiates a new Generic responder.
+   *
+   * @param local the local
+   * @param data  the data
+   */
   public GenericResponder(Protocol local, GenericData data) {
     super(local);
     this.data = data;
   }
 
+  /**
+   * Gets generic data.
+   *
+   * @return the generic data
+   */
   public GenericData getGenericData() { return data; }
 
+  /**
+   * Gets datum writer.
+   *
+   * @param schema the schema
+   * @return the datum writer
+   */
   protected DatumWriter<Object> getDatumWriter(Schema schema) {
     return new GenericDatumWriter<>(schema, data);
   }
 
+  /**
+   * Gets datum reader.
+   *
+   * @param actual   the actual
+   * @param expected the expected
+   * @return the datum reader
+   */
   protected DatumReader<Object> getDatumReader(Schema actual, Schema expected) {
     return new GenericDatumReader<>(actual, expected, data);
   }

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/reflect/ReflectRequestor.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/reflect/ReflectRequestor.java
@@ -31,31 +31,68 @@ import org.apache.avro.reflect.ReflectDatumWriter;
 import org.apache.avro.ipc.Transceiver;
 import org.apache.avro.ipc.specific.SpecificRequestor;
 
-/** A {@link org.apache.avro.ipc.Requestor} for existing interfaces. */
+/**
+ * A {@link org.apache.avro.ipc.Requestor} for existing interfaces.
+ */
 public class ReflectRequestor extends SpecificRequestor {
 
+  /**
+   * Instantiates a new Reflect requestor.
+   *
+   * @param iface       the iface
+   * @param transceiver the transceiver
+   * @throws IOException the io exception
+   */
   public ReflectRequestor(Class<?> iface, Transceiver transceiver)
     throws IOException {
     this(iface, transceiver, new ReflectData(iface.getClassLoader()));
   }
 
+  /**
+   * Instantiates a new Reflect requestor.
+   *
+   * @param protocol    the protocol
+   * @param transceiver the transceiver
+   * @throws IOException the io exception
+   */
   protected ReflectRequestor(Protocol protocol, Transceiver transceiver)
     throws IOException {
     this(protocol, transceiver, ReflectData.get());
   }
 
+  /**
+   * Instantiates a new Reflect requestor.
+   *
+   * @param iface       the iface
+   * @param transceiver the transceiver
+   * @param data        the data
+   * @throws IOException the io exception
+   */
   public ReflectRequestor(Class<?> iface, Transceiver transceiver,
                           ReflectData data)
     throws IOException {
     this(data.getProtocol(iface), transceiver, data);
   }
 
+  /**
+   * Instantiates a new Reflect requestor.
+   *
+   * @param protocol    the protocol
+   * @param transceiver the transceiver
+   * @param data        the data
+   * @throws IOException the io exception
+   */
   public ReflectRequestor(Protocol protocol, Transceiver transceiver,
                           ReflectData data)
     throws IOException {
     super(protocol, transceiver, data);
   }
 
+  /**
+   * Gets reflect data.
+   *
+   * @return the reflect data
+   */
   public ReflectData getReflectData() { return (ReflectData)getSpecificData(); }
 
   @Override
@@ -68,14 +105,29 @@ public class ReflectRequestor extends SpecificRequestor {
     return new ReflectDatumReader<>(writer, reader, getReflectData());
   }
 
-  /** Create a proxy instance whose methods invoke RPCs. */
+  /**
+   * Create a proxy instance whose methods invoke RPCs.  @param <T>  the type parameter
+   *
+   * @param iface       the iface
+   * @param transceiver the transceiver
+   * @return the client
+   * @throws IOException the io exception
+   */
   public static <T> T getClient(Class<T> iface, Transceiver transceiver)
     throws IOException {
     return getClient(iface, transceiver,
                      new ReflectData(iface.getClassLoader()));
   }
 
-  /** Create a proxy instance whose methods invoke RPCs. */
+  /**
+   * Create a proxy instance whose methods invoke RPCs.  @param <T>  the type parameter
+   *
+   * @param iface       the iface
+   * @param transceiver the transceiver
+   * @param reflectData the reflect data
+   * @return the client
+   * @throws IOException the io exception
+   */
   @SuppressWarnings("unchecked")
   public static <T> T getClient(Class<T> iface, Transceiver transceiver,
                                 ReflectData reflectData) throws IOException {
@@ -86,7 +138,14 @@ public class ReflectRequestor extends SpecificRequestor {
        new ReflectRequestor(protocol, transceiver, reflectData));
   }
 
-  /** Create a proxy instance whose methods invoke RPCs. */
+  /**
+   * Create a proxy instance whose methods invoke RPCs.  @param <T>  the type parameter
+   *
+   * @param iface the iface
+   * @param rreq  the rreq
+   * @return the client
+   * @throws IOException the io exception
+   */
   @SuppressWarnings("unchecked")
   public static <T> T getClient(Class<T> iface, ReflectRequestor rreq)
     throws IOException {

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/reflect/ReflectResponder.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/reflect/ReflectResponder.java
@@ -30,24 +30,57 @@ import org.apache.avro.reflect.ReflectData;
 import org.apache.avro.reflect.ReflectDatumReader;
 import org.apache.avro.reflect.ReflectDatumWriter;
 
-/** {@link org.apache.avro.ipc.Responder} for existing interfaces.*/
+/**
+ * {@link org.apache.avro.ipc.Responder} for existing interfaces.
+ */
 public class ReflectResponder extends SpecificResponder {
+  /**
+   * Instantiates a new Reflect responder.
+   *
+   * @param iface the iface
+   * @param impl  the
+   */
   public ReflectResponder(Class iface, Object impl) {
     this(iface, impl, new ReflectData(impl.getClass().getClassLoader()));
   }
 
+  /**
+   * Instantiates a new Reflect responder.
+   *
+   * @param protocol the protocol
+   * @param impl     the
+   */
   public ReflectResponder(Protocol protocol, Object impl) {
     this(protocol, impl, new ReflectData(impl.getClass().getClassLoader()));
   }
 
+  /**
+   * Instantiates a new Reflect responder.
+   *
+   * @param iface the iface
+   * @param impl  the
+   * @param data  the data
+   */
   public ReflectResponder(Class iface, Object impl, ReflectData data) {
     this(data.getProtocol(iface), impl, data);
   }
 
+  /**
+   * Instantiates a new Reflect responder.
+   *
+   * @param protocol the protocol
+   * @param impl     the
+   * @param data     the data
+   */
   public ReflectResponder(Protocol protocol, Object impl, ReflectData data) {
     super(protocol, impl, data);
   }
 
+  /**
+   * Gets reflect data.
+   *
+   * @return the reflect data
+   */
   public ReflectData getReflectData() { return (ReflectData)getSpecificData(); }
 
   @Override

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/specific/SpecificRequestor.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/specific/SpecificRequestor.java
@@ -40,26 +40,61 @@ import org.apache.avro.specific.SpecificData;
 import org.apache.avro.specific.SpecificDatumReader;
 import org.apache.avro.specific.SpecificDatumWriter;
 
-/** {@link org.apache.avro.ipc.Requestor Requestor} for generated interfaces. */
+/**
+ * {@link org.apache.avro.ipc.Requestor Requestor} for generated interfaces.
+ */
 public class SpecificRequestor extends Requestor implements InvocationHandler {
+  /**
+   * The Data.
+   */
   SpecificData data;
 
+  /**
+   * Instantiates a new Specific requestor.
+   *
+   * @param iface       the iface
+   * @param transceiver the transceiver
+   * @throws IOException the io exception
+   */
   public SpecificRequestor(Class<?> iface, Transceiver transceiver)
     throws IOException {
     this(iface, transceiver, new SpecificData(iface.getClassLoader()));
   }
 
+  /**
+   * Instantiates a new Specific requestor.
+   *
+   * @param protocol    the protocol
+   * @param transceiver the transceiver
+   * @throws IOException the io exception
+   */
   protected SpecificRequestor(Protocol protocol, Transceiver transceiver)
     throws IOException {
     this(protocol, transceiver, SpecificData.get());
   }
 
+  /**
+   * Instantiates a new Specific requestor.
+   *
+   * @param iface       the iface
+   * @param transceiver the transceiver
+   * @param data        the data
+   * @throws IOException the io exception
+   */
   public SpecificRequestor(Class<?> iface, Transceiver transceiver,
                            SpecificData data)
     throws IOException {
     this(data.getProtocol(iface), transceiver, data);
   }
 
+  /**
+   * Instantiates a new Specific requestor.
+   *
+   * @param protocol    the protocol
+   * @param transceiver the transceiver
+   * @param data        the data
+   * @throws IOException the io exception
+   */
   public SpecificRequestor(Protocol protocol, Transceiver transceiver,
                            SpecificData data)
     throws IOException {
@@ -67,6 +102,11 @@ public class SpecificRequestor extends Requestor implements InvocationHandler {
     this.data = data;
   }
 
+  /**
+   * Gets specific data.
+   *
+   * @return the specific data
+   */
   public SpecificData getSpecificData() { return data; }
 
   @Override
@@ -136,15 +176,34 @@ public class SpecificRequestor extends Requestor implements InvocationHandler {
     }
   }
 
+  /**
+   * Gets datum writer.
+   *
+   * @param schema the schema
+   * @return the datum writer
+   */
   protected DatumWriter<Object> getDatumWriter(Schema schema) {
     return new SpecificDatumWriter<>(schema, data);
   }
 
+  /**
+   * Gets datum reader.
+   *
+   * @param schema the schema
+   * @return the datum reader
+   */
   @Deprecated                                     // for compatibility in 1.5
   protected DatumReader<Object> getDatumReader(Schema schema) {
     return getDatumReader(schema, schema);
   }
 
+  /**
+   * Gets datum reader.
+   *
+   * @param writer the writer
+   * @param reader the reader
+   * @return the datum reader
+   */
   protected DatumReader<Object> getDatumReader(Schema writer, Schema reader) {
     return new SpecificDatumReader<>(writer, reader, data);
   }
@@ -173,14 +232,29 @@ public class SpecificRequestor extends Requestor implements InvocationHandler {
     return new AvroRuntimeException(value.toString());
   }
 
-  /** Create a proxy instance whose methods invoke RPCs. */
+  /**
+   * Create a proxy instance whose methods invoke RPCs.  @param <T>  the type parameter
+   *
+   * @param iface       the iface
+   * @param transceiver the transceiver
+   * @return the client
+   * @throws IOException the io exception
+   */
   public static  <T> T getClient(Class<T> iface, Transceiver transceiver)
     throws IOException {
     return getClient(iface, transceiver,
                      new SpecificData(iface.getClassLoader()));
   }
 
-  /** Create a proxy instance whose methods invoke RPCs. */
+  /**
+   * Create a proxy instance whose methods invoke RPCs.  @param <T>  the type parameter
+   *
+   * @param iface       the iface
+   * @param transceiver the transceiver
+   * @param data        the data
+   * @return the client
+   * @throws IOException the io exception
+   */
   @SuppressWarnings("unchecked")
   public static  <T> T getClient(Class<T> iface, Transceiver transceiver,
                                  SpecificData data)
@@ -192,7 +266,14 @@ public class SpecificRequestor extends Requestor implements InvocationHandler {
        new SpecificRequestor(protocol, transceiver, data));
   }
 
-  /** Create a proxy instance whose methods invoke RPCs. */
+  /**
+   * Create a proxy instance whose methods invoke RPCs.  @param <T>  the type parameter
+   *
+   * @param iface     the iface
+   * @param requestor the requestor
+   * @return the client
+   * @throws IOException the io exception
+   */
   @SuppressWarnings("unchecked")
   public static <T> T getClient(Class<T> iface, SpecificRequestor requestor)
     throws IOException {
@@ -200,7 +281,12 @@ public class SpecificRequestor extends Requestor implements InvocationHandler {
                                   new Class[] { iface }, requestor);
   }
 
-  /** Return the remote protocol for a proxy. */
+  /**
+   * Return the remote protocol for a proxy.  @param proxy the proxy
+   *
+   * @return the remote
+   * @throws IOException the io exception
+   */
   public static Protocol getRemote(Object proxy) throws IOException {
     return ((Requestor)Proxy.getInvocationHandler(proxy)).getRemote();
 

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/specific/SpecificResponder.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/specific/SpecificResponder.java
@@ -35,27 +35,60 @@ import org.apache.avro.specific.SpecificDatumReader;
 import org.apache.avro.specific.SpecificDatumWriter;
 import org.apache.avro.ipc.generic.GenericResponder;
 
-/** {@link org.apache.avro.ipc.Responder Responder} for generated interfaces.*/
+/**
+ * {@link org.apache.avro.ipc.Responder Responder} for generated interfaces.
+ */
 public class SpecificResponder extends GenericResponder {
   private Object impl;
 
+  /**
+   * Instantiates a new Specific responder.
+   *
+   * @param iface the iface
+   * @param impl  the
+   */
   public SpecificResponder(Class iface, Object impl) {
     this(iface, impl, new SpecificData(impl.getClass().getClassLoader()));
   }
 
+  /**
+   * Instantiates a new Specific responder.
+   *
+   * @param protocol the protocol
+   * @param impl     the
+   */
   public SpecificResponder(Protocol protocol, Object impl) {
     this(protocol, impl, new SpecificData(impl.getClass().getClassLoader()));
   }
 
+  /**
+   * Instantiates a new Specific responder.
+   *
+   * @param iface the iface
+   * @param impl  the
+   * @param data  the data
+   */
   public SpecificResponder(Class iface, Object impl, SpecificData data) {
     this(data.getProtocol(iface), impl, data);
   }
 
+  /**
+   * Instantiates a new Specific responder.
+   *
+   * @param protocol the protocol
+   * @param impl     the
+   * @param data     the data
+   */
   public SpecificResponder(Protocol protocol, Object impl, SpecificData data) {
     super(protocol, data);
     this.impl = impl;
   }
 
+  /**
+   * Gets specific data.
+   *
+   * @return the specific data
+   */
   public SpecificData getSpecificData() {return (SpecificData)getGenericData();}
 
   @Override

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/stats/FloatHistogram.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/stats/FloatHistogram.java
@@ -20,12 +20,18 @@ package org.apache.avro.ipc.stats;
 /**
  * Specific implementation of histogram for floats,
  * which also keeps track of basic summary statistics.
- * @param <B>
+ *
+ * @param <B> the type parameter
  */
 class FloatHistogram<B> extends Histogram<B, Float> {
   private float runningSum;
   private float runningSumOfSquares;
 
+  /**
+   * Instantiates a new Float histogram.
+   *
+   * @param segmenter the segmenter
+   */
   public FloatHistogram(Segmenter<B, Float> segmenter) {
     super(segmenter);
   }
@@ -37,6 +43,11 @@ class FloatHistogram<B> extends Histogram<B, Float> {
     runningSumOfSquares += value*value;
   }
 
+  /**
+   * Gets mean.
+   *
+   * @return the mean
+   */
   public float getMean() {
     if (totalCount == 0) {
       return Float.NaN;
@@ -44,6 +55,11 @@ class FloatHistogram<B> extends Histogram<B, Float> {
     return runningSum / totalCount;
   }
 
+  /**
+   * Gets unbiased std dev.
+   *
+   * @return the unbiased std dev
+   */
   public float getUnbiasedStdDev() {
     if (totalCount <= 1) {
       return Float.NaN;

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/stats/Histogram.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/stats/Histogram.java
@@ -29,10 +29,10 @@ import java.util.TreeMap;
  * Represents a histogram of values.  This class uses a {@link Segmenter}
  * to determine which bucket to place a given value into. Also stores the last
  * MAX_HISTORY_SIZE entries which have been added to this histogram, in order.
- *
+ * <p>
  * Note that Histogram, by itself, is not synchronized.
- * @param <B> Bucket type.  Often String, since buckets are typically
- * used for their toString() representation.
+ *
+ * @param <B> Bucket type.  Often String, since buckets are typically used for their toString() representation.
  * @param <T> Type of value
  */
 class Histogram<B, T> {
@@ -43,52 +43,88 @@ class Histogram<B, T> {
 
   private Segmenter<B, T> segmenter;
   private int[] counts;
+  /**
+   * The Total count.
+   */
   protected int totalCount;
   private LinkedList<T> recentAdditions;
 
   /**
    * Interface to determine which bucket to place a value in.
-   *
+   * <p>
    * Segmenters should be immutable, so many histograms can re-use
    * the same segmenter.
+   *
+   * @param <B> the type parameter
+   * @param <T> the type parameter
    */
   interface Segmenter<B, T> {
-    /** Number of buckets to use. */
+    /**
+     * Number of buckets to use.  @return the int
+     */
     int size();
+
     /**
      * Which bucket to place value in.
      *
+     * @param value the value
      * @return Index of bucket for the value.  At least 0 and less than size().
      * @throws SegmenterException if value does not fit in a bucket.
      */
     int segment(T value);
+
     /**
      * Returns an iterator of buckets. The order of iteration
      * is consistent with the segment numbers.
+     *
+     * @return the buckets
      */
     Iterator<B> getBuckets();
 
     /**
      * Returns a List of bucket boundaries. Useful for printing
      * segmenters.
+     *
+     * @return the boundary labels
      */
     List<String> getBoundaryLabels();
 
     /**
      * Returns the bucket labels as an array;
+     *
+     * @return the bucket labels
      */
     List<String> getBucketLabels();
   }
 
+  /**
+   * The type Segmenter exception.
+   */
   public static class SegmenterException extends RuntimeException {
+    /**
+     * Instantiates a new Segmenter exception.
+     *
+     * @param s the s
+     */
     public SegmenterException(String s) {
       super(s);
     }
   }
 
+  /**
+   * The type Tree map segmenter.
+   *
+   * @param <T> the type parameter
+   */
   public static class TreeMapSegmenter<T extends Comparable<T>>
       implements Segmenter<String, T> {
     private TreeMap<T, Integer> index = new TreeMap<>();
+
+    /**
+     * Instantiates a new Tree map segmenter.
+     *
+     * @param leftEndpoints the left endpoints
+     */
     public TreeMapSegmenter(SortedSet<T> leftEndpoints) {
       if (leftEndpoints.isEmpty()) {
         throw new IllegalArgumentException(
@@ -166,6 +202,8 @@ class Histogram<B, T> {
 
   /**
    * Creates a histogram using the specified segmenter.
+   *
+   * @param segmenter the segmenter
    */
   public Histogram(Segmenter<B, T> segmenter) {
     this.segmenter = segmenter;
@@ -173,7 +211,9 @@ class Histogram<B, T> {
     this.recentAdditions = new LinkedList<>();
   }
 
-  /** Tallies a value in the histogram. */
+  /**
+   * Tallies a value in the histogram.  @param value the value
+   */
   public void add(T value) {
     int i = segmenter.segment(value);
     counts[i]++;
@@ -186,6 +226,8 @@ class Histogram<B, T> {
 
   /**
    * Returns the underlying bucket values.
+   *
+   * @return the int [ ]
    */
   public int[] getHistogram() {
     return counts;
@@ -193,6 +235,8 @@ class Histogram<B, T> {
 
   /**
    * Returns the underlying segmenter used for this histogram.
+   *
+   * @return the segmenter
    */
   public Segmenter<B, T> getSegmenter() {
     return this.segmenter;
@@ -201,12 +245,16 @@ class Histogram<B, T> {
   /**
    * Returns values recently added to this histogram. These are in reverse
    * order (most recent first).
+   *
+   * @return the recent additions
    */
   public List<T> getRecentAdditions() {
     return this.recentAdditions;
   }
 
-  /** Returns the total count of entries. */
+  /**
+   * Returns the total count of entries.  @return the count
+   */
   public int getCount() {
     return totalCount;
   }
@@ -226,17 +274,41 @@ class Histogram<B, T> {
     return sb.toString();
   }
 
+  /**
+   * The type Entry.
+   *
+   * @param <B> the type parameter
+   */
   static class Entry<B> {
+    /**
+     * Instantiates a new Entry.
+     *
+     * @param bucket the bucket
+     * @param count  the count
+     */
     public Entry(B bucket, int count) {
       this.bucket = bucket;
       this.count = count;
     }
+
+    /**
+     * The Bucket.
+     */
     B bucket;
+    /**
+     * The Count.
+     */
     int count;
   }
 
   private class EntryIterator implements Iterable<Entry<B>>, Iterator<Entry<B>> {
+    /**
+     * The .
+     */
     int i = 0;
+    /**
+     * The Bucket name iterator.
+     */
     Iterator<B> bucketNameIterator = segmenter.getBuckets();
 
     @Override
@@ -261,6 +333,11 @@ class Histogram<B, T> {
 
   }
 
+  /**
+   * Entries iterable.
+   *
+   * @return the iterable
+   */
   public Iterable<Entry<B>> entries() {
     return new EntryIterator();
   }

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/stats/IntegerHistogram.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/stats/IntegerHistogram.java
@@ -20,12 +20,18 @@ package org.apache.avro.ipc.stats;
 /**
  * Specific implementation of histogram for integers,
  * which also keeps track of basic summary statistics.
- * @param <B>
+ *
+ * @param <B> the type parameter
  */
 class IntegerHistogram<B> extends Histogram<B, Integer> {
   private float runningSum;
   private float runningSumOfSquares;
 
+  /**
+   * Instantiates a new Integer histogram.
+   *
+   * @param segmenter the segmenter
+   */
   public IntegerHistogram(Segmenter<B, Integer> segmenter) {
     super(segmenter);
   }
@@ -37,6 +43,11 @@ class IntegerHistogram<B> extends Histogram<B, Integer> {
     runningSumOfSquares += value*value;
   }
 
+  /**
+   * Gets mean.
+   *
+   * @return the mean
+   */
   public float getMean() {
     if (totalCount == 0) {
       return -1;
@@ -44,6 +55,11 @@ class IntegerHistogram<B> extends Histogram<B, Integer> {
     return runningSum / (float) totalCount;
   }
 
+  /**
+   * Gets unbiased std dev.
+   *
+   * @return the unbiased std dev
+   */
   public float getUnbiasedStdDev() {
     if (totalCount <= 1) {
       return -1;

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/stats/StatsPlugin.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/stats/StatsPlugin.java
@@ -37,12 +37,14 @@ import org.apache.avro.ipc.stats.Stopwatch.Ticks;
  * Collects count and latency statistics about RPC calls.  Keeps
  * data for every method. Can be added to a Requestor (client)
  * or Responder (server).
- *
+ * <p>
  * This uses milliseconds as the standard unit of measure
  * throughout the class, stored in floats.
  */
 public class StatsPlugin extends RPCPlugin {
-  /** Static declaration of histogram buckets. */
+  /**
+   * Static declaration of histogram buckets.
+   */
   static final Segmenter<String, Float> LATENCY_SEGMENTER =
       new Histogram.TreeMapSegmenter<>(new TreeSet<>(Arrays.asList(
             0f,
@@ -61,6 +63,9 @@ public class StatsPlugin extends RPCPlugin {
         60000f, // 1 minute
        600000f)));
 
+  /**
+   * The Payload segmenter.
+   */
   static final Segmenter<String, Integer> PAYLOAD_SEGMENTER =
       new Histogram.TreeMapSegmenter<>(new TreeSet<>(Arrays.asList(
             0,
@@ -79,29 +84,46 @@ public class StatsPlugin extends RPCPlugin {
         50000,
        100000)));
 
-  /** Per-method histograms.
-   * Must be accessed while holding a lock. */
+  /**
+   * Per-method histograms.
+   * Must be accessed while holding a lock.
+   */
   Map<Message, FloatHistogram<?>> methodTimings =
     new HashMap<>();
 
+  /**
+   * The Send payloads.
+   */
   Map<Message, IntegerHistogram<?>> sendPayloads =
     new HashMap<>();
 
+  /**
+   * The Receive payloads.
+   */
   Map<Message, IntegerHistogram<?>> receivePayloads =
     new HashMap<>();
 
-  /** RPCs in flight. */
+  /**
+   * RPCs in flight.
+   */
   ConcurrentMap<RPCContext, Stopwatch> activeRpcs =
     new ConcurrentHashMap<>();
   private Ticks ticks;
 
-  /** How long I've been alive */
+  /**
+   * How long I've been alive
+   */
   public Date startupTime = new Date();
 
   private Segmenter<?, Float> floatSegmenter;
   private Segmenter<?, Integer> integerSegmenter;
 
-  /** Construct a plugin with custom Ticks and Segmenter implementations. */
+  /**
+   * Construct a plugin with custom Ticks and Segmenter implementations.  @param ticks the ticks
+   *
+   * @param floatSegmenter   the float segmenter
+   * @param integerSegmenter the integer segmenter
+   */
   StatsPlugin(Ticks ticks, Segmenter<?, Float> floatSegmenter,
       Segmenter<?, Integer> integerSegmenter) {
     this.floatSegmenter = floatSegmenter;
@@ -109,8 +131,10 @@ public class StatsPlugin extends RPCPlugin {
     this.ticks = ticks;
   }
 
-  /** Construct a plugin with default (system) ticks, and default
-   * histogram segmentation. */
+  /**
+   * Construct a plugin with default (system) ticks, and default
+   * histogram segmentation.
+   */
   public StatsPlugin() {
     this(Stopwatch.SYSTEM_TICKS, LATENCY_SEGMENTER, PAYLOAD_SEGMENTER);
   }
@@ -219,7 +243,11 @@ public class StatsPlugin extends RPCPlugin {
     return new IntegerHistogram(integerSegmenter);
   }
 
-  /** Converts nanoseconds to milliseconds. */
+  /**
+   * Converts nanoseconds to milliseconds.  @param elapsedNanos the elapsed nanos
+   *
+   * @return the float
+   */
   static float nanosToMillis(long elapsedNanos) {
     return elapsedNanos / 1000000.0f;
   }

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/stats/StatsServer.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/stats/StatsServer.java
@@ -20,6 +20,9 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 
+/**
+ * The type Stats server.
+ */
 /* This is a server that displays live information from a StatsPlugin.
  *
  *  Typical usage is as follows:
@@ -29,9 +32,22 @@ import org.eclipse.jetty.servlet.ServletHolder;
  *
  *  */
 public class StatsServer {
+  /**
+   * The Http server.
+   */
   Server httpServer;
+  /**
+   * The Plugin.
+   */
   StatsPlugin plugin;
 
+  /**
+   * Instantiates a new Stats server.
+   *
+   * @param plugin the plugin
+   * @param port   the port
+   * @throws Exception the exception
+   */
   /* Start a stats server on the given port,
    * responsible for the given plugin. */
   public StatsServer(StatsPlugin plugin, int port) throws Exception {
@@ -47,6 +63,11 @@ public class StatsServer {
     httpServer.start();
   }
 
+  /**
+   * Stop.
+   *
+   * @throws Exception the exception
+   */
   /* Stops this server. */
   public void stop() throws Exception {
     this.httpServer.stop();

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/stats/StatsServlet.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/stats/StatsServlet.java
@@ -45,7 +45,7 @@ import org.apache.avro.ipc.RPCContext;
 /**
  * Exposes information provided by a StatsPlugin as
  * a web page.
- *
+ * <p>
  * This class follows the same synchronization conventions
  * as StatsPlugin, to avoid requiring StatsPlugin to serve
  * a copy of the data.
@@ -56,6 +56,12 @@ public class StatsServlet extends HttpServlet {
   private static final SimpleDateFormat FORMATTER =
     new SimpleDateFormat("dd-MMM-yyyy HH:mm:ss");
 
+  /**
+   * Instantiates a new Stats servlet.
+   *
+   * @param statsPlugin the stats plugin
+   * @throws UnavailableException the unavailable exception
+   */
   public StatsServlet(StatsPlugin statsPlugin) throws UnavailableException {
     this.statsPlugin = statsPlugin;
     this.velocityEngine = new VelocityEngine();
@@ -70,33 +76,71 @@ public class StatsServlet extends HttpServlet {
     velocityEngine.setProperty("runtime.log.logsystem.class", logChuteName);
   }
 
+  /**
+   * The type Renderable message.
+   */
   /* Helper class to store per-message data which is passed to templates.
    *
    * The template expects a list of charts, each of which is parameterized by
    * map key-value string attributes. */
   public class RenderableMessage { // Velocity brakes if not public
+    /**
+     * The Name.
+     */
     public String name;
+    /**
+     * The Num calls.
+     */
     public int numCalls;
+    /**
+     * The Charts.
+     */
     public ArrayList<HashMap<String, String>> charts;
 
+    /**
+     * Instantiates a new Renderable message.
+     *
+     * @param name the name
+     */
     public RenderableMessage(String name) {
       this.name = name;
       this.charts = new ArrayList<>();
     }
 
+    /**
+     * Gets charts.
+     *
+     * @return the charts
+     */
     public ArrayList<HashMap<String, String>> getCharts() {
       return this.charts;
     }
 
+    /**
+     * Gets .
+     *
+     * @return the
+     */
     public String getname() {
       return this.name;
     }
 
+    /**
+     * Gets num calls.
+     *
+     * @return the num calls
+     */
     public int getNumCalls() {
       return this.numCalls;
     }
   }
 
+  /**
+   * Escape string array list.
+   *
+   * @param input the input
+   * @return the list
+   */
   /* Surround each string in an array with
    * quotation marks and escape existing quotes.
    *
@@ -125,6 +169,12 @@ public class StatsServlet extends HttpServlet {
     }
   }
 
+  /**
+   * Write stats.
+   *
+   * @param w the w
+   * @throws IOException the io exception
+   */
   void writeStats(Writer w) throws IOException {
     VelocityContext context = new VelocityContext();
     context.put("title", "Avro RPC Stats");

--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/stats/Stopwatch.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/stats/Stopwatch.java
@@ -17,18 +17,26 @@
  */
 package org.apache.avro.ipc.stats;
 
-/** Encapsulates the passing of time. */
+/**
+ * Encapsulates the passing of time.
+ */
 class Stopwatch  {
-  /** Encapsulates ticking time sources. */
+  /**
+   * Encapsulates ticking time sources.
+   */
   interface Ticks {
     /**
      * Returns a number of "ticks" in nanoseconds.
      * This should be monotonically non-decreasing.
+     *
+     * @return the long
      */
     long ticks();
   }
 
-  /** Default System time source. */
+  /**
+   * Default System time source.
+   */
   public final static Ticks SYSTEM_TICKS = new SystemTicks();
 
   private Ticks ticks;
@@ -36,11 +44,18 @@ class Stopwatch  {
   private long elapsed = -1;
   private boolean running;
 
+  /**
+   * Instantiates a new Stopwatch.
+   *
+   * @param ticks the ticks
+   */
   public Stopwatch(Ticks ticks) {
     this.ticks = ticks;
   }
 
-  /** Returns seconds that have elapsed since start() */
+  /**
+   * Returns seconds that have elapsed since start()  @return the long
+   */
   public long elapsedNanos() {
     if (running) {
       return this.ticks.ticks() - start;
@@ -50,14 +65,18 @@ class Stopwatch  {
     }
   }
 
-  /** Starts the stopwatch. */
+  /**
+   * Starts the stopwatch.
+   */
   public void start() {
     if (running) throw new IllegalStateException();
     start = ticks.ticks();
     running = true;
   }
 
-  /** Stops the stopwatch and calculates the elapsed time. */
+  /**
+   * Stops the stopwatch and calculates the elapsed time.
+   */
   public void stop() {
     if (!running) throw new IllegalStateException();
     elapsed = ticks.ticks() - start;

--- a/lang/java/ipc/src/test/java/org/apache/avro/DataFileInteropTest.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/DataFileInteropTest.java
@@ -29,17 +29,28 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+/**
+ * The type Data file interop test.
+ */
 public class DataFileInteropTest {
 
   private static final File DATAFILE_DIR =
     new File(System.getProperty("test.dir", "/tmp"));
 
+  /**
+   * Print dir.
+   */
   @BeforeClass
   public static void printDir() {
     System.out.println("Reading data files from directory: "
         + DATAFILE_DIR.getAbsolutePath());
   }
 
+  /**
+   * Test generated generic.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testGeneratedGeneric() throws IOException {
     System.out.println("Reading with generic:");
@@ -51,6 +62,11 @@ public class DataFileInteropTest {
     readFiles(provider);
   }
 
+  /**
+   * Test generated specific.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testGeneratedSpecific() throws IOException {
     System.out.println("Reading with specific:");
@@ -95,7 +111,17 @@ public class DataFileInteropTest {
     }
   }
 
+  /**
+   * The interface Datum reader provider.
+   *
+   * @param <T> the type parameter
+   */
   interface DatumReaderProvider<T extends Object> {
+    /**
+     * Get datum reader.
+     *
+     * @return the datum reader
+     */
     public DatumReader<T> get();
   }
 

--- a/lang/java/ipc/src/test/java/org/apache/avro/RPCMetaTestPlugin.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/RPCMetaTestPlugin.java
@@ -35,8 +35,16 @@ import org.apache.avro.ipc.RPCPlugin;
  */
 public final class RPCMetaTestPlugin extends RPCPlugin {
 
+  /**
+   * The Key.
+   */
   protected final String key;
 
+  /**
+   * Instantiates a new Rpc meta test plugin.
+   *
+   * @param keyname the keyname
+   */
   public RPCMetaTestPlugin(String keyname) {
     key = keyname;
   }
@@ -171,6 +179,11 @@ public final class RPCMetaTestPlugin extends RPCPlugin {
     checkRPCMetaMap(context.responseCallMeta());
   }
 
+  /**
+   * Check rpc meta map.
+   *
+   * @param rpcMeta the rpc meta
+   */
   protected void checkRPCMetaMap(Map<String,ByteBuffer> rpcMeta) {
     Assert.assertNotNull(rpcMeta);
     Assert.assertTrue("key not present in map", rpcMeta.containsKey(key));

--- a/lang/java/ipc/src/test/java/org/apache/avro/RandomData.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/RandomData.java
@@ -32,16 +32,31 @@ import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.util.Utf8;
 
-/** Generates schema data as Java objects with random values. */
+/**
+ * Generates schema data as Java objects with random values.
+ */
 public class RandomData implements Iterable<Object> {
   private final Schema root;
   private final long seed;
   private final int count;
 
+  /**
+   * Instantiates a new Random data.
+   *
+   * @param schema the schema
+   * @param count  the count
+   */
   public RandomData(Schema schema, int count) {
     this(schema, count, System.currentTimeMillis());
   }
 
+  /**
+   * Instantiates a new Random data.
+   *
+   * @param schema the schema
+   * @param count  the count
+   * @param seed   the seed
+   */
   public RandomData(Schema schema, int count, long seed) {
     this.root = schema;
     this.seed = seed;
@@ -122,6 +137,12 @@ public class RandomData implements Iterable<Object> {
     return bytes;
   }
 
+  /**
+   * The entry point of application.
+   *
+   * @param args the input arguments
+   * @throws Exception the exception
+   */
   public static void main(String[] args) throws Exception {
     if(args.length != 3) {
       System.out.println("Usage: RandomData <schemafile> <outputfile> <count>");

--- a/lang/java/ipc/src/test/java/org/apache/avro/SimpleException.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/SimpleException.java
@@ -17,9 +17,20 @@
  */
 package org.apache.avro;
 
-/** This should be a static nested class in TestProtocolReflect, but that
- * breaks CheckStyle (http://jira.codehaus.org/browse/MPCHECKSTYLE-20). */
+/**
+ * This should be a static nested class in TestProtocolReflect, but that
+ * breaks CheckStyle (http://jira.codehaus.org/browse/MPCHECKSTYLE-20).
+ */
 public class SimpleException extends Exception {
+  /**
+   * Instantiates a new Simple exception.
+   */
   SimpleException() {}
+
+  /**
+   * Instantiates a new Simple exception.
+   *
+   * @param message the message
+   */
   SimpleException(String message) { super(message) ; }
 }

--- a/lang/java/ipc/src/test/java/org/apache/avro/TestAnnotation.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/TestAnnotation.java
@@ -22,6 +22,9 @@ import java.lang.annotation.Target;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
+/**
+ * The interface Test annotation.
+ */
 @Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface TestAnnotation {

--- a/lang/java/ipc/src/test/java/org/apache/avro/TestBulkData.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/TestBulkData.java
@@ -36,6 +36,9 @@ import java.util.Random;
 
 import org.apache.avro.test.BulkData;
 
+/**
+ * The type Test bulk data.
+ */
 public class TestBulkData {
   private static final long COUNT =
     Integer.parseInt(System.getProperty("test.count", "10"));
@@ -50,6 +53,9 @@ public class TestBulkData {
     rand.nextBytes(DATA.array());
   }
 
+  /**
+   * The type Bulk data.
+   */
   public static class BulkDataImpl implements BulkData {
     public ByteBuffer read() { return DATA.duplicate(); }
     public Void write(ByteBuffer data) {
@@ -62,6 +68,11 @@ public class TestBulkData {
   private static Transceiver client;
   private static BulkData proxy;
 
+  /**
+   * Start server.
+   *
+   * @throws Exception the exception
+   */
   @Before
   public void startServer() throws Exception {
     if (server != null) return;
@@ -74,23 +85,44 @@ public class TestBulkData {
     proxy = SpecificRequestor.getClient(BulkData.class, client);
   }
 
+  /**
+   * Test read.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testRead() throws IOException {
     for (int i = 0; i < COUNT; i++)
       Assert.assertEquals(SIZE, proxy.read().remaining());
   }
 
+  /**
+   * Test write.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testWrite() throws IOException {
     for (int i = 0; i < COUNT; i++)
       proxy.write(DATA.duplicate());
   }
 
+  /**
+   * Stop server.
+   *
+   * @throws Exception the exception
+   */
   @AfterClass
   public static void stopServer() throws Exception {
     server.close();
   }
 
+  /**
+   * The entry point of application.
+   *
+   * @param args the input arguments
+   * @throws Exception the exception
+   */
   public static void main(String[] args) throws Exception {
     TestBulkData test = new TestBulkData();
     test.startServer();

--- a/lang/java/ipc/src/test/java/org/apache/avro/TestCompare.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/TestCompare.java
@@ -39,8 +39,16 @@ import org.apache.avro.test.TestRecord;
 import org.apache.avro.test.Kind;
 import org.apache.avro.test.MD5;
 
+/**
+ * The type Test compare.
+ */
 public class TestCompare {
 
+  /**
+   * Test null.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testNull() throws Exception {
     Schema schema = Schema.parse("\"null\"");
@@ -48,11 +56,21 @@ public class TestCompare {
     assertEquals(0, BinaryData.compare(b, 0, b, 0, schema));
   }
 
+  /**
+   * Test boolean.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testBoolean() throws Exception {
     check("\"boolean\"", Boolean.FALSE, Boolean.TRUE);
   }
 
+  /**
+   * Test string.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testString() throws Exception {
     check("\"string\"", new Utf8(""), new Utf8("a"));
@@ -61,6 +79,11 @@ public class TestCompare {
     check("\"string\"", new Utf8("ab"), new Utf8("b"));
   }
 
+  /**
+   * Test bytes.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testBytes() throws Exception {
     check("\"bytes\"",
@@ -74,30 +97,55 @@ public class TestCompare {
           ByteBuffer.wrap(new byte[]{2}));
   }
 
+  /**
+   * Test int.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testInt() throws Exception {
     check("\"int\"", new Integer(-1), new Integer(0));
     check("\"int\"", new Integer(0), new Integer(1));
   }
 
+  /**
+   * Test long.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testLong() throws Exception {
     check("\"long\"", new Long(11), new Long(12));
     check("\"long\"", new Long(-1), new Long(1));
   }
 
+  /**
+   * Test float.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testFloat() throws Exception {
     check("\"float\"", new Float(1.1), new Float(1.2));
     check("\"float\"", new Float(-1.1), new Float(1.0));
   }
 
+  /**
+   * Test double.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testDouble() throws Exception {
     check("\"double\"", new Double(1.2), new Double(1.3));
     check("\"double\"", new Double(-1.2), new Double(1.3));
   }
 
+  /**
+   * Test array.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testArray() throws Exception {
     String json = "{\"type\":\"array\", \"items\": \"long\"}";
@@ -110,6 +158,11 @@ public class TestCompare {
     check(json, a1, a2);
   }
 
+  /**
+   * Test record.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testRecord() throws Exception {
     String fields = " \"fields\":["
@@ -141,6 +194,11 @@ public class TestCompare {
     assert(!r1.equals(r3));                       // same fields, diff name
   }
 
+  /**
+   * Test enum.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testEnum() throws Exception {
     String json =
@@ -151,6 +209,11 @@ public class TestCompare {
           new GenericData.EnumSymbol(schema, "B"));
   }
 
+  /**
+   * Test fixed.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testFixed() throws Exception {
     String json = "{\"type\": \"fixed\", \"name\":\"Test\", \"size\": 1}";
@@ -160,6 +223,11 @@ public class TestCompare {
           new GenericData.Fixed(schema, new byte[]{(byte)'b'}));
   }
 
+  /**
+   * Test union.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testUnion() throws Exception {
     check("[\"string\", \"long\"]", new Utf8("a"), new Utf8("b"), false);
@@ -167,6 +235,11 @@ public class TestCompare {
     check("[\"string\", \"long\"]", new Utf8("a"), new Long(1), false);
   }
 
+  /**
+   * Test specific record.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testSpecificRecord() throws Exception {
     TestRecord s1 = new TestRecord();

--- a/lang/java/ipc/src/test/java/org/apache/avro/TestDataFileSpecific.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/TestDataFileSpecific.java
@@ -31,12 +31,20 @@ import org.junit.Test;
 
 import org.apache.avro.Foo;
 
+/**
+ * The type Test data file specific.
+ */
 public class TestDataFileSpecific {
 
   private static final File DIR =
     new File(System.getProperty("test.dir","/tmp"));
   private static final File FILE = new File(DIR, "specific.avro");
 
+  /**
+   * Test specific datum reader default ctor.
+   *
+   * @throws IOException the io exception
+   */
   /* Test when using SpecificDatumReader<T>() constructor to read from a file
    * with a different schema that both reader & writer schemas are found.*/
   @Test

--- a/lang/java/ipc/src/test/java/org/apache/avro/TestNamespaceReflect.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/TestNamespaceReflect.java
@@ -26,6 +26,9 @@ import org.junit.Before;
 
 import java.net.InetSocketAddress;
 
+/**
+ * The type Test namespace reflect.
+ */
 public class TestNamespaceReflect extends TestNamespaceSpecific {
 
   @Before @Override

--- a/lang/java/ipc/src/test/java/org/apache/avro/TestNamespaceSpecific.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/TestNamespaceSpecific.java
@@ -35,8 +35,14 @@ import static org.junit.Assert.assertNotNull;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 
+/**
+ * The type Test namespace specific.
+ */
 public class TestNamespaceSpecific {
 
+  /**
+   * The type Test.
+   */
   public static class TestImpl implements TestNamespace {
     public TestRecord echo(TestRecord record) { return record; }
     public Void error() throws AvroRemoteException {
@@ -44,10 +50,24 @@ public class TestNamespaceSpecific {
     }
   }
 
+  /**
+   * The constant server.
+   */
   protected static SocketServer server;
+  /**
+   * The constant client.
+   */
   protected static Transceiver client;
+  /**
+   * The constant proxy.
+   */
   protected static TestNamespace proxy;
 
+  /**
+   * Test start server.
+   *
+   * @throws Exception the exception
+   */
   @Before
   public void testStartServer() throws Exception {
     if (server != null) return;
@@ -58,6 +78,11 @@ public class TestNamespaceSpecific {
     proxy = SpecificRequestor.getClient(TestNamespace.class, client);
   }
 
+  /**
+   * Test echo.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testEcho() throws IOException {
     TestRecord record = new TestRecord();
@@ -67,6 +92,11 @@ public class TestNamespaceSpecific {
     assertEquals(record.hashCode(), echoed.hashCode());
   }
 
+  /**
+   * Test error.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testError() throws IOException {
     TestError error = null;
@@ -79,6 +109,11 @@ public class TestNamespaceSpecific {
     assertEquals("an error", error.getMessage$());
   }
 
+  /**
+   * Test stop server.
+   *
+   * @throws IOException the io exception
+   */
   @AfterClass
   public static void testStopServer() throws IOException {
     client.close();

--- a/lang/java/ipc/src/test/java/org/apache/avro/TestProtocolDatagram.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/TestProtocolDatagram.java
@@ -28,6 +28,9 @@ import org.apache.avro.ipc.Transceiver;
 import org.apache.avro.ipc.specific.SpecificResponder;
 import org.apache.avro.test.Simple;
 
+/**
+ * The type Test protocol datagram.
+ */
 public class TestProtocolDatagram extends TestProtocolSpecific {
   @Override
   public Server createServer(Responder testResponder) throws Exception {

--- a/lang/java/ipc/src/test/java/org/apache/avro/TestProtocolGeneric.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/TestProtocolGeneric.java
@@ -44,11 +44,20 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
+/**
+ * The type Test protocol generic.
+ */
 public class TestProtocolGeneric {
   private static final Logger LOG
     = LoggerFactory.getLogger(TestProtocolGeneric.class);
 
+  /**
+   * The constant FILE.
+   */
   protected static final File FILE = new File("../../../share/test/schemas/simple.avpr");
+  /**
+   * The constant PROTOCOL.
+   */
   protected static final Protocol PROTOCOL;
   static {
     try {
@@ -60,7 +69,13 @@ public class TestProtocolGeneric {
 
   private static boolean throwUndeclaredError;
 
+  /**
+   * The type Test responder.
+   */
   protected static class TestResponder extends GenericResponder {
+    /**
+     * Instantiates a new Test responder.
+     */
     public TestResponder() { super(PROTOCOL); }
     public Object respond(Message message, Object request)
       throws AvroRemoteException {
@@ -96,10 +111,24 @@ public class TestProtocolGeneric {
 
   }
 
+  /**
+   * The constant server.
+   */
   protected static SocketServer server;
+  /**
+   * The constant client.
+   */
   protected static Transceiver client;
+  /**
+   * The constant requestor.
+   */
   protected static GenericRequestor requestor;
 
+  /**
+   * Test start server.
+   *
+   * @throws Exception the exception
+   */
   @Before
   public void testStartServer() throws Exception {
     if (server != null) return;
@@ -109,6 +138,11 @@ public class TestProtocolGeneric {
     requestor = new GenericRequestor(PROTOCOL, client);
   }
 
+  /**
+   * Test hello.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testHello() throws IOException {
     GenericRecord params =
@@ -118,6 +152,11 @@ public class TestProtocolGeneric {
     assertEquals(new Utf8("goodbye"), response);
   }
 
+  /**
+   * Test echo.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testEcho() throws IOException {
     GenericRecord record =
@@ -135,6 +174,11 @@ public class TestProtocolGeneric {
     assertEquals(record, echoed);
   }
 
+  /**
+   * Test echo bytes.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testEchoBytes() throws IOException {
     Random random = new Random();
@@ -149,6 +193,11 @@ public class TestProtocolGeneric {
     assertEquals(data, echoed);
   }
 
+  /**
+   * Test error.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testError() throws IOException {
     GenericRecord params =
@@ -163,6 +212,11 @@ public class TestProtocolGeneric {
     assertEquals("an error", ((GenericRecord)error.getValue()).get("message").toString());
   }
 
+  /**
+   * Test undeclared error.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testUndeclaredError() throws IOException {
     this.throwUndeclaredError = true;
@@ -180,6 +234,11 @@ public class TestProtocolGeneric {
     assertTrue(error.toString().contains("foo"));
   }
 
+  /**
+   * Test handshake.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   /** Construct and use a different protocol whose "hello" method has an extra
       argument to check that schema is sent to parse request. */
@@ -211,6 +270,11 @@ public class TestProtocolGeneric {
     }
   }
 
+  /**
+   * Test response change.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   /** Construct and use a different protocol whose "echo" response has an extra
       field to check that correct schema is used to parse response. */
@@ -255,6 +319,11 @@ public class TestProtocolGeneric {
     }
   }
 
+  /**
+   * Test stop server.
+   *
+   * @throws IOException the io exception
+   */
   @AfterClass
   public static void testStopServer() throws IOException {
     client.close();

--- a/lang/java/ipc/src/test/java/org/apache/avro/TestProtocolGenericMeta.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/TestProtocolGenericMeta.java
@@ -25,6 +25,9 @@ import org.apache.avro.ipc.SocketTransceiver;
 import org.apache.avro.ipc.generic.GenericRequestor;
 import org.junit.Before;
 
+/**
+ * The type Test protocol generic meta.
+ */
 public class TestProtocolGenericMeta extends TestProtocolGeneric {
 
   @Before @Override

--- a/lang/java/ipc/src/test/java/org/apache/avro/TestProtocolHttp.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/TestProtocolHttp.java
@@ -35,6 +35,9 @@ import java.net.ServerSocket;
 import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 
+/**
+ * The type Test protocol http.
+ */
 public class TestProtocolHttp extends TestProtocolSpecific {
 
   @Override
@@ -51,6 +54,11 @@ public class TestProtocolHttp extends TestProtocolSpecific {
     return REPEATING;
   }
 
+  /**
+   * Test timeout.
+   *
+   * @throws Throwable the throwable
+   */
   @Test(expected=SocketTimeoutException.class)
     public void testTimeout() throws Throwable {
     ServerSocket s = new ServerSocket(0);
@@ -67,7 +75,9 @@ public class TestProtocolHttp extends TestProtocolSpecific {
     }
   }
 
-  /** Test that Responder ignores one-way with stateless transport. */
+  /**
+   * Test that Responder ignores one-way with stateless transport.  @throws Exception the exception
+   */
   @Test public void testStatelessOneway() throws Exception {
     // a version of the Simple protocol that doesn't declare "ack" one-way
     Protocol protocol = new Protocol("Simple", "org.apache.avro.test");

--- a/lang/java/ipc/src/test/java/org/apache/avro/TestProtocolHttps.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/TestProtocolHttps.java
@@ -29,6 +29,9 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 
 import java.net.URL;
 
+/**
+ * The type Test protocol https.
+ */
 public class TestProtocolHttps extends TestProtocolSpecific {
 
   @Override

--- a/lang/java/ipc/src/test/java/org/apache/avro/TestProtocolParsing.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/TestProtocolParsing.java
@@ -28,12 +28,26 @@ import org.junit.Test;
 
 import org.apache.avro.Protocol.Message;
 
+/**
+ * The type Test protocol parsing.
+ */
 public class TestProtocolParsing {
+  /**
+   * Gets simple protocol.
+   *
+   * @return the simple protocol
+   * @throws IOException the io exception
+   */
   public static Protocol getSimpleProtocol() throws IOException {
     File file = new File("../../../share/test/schemas/simple.avpr");
     return Protocol.parse(file);
   }
 
+  /**
+   * Test parsing.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testParsing() throws IOException {
     Protocol protocol = getSimpleProtocol();
@@ -51,6 +65,11 @@ public class TestProtocolParsing {
                           + "}}").getMessages().values().iterator().next();
   }
 
+  /**
+   * One way.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void oneWay() throws Exception {
     Message m;
@@ -67,6 +86,11 @@ public class TestProtocolParsing {
     assertTrue(m.isOneWay());
   }
 
+  /**
+   * One way response.
+   *
+   * @throws Exception the exception
+   */
   @Test(expected=SchemaParseException.class)
   public void oneWayResponse() throws Exception {
     // prohibit one-way messages with a non-null response type
@@ -76,6 +100,11 @@ public class TestProtocolParsing {
                  +"\"one-way\": true}");
   }
 
+  /**
+   * One way error.
+   *
+   * @throws Exception the exception
+   */
   @Test(expected=SchemaParseException.class)
   public void oneWayError() throws Exception {
     // prohibit one-way messages with errors
@@ -85,6 +114,11 @@ public class TestProtocolParsing {
                  +"\"one-way\": true}");
   }
 
+  /**
+   * Test message field aliases.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testMessageFieldAliases() throws IOException{
     Protocol protocol = getSimpleProtocol();
@@ -95,6 +129,11 @@ public class TestProtocolParsing {
     assertTrue(field.aliases().contains("salute"));
   }
 
+  /**
+   * Test message custom properties.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testMessageCustomProperties() throws IOException{
     Protocol protocol = getSimpleProtocol();

--- a/lang/java/ipc/src/test/java/org/apache/avro/TestProtocolReflect.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/TestProtocolReflect.java
@@ -37,8 +37,14 @@ import java.net.InetSocketAddress;
 import java.util.Random;
 import java.io.IOException;
 
+/**
+ * The type Test protocol reflect.
+ */
 public class TestProtocolReflect {
 
+  /**
+   * The type Test record.
+   */
   public static class TestRecord {
     private String name;
     public int hashCode() { return this.name.hashCode(); }
@@ -47,16 +53,56 @@ public class TestProtocolReflect {
     }
   }
 
+  /**
+   * The interface Simple.
+   */
   public interface Simple {
+    /**
+     * Hello string.
+     *
+     * @param greeting the greeting
+     * @return the string
+     */
     String hello(String greeting);
+
+    /**
+     * Echo test record.
+     *
+     * @param record the record
+     * @return the test record
+     */
     TestRecord echo(TestRecord record);
+
+    /**
+     * Add int.
+     *
+     * @param arg1 the arg 1
+     * @param arg2 the arg 2
+     * @return the int
+     */
     int add(int arg1, int arg2);
+
+    /**
+     * Echo bytes byte [ ].
+     *
+     * @param data the data
+     * @return the byte [ ]
+     */
     byte[] echoBytes(byte[] data);
+
+    /**
+     * Error.
+     *
+     * @throws SimpleException the simple exception
+     */
     void error() throws SimpleException;
   }
 
   private static boolean throwUndeclaredError;
 
+  /**
+   * The type Test.
+   */
   public static class TestImpl implements Simple {
     public String hello(String greeting) { return "goodbye"; }
     public int add(int arg1, int arg2) { return arg1 + arg2; }
@@ -68,10 +114,24 @@ public class TestProtocolReflect {
     }
   }
 
+  /**
+   * The constant server.
+   */
   protected static Server server;
+  /**
+   * The constant client.
+   */
   protected static Transceiver client;
+  /**
+   * The constant proxy.
+   */
   protected static Simple proxy;
 
+  /**
+   * Test start server.
+   *
+   * @throws Exception the exception
+   */
   @Before
   public void testStartServer() throws Exception {
     if (server != null) return;
@@ -82,6 +142,11 @@ public class TestProtocolReflect {
     proxy = ReflectRequestor.getClient(Simple.class, client);
   }
 
+  /**
+   * Test class loader.
+   *
+   * @throws Exception the exception
+   */
   @Test public void testClassLoader() throws Exception {
     ClassLoader loader = new ClassLoader() {};
 
@@ -95,12 +160,22 @@ public class TestProtocolReflect {
     assertEquals(requestor.getReflectData().getClassLoader(), loader);
   }
 
+  /**
+   * Test hello.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testHello() throws IOException {
     String response = proxy.hello("bob");
     assertEquals("goodbye", response);
   }
 
+  /**
+   * Test echo.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testEcho() throws IOException {
     TestRecord record = new TestRecord();
@@ -109,12 +184,22 @@ public class TestProtocolReflect {
     assertEquals(record, echoed);
   }
 
+  /**
+   * Test add.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testAdd() throws IOException {
     int result = proxy.add(1, 2);
     assertEquals(3, result);
   }
 
+  /**
+   * Test echo bytes.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testEchoBytes() throws IOException {
     Random random = new Random();
@@ -125,6 +210,11 @@ public class TestProtocolReflect {
     assertArrayEquals(data, echoed);
   }
 
+  /**
+   * Test error.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testError() throws IOException {
     SimpleException error = null;
@@ -137,6 +227,11 @@ public class TestProtocolReflect {
     assertEquals("foo", error.getMessage());
   }
 
+  /**
+   * Test undeclared error.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testUndeclaredError() throws Exception {
     this.throwUndeclaredError = true;
@@ -152,6 +247,11 @@ public class TestProtocolReflect {
     assertTrue(error.toString().contains("foo"));
   }
 
+  /**
+   * Test stop server.
+   *
+   * @throws IOException the io exception
+   */
   @AfterClass
   public static void testStopServer() throws IOException {
     client.close();

--- a/lang/java/ipc/src/test/java/org/apache/avro/TestProtocolReflectMeta.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/TestProtocolReflectMeta.java
@@ -25,6 +25,9 @@ import org.junit.Before;
 
 import java.net.InetSocketAddress;
 
+/**
+ * The type Test protocol reflect meta.
+ */
 public class TestProtocolReflectMeta extends TestProtocolReflect {
 
   @Before @Override

--- a/lang/java/ipc/src/test/java/org/apache/avro/TestProtocolSpecific.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/TestProtocolSpecific.java
@@ -57,16 +57,31 @@ import java.util.ArrayList;
 import java.util.HashSet;
 
 
+/**
+ * The type Test protocol specific.
+ */
 public class TestProtocolSpecific {
 
+  /**
+   * The constant REPEATING.
+   */
   protected static final int REPEATING = -1;
+  /**
+   * The constant SERVER_PORTS_DIR.
+   */
   protected static final File SERVER_PORTS_DIR
   = new File(System.getProperty("test.dir", "/tmp")+"/server-ports/");
 
+  /**
+   * The constant ackCount.
+   */
   public static int ackCount;
 
   private static boolean throwUndeclaredError;
 
+  /**
+   * The type Test.
+   */
   public static class TestImpl implements Simple {
     public String hello(String greeting) { return "goodbye"; }
     public int add(int arg1, int arg2) { return arg1 + arg2; }
@@ -79,14 +94,34 @@ public class TestProtocolSpecific {
     public void ack() { ackCount++; }
   }
 
+  /**
+   * The constant server.
+   */
   protected static Server server;
+  /**
+   * The constant client.
+   */
   protected static Transceiver client;
+  /**
+   * The constant proxy.
+   */
   protected static Simple proxy;
 
+  /**
+   * The constant responder.
+   */
   protected static SpecificResponder responder;
 
+  /**
+   * The constant monitor.
+   */
   protected static HandshakeMonitor monitor;
 
+  /**
+   * Test start server.
+   *
+   * @throws Exception the exception
+   */
   @Before
   public void testStartServer() throws Exception {
     if (server != null) return;
@@ -103,17 +138,40 @@ public class TestProtocolSpecific {
     responder.addRPCPlugin(monitor);
   }
 
+  /**
+   * Add rpc plugins.
+   *
+   * @param requestor the requestor
+   */
   public void addRpcPlugins(Requestor requestor){}
 
+  /**
+   * Create server server.
+   *
+   * @param testResponder the test responder
+   * @return the server
+   * @throws Exception the exception
+   */
   public Server createServer(Responder testResponder) throws Exception{
     return server = new SocketServer(testResponder,
                               new InetSocketAddress(0));
   }
 
+  /**
+   * Create transceiver transceiver.
+   *
+   * @return the transceiver
+   * @throws Exception the exception
+   */
   public Transceiver createTransceiver() throws Exception{
     return new SocketTransceiver(new InetSocketAddress(server.getPort()));
   }
 
+  /**
+   * Test class loader.
+   *
+   * @throws Exception the exception
+   */
   @Test public void testClassLoader() throws Exception {
     ClassLoader loader = new ClassLoader() {};
 
@@ -127,22 +185,42 @@ public class TestProtocolSpecific {
     assertEquals(requestor.getSpecificData().getClassLoader(), loader);
   }
 
+  /**
+   * Test get remote.
+   *
+   * @throws IOException the io exception
+   */
   @Test public void testGetRemote() throws IOException {
     assertEquals(Simple.PROTOCOL, SpecificRequestor.getRemote(proxy));
   }
 
+  /**
+   * Test hello.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testHello() throws IOException {
     String response = proxy.hello("bob");
     assertEquals("goodbye", response);
   }
 
+  /**
+   * Test hash code.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testHashCode() throws IOException {
     TestError error = new TestError();
     error.hashCode();
   }
 
+  /**
+   * Test echo.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testEcho() throws IOException {
     TestRecord record = new TestRecord();
@@ -154,12 +232,22 @@ public class TestProtocolSpecific {
     assertEquals(record.hashCode(), echoed.hashCode());
   }
 
+  /**
+   * Test add.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testAdd() throws IOException {
     int result = proxy.add(1, 2);
     assertEquals(3, result);
   }
 
+  /**
+   * Test echo bytes.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testEchoBytes() throws IOException {
     Random random = new Random();
@@ -171,6 +259,11 @@ public class TestProtocolSpecific {
     assertEquals(data, echoed);
   }
 
+  /**
+   * Test empty echo bytes.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testEmptyEchoBytes() throws IOException {
     ByteBuffer data = ByteBuffer.allocate(0);
@@ -179,6 +272,11 @@ public class TestProtocolSpecific {
     assertEquals(data, echoed);
   }
 
+  /**
+   * Test error.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testError() throws IOException {
     TestError error = null;
@@ -191,6 +289,11 @@ public class TestProtocolSpecific {
     assertEquals("an error", error.getMessage$());
   }
 
+  /**
+   * Test undeclared error.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testUndeclaredError() throws Exception {
     this.throwUndeclaredError = true;
@@ -207,6 +310,11 @@ public class TestProtocolSpecific {
   }
 
 
+  /**
+   * Test one way.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testOneWay() throws IOException {
     ackCount = 0;
@@ -217,6 +325,11 @@ public class TestProtocolSpecific {
     assertEquals(2, ackCount);
   }
 
+  /**
+   * Test repeated access.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testRepeatedAccess() throws Exception {
     for (int x = 0; x < 1000; x++) {
@@ -224,6 +337,11 @@ public class TestProtocolSpecific {
     }
   }
 
+  /**
+   * Test connection refused one way.
+   *
+   * @throws IOException the io exception
+   */
   @Test(expected = Exception.class)
   public void testConnectionRefusedOneWay() throws IOException {
     Transceiver client = new HttpTransceiver(new URL("http://localhost:4444"));
@@ -233,6 +351,11 @@ public class TestProtocolSpecific {
     proxy.ack();
   }
 
+  /**
+   * Test param variation.
+   *
+   * @throws Exception the exception
+   */
   @Test
   /** Construct and use a protocol whose "hello" method has an extra
       argument to check that schema is sent to parse request. */
@@ -264,11 +387,21 @@ public class TestProtocolSpecific {
     }
   }
 
+  /**
+   * Test handshake count.
+   *
+   * @throws IOException the io exception
+   */
   @AfterClass
   public static void testHandshakeCount() throws IOException {
     monitor.assertHandshake();
   }
 
+  /**
+   * Test stop server.
+   *
+   * @throws IOException the io exception
+   */
   @AfterClass
   public static void testStopServer() throws IOException {
     client.close();
@@ -276,6 +409,9 @@ public class TestProtocolSpecific {
     server = null;
   }
 
+  /**
+   * The type Handshake monitor.
+   */
   public class HandshakeMonitor extends RPCPlugin{
 
     private int handshakes;
@@ -298,6 +434,9 @@ public class TestProtocolSpecific {
       }
     }
 
+    /**
+     * Assert handshake.
+     */
     public void assertHandshake(){
       int expected = getExpectedHandshakeCount();
       if(expected != REPEATING){
@@ -306,13 +445,26 @@ public class TestProtocolSpecific {
     }
   }
 
+  /**
+   * Gets expected handshake count.
+   *
+   * @return the expected handshake count
+   */
   protected int getExpectedHandshakeCount() {
    return 3;
   }
 
+  /**
+   * The type Interop test.
+   */
   public static class InteropTest {
 
-  @Test
+    /**
+     * Test client.
+     *
+     * @throws Exception the exception
+     */
+    @Test
     public void testClient() throws Exception {
       for (File f : SERVER_PORTS_DIR.listFiles()) {
         LineNumberReader reader = new LineNumberReader(new FileReader(f));
@@ -334,6 +486,9 @@ public class TestProtocolSpecific {
 
     /**
      * Starts the RPC server.
+     *
+     * @param args the input arguments
+     * @throws Exception the exception
      */
     public static void main(String[] args) throws Exception {
       SocketServer server = new SocketServer(

--- a/lang/java/ipc/src/test/java/org/apache/avro/TestProtocolSpecificMeta.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/TestProtocolSpecificMeta.java
@@ -27,6 +27,9 @@ import org.apache.avro.ipc.SocketTransceiver;
 import org.apache.avro.ipc.Transceiver;
 
 
+/**
+ * The type Test protocol specific meta.
+ */
 public class TestProtocolSpecificMeta extends TestProtocolSpecific {
 
   @Override

--- a/lang/java/ipc/src/test/java/org/apache/avro/TestSchema.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/TestSchema.java
@@ -51,17 +51,29 @@ import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.util.Utf8;
 import org.junit.Test;
 
+/**
+ * The type Test schema.
+ */
 public class TestSchema {
 
+  /**
+   * The constant LISP_SCHEMA.
+   */
   public static final String LISP_SCHEMA = "{\"type\": \"record\", \"name\": \"Lisp\", \"fields\": ["
             +"{\"name\":\"value\", \"type\":[\"null\", \"string\","
             +"{\"type\": \"record\", \"name\": \"Cons\", \"fields\": ["
             +"{\"name\":\"car\", \"type\":\"Lisp\"},"
             +"{\"name\":\"cdr\", \"type\":\"Lisp\"}]}]}]}";
 
+  /**
+   * The constant BASIC_ENUM_SCHEMA.
+   */
   public static final String BASIC_ENUM_SCHEMA = "{\"type\":\"enum\", \"name\":\"Test\","
             +"\"symbols\": [\"A\", \"B\"]}";
 
+  /**
+   * The constant SCHEMA_WITH_DOC_TAGS.
+   */
   public static final String SCHEMA_WITH_DOC_TAGS = "{\n"
       + "  \"type\": \"record\",\n"
       + "  \"name\": \"outer_record\",\n"
@@ -83,6 +95,11 @@ public class TestSchema {
   private static final int COUNT =
     Integer.parseInt(System.getProperty("test.count", "30"));
 
+  /**
+   * Test null.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testNull() throws Exception {
     assertEquals(Schema.create(Type.NULL), Schema.parse("\"null\""));
@@ -90,6 +107,11 @@ public class TestSchema {
     check("\"null\"", "null", null);
   }
 
+  /**
+   * Test boolean.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testBoolean() throws Exception {
     assertEquals(Schema.create(Type.BOOLEAN), Schema.parse("\"boolean\""));
@@ -98,6 +120,11 @@ public class TestSchema {
     check("\"boolean\"", "true", Boolean.TRUE);
   }
 
+  /**
+   * Test string.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testString() throws Exception {
     assertEquals(Schema.create(Type.STRING), Schema.parse("\"string\""));
@@ -106,6 +133,11 @@ public class TestSchema {
     check("\"string\"", "\"foo\"", new Utf8("foo"));
   }
 
+  /**
+   * Test bytes.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testBytes() throws Exception {
     assertEquals(Schema.create(Type.BYTES), Schema.parse("\"bytes\""));
@@ -115,6 +147,11 @@ public class TestSchema {
           ByteBuffer.wrap(new byte[]{0,65,66,67,-1}));
   }
 
+  /**
+   * Test int.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testInt() throws Exception {
     assertEquals(Schema.create(Type.INT), Schema.parse("\"int\""));
@@ -122,6 +159,11 @@ public class TestSchema {
     check("\"int\"", "9", new Integer(9));
   }
 
+  /**
+   * Test long.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testLong() throws Exception {
     assertEquals(Schema.create(Type.LONG), Schema.parse("\"long\""));
@@ -129,6 +171,11 @@ public class TestSchema {
     check("\"long\"", "11", new Long(11));
   }
 
+  /**
+   * Test float.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testFloat() throws Exception {
     assertEquals(Schema.create(Type.FLOAT), Schema.parse("\"float\""));
@@ -140,6 +187,11 @@ public class TestSchema {
     checkDefault("\"float\"", "\"-Infinity\"", Float.NEGATIVE_INFINITY);
   }
 
+  /**
+   * Test double.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testDouble() throws Exception {
     assertEquals(Schema.create(Type.DOUBLE), Schema.parse("\"double\""));
@@ -151,6 +203,11 @@ public class TestSchema {
     checkDefault("\"double\"", "\"-Infinity\"", Double.NEGATIVE_INFINITY);
   }
 
+  /**
+   * Test array.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testArray() throws Exception {
     String json = "{\"type\":\"array\", \"items\": \"long\"}";
@@ -164,6 +221,11 @@ public class TestSchema {
     checkParseError("{\"type\":\"array\"}");      // items required
   }
 
+  /**
+   * Test map.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testMap() throws Exception {
     HashMap<Utf8,Long> map = new HashMap<>();
@@ -172,6 +234,11 @@ public class TestSchema {
     checkParseError("{\"type\":\"map\"}");        // values required
   }
 
+  /**
+   * Test union map.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testUnionMap() throws Exception {
     String unionMapSchema = "{\"name\":\"foo\", \"type\":\"record\"," +
@@ -184,6 +251,11 @@ public class TestSchema {
     check(unionMapSchema, true);
   }
 
+  /**
+   * Test record.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testRecord() throws Exception {
     String recordJson = "{\"type\":\"record\", \"name\":\"Test\", \"fields\":"
@@ -220,12 +292,20 @@ public class TestSchema {
                     +"{\"name\":\"f.g\",\"type\":\"int\"}]}");
   }
 
+  /**
+   * Test invalid name tolerance.
+   */
   @Test public void testInvalidNameTolerance() {
     Schema.parse("{\"type\":\"record\",\"name\":\"1X\",\"fields\":[]}", false);
     Schema.parse("{\"type\":\"record\",\"name\":\"X-\",\"fields\":[]}", false);
     Schema.parse("{\"type\":\"record\",\"name\":\"X$\",\"fields\":[]}", false);
   }
 
+  /**
+   * Test map in record.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testMapInRecord() throws Exception {
     String json = "{\"type\":\"record\", \"name\":\"Test\", \"fields\":"
@@ -240,6 +320,11 @@ public class TestSchema {
   }
 
 
+  /**
+   * Test enum.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testEnum() throws Exception {
     check(BASIC_ENUM_SCHEMA, "\"B\"",
@@ -255,6 +340,11 @@ public class TestSchema {
     checkParseError("{\"type\":\"enum\",\"name\":\"X\",\"symbols\":[\"X.Y\"]}");
   }
 
+  /**
+   * Test fixed.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testFixed() throws Exception {
     String json = "{\"type\": \"fixed\", \"name\":\"Test\", \"size\": 1}";
@@ -264,6 +354,11 @@ public class TestSchema {
     checkParseError("{\"type\":\"fixed\"}");        // size required
   }
 
+  /**
+   * Test recursive.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testRecursive() throws Exception {
     check("{\"type\": \"record\", \"name\": \"Node\", \"fields\": ["
@@ -273,6 +368,11 @@ public class TestSchema {
           false);
   }
 
+  /**
+   * Test recursive equals.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testRecursiveEquals() throws Exception {
     String jsonSchema = "{\"type\":\"record\", \"name\":\"List\", \"fields\": ["
@@ -283,6 +383,11 @@ public class TestSchema {
     s1.hashCode();                                // test no stackoverflow
   }
 
+  /**
+   * Test schema explosion.
+   *
+   * @throws Exception the exception
+   */
   @Test
   /** Test that equals() and hashCode() don't require exponential time on
    *  certain pathological schemas. */
@@ -310,11 +415,21 @@ public class TestSchema {
     }
   }
 
+  /**
+   * Test lisp.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testLisp() throws Exception {
     check(LISP_SCHEMA, false);
   }
 
+  /**
+   * Test union.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testUnion() throws Exception {
     check("[\"string\", \"long\"]", false);
@@ -360,6 +475,11 @@ public class TestSchema {
               "{\"Baz\":\"X\"}");
   }
 
+  /**
+   * Test complex unions.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testComplexUnions() throws Exception {
     // one of each unnamed type and two of named types
@@ -426,6 +546,11 @@ public class TestSchema {
     checkUnionError(new Schema[] {union});
   }
 
+  /**
+   * Test complex prop.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testComplexProp() throws Exception {
     String json = "{\"type\":\"null\", \"foo\": [0]}";
@@ -433,12 +558,22 @@ public class TestSchema {
     assertEquals(null, s.getProp("foo"));
   }
 
+  /**
+   * Test prop ordering.
+   *
+   * @throws Exception the exception
+   */
   @Test public void testPropOrdering() throws Exception {
     String json = "{\"type\":\"int\",\"z\":\"c\",\"yy\":\"b\",\"x\":\"a\"}";
     Schema s = Schema.parse(json);
     assertEquals(json, s.toString());
   }
 
+  /**
+   * Test parse input stream.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testParseInputStream() throws IOException {
     Schema s = Schema.parse(
@@ -446,6 +581,11 @@ public class TestSchema {
     assertEquals(Schema.parse("\"boolean\""), s);
   }
 
+  /**
+   * Test namespace scope.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testNamespaceScope() throws Exception {
     String z = "{\"type\":\"record\",\"name\":\"Z\",\"fields\":[]}";
@@ -461,6 +601,11 @@ public class TestSchema {
     assertEquals("q.Z", ys.getField("f").schema().getFullName());
   }
 
+  /**
+   * Test namespace nesting.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testNamespaceNesting() throws Exception {
     String y = "{\"type\":\"record\",\"name\":\"y.Y\",\"fields\":["
@@ -472,6 +617,11 @@ public class TestSchema {
     assertEquals(xs, Schema.parse(xs.toString()));
   }
 
+  /**
+   * Test nested null namespace.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testNestedNullNamespace() throws Exception {
     Schema inner =
@@ -481,6 +631,9 @@ public class TestSchema {
     assertEquals(outer, Schema.parse(outer.toString()));
   }
 
+  /**
+   * Test nested null namespace referencing.
+   */
   @Test
   public void testNestedNullNamespaceReferencing() {
     Schema inner =
@@ -491,6 +644,9 @@ public class TestSchema {
     assertEquals(outer, Schema.parse(outer.toString()));
   }
 
+  /**
+   * Test nested null namespace referencing with union.
+   */
   @Test
   public void testNestedNullNamespaceReferencingWithUnion() {
     Schema inner =
@@ -502,6 +658,11 @@ public class TestSchema {
     assertEquals(outer, Schema.parse(outer.toString()));
   }
 
+  /**
+   * Test nested non null namespace 1.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testNestedNonNullNamespace1() throws Exception {
     Schema inner1 = Schema.createEnum("InnerEnum", null, "space", Arrays.asList("x"));
@@ -513,6 +674,11 @@ public class TestSchema {
     assertEquals(nullOuter, Schema.parse(nullOuter.toString()));
   }
 
+  /**
+   * Test nested non null namespace 2.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testNestedNonNullNamespace2() throws Exception {
     Schema inner1 = Schema.createFixed("InnerFixed", null, "space", 1);
@@ -524,6 +690,11 @@ public class TestSchema {
     assertEquals(nullOuter, Schema.parse(nullOuter.toString()));
   }
 
+  /**
+   * Test null namespace alias.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testNullNamespaceAlias() throws Exception {
     Schema s =
@@ -535,6 +706,11 @@ public class TestSchema {
     assertEquals("x.Y", u.getFullName());
   }
 
+  /**
+   * Test null pointer.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testNullPointer() throws Exception {
     String recordJson = "{\"type\":\"record\", \"name\":\"Test\", \"fields\":"
@@ -591,6 +767,9 @@ public class TestSchema {
     assertEquals("Inner Union", schema.getField("inner_union").doc());
   }
 
+  /**
+   * Test field docs.
+   */
   @Test
   public void testFieldDocs() {
     String schemaStr = "{\"name\": \"Rec\",\"type\": \"record\",\"fields\" : ["+
@@ -605,6 +784,11 @@ public class TestSchema {
     assertEquals("test", schema.getField("f").doc());
   }
 
+  /**
+   * Test aliases.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testAliases() throws Exception {
     String t1 = "{\"type\":\"record\",\"name\":\"a.b\",\"fields\":["
@@ -709,6 +893,15 @@ public class TestSchema {
     assertFalse(s0.equals(s2));
   }
 
+  /**
+   * Check binary.
+   *
+   * @param schema the schema
+   * @param datum  the datum
+   * @param writer the writer
+   * @param reader the reader
+   * @throws IOException the io exception
+   */
   public static void checkBinary(Schema schema, Object datum,
                                  DatumWriter<Object> writer,
                                  DatumReader<Object> reader)
@@ -716,6 +909,17 @@ public class TestSchema {
     checkBinary(schema, datum, writer, reader, null);
   }
 
+  /**
+   * Check binary object.
+   *
+   * @param schema the schema
+   * @param datum  the datum
+   * @param writer the writer
+   * @param reader the reader
+   * @param reuse  the reuse
+   * @return the object
+   * @throws IOException the io exception
+   */
   public static Object checkBinary(Schema schema, Object datum,
                                  DatumWriter<Object> writer,
                                  DatumReader<Object> reader,
@@ -738,6 +942,15 @@ public class TestSchema {
     return decoded;
   }
 
+  /**
+   * Check direct binary.
+   *
+   * @param schema the schema
+   * @param datum  the datum
+   * @param writer the writer
+   * @param reader the reader
+   * @throws IOException the io exception
+   */
   public static void checkDirectBinary(Schema schema, Object datum,
       DatumWriter<Object> writer, DatumReader<Object> reader)
       throws IOException {
@@ -756,6 +969,15 @@ public class TestSchema {
     assertEquals("Decoded data does not match.", datum, decoded);
   }
 
+  /**
+   * Check blocking binary.
+   *
+   * @param schema the schema
+   * @param datum  the datum
+   * @param writer the writer
+   * @param reader the reader
+   * @throws IOException the io exception
+   */
   public static void checkBlockingBinary(Schema schema, Object datum,
       DatumWriter<Object> writer, DatumReader<Object> reader)
       throws IOException {
@@ -817,6 +1039,12 @@ public class TestSchema {
     assertEquals("Decoded data does not match.", datum, decoded);
   }
 
+  /**
+   * Check binary json.
+   *
+   * @param json the json
+   * @throws Exception the exception
+   */
   public static void checkBinaryJson(String json) throws Exception {
     Object node = Json.parseJson(json);
     ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -867,6 +1095,11 @@ public class TestSchema {
     }
   }
 
+  /**
+   * Test no default field.
+   *
+   * @throws Exception the exception
+   */
   @Test(expected=AvroTypeException.class)
   public void testNoDefaultField() throws Exception {
     Schema expected =
@@ -877,6 +1110,11 @@ public class TestSchema {
         new ByteArrayInputStream(new byte[0]), null));
   }
 
+  /**
+   * Test enum mismatch.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testEnumMismatch() throws Exception {
     Schema actual = Schema.parse
@@ -903,11 +1141,17 @@ public class TestSchema {
     }
   }
 
+  /**
+   * Test record with primitive name.
+   */
   @Test(expected=AvroTypeException.class)
   public void testRecordWithPrimitiveName() {
     Schema.parse("{\"type\":\"record\", \"name\":\"string\", \"fields\": []}");
   }
 
+  /**
+   * Test enum with primitive name.
+   */
   @Test(expected=AvroTypeException.class)
   public void testEnumWithPrimitiveName() {
     Schema.parse("{\"type\":\"enum\", \"name\":\"null\", \"symbols\": [\"A\"]}");
@@ -918,6 +1162,9 @@ public class TestSchema {
         + "\"symbols\": [\"a\", \"b\"]}");
   }
 
+  /**
+   * Test immutability 1.
+   */
   @Test(expected=AvroRuntimeException.class)
   public void testImmutability1() {
     Schema s = enumSchema();
@@ -925,6 +1172,9 @@ public class TestSchema {
     s.addProp("p1", "2");
   }
 
+  /**
+   * Test immutability 2.
+   */
   @Test(expected=AvroRuntimeException.class)
   public void testImmutability2() {
     Schema s = enumSchema();
@@ -936,50 +1186,77 @@ public class TestSchema {
         "a", "b", "c"})).lock();
   }
 
+  /**
+   * Test locked array list 1.
+   */
   @Test(expected=IllegalStateException.class)
   public void testLockedArrayList1() {
     lockedArrayList().add("p");
   }
 
+  /**
+   * Test locked array list 2.
+   */
   @Test(expected=IllegalStateException.class)
   public void testLockedArrayList2() {
     lockedArrayList().remove("a");
   }
 
+  /**
+   * Test locked array list 3.
+   */
   @Test(expected=IllegalStateException.class)
   public void testLockedArrayList3() {
     lockedArrayList().addAll(Arrays.asList(new String[] { "p" }));
   }
 
+  /**
+   * Test locked array list 4.
+   */
   @Test(expected=IllegalStateException.class)
   public void testLockedArrayList4() {
     lockedArrayList().addAll(0,
         Arrays.asList(new String[] { "p" }));
   }
 
+  /**
+   * Test locked array list 5.
+   */
   @Test(expected=IllegalStateException.class)
   public void testLockedArrayList5() {
     lockedArrayList().
       removeAll(Arrays.asList(new String[] { "a" }));
   }
 
+  /**
+   * Test locked array list 6.
+   */
   @Test(expected=IllegalStateException.class)
   public void testLockedArrayList6() {
     lockedArrayList().
       retainAll(Arrays.asList(new String[] { "a" }));
   }
 
+  /**
+   * Test locked array list 7.
+   */
   @Test(expected=IllegalStateException.class)
   public void testLockedArrayList7() {
     lockedArrayList().clear();
   }
 
+  /**
+   * Test locked array list 8.
+   */
   @Test(expected=IllegalStateException.class)
   public void testLockedArrayList8() {
     lockedArrayList().iterator().remove();
   }
 
 
+  /**
+   * Test locked array list 9.
+   */
   @Test(expected=IllegalStateException.class)
   public void testLockedArrayList9() {
     Iterator<String> it = lockedArrayList().iterator();
@@ -987,11 +1264,17 @@ public class TestSchema {
     it.remove();
   }
 
+  /**
+   * Test locked array list 10.
+   */
   @Test(expected=IllegalStateException.class)
   public void testLockedArrayList10() {
     lockedArrayList().remove(1);
   }
 
+  /**
+   * Test names get with inherited namespace.
+   */
   @Test
   public void testNames_GetWithInheritedNamespace() {
     Schema schema = Schema.create(Type.STRING);
@@ -1002,6 +1285,9 @@ public class TestSchema {
     assertEquals(schema, names.get("Name"));
   }
 
+  /**
+   * Test names get with null namespace.
+   */
   @Test
   public void testNames_GetWithNullNamespace() {
     Schema schema = Schema.create(Type.STRING);
@@ -1012,6 +1298,9 @@ public class TestSchema {
     assertEquals(schema, names.get("Name"));
   }
 
+  /**
+   * Test names get not found.
+   */
   @Test
   public void testNames_GetNotFound() {
     Schema.Names names = new Schema.Names("space");

--- a/lang/java/ipc/src/test/java/org/apache/avro/compiler/specific/TestSpecificCompiler.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/compiler/specific/TestSpecificCompiler.java
@@ -53,7 +53,13 @@ import org.apache.avro.test.Kind;
 import org.apache.avro.compiler.specific.SpecificCompiler.OutputFile;
 import org.junit.Test;
 
+/**
+ * The type Test specific compiler.
+ */
 public class TestSpecificCompiler {
+  /**
+   * The Protocol.
+   */
   static final String PROTOCOL = "" +
         "{ \"protocol\": \"default\",\n" +
         "  \"types\":\n" +
@@ -72,11 +78,17 @@ public class TestSpecificCompiler {
         "   }\n" +
         "}\n";
 
+  /**
+   * Test esc.
+   */
   @Test
   public void testEsc() {
     assertEquals("\\\"", SpecificCompiler.javaEscape("\""));
   }
 
+  /**
+   * Test make path.
+   */
   @Test
   public void testMakePath() {
     SpecificCompiler compiler = new SpecificCompiler();
@@ -84,11 +96,19 @@ public class TestSpecificCompiler {
     assertEquals("baz.java", compiler.makePath("baz", ""));
   }
 
+  /**
+   * Test primitive schema generates nothing.
+   */
   @Test
   public void testPrimitiveSchemaGeneratesNothing() {
     assertEquals(0, new SpecificCompiler(Schema.parse("\"double\"")).compile().size());
   }
 
+  /**
+   * Test simple enum schema.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testSimpleEnumSchema() throws IOException {
     Collection<OutputFile> outputs = new SpecificCompiler(Schema.parse(TestSchema.BASIC_ENUM_SCHEMA)).compile();
@@ -99,12 +119,20 @@ public class TestSpecificCompiler {
     assertCompilesWithJavaCompiler(outputs);
   }
 
+  /**
+   * Test mangle if reserved.
+   */
   @Test
   public void testMangleIfReserved() {
     assertEquals("foo", SpecificCompiler.mangle("foo"));
     assertEquals("goto$", SpecificCompiler.mangle("goto"));
   }
 
+  /**
+   * Test mangling for protocols.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testManglingForProtocols() throws IOException {
     String protocolDef = PROTOCOL;
@@ -135,6 +163,11 @@ public class TestSpecificCompiler {
       "                {\"name\": \"short\", \"type\": \"volatile\" } ] }";
 
 
+  /**
+   * Test mangling for records.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testManglingForRecords() throws IOException {
     Collection<OutputFile> c =
@@ -149,6 +182,11 @@ public class TestSpecificCompiler {
     assertCompilesWithJavaCompiler(c);
   }
 
+  /**
+   * Test mangling for enums.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testManglingForEnums() throws IOException {
     String enumSchema = "" +
@@ -164,6 +202,11 @@ public class TestSpecificCompiler {
     assertCompilesWithJavaCompiler(c);
   }
 
+  /**
+   * Test schema split.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testSchemaSplit() throws IOException {
     SpecificCompiler compiler = new SpecificCompiler(Schema.parse(SCHEMA));
@@ -172,6 +215,11 @@ public class TestSpecificCompiler {
     assertCompilesWithJavaCompiler(files);
   }
 
+  /**
+   * Test protocol split.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testProtocolSplit() throws IOException {
     SpecificCompiler compiler = new SpecificCompiler(Protocol.parse(PROTOCOL));
@@ -180,6 +228,9 @@ public class TestSpecificCompiler {
     assertCompilesWithJavaCompiler(files);
   }
 
+  /**
+   * Test schema with docs.
+   */
   @Test
   public void testSchemaWithDocs() {
     Collection<OutputFile> outputs = new SpecificCompiler(
@@ -208,6 +259,11 @@ public class TestSpecificCompiler {
     assertEquals(3, count);
   }
 
+  /**
+   * Test protocol with docs.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testProtocolWithDocs() throws IOException {
     Protocol protocol = TestProtocolParsing.getSimpleProtocol();
@@ -224,6 +280,12 @@ public class TestSpecificCompiler {
     assertEquals("Missed generated protocol!", 1, count);
   }
 
+  /**
+   * Test need compile.
+   *
+   * @throws IOException          the io exception
+   * @throws InterruptedException the interrupted exception
+   */
   @Test
   public void testNeedCompile() throws IOException, InterruptedException {
     String schema = "" +
@@ -272,6 +334,9 @@ public class TestSpecificCompiler {
     return record;
   }
 
+  /**
+   * Generate get method.
+   */
   @Test
   public void generateGetMethod() {
     Field height = new Field("height", Schema.create(Type.INT), null, null);
@@ -368,6 +433,9 @@ public class TestSpecificCompiler {
         createRecord("test", false, schema, Schema$), Schema$));
   }
 
+  /**
+   * Generate set method.
+   */
   @Test
   public void generateSetMethod() {
     Field height = new Field("height", Schema.create(Type.INT), null, null);
@@ -464,6 +532,9 @@ public class TestSpecificCompiler {
         createRecord("test", false, schema, Schema$), Schema$));
   }
 
+  /**
+   * Generate has method.
+   */
   @Test
   public void generateHasMethod() {
     Field height = new Field("height", Schema.create(Type.INT), null, null);
@@ -560,6 +631,9 @@ public class TestSpecificCompiler {
         createRecord("test", false, schema, Schema$), Schema$));
   }
 
+  /**
+   * Generate clear method.
+   */
   @Test
   public void generateClearMethod() {
     Field height = new Field("height", Schema.create(Type.INT), null, null);
@@ -656,6 +730,11 @@ public class TestSpecificCompiler {
         createRecord("test", false, schema, Schema$), Schema$));
   }
 
+  /**
+   * Test annotations.
+   *
+   * @throws Exception the exception
+   */
   @Test public void testAnnotations() throws Exception {
     // an interface generated for protocol
     assertNotNull(Simple.class.getAnnotation(TestAnnotation.class));
@@ -674,6 +753,11 @@ public class TestSpecificCompiler {
                   .getAnnotation(TestAnnotation.class));
   }
 
+  /**
+   * Test aliases.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testAliases() throws IOException {
     Schema s = Schema.parse
@@ -693,6 +777,10 @@ public class TestSpecificCompiler {
    * Checks that a schema passes through the SpecificCompiler, and,
    * optionally, uses the system's Java compiler to check
    * that the generated code is valid.
+   *
+   * @param schema          the schema
+   * @param useJavaCompiler the use java compiler
+   * @throws IOException the io exception
    */
   public static void
       assertCompiles(Schema schema, boolean useJavaCompiler)
@@ -708,6 +796,10 @@ public class TestSpecificCompiler {
    * Checks that a protocol passes through the SpecificCompiler,
    * and, optionally, uses the system's Java compiler to check
    * that the generated code is valid.
+   *
+   * @param protocol        the protocol
+   * @param useJavaCompiler the use java compiler
+   * @throws IOException the io exception
    */
   public static void assertCompiles(Protocol protocol, boolean useJavaCompiler)
   throws IOException {
@@ -718,7 +810,11 @@ public class TestSpecificCompiler {
     }
   }
 
-  /** Uses the system's java compiler to actually compile the generated code. */
+  /**
+   * Uses the system's java compiler to actually compile the generated code.  @param outputs the outputs
+   *
+   * @throws IOException the io exception
+   */
   static void assertCompilesWithJavaCompiler(Collection<OutputFile> outputs)
   throws IOException {
     if (outputs.isEmpty()) {

--- a/lang/java/ipc/src/test/java/org/apache/avro/generic/TestDeepCopy.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/generic/TestDeepCopy.java
@@ -37,8 +37,13 @@ import org.apache.avro.Schema.Type;
 import org.apache.avro.specific.SpecificData;
 import org.junit.Test;
 
-/** Unit test for performing a deep copy of an object with a schema */
+/**
+ * Unit test for performing a deep copy of an object with a schema
+ */
 public class TestDeepCopy {
+  /**
+   * Test deep copy.
+   */
   @Test
   public void testDeepCopy() {
     // Set all non-default fields in an Interop instance:

--- a/lang/java/ipc/src/test/java/org/apache/avro/io/Perf.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/io/Perf.java
@@ -59,17 +59,41 @@ public class Perf {
    */
   private static final long SEED = 19781210;
 
+  /**
+   * New random random.
+   *
+   * @return the random
+   */
   protected static Random newRandom() {
     return new Random(SEED);
   }
 
   private static class TestDescriptor {
+    /**
+     * The Test.
+     */
     Class<? extends Test> test;
+    /**
+     * The Param.
+     */
     String param;
+
+    /**
+     * Instantiates a new Test descriptor.
+     *
+     * @param test  the test
+     * @param param the param
+     */
     TestDescriptor(Class<? extends Test> test, String param) {
       this.test = test;
       this.param = param;
     }
+
+    /**
+     * Add.
+     *
+     * @param typeList the type list
+     */
     void add(List<TestDescriptor> typeList) {
       ALL_TESTS.put(param, this);
       typeList.add(this);
@@ -155,6 +179,12 @@ public class Perf {
     System.out.print(details.toString());
   }
 
+  /**
+   * The entry point of application.
+   *
+   * @param args the input arguments
+   * @throws Exception the exception
+   */
   public static void main(String[] args) throws Exception {
     List<Test> tests = new ArrayList<>();
     boolean writeTests = true;
@@ -273,14 +303,42 @@ public class Perf {
      * Name of the test.
      */
     public final String name;
+    /**
+     * The Count.
+     */
     public final int count;
+    /**
+     * The Cycles.
+     */
     public final int cycles;
+    /**
+     * The Encoded size.
+     */
     public long encodedSize = 0;
+    /**
+     * The Is read test.
+     */
     protected boolean isReadTest = true;
+    /**
+     * The Is write test.
+     */
     protected boolean isWriteTest = true;
+    /**
+     * The Decoder factory.
+     */
     static DecoderFactory decoder_factory = new DecoderFactory();
+    /**
+     * The Encoder factory.
+     */
     static EncoderFactory encoder_factory = new EncoderFactory();
 
+    /**
+     * Instantiates a new Test.
+     *
+     * @param name   the name
+     * @param cycles the cycles
+     * @param count  the count
+     */
     public Test(String name, int cycles, int count) {
       this.name = name;
       this.cycles = cycles;
@@ -289,26 +347,46 @@ public class Perf {
 
     /**
      * Reads data from a Decoder and returns the time taken in nanoseconds.
+     *
+     * @return the long
+     * @throws IOException the io exception
      */
     abstract long readTest() throws IOException;
 
     /**
      * Writes data to an Encoder and returns the time taken in nanoseconds.
+     *
+     * @return the long
+     * @throws IOException the io exception
      */
     abstract long writeTest() throws IOException;
 
+    /**
+     * Is write test boolean.
+     *
+     * @return the boolean
+     */
     final boolean isWriteTest() {
       return isWriteTest;
     }
 
+    /**
+     * Is read test boolean.
+     *
+     * @return the boolean
+     */
     final boolean isReadTest() {
       return isReadTest;
     }
 
-    /** initializes data for read and write tests **/
+    /**
+     * initializes data for read and write tests  @throws IOException the io exception
+     */
     abstract void init() throws IOException;
 
-    /** clears generated data arrays and other large objects created during initialization **/
+    /**
+     * clears generated data arrays and other large objects created during initialization
+     */
     abstract void reset();
 
     @Override
@@ -323,11 +401,34 @@ public class Perf {
    * higher level constructs, just manual serialization.
    */
   private static abstract class BasicTest extends Test {
+    /**
+     * The Schema.
+     */
     protected final Schema schema;
+    /**
+     * The Data.
+     */
     protected byte[] data;
+
+    /**
+     * Instantiates a new Basic test.
+     *
+     * @param name the name
+     * @param json the json
+     * @throws IOException the io exception
+     */
     BasicTest(String name, String json) throws IOException {
       this(name, json, 1);
     }
+
+    /**
+     * Instantiates a new Basic test.
+     *
+     * @param name   the name
+     * @param json   the json
+     * @param factor the factor
+     * @throws IOException the io exception
+     */
     BasicTest(String name, String json, int factor) throws IOException {
       super(name, CYCLES, COUNT/factor);
       this.schema = new Schema.Parser().parse(json);
@@ -350,6 +451,12 @@ public class Perf {
       return (System.nanoTime() - t);
     }
 
+    /**
+     * Gets decoder.
+     *
+     * @return the decoder
+     * @throws IOException the io exception
+     */
     protected Decoder getDecoder() throws IOException {
       return newDecoder();
     }
@@ -358,10 +465,22 @@ public class Perf {
       return newEncoder(getOutputStream());
     }
 
+    /**
+     * New decoder decoder.
+     *
+     * @return the decoder
+     */
     protected Decoder newDecoder() {
       return decoder_factory.binaryDecoder(data, null);
     }
 
+    /**
+     * New encoder encoder.
+     *
+     * @param out the out
+     * @return the encoder
+     * @throws IOException the io exception
+     */
     protected Encoder newEncoder(ByteArrayOutputStream out) throws IOException {
       Encoder e = encoder_factory.binaryEncoder(out, null);
 //    Encoder e = encoder_factory.directBinaryEncoder(out, null);
@@ -386,13 +505,42 @@ public class Perf {
       //System.out.println(this.getClass().getSimpleName() + " encodedSize=" + encodedSize);
     }
 
+    /**
+     * Gen source data.
+     */
     abstract void genSourceData();
+
+    /**
+     * Read internal.
+     *
+     * @param d the d
+     * @throws IOException the io exception
+     */
     abstract void readInternal(Decoder d) throws IOException;
+
+    /**
+     * Write internal.
+     *
+     * @param e the e
+     * @throws IOException the io exception
+     */
     abstract void writeInternal(Encoder e) throws IOException;
   }
 
+  /**
+   * The type Int test.
+   */
   static class IntTest extends BasicTest {
+    /**
+     * The Source data.
+     */
     protected int[] sourceData = null;
+
+    /**
+     * Instantiates a new Int test.
+     *
+     * @throws IOException the io exception
+     */
     public IntTest() throws IOException {
       this("Int", "{ \"type\": \"int\"} ");
     }
@@ -440,8 +588,16 @@ public class Perf {
     }
   }
 
-  // This is the same data as ReadInt, but using readLong.
+  /**
+   * The type Small long test.
+   */
+// This is the same data as ReadInt, but using readLong.
   static class SmallLongTest extends IntTest {
+    /**
+     * Instantiates a new Small long test.
+     *
+     * @throws IOException the io exception
+     */
     public SmallLongTest() throws IOException {
       super("SmallLong", "{ \"type\": \"long\"} ");
     }
@@ -467,9 +623,18 @@ public class Perf {
     }
   }
 
-  // this tests reading Longs that are sometimes very large
+  /**
+   * The type Long test.
+   */
+// this tests reading Longs that are sometimes very large
   static class LongTest extends BasicTest {
     private long[] sourceData = null;
+
+    /**
+     * Instantiates a new Long test.
+     *
+     * @throws IOException the io exception
+     */
     public LongTest() throws IOException {
       super("Long", "{ \"type\": \"long\"} ");
     }
@@ -517,11 +682,31 @@ public class Perf {
     }
   }
 
+  /**
+   * The type Float test.
+   */
   static class FloatTest extends BasicTest {
+    /**
+     * The Source data.
+     */
     float[] sourceData = null;
+
+    /**
+     * Instantiates a new Float test.
+     *
+     * @throws IOException the io exception
+     */
     public FloatTest() throws IOException {
       this("Float", "{ \"type\": \"float\"} ");
     }
+
+    /**
+     * Instantiates a new Float test.
+     *
+     * @param name   the name
+     * @param schema the schema
+     * @throws IOException the io exception
+     */
     public FloatTest(String name, String schema) throws IOException {
       super(name, schema);
     }
@@ -562,8 +747,20 @@ public class Perf {
     }
   }
 
+  /**
+   * The type Double test.
+   */
   static class DoubleTest extends BasicTest {
+    /**
+     * The Source data.
+     */
     double[] sourceData = null;
+
+    /**
+     * Instantiates a new Double test.
+     *
+     * @throws IOException the io exception
+     */
     public DoubleTest() throws IOException {
       super("Double", "{ \"type\": \"double\"} ");
     }
@@ -604,8 +801,20 @@ public class Perf {
     }
   }
 
+  /**
+   * The type Bool test.
+   */
   static class BoolTest extends BasicTest {
+    /**
+     * The Source data.
+     */
     boolean[] sourceData = null;
+
+    /**
+     * Instantiates a new Bool test.
+     *
+     * @throws IOException the io exception
+     */
     public BoolTest() throws IOException {
       super("Boolean", "{ \"type\": \"boolean\"} ");
     }
@@ -646,8 +855,20 @@ public class Perf {
     }
   }
 
+  /**
+   * The type Bytes test.
+   */
   static class BytesTest extends BasicTest {
+    /**
+     * The Source data.
+     */
     byte[][] sourceData = null;
+
+    /**
+     * Instantiates a new Bytes test.
+     *
+     * @throws IOException the io exception
+     */
     public BytesTest() throws IOException {
       super("Bytes", "{ \"type\": \"bytes\"} ", 5);
     }
@@ -699,8 +920,20 @@ public class Perf {
     return new String(data);
   }
 
+  /**
+   * The type String test.
+   */
   static class StringTest extends BasicTest {
+    /**
+     * The Source data.
+     */
     String[] sourceData = null;
+
+    /**
+     * Instantiates a new String test.
+     *
+     * @throws IOException the io exception
+     */
     public StringTest() throws IOException {
       super("String", "{ \"type\": \"string\"} ", 5);
     }
@@ -741,7 +974,15 @@ public class Perf {
     }
   }
 
+  /**
+   * The type Array test.
+   */
   static class ArrayTest extends FloatTest {
+    /**
+     * Instantiates a new Array test.
+     *
+     * @throws IOException the io exception
+     */
     public ArrayTest() throws IOException {
       super("Array",
           "{ \"type\": \"array\", \"items\": " +
@@ -792,7 +1033,15 @@ public class Perf {
     }
   }
 
+  /**
+   * The type Map test.
+   */
   static class MapTest extends FloatTest {
+    /**
+     * Instantiates a new Map test.
+     *
+     * @throws IOException the io exception
+     */
     public MapTest() throws IOException {
       super("Map", "{ \"type\": \"map\", \"values\": " +
           "  { \"type\": \"record\", \"name\":\"Vals\", \"fields\": [" +
@@ -859,15 +1108,43 @@ public class Perf {
     + "] }";
 
   private static class Rec {
+    /**
+     * The F 1.
+     */
     double f1;
+    /**
+     * The F 2.
+     */
     double f2;
+    /**
+     * The F 3.
+     */
     double f3;
+    /**
+     * The F 4.
+     */
     int f4;
+    /**
+     * The F 5.
+     */
     int f5;
+    /**
+     * The F 6.
+     */
     int f6;
+
+    /**
+     * Instantiates a new Rec.
+     */
     Rec() {
 
     }
+
+    /**
+     * Instantiates a new Rec.
+     *
+     * @param r the r
+     */
     Rec(Random r) {
       f1 = r.nextDouble();
       f2 = r.nextDouble();
@@ -878,11 +1155,30 @@ public class Perf {
     }
   }
 
+  /**
+   * The type Record test.
+   */
   static class RecordTest extends BasicTest {
+    /**
+     * The Source data.
+     */
     Rec[] sourceData = null;
+
+    /**
+     * Instantiates a new Record test.
+     *
+     * @throws IOException the io exception
+     */
     public RecordTest() throws IOException {
       this("Record");
     }
+
+    /**
+     * Instantiates a new Record test.
+     *
+     * @param name the name
+     * @throws IOException the io exception
+     */
     public RecordTest(String name) throws IOException {
       super(name, RECORD_SCHEMA, 6);
     }
@@ -924,7 +1220,15 @@ public class Perf {
     }
   }
 
+  /**
+   * The type Validating record.
+   */
   static class ValidatingRecord extends RecordTest {
+    /**
+     * Instantiates a new Validating record.
+     *
+     * @throws IOException the io exception
+     */
     ValidatingRecord() throws IOException {
       super("ValidatingRecord");
     }
@@ -938,7 +1242,15 @@ public class Perf {
     }
   }
 
+  /**
+   * The type Resolving record.
+   */
   static class ResolvingRecord extends RecordTest {
+    /**
+     * Instantiates a new Resolving record.
+     *
+     * @throws IOException the io exception
+     */
     public ResolvingRecord() throws IOException {
       super("ResolvingRecord");
       isWriteTest = false;
@@ -989,6 +1301,12 @@ public class Perf {
    */
   static class RecordWithDefault extends RecordTest {
     private final Schema readerSchema;
+
+    /**
+     * Instantiates a new Record with default.
+     *
+     * @throws IOException the io exception
+     */
     public RecordWithDefault() throws IOException {
       super("RecordWithDefault");
       readerSchema = new Schema.Parser().parse(RECORD_SCHEMA_WITH_DEFAULT);
@@ -1031,6 +1349,12 @@ public class Perf {
    */
   static class RecordWithOutOfOrder extends RecordTest {
     private final Schema readerSchema;
+
+    /**
+     * Instantiates a new Record with out of order.
+     *
+     * @throws IOException the io exception
+     */
     public RecordWithOutOfOrder() throws IOException {
       super("RecordWithOutOfOrder");
       readerSchema = new Schema.Parser().parse(RECORD_SCHEMA_WITH_OUT_OF_ORDER);
@@ -1069,6 +1393,12 @@ public class Perf {
    */
   static class RecordWithPromotion extends RecordTest {
     private final Schema readerSchema;
+
+    /**
+     * Instantiates a new Record with promotion.
+     *
+     * @throws IOException the io exception
+     */
     public RecordWithPromotion() throws IOException {
       super("RecordWithPromotion");
       readerSchema = new Schema.Parser().parse(RECORD_SCHEMA_WITH_PROMOTION);
@@ -1102,22 +1432,64 @@ public class Perf {
     }
   }
 
+  /**
+   * The type Generic test.
+   */
   static class GenericTest extends BasicTest {
+    /**
+     * The Source data.
+     */
     GenericRecord[] sourceData = null;
+    /**
+     * The Reader.
+     */
     protected final GenericDatumReader<Object> reader;
+
+    /**
+     * Instantiates a new Generic test.
+     *
+     * @throws IOException the io exception
+     */
     public GenericTest() throws IOException {
       this("Generic");
     }
+
+    /**
+     * Instantiates a new Generic test.
+     *
+     * @param name the name
+     * @throws IOException the io exception
+     */
     protected GenericTest(String name) throws IOException {
       this(name, RECORD_SCHEMA);
     }
+
+    /**
+     * Instantiates a new Generic test.
+     *
+     * @param name         the name
+     * @param writerSchema the writer schema
+     * @throws IOException the io exception
+     */
     protected GenericTest(String name, String writerSchema) throws IOException {
       super(name, writerSchema, 12);
       reader = newReader();
     }
+
+    /**
+     * Gets reader.
+     *
+     * @return the reader
+     */
     protected GenericDatumReader<Object> getReader() {
       return reader;
     }
+
+    /**
+     * New reader generic datum reader.
+     *
+     * @return the generic datum reader
+     */
     protected GenericDatumReader<Object> newReader() {
       return new GenericDatumReader<>(schema);
     }
@@ -1164,7 +1536,15 @@ public class Perf {
     + "{ \"name\": \"f3\", \"type\": \"string\" }\n"
     + "] }";
 
+  /**
+   * The type Generic strings.
+   */
   static class GenericStrings extends GenericTest {
+    /**
+     * Instantiates a new Generic strings.
+     *
+     * @throws IOException the io exception
+     */
     public GenericStrings() throws IOException {
       super("GenericStrings", GENERIC_STRINGS);
     }
@@ -1182,7 +1562,15 @@ public class Perf {
     }
   }
 
+  /**
+   * The type Generic nested.
+   */
   static class GenericNested extends GenericTest {
+    /**
+     * Instantiates a new Generic nested.
+     *
+     * @throws IOException the io exception
+     */
     public GenericNested() throws IOException {
       super("GenericNested_", NESTED_RECORD_SCHEMA);
     }
@@ -1191,6 +1579,14 @@ public class Perf {
       sourceData = generateGenericNested(schema, count);
     }
   }
+
+  /**
+   * Generate generic nested generic record [ ].
+   *
+   * @param schema the schema
+   * @param count  the count
+   * @return the generic record [ ]
+   */
   static GenericRecord[] generateGenericNested(Schema schema, int count) {
     Random r = newRandom();
     GenericRecord[] sourceData = new GenericRecord[count];
@@ -1215,10 +1611,22 @@ public class Perf {
     return sourceData;
   }
 
+  /**
+   * The type Generic nested fake.
+   */
   static class GenericNestedFake extends BasicTest {
-    //reads and writes generic data, but not using
+    /**
+     * The Source data.
+     */
+//reads and writes generic data, but not using
     //GenericDatumReader or GenericDatumWriter
     GenericRecord[] sourceData = null;
+
+    /**
+     * Instantiates a new Generic nested fake.
+     *
+     * @throws IOException the io exception
+     */
     public GenericNestedFake() throws IOException {
       super("GenericNestedFake_", NESTED_RECORD_SCHEMA, 12);
     }
@@ -1271,6 +1679,12 @@ public class Perf {
   }
 
   private static abstract class GenericResolving extends GenericTest {
+    /**
+     * Instantiates a new Generic resolving.
+     *
+     * @param name the name
+     * @throws IOException the io exception
+     */
     protected GenericResolving(String name)
     throws IOException {
       super(name);
@@ -1280,10 +1694,24 @@ public class Perf {
     protected GenericDatumReader<Object> newReader() {
       return new GenericDatumReader<>(schema, getReaderSchema());
     }
+
+    /**
+     * Gets reader schema.
+     *
+     * @return the reader schema
+     */
     protected abstract Schema getReaderSchema();
   }
 
+  /**
+   * The type Generic with default.
+   */
   static class GenericWithDefault extends GenericResolving {
+    /**
+     * Instantiates a new Generic with default.
+     *
+     * @throws IOException the io exception
+     */
     GenericWithDefault() throws IOException {
       super("GenericWithDefault_");
     }
@@ -1293,7 +1721,15 @@ public class Perf {
     }
   }
 
+  /**
+   * The type Generic with out of order.
+   */
   static class GenericWithOutOfOrder extends GenericResolving {
+    /**
+     * Instantiates a new Generic with out of order.
+     *
+     * @throws IOException the io exception
+     */
     GenericWithOutOfOrder() throws IOException {
       super("GenericWithOutOfOrder_");
     }
@@ -1303,7 +1739,15 @@ public class Perf {
     }
   }
 
+  /**
+   * The type Generic with promotion.
+   */
   static class GenericWithPromotion extends GenericResolving {
+    /**
+     * Instantiates a new Generic with promotion.
+     *
+     * @throws IOException the io exception
+     */
     GenericWithPromotion() throws IOException {
       super("GenericWithPromotion_");
     }
@@ -1313,7 +1757,15 @@ public class Perf {
     }
   }
 
+  /**
+   * The type Generic one time decoder use.
+   */
   static class GenericOneTimeDecoderUse extends GenericTest {
+    /**
+     * Instantiates a new Generic one time decoder use.
+     *
+     * @throws IOException the io exception
+     */
     public GenericOneTimeDecoderUse() throws IOException {
       super("GenericOneTimeDecoderUse_");
       isWriteTest = false;
@@ -1324,7 +1776,15 @@ public class Perf {
     }
   }
 
+  /**
+   * The type Generic one time reader use.
+   */
   static class GenericOneTimeReaderUse extends GenericTest {
+    /**
+     * Instantiates a new Generic one time reader use.
+     *
+     * @throws IOException the io exception
+     */
     public GenericOneTimeReaderUse() throws IOException {
       super("GenericOneTimeReaderUse_");
       isWriteTest = false;
@@ -1335,7 +1795,15 @@ public class Perf {
     }
   }
 
+  /**
+   * The type Generic one time use.
+   */
   static class GenericOneTimeUse extends GenericTest {
+    /**
+     * Instantiates a new Generic one time use.
+     *
+     * @throws IOException the io exception
+     */
     public GenericOneTimeUse() throws IOException {
       super("GenericOneTimeUse_");
       isWriteTest = false;
@@ -1350,25 +1818,67 @@ public class Perf {
     }
   }
 
+  /**
+   * The type Specific test.
+   *
+   * @param <T> the type parameter
+   */
   static abstract class SpecificTest<T extends SpecificRecordBase> extends BasicTest {
+    /**
+     * The Reader.
+     */
     protected final SpecificDatumReader<T> reader;
+    /**
+     * The Writer.
+     */
     protected final SpecificDatumWriter<T> writer;
     private Object[] sourceData;
 
+    /**
+     * Instantiates a new Specific test.
+     *
+     * @param name         the name
+     * @param writerSchema the writer schema
+     * @throws IOException the io exception
+     */
     protected SpecificTest(String name, String writerSchema) throws IOException {
       super(name, writerSchema, 48);
       reader = newReader();
       writer = newWriter();
     }
+
+    /**
+     * Gets reader.
+     *
+     * @return the reader
+     */
     protected SpecificDatumReader<T> getReader() {
       return reader;
     }
+
+    /**
+     * Gets writer.
+     *
+     * @return the writer
+     */
     protected SpecificDatumWriter<T> getWriter() {
       return writer;
     }
+
+    /**
+     * New reader specific datum reader.
+     *
+     * @return the specific datum reader
+     */
     protected SpecificDatumReader<T> newReader() {
       return new SpecificDatumReader<>(schema);
     }
+
+    /**
+     * New writer specific datum writer.
+     *
+     * @return the specific datum writer
+     */
     protected SpecificDatumWriter<T> newWriter() {
       return new SpecificDatumWriter<>(schema);
     }
@@ -1381,6 +1891,12 @@ public class Perf {
       }
     }
 
+    /**
+     * Gen single record t.
+     *
+     * @param r the r
+     * @return the t
+     */
     protected abstract T genSingleRecord(Random r);
 
     @Override
@@ -1404,8 +1920,16 @@ public class Perf {
     }
   }
 
+  /**
+   * The type Foo bar specific record test.
+   */
   static class FooBarSpecificRecordTest extends
       SpecificTest<FooBarSpecificRecord> {
+    /**
+     * Instantiates a new Foo bar specific record test.
+     *
+     * @throws IOException the io exception
+     */
     public FooBarSpecificRecordTest() throws IOException {
       super("FooBarSpecificRecordTest", FooBarSpecificRecord.SCHEMA$.toString());
     }
@@ -1430,12 +1954,37 @@ public class Perf {
     }
   }
 
+  /**
+   * The type Reflect test.
+   *
+   * @param <T> the type parameter
+   */
   static abstract class ReflectTest<T> extends BasicTest {
+    /**
+     * The Source data.
+     */
     T[] sourceData = null;
+    /**
+     * The Reader.
+     */
     ReflectDatumReader<T> reader;
+    /**
+     * The Writer.
+     */
     ReflectDatumWriter<T> writer;
+    /**
+     * The Clazz.
+     */
     Class<T> clazz;
 
+    /**
+     * Instantiates a new Reflect test.
+     *
+     * @param name   the name
+     * @param sample the sample
+     * @param factor the factor
+     * @throws IOException the io exception
+     */
     @SuppressWarnings("unchecked")
     ReflectTest(String name, T sample, int factor) throws IOException {
       super(name, ReflectData.get().getSchema(sample.getClass()).toString(), factor);
@@ -1454,6 +2003,12 @@ public class Perf {
       }
     }
 
+    /**
+     * Create datum t.
+     *
+     * @param r the r
+     * @return the t
+     */
     protected abstract T createDatum(Random r);
 
     @Override
@@ -1477,7 +2032,15 @@ public class Perf {
     }
   }
 
+  /**
+   * The type Reflect record test.
+   */
   static class ReflectRecordTest extends ReflectTest<Rec> {
+    /**
+     * Instantiates a new Reflect record test.
+     *
+     * @throws IOException the io exception
+     */
     ReflectRecordTest() throws IOException {
       super("ReflectRecord", new Rec(), 12);
     }
@@ -1488,7 +2051,15 @@ public class Perf {
     }
   }
 
+  /**
+   * The type Reflect float test.
+   */
   static class ReflectFloatTest extends ReflectTest<float[]> {
+    /**
+     * Instantiates a new Reflect float test.
+     *
+     * @throws IOException the io exception
+     */
     ReflectFloatTest() throws IOException {
       super("ReflectFloat", new float[0], COUNT);
     }
@@ -1499,7 +2070,15 @@ public class Perf {
     }
   }
 
+  /**
+   * The type Reflect double test.
+   */
   static class ReflectDoubleTest extends ReflectTest<double[]> {
+    /**
+     * Instantiates a new Reflect double test.
+     *
+     * @throws IOException the io exception
+     */
     ReflectDoubleTest() throws IOException {
       super("ReflectDouble", new double[0], COUNT);
     }
@@ -1510,7 +2089,15 @@ public class Perf {
     }
   }
 
+  /**
+   * The type Reflect float array test.
+   */
   static class ReflectFloatArrayTest extends ReflectTest<float[]> {
+    /**
+     * Instantiates a new Reflect float array test.
+     *
+     * @throws IOException the io exception
+     */
     ReflectFloatArrayTest() throws IOException {
       super("ReflectFloatArray", new float[0], 10);
     }
@@ -1521,7 +2108,15 @@ public class Perf {
     }
   }
 
+  /**
+   * The type Reflect double array test.
+   */
   static class ReflectDoubleArrayTest extends ReflectTest<double[]> {
+    /**
+     * Instantiates a new Reflect double array test.
+     *
+     * @throws IOException the io exception
+     */
     ReflectDoubleArrayTest() throws IOException {
       super("ReflectDoubleArray", new double[0], 20);
     }
@@ -1532,7 +2127,15 @@ public class Perf {
     }
   }
 
+  /**
+   * The type Reflect int array test.
+   */
   static class ReflectIntArrayTest extends ReflectTest<int[]> {
+    /**
+     * Instantiates a new Reflect int array test.
+     *
+     * @throws IOException the io exception
+     */
     ReflectIntArrayTest() throws IOException {
       super("ReflectIntArray", new int[0], 12);
     }
@@ -1543,7 +2146,15 @@ public class Perf {
     }
   }
 
+  /**
+   * The type Reflect long array test.
+   */
   static class ReflectLongArrayTest extends ReflectTest<long[]> {
+    /**
+     * Instantiates a new Reflect long array test.
+     *
+     * @throws IOException the io exception
+     */
     ReflectLongArrayTest() throws IOException {
       super("ReflectLongArray", new long[0], 24);
     }
@@ -1555,8 +2166,16 @@ public class Perf {
   }
 
 
+  /**
+   * The type Reflect nested object array test.
+   */
   static class ReflectNestedObjectArrayTest extends
       ReflectTest<ReflectNestedObjectArrayTest.Foo> {
+    /**
+     * Instantiates a new Reflect nested object array test.
+     *
+     * @throws IOException the io exception
+     */
     ReflectNestedObjectArrayTest() throws IOException {
       super("ReflectNestedObjectArray", new Foo(new Random()), 50);
     }
@@ -1566,12 +2185,26 @@ public class Perf {
       return new Foo(r);
     }
 
+    /**
+     * The type Foo.
+     */
     static public class Foo {
+      /**
+       * The Bar.
+       */
       Vals[] bar;
 
+      /**
+       * Instantiates a new Foo.
+       */
       Foo() {
       }
 
+      /**
+       * Instantiates a new Foo.
+       *
+       * @param r the r
+       */
       Foo(Random r) {
         bar = new Vals[smallArraySize(r)];
         for (int i = 0; i < bar.length; i++) {
@@ -1580,15 +2213,38 @@ public class Perf {
       }
     }
 
+    /**
+     * The type Vals.
+     */
     static class Vals {
+      /**
+       * The F 1.
+       */
       float f1;
+      /**
+       * The F 2.
+       */
       float f2;
+      /**
+       * The F 3.
+       */
       float f3;
+      /**
+       * The F 4.
+       */
       float f4;
 
+      /**
+       * Instantiates a new Vals.
+       */
       Vals(){
       }
 
+      /**
+       * Instantiates a new Vals.
+       *
+       * @param r the r
+       */
       Vals(Random r) {
         this.f1 = r.nextFloat();
         this.f2 = r.nextFloat();
@@ -1599,12 +2255,27 @@ public class Perf {
 
   }
 
+  /**
+   * The type Float foo.
+   */
   static public class FloatFoo {
+    /**
+     * The Float bar.
+     */
     float[] floatBar;
 
+    /**
+     * Instantiates a new Float foo.
+     */
     FloatFoo() {
     }
 
+    /**
+     * Instantiates a new Float foo.
+     *
+     * @param r     the r
+     * @param large the large
+     */
     FloatFoo(Random r, boolean large) {
       floatBar = populateFloatArray(r, large);
     }
@@ -1620,11 +2291,25 @@ public class Perf {
     return r.nextInt(97) + 16;
   }
 
+  /**
+   * Populate float array float [ ].
+   *
+   * @param r     the r
+   * @param large the large
+   * @return the float [ ]
+   */
   static float[] populateFloatArray(Random r, boolean large) {
     int size = large ? largeArraySize(r) : smallArraySize(r);
     return populateFloatArray(r, size);
   }
 
+  /**
+   * Populate float array float [ ].
+   *
+   * @param r    the r
+   * @param size the size
+   * @return the float [ ]
+   */
   static float[] populateFloatArray(Random r, int size) {
     float[] result = new float[size];
     for (int i = 0; i < result.length; i++) {
@@ -1633,10 +2318,23 @@ public class Perf {
     return result;
   }
 
+  /**
+   * Populate double array double [ ].
+   *
+   * @param r the r
+   * @return the double [ ]
+   */
   static double[] populateDoubleArray(Random r) {
     return populateDoubleArray(r, smallArraySize(r));
   }
 
+  /**
+   * Populate double array double [ ].
+   *
+   * @param r    the r
+   * @param size the size
+   * @return the double [ ]
+   */
   static double[] populateDoubleArray(Random r, int size) {
     double[] result = new double[size];
     for (int i = 0; i < result.length; i++) {
@@ -1645,6 +2343,12 @@ public class Perf {
     return result;
   }
 
+  /**
+   * Populate int array int [ ].
+   *
+   * @param r the r
+   * @return the int [ ]
+   */
   static int[] populateIntArray(Random r) {
     int size = smallArraySize(r);
     int[] result = new int[size];
@@ -1654,6 +2358,12 @@ public class Perf {
     return result;
   }
 
+  /**
+   * Populate long array long [ ].
+   *
+   * @param r the r
+   * @return the long [ ]
+   */
   static long[] populateLongArray(Random r) {
     int size = smallArraySize(r);
     long[] result = new long[size];
@@ -1663,7 +2373,15 @@ public class Perf {
     return result;
   }
 
+  /**
+   * The type Reflect nested float array test.
+   */
   static class ReflectNestedFloatArrayTest extends ReflectTest<FloatFoo> {
+    /**
+     * Instantiates a new Reflect nested float array test.
+     *
+     * @throws IOException the io exception
+     */
     public ReflectNestedFloatArrayTest() throws IOException {
       super("ReflectNestedFloatArray", new FloatFoo(new Random(), false), 10);
     }
@@ -1674,7 +2392,15 @@ public class Perf {
     }
   }
 
+  /**
+   * The type Reflect nested large float array test.
+   */
   static class ReflectNestedLargeFloatArrayTest extends ReflectTest<FloatFoo> {
+    /**
+     * Instantiates a new Reflect nested large float array test.
+     *
+     * @throws IOException the io exception
+     */
     public ReflectNestedLargeFloatArrayTest() throws IOException {
       super("ReflectNestedLargeFloatArray", new FloatFoo(new Random(), true),
           60);
@@ -1687,7 +2413,15 @@ public class Perf {
 
   }
 
+  /**
+   * The type Reflect nested large float array blocked test.
+   */
   static class ReflectNestedLargeFloatArrayBlockedTest extends ReflectTest<FloatFoo> {
+    /**
+     * Instantiates a new Reflect nested large float array blocked test.
+     *
+     * @throws IOException the io exception
+     */
     public ReflectNestedLargeFloatArrayBlockedTest() throws IOException {
       super("ReflectNestedLargeFloatArrayBlocked", new FloatFoo(new Random(), true),
           60);
@@ -1707,22 +2441,66 @@ public class Perf {
 
   @SuppressWarnings("unused")
   private static class Rec1 {
+    /**
+     * The D 1.
+     */
     double d1;
+    /**
+     * The D 11.
+     */
     double d11;
+    /**
+     * The F 2.
+     */
     float f2;
+    /**
+     * The F 22.
+     */
     float f22;
+    /**
+     * The F 3.
+     */
     int f3;
+    /**
+     * The F 33.
+     */
     int f33;
+    /**
+     * The F 4.
+     */
     long f4;
+    /**
+     * The F 44.
+     */
     long f44;
+    /**
+     * The F 5.
+     */
     byte f5;
+    /**
+     * The F 55.
+     */
     byte f55;
+    /**
+     * The F 6.
+     */
     short f6;
+    /**
+     * The F 66.
+     */
     short f66;
 
+    /**
+     * Instantiates a new Rec 1.
+     */
     Rec1() {
     }
 
+    /**
+     * Instantiates a new Rec 1.
+     *
+     * @param r the r
+     */
     Rec1(Random r) {
       d1 = r.nextDouble();
       d11 = r.nextDouble();
@@ -1739,7 +2517,15 @@ public class Perf {
     }
   }
 
+  /**
+   * The type Reflect big record test.
+   */
   static class ReflectBigRecordTest extends ReflectTest<Rec1> {
+    /**
+     * Instantiates a new Reflect big record test.
+     *
+     * @throws IOException the io exception
+     */
     public ReflectBigRecordTest() throws IOException {
       super("ReflectBigRecord", new Rec1(new Random()), 20);
     }

--- a/lang/java/ipc/src/test/java/org/apache/avro/ipc/NettyTransceiverWhenFailsToConnect.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/ipc/NettyTransceiverWhenFailsToConnect.java
@@ -35,7 +35,12 @@ import static org.junit.Assert.assertEquals;
  */
 public class NettyTransceiverWhenFailsToConnect {
 
-    @Test(expected = IOException.class)
+  /**
+   * Test netty transceiver releases netty channel on failing to connect.
+   *
+   * @throws Exception the exception
+   */
+  @Test(expected = IOException.class)
     public void testNettyTransceiverReleasesNettyChannelOnFailingToConnect() throws Exception {
         ServerSocket serverSocket = null;
         LastChannelRememberingChannelFactory socketChannelFactory = null;
@@ -68,9 +73,15 @@ public class NettyTransceiverWhenFailsToConnect {
         }
     }
 
-    class LastChannelRememberingChannelFactory extends NioClientSocketChannelFactory implements ChannelFactory {
+  /**
+   * The type Last channel remembering channel factory.
+   */
+  class LastChannelRememberingChannelFactory extends NioClientSocketChannelFactory implements ChannelFactory {
 
-        volatile SocketChannel lastChannel;
+    /**
+     * The Last channel.
+     */
+    volatile SocketChannel lastChannel;
 
         @Override
         public SocketChannel newChannel(ChannelPipeline pipeline) {

--- a/lang/java/ipc/src/test/java/org/apache/avro/ipc/TestLocalTransceiver.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/ipc/TestLocalTransceiver.java
@@ -31,14 +31,28 @@ import org.apache.avro.ipc.generic.GenericResponder;
 import org.apache.avro.util.Utf8;
 import org.junit.Test;
 
+/**
+ * The type Test local transceiver.
+ */
 public class TestLocalTransceiver {
 
+  /**
+   * The Protocol.
+   */
   Protocol protocol = Protocol.parse("" + "{\"protocol\": \"Minimal\", "
       + "\"messages\": { \"m\": {"
       + "   \"request\": [{\"name\": \"x\", \"type\": \"string\"}], "
       + "   \"response\": \"string\"} } }");
 
+  /**
+   * The type Test responder.
+   */
   static class TestResponder extends GenericResponder {
+    /**
+     * Instantiates a new Test responder.
+     *
+     * @param local the local
+     */
     public TestResponder(Protocol local) {
       super(local);
     }
@@ -52,6 +66,11 @@ public class TestLocalTransceiver {
 
   }
 
+  /**
+   * Test single rpc.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testSingleRpc() throws IOException {
     Transceiver t = new LocalTransceiver(new TestResponder(protocol));

--- a/lang/java/ipc/src/test/java/org/apache/avro/ipc/TestNettyServer.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/ipc/TestNettyServer.java
@@ -38,13 +38,22 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+/**
+ * The type Test netty server.
+ */
 public class TestNettyServer {
+  /**
+   * The Connect timeout millis.
+   */
   static final long CONNECT_TIMEOUT_MILLIS = 2000; // 2 sec
   private static Server server;
   private static Transceiver transceiver;
   private static Mail proxy;
   private static MailImpl mailService;
 
+  /**
+   * The type Mail.
+   */
   public static class MailImpl implements Mail {
 
     private CountDownLatch allMessages = new CountDownLatch(5);
@@ -68,11 +77,19 @@ public class TestNettyServer {
       assertEquals(0, allMessages.getCount());
     }
 
+    /**
+     * Reset.
+     */
     public void reset() {
       allMessages = new CountDownLatch(5);
     }
   }
 
+  /**
+   * Initialize connections.
+   *
+   * @throws Exception the exception
+   */
   @BeforeClass
   public static void initializeConnections()throws Exception {
     // start server
@@ -89,21 +106,44 @@ public class TestNettyServer {
     proxy = SpecificRequestor.getClient(Mail.class, transceiver);
   }
 
+  /**
+   * Initialize server server.
+   *
+   * @param responder the responder
+   * @return the server
+   */
   protected static Server initializeServer(Responder responder) {
     return new NettyServer(responder, new InetSocketAddress(0));
   }
 
+  /**
+   * Initialize transceiver transceiver.
+   *
+   * @param serverPort the server port
+   * @return the transceiver
+   * @throws IOException the io exception
+   */
   protected static Transceiver initializeTransceiver(int serverPort) throws IOException {
     return new NettyTransceiver(new InetSocketAddress(
         serverPort), CONNECT_TIMEOUT_MILLIS);
   }
 
+  /**
+   * Tear down connections.
+   *
+   * @throws Exception the exception
+   */
   @AfterClass
   public static void tearDownConnections() throws Exception{
     transceiver.close();
     server.close();
   }
 
+  /**
+   * Test request response.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testRequestResponse() throws Exception {
       for(int x = 0; x < 5; x++) {
@@ -117,6 +157,11 @@ public class TestNettyServer {
         result);
   }
 
+  /**
+   * Test oneway.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testOneway() throws Exception {
     for (int x = 0; x < 5; x++) {
@@ -126,6 +171,11 @@ public class TestNettyServer {
     mailService.assertAllMessagesReceived();
   }
 
+  /**
+   * Test mixture of requests.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testMixtureOfRequests() throws Exception {
     mailService.reset();
@@ -139,6 +189,11 @@ public class TestNettyServer {
 
   }
 
+  /**
+   * Test connections count.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testConnectionsCount() throws Exception {
     Transceiver transceiver2 = new NettyTransceiver(new InetSocketAddress(
@@ -169,7 +224,12 @@ public class TestNettyServer {
     return msg;
   }
 
-  // send a malformed request (HTTP) to the NettyServer port
+  /**
+   * Test bad request.
+   *
+   * @throws IOException the io exception
+   */
+// send a malformed request (HTTP) to the NettyServer port
   @Test
   public void testBadRequest() throws IOException {
     int port = server.getPort();

--- a/lang/java/ipc/src/test/java/org/apache/avro/ipc/TestNettyServerConcurrentExecution.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/ipc/TestNettyServerConcurrentExecution.java
@@ -40,28 +40,33 @@ import org.junit.Test;
  * Verifies that RPCs executed by different client threads using the same
  * NettyTransceiver will execute concurrently.  The test follows these steps:
  * 1. Execute the {@link #org.apache.avro.test.Simple.add(int, int)} RPC to
- *    complete the Avro IPC handshake.
+ * complete the Avro IPC handshake.
  * 2a. In a background thread, wait for the waitLatch.
  * 3a. In the main thread, invoke
- *    {@link #org.apache.avro.test.Simple.hello(String)} with the argument
- *    "wait".  This causes the ClientImpl running on the server to count down
- *    the wait latch, which will unblock the background thread and allow it to
- *    proceed.  After counting down the latch, this call blocks, waiting for
- *    {@link #org.apache.avro.test.Simple.ack()} to be invoked.
+ * {@link #org.apache.avro.test.Simple.hello(String)} with the argument
+ * "wait".  This causes the ClientImpl running on the server to count down
+ * the wait latch, which will unblock the background thread and allow it to
+ * proceed.  After counting down the latch, this call blocks, waiting for
+ * {@link #org.apache.avro.test.Simple.ack()} to be invoked.
  * 2b. The background thread wakes up because the waitLatch has been counted
- *     down.  Now we know that some thread is executing inside hello(String).
- *     Next, execute {@link #org.apache.avro.test.Simple.ack()} in the
- *     background thread, which will allow the thread executing hello(String)
- *     to return.
+ * down.  Now we know that some thread is executing inside hello(String).
+ * Next, execute {@link #org.apache.avro.test.Simple.ack()} in the
+ * background thread, which will allow the thread executing hello(String)
+ * to return.
  * 3b. The thread executing hello(String) on the server unblocks (since ack()
- *     has been called), allowing hello(String) to return.
+ * has been called), allowing hello(String) to return.
  * 4. If control returns to the main thread, we know that two RPCs
- *    (hello(String) and ack()) were executing concurrently.
+ * (hello(String) and ack()) were executing concurrently.
  */
 public class TestNettyServerConcurrentExecution {
   private Server server;
   private Transceiver transceiver;
 
+  /**
+   * Clean up after.
+   *
+   * @throws Exception the exception
+   */
   @After
   public void cleanUpAfter() throws Exception {
     try {
@@ -80,6 +85,11 @@ public class TestNettyServerConcurrentExecution {
     }
   }
 
+  /**
+   * Test.
+   *
+   * @throws Exception the exception
+   */
   @Test(timeout=30000)
   public void test() throws Exception {
     final CountDownLatch waitLatch = new CountDownLatch(1);
@@ -144,6 +154,7 @@ public class TestNettyServerConcurrentExecution {
 
     /**
      * Creates a SimpleImpl that uses the given CountDownLatch.
+     *
      * @param waitLatch the CountDownLatch to use in {@link #hello(String)}.
      */
     public SimpleImpl(final CountDownLatch waitLatch) {

--- a/lang/java/ipc/src/test/java/org/apache/avro/ipc/TestNettyServerWithCallbacks.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/ipc/TestNettyServerWithCallbacks.java
@@ -57,6 +57,11 @@ public class TestNettyServerWithCallbacks {
     new AtomicReference<>(new CountDownLatch(1));
   private static Simple simpleService = new SimpleImpl(ackFlag);
 
+  /**
+   * Initialize connections.
+   *
+   * @throws Exception the exception
+   */
   @BeforeClass
   public static void initializeConnections() throws Exception {
     // start server
@@ -72,6 +77,11 @@ public class TestNettyServerWithCallbacks {
     simpleClient = SpecificRequestor.getClient(Simple.Callback.class, transceiver);
   }
 
+  /**
+   * Tear down connections.
+   *
+   * @throws Exception the exception
+   */
   @AfterClass
   public static void tearDownConnections() throws Exception {
     if (transceiver != null) {
@@ -82,6 +92,11 @@ public class TestNettyServerWithCallbacks {
     }
   }
 
+  /**
+   * Greeting.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void greeting() throws Exception {
     // Test synchronous RPC:
@@ -109,6 +124,11 @@ public class TestNettyServerWithCallbacks {
     Assert.assertNull(future2.getError());
   }
 
+  /**
+   * Echo.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void echo() throws Exception {
     TestRecord record = TestRecord.newBuilder().setHash(
@@ -142,6 +162,11 @@ public class TestNettyServerWithCallbacks {
     Assert.assertNull(future2.getError());
   }
 
+  /**
+   * Add.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void add() throws Exception {
     // Test synchronous RPC:
@@ -169,6 +194,11 @@ public class TestNettyServerWithCallbacks {
     Assert.assertNull(future2.getError());
   }
 
+  /**
+   * Echo bytes.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void echoBytes() throws Exception {
     ByteBuffer byteBuffer = ByteBuffer.wrap(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 });
@@ -198,6 +228,13 @@ public class TestNettyServerWithCallbacks {
     Assert.assertNull(future2.getError());
   }
 
+  /**
+   * Error.
+   *
+   * @throws IOException          the io exception
+   * @throws InterruptedException the interrupted exception
+   * @throws TimeoutException     the timeout exception
+   */
   @Test()
   public void error() throws IOException, InterruptedException, TimeoutException {
     // Test synchronous RPC:
@@ -245,6 +282,11 @@ public class TestNettyServerWithCallbacks {
     Assert.assertTrue(errorRef.get() instanceof TestError);
   }
 
+  /**
+   * Ack.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void ack() throws Exception {
     simpleClient.ack();
@@ -257,6 +299,11 @@ public class TestNettyServerWithCallbacks {
     Assert.assertFalse("Expected ack flag to be cleared", ackFlag.get());
   }
 
+  /**
+   * Test send after channel close.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testSendAfterChannelClose() throws Exception {
     // Start up a second server so that closing the server doesn't
@@ -324,6 +371,11 @@ public class TestNettyServerWithCallbacks {
     }
   }
 
+  /**
+   * Cancel pending requests on transceiver close.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void cancelPendingRequestsOnTransceiverClose() throws Exception {
     // Start up a second server so that closing the server doesn't
@@ -371,6 +423,11 @@ public class TestNettyServerWithCallbacks {
     }
   }
 
+  /**
+   * Cancel pending requests after channel close by server shutdown.
+   *
+   * @throws Throwable the throwable
+   */
   @Test(timeout = 20000)
   public void cancelPendingRequestsAfterChannelCloseByServerShutdown() throws Throwable {
     // The purpose of this test is to verify that a client doesn't stay
@@ -451,6 +508,11 @@ public class TestNettyServerWithCallbacks {
     }
   }
 
+  /**
+   * Client reconnect after server restart.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void clientReconnectAfterServerRestart() throws Exception {
     // Start up a second server so that closing the server doesn't
@@ -492,6 +554,11 @@ public class TestNettyServerWithCallbacks {
     }
   }
 
+  /**
+   * Performance test.
+   *
+   * @throws Exception the exception
+   */
   @Ignore
   @Test
   public void performanceTest() throws Exception {
@@ -539,6 +606,7 @@ public class TestNettyServerWithCallbacks {
 
     /**
      * Creates a SimpleImpl.
+     *
      * @param ackFlag the AtomicBoolean to toggle when ack() is called.
      */
     public SimpleImpl(final AtomicBoolean ackFlag) {

--- a/lang/java/ipc/src/test/java/org/apache/avro/ipc/TestNettyServerWithCompression.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/ipc/TestNettyServerWithCompression.java
@@ -31,9 +31,18 @@ import org.jboss.netty.channel.socket.nio.NioServerSocketChannelFactory;
 import org.jboss.netty.handler.codec.compression.ZlibDecoder;
 import org.jboss.netty.handler.codec.compression.ZlibEncoder;
 
+/**
+ * The type Test netty server with compression.
+ */
 public class TestNettyServerWithCompression extends TestNettyServer{
 
 
+  /**
+   * Initialize server server.
+   *
+   * @param responder the responder
+   * @return the server
+   */
   protected static Server initializeServer(Responder responder) {
     ChannelFactory channelFactory = new NioServerSocketChannelFactory(
         Executors.newCachedThreadPool(),
@@ -44,6 +53,13 @@ public class TestNettyServerWithCompression extends TestNettyServer{
         null);
   }
 
+  /**
+   * Initialize transceiver transceiver.
+   *
+   * @param serverPort the server port
+   * @return the transceiver
+   * @throws IOException the io exception
+   */
   protected static Transceiver initializeTransceiver(int serverPort) throws IOException {
     return  new NettyTransceiver(new InetSocketAddress(serverPort),
         new CompressionChannelFactory(),
@@ -55,6 +71,9 @@ public class TestNettyServerWithCompression extends TestNettyServer{
    * Factory of Compression-enabled client channels
    */
   private static class CompressionChannelFactory extends NioClientSocketChannelFactory {
+    /**
+     * Instantiates a new Compression channel factory.
+     */
     public CompressionChannelFactory() {
       super(Executors.newCachedThreadPool(), Executors.newCachedThreadPool());
     }

--- a/lang/java/ipc/src/test/java/org/apache/avro/ipc/TestNettyServerWithSSL.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/ipc/TestNettyServerWithSSL.java
@@ -39,10 +39,25 @@ import org.jboss.netty.channel.socket.nio.NioClientSocketChannelFactory;
 import org.jboss.netty.channel.socket.nio.NioServerSocketChannelFactory;
 import org.jboss.netty.handler.ssl.SslHandler;
 
+/**
+ * The type Test netty server with ssl.
+ */
 public class TestNettyServerWithSSL extends TestNettyServer{
+  /**
+   * The constant TEST_CERTIFICATE.
+   */
   public static final String TEST_CERTIFICATE = "servercert.p12";
+  /**
+   * The constant TEST_CERTIFICATE_PASSWORD.
+   */
   public static final String TEST_CERTIFICATE_PASSWORD = "s3cret";
 
+  /**
+   * Initialize server server.
+   *
+   * @param responder the responder
+   * @return the server
+   */
   protected static Server initializeServer(Responder responder) {
     ChannelFactory channelFactory = new NioServerSocketChannelFactory(
         Executors.newCachedThreadPool(),
@@ -53,6 +68,13 @@ public class TestNettyServerWithSSL extends TestNettyServer{
         null);
   }
 
+  /**
+   * Initialize transceiver transceiver.
+   *
+   * @param serverPort the server port
+   * @return the transceiver
+   * @throws IOException the io exception
+   */
   protected static Transceiver initializeTransceiver(int serverPort) throws IOException {
     return  new NettyTransceiver(new InetSocketAddress(serverPort),
         new SSLChannelFactory(),
@@ -64,6 +86,9 @@ public class TestNettyServerWithSSL extends TestNettyServer{
    * Factory of SSL-enabled client channels
    */
   private static class SSLChannelFactory extends NioClientSocketChannelFactory {
+    /**
+     * Instantiates a new Ssl channel factory.
+     */
     public SSLChannelFactory() {
       super(Executors.newCachedThreadPool(), Executors.newCachedThreadPool());
     }

--- a/lang/java/ipc/src/test/java/org/apache/avro/ipc/TestNettyTransceiverWhenServerStops.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/ipc/TestNettyTransceiverWhenServerStops.java
@@ -30,7 +30,15 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.fail;
 
+/**
+ * The type Test netty transceiver when server stops.
+ */
 public class TestNettyTransceiverWhenServerStops {
+  /**
+   * Test netty transceiver when server stops.
+   *
+   * @throws Exception the exception
+   */
 //  @Test                                           // disable flakey test!
     public void testNettyTransceiverWhenServerStops() throws Exception {
     Mail mailService = new TestNettyServer.MailImpl();

--- a/lang/java/ipc/src/test/java/org/apache/avro/ipc/TestRpcPluginOrdering.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/ipc/TestRpcPluginOrdering.java
@@ -32,10 +32,16 @@ import org.apache.avro.test.Mail;
 import org.apache.avro.test.Message;
 import org.junit.Test;
 
+/**
+ * The type Test rpc plugin ordering.
+ */
 public class TestRpcPluginOrdering {
 
   private static AtomicInteger orderCounter = new AtomicInteger();
 
+  /**
+   * The type Order plugin.
+   */
   public class OrderPlugin extends RPCPlugin{
 
     public void clientStartConnect(RPCContext context) {
@@ -67,6 +73,11 @@ public class TestRpcPluginOrdering {
     }
   }
 
+  /**
+   * Test rpc plugin ordering.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testRpcPluginOrdering() throws Exception {
     OrderPlugin plugin = new OrderPlugin();

--- a/lang/java/ipc/src/test/java/org/apache/avro/ipc/TestSaslAnonymous.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/ipc/TestSaslAnonymous.java
@@ -33,6 +33,9 @@ import org.slf4j.LoggerFactory;
 import org.junit.Before;
 import org.junit.Test;
 
+/**
+ * The type Test sasl anonymous.
+ */
 public class TestSaslAnonymous extends TestProtocolGeneric {
 
   private static final Logger LOG =
@@ -50,11 +53,25 @@ public class TestSaslAnonymous extends TestProtocolGeneric {
   @Override public void testHandshake() throws IOException {}
   @Override public void testResponseChange() throws IOException {}
 
+  /**
+   * The interface Proto interface.
+   */
   public interface ProtoInterface {
+    /**
+     * Test byte [ ].
+     *
+     * @param b the b
+     * @return the byte [ ]
+     */
     byte[] test(byte[] b);
   }
 
-  // test big enough to fill socket output buffer
+  /**
+   * Test 64 k request.
+   *
+   * @throws Exception the exception
+   */
+// test big enough to fill socket output buffer
   @Test
   public void test64kRequest() throws Exception {
     SaslSocketServer s = new SaslSocketServer

--- a/lang/java/ipc/src/test/java/org/apache/avro/ipc/TestSaslDigestMd5.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/ipc/TestSaslDigestMd5.java
@@ -47,6 +47,9 @@ import org.junit.Before;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
+/**
+ * The type Test sasl digest md 5.
+ */
 public class TestSaslDigestMd5 extends TestProtocolGeneric {
 
   private static final Logger LOG =
@@ -106,6 +109,11 @@ public class TestSaslDigestMd5 extends TestProtocolGeneric {
     requestor = new GenericRequestor(PROTOCOL, client);
   }
 
+  /**
+   * Test anonymous client.
+   *
+   * @throws Exception the exception
+   */
   @Test(expected=SaslException.class)
   public void testAnonymousClient() throws Exception {
     Server s = new SaslSocketServer
@@ -145,6 +153,11 @@ public class TestSaslDigestMd5 extends TestProtocolGeneric {
     }
   }
 
+  /**
+   * Test wrong password.
+   *
+   * @throws Exception the exception
+   */
   @Test(expected=SaslException.class)
   public void testWrongPassword() throws Exception {
     Server s = new SaslSocketServer

--- a/lang/java/ipc/src/test/java/org/apache/avro/ipc/specific/TestSpecificRequestor.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/ipc/specific/TestSpecificRequestor.java
@@ -28,13 +28,30 @@ import org.apache.avro.ipc.HttpTransceiver;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+/**
+ * The type Test specific requestor.
+ */
 public class TestSpecificRequestor {
+  /**
+   * The interface Sample specific protocol.
+   */
   public interface SampleSpecificProtocol {
+    /**
+     * The constant PROTOCOL.
+     */
     public static final Protocol PROTOCOL = Protocol.parse("{\"protocol\":\"SampleSpecificProtocol\",\"namespace\":\"org.apache.avro.ipc.specific\",\"types\":[],\"messages\":{}}");
   }
 
+  /**
+   * The Proxy.
+   */
   static Object proxy;
 
+  /**
+   * Initialize proxy.
+   *
+   * @throws Exception the exception
+   */
   @BeforeClass
   public static void initializeProxy() throws Exception {
     HttpTransceiver client = new HttpTransceiver(new URL("http://localhost"));
@@ -42,6 +59,11 @@ public class TestSpecificRequestor {
     proxy = SpecificRequestor.getClient(SampleSpecificProtocol.class, requestor);
   }
 
+  /**
+   * Test hash code.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testHashCode() throws IOException {
     try {
@@ -51,6 +73,11 @@ public class TestSpecificRequestor {
     }
   }
 
+  /**
+   * Test equals.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testEquals() throws IOException {
     try {
@@ -60,6 +87,11 @@ public class TestSpecificRequestor {
     }
   }
 
+  /**
+   * Test to string.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testToString() throws IOException {
     try {

--- a/lang/java/ipc/src/test/java/org/apache/avro/ipc/stats/FakeTicks.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/ipc/stats/FakeTicks.java
@@ -19,8 +19,13 @@ package org.apache.avro.ipc.stats;
 
 import org.apache.avro.ipc.stats.Stopwatch.Ticks;
 
-/** Implements Ticks with manual time-winding. */
+/**
+ * Implements Ticks with manual time-winding.
+ */
 class FakeTicks implements Ticks {
+  /**
+   * The Time.
+   */
   long time = 0;
 
   @Override
@@ -28,6 +33,11 @@ class FakeTicks implements Ticks {
     return time;
   }
 
+  /**
+   * Pass time.
+   *
+   * @param nanos the nanos
+   */
   public void passTime(long nanos) {
     time += nanos;
   }

--- a/lang/java/ipc/src/test/java/org/apache/avro/ipc/stats/StatsPluginOverhead.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/ipc/stats/StatsPluginOverhead.java
@@ -32,7 +32,7 @@ import org.apache.avro.ipc.generic.GenericResponder;
 
 /**
  * Naively measures overhead of using the stats plugin.
- *
+ * <p>
  * The API used is the generic one.
  * The protocol is the "null" protocol: null is sent
  * and returned.
@@ -47,6 +47,11 @@ public class StatsPluginOverhead {
       + "   \"response\": \"null\"} } }");
 
   private static class IdentityResponder extends GenericResponder {
+    /**
+     * Instantiates a new Identity responder.
+     *
+     * @param local the local
+     */
     public IdentityResponder(Protocol local) {
       super(local);
     }
@@ -58,6 +63,12 @@ public class StatsPluginOverhead {
     }
   }
 
+  /**
+   * The entry point of application.
+   *
+   * @param args the input arguments
+   * @throws Exception the exception
+   */
   public static void main(String[] args) throws Exception {
     double with = sendRpcs(true)/1000000000.0;
     double without = sendRpcs(false)/1000000000.0;

--- a/lang/java/ipc/src/test/java/org/apache/avro/ipc/stats/TestHistogram.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/ipc/stats/TestHistogram.java
@@ -31,8 +31,14 @@ import org.apache.avro.ipc.stats.Histogram.Entry;
 import org.apache.avro.ipc.stats.Histogram.Segmenter;
 import org.junit.Test;
 
+/**
+ * The type Test histogram.
+ */
 public class TestHistogram {
 
+  /**
+   * Test basic operation.
+   */
   @Test
   public void testBasicOperation() {
     Segmenter<String, Integer> s = new Histogram.TreeMapSegmenter<>(
@@ -95,6 +101,9 @@ public class TestHistogram {
 
   }
 
+  /**
+   * Test bad value.
+   */
   @Test(expected=Histogram.SegmenterException.class)
   public void testBadValue() {
     Segmenter<String, Long> s = new Histogram.TreeMapSegmenter<>(
@@ -104,7 +113,9 @@ public class TestHistogram {
     h.add(-1L);
   }
 
-  /** Only has one bucket */
+  /**
+   * Only has one bucket
+   */
   static class SingleBucketSegmenter implements Segmenter<String, Float >{
     @Override
     public Iterator<String> getBuckets() {
@@ -127,6 +138,9 @@ public class TestHistogram {
 
   }
 
+  /**
+   * Test float histogram.
+   */
   @Test
   public void testFloatHistogram() {
     FloatHistogram<String> h = new FloatHistogram<>(new SingleBucketSegmenter());

--- a/lang/java/ipc/src/test/java/org/apache/avro/ipc/stats/TestStatsPluginAndServlet.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/ipc/stats/TestStatsPluginAndServlet.java
@@ -43,11 +43,20 @@ import org.apache.avro.ipc.generic.GenericRequestor;
 import org.apache.avro.ipc.generic.GenericResponder;
 import org.junit.Test;
 
+/**
+ * The type Test stats plugin and servlet.
+ */
 public class TestStatsPluginAndServlet {
+  /**
+   * The Protocol.
+   */
   Protocol protocol = Protocol.parse("" + "{\"protocol\": \"Minimal\", "
       + "\"messages\": { \"m\": {"
       + "   \"request\": [{\"name\": \"x\", \"type\": \"int\"}], "
       + "   \"response\": \"int\"} } }");
+  /**
+   * The Message.
+   */
   Message message = protocol.getMessages().get("m");
 
   private static final long MS = 1000*1000L;
@@ -71,8 +80,15 @@ public class TestStatsPluginAndServlet {
     return o;
   }
 
-  /** Expects 0 and returns 1. */
+  /**
+   * Expects 0 and returns 1.
+   */
   static class TestResponder extends GenericResponder {
+    /**
+     * Instantiates a new Test responder.
+     *
+     * @param local the local
+     */
     public TestResponder(Protocol local) {
       super(local);
     }
@@ -94,6 +110,11 @@ public class TestStatsPluginAndServlet {
     assertEquals(1, r.request("m", params));
   }
 
+  /**
+   * Test full server path.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testFullServerPath() throws IOException {
     Responder r = new TestResponder(protocol);
@@ -109,6 +130,11 @@ public class TestStatsPluginAndServlet {
     assertTrue(o.contains("10 calls"));
   }
 
+  /**
+   * Test multiple rp cs.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testMultipleRPCs() throws IOException {
     FakeTicks t = new FakeTicks();
@@ -130,6 +156,11 @@ public class TestStatsPluginAndServlet {
     assertTrue(r.contains("Average: 500.0ms"));
   }
 
+  /**
+   * Test payload size.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testPayloadSize() throws IOException {
     Responder r = new TestResponder(protocol);
@@ -151,6 +182,11 @@ public class TestStatsPluginAndServlet {
 
   /** Sleeps as requested. */
   private static class SleepyResponder extends GenericResponder {
+    /**
+     * Instantiates a new Sleepy responder.
+     *
+     * @param local the local
+     */
     public SleepyResponder(Protocol local) {
       super(local);
     }
@@ -174,8 +210,9 @@ public class TestStatsPluginAndServlet {
    * <pre>
    * java -jar build/avro-tools-*.jar rpcsend '{"protocol":"sleepy","namespace":null,"types":[],"messages":{"sleep":{"request":[{"name":"millis","type":"long"}],"response":"null"}}}' sleep localhost 7002 '{"millis": 20000}'
    * </pre>
-   * @param args
-   * @throws Exception
+   *
+   * @param args the input arguments
+   * @throws Exception the exception
    */
   public static void main(String[] args) throws Exception {
     if (args.length == 0) {

--- a/lang/java/ipc/src/test/java/org/apache/avro/ipc/stats/TestStopwatch.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/ipc/stats/TestStopwatch.java
@@ -23,7 +23,13 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
+/**
+ * The type Test stopwatch.
+ */
 public class TestStopwatch {
+  /**
+   * Test normal.
+   */
   @Test
   public void testNormal() {
     FakeTicks f = new FakeTicks();
@@ -38,6 +44,9 @@ public class TestStopwatch {
     assertEquals(60, s.elapsedNanos());
   }
 
+  /**
+   * Test not started 1.
+   */
   @Test(expected=IllegalStateException.class)
   public void testNotStarted1() {
     FakeTicks f = new FakeTicks();
@@ -45,6 +54,9 @@ public class TestStopwatch {
     s.elapsedNanos();
   }
 
+  /**
+   * Test not started 2.
+   */
   @Test(expected=IllegalStateException.class)
   public void testNotStarted2() {
     FakeTicks f = new FakeTicks();
@@ -52,6 +64,9 @@ public class TestStopwatch {
     s.stop();
   }
 
+  /**
+   * Test twice started.
+   */
   @Test(expected=IllegalStateException.class)
   public void testTwiceStarted() {
     FakeTicks f = new FakeTicks();
@@ -60,6 +75,9 @@ public class TestStopwatch {
     s.start();
   }
 
+  /**
+   * Test twice stopped.
+   */
   @Test(expected=IllegalStateException.class)
   public void testTwiceStopped() {
     FakeTicks f = new FakeTicks();
@@ -69,6 +87,9 @@ public class TestStopwatch {
     s.stop();
   }
 
+  /**
+   * Test system stopwatch.
+   */
   @Test
   public void testSystemStopwatch() {
     Stopwatch s = new Stopwatch(Stopwatch.SYSTEM_TICKS);

--- a/lang/java/ipc/src/test/java/org/apache/avro/message/TestCustomSchemaStore.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/message/TestCustomSchemaStore.java
@@ -31,10 +31,23 @@ import java.nio.ByteBuffer;
 
 import static org.junit.Assert.assertEquals;
 
+/**
+ * The type Test custom schema store.
+ */
 public class TestCustomSchemaStore {
 
+  /**
+   * The type Custom schema store.
+   */
   static class CustomSchemaStore implements SchemaStore {
+    /**
+     * The Cache.
+     */
     Cache cache;
+
+    /**
+     * Instantiates a new Custom schema store.
+     */
     CustomSchemaStore() {
       cache = new Cache();
       cache.addSchema(NestedEvolve1.getClassSchema());
@@ -49,6 +62,11 @@ public class TestCustomSchemaStore {
 
   private BinaryMessageDecoder<NestedEvolve1> decoder = NestedEvolve1.createDecoder(new CustomSchemaStore());
 
+  /**
+   * Test compatible read with schema from schema store.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testCompatibleReadWithSchemaFromSchemaStore() throws Exception {
     // Create and encode a NestedEvolve2 record.
@@ -65,6 +83,11 @@ public class TestCustomSchemaStore {
     assertEquals(nestedEvolve1.getNested().getValue(), Long.valueOf(1));
   }
 
+  /**
+   * Test incompatible read with schema from schema store.
+   *
+   * @throws Exception the exception
+   */
   @Test(expected = MissingSchemaException.class)
   public void testIncompatibleReadWithSchemaFromSchemaStore() throws Exception {
     // Create and encode a NestedEvolve3 record.

--- a/lang/java/ipc/src/test/java/org/apache/avro/specific/TestSpecificBuilderTree.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/specific/TestSpecificBuilderTree.java
@@ -29,6 +29,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+/**
+ * The type Test specific builder tree.
+ */
 public class TestSpecificBuilderTree {
 
   private Request.Builder createPartialBuilder() {
@@ -70,6 +73,9 @@ public class TestSpecificBuilderTree {
     return requestBuilder;
   }
 
+  /**
+   * Fail on incomplete tree.
+   */
   @Test(expected = AvroMissingFieldException.class)
   public void failOnIncompleteTree() {
     try {
@@ -82,6 +88,9 @@ public class TestSpecificBuilderTree {
     fail("Should NEVER get here");
   }
 
+  /**
+   * Copy builder.
+   */
   @Test
   public void copyBuilder() {
     Request.Builder requestBuilder1 = createPartialBuilder();
@@ -125,6 +134,9 @@ public class TestSpecificBuilderTree {
     assertEquals("Bar",             request2.getHttpRequest().getURI().getParameters().get(0).getValue());
   }
 
+  /**
+   * Create builder from instance.
+   */
   @Test
   public void createBuilderFromInstance(){
     Request.Builder requestBuilder1 = createPartialBuilder();
@@ -190,6 +202,9 @@ public class TestSpecificBuilderTree {
     return requestBuilder;
   }
 
+  /**
+   * Last one wins setter.
+   */
   @Test
   public void lastOneWins_Setter() {
     Request.Builder requestBuilder = createLastOneTestsBuilder();
@@ -226,6 +241,9 @@ public class TestSpecificBuilderTree {
     assertEquals("/login.php",      request.getHttpRequest().getURI().getPath());
   }
 
+  /**
+   * Last one wins builder.
+   */
   @Test
   public void lastOneWins_Builder() {
     Request.Builder requestBuilder = createLastOneTestsBuilder();
@@ -263,6 +281,9 @@ public class TestSpecificBuilderTree {
     assertEquals("/index.html",     request.getHttpRequest().getURI().getPath());
   }
 
+  /**
+   * Copy builder with nullables.
+   */
   @Test
   public void copyBuilderWithNullables() {
     RecordWithNullables.Builder builder = RecordWithNullables.newBuilder();
@@ -288,6 +309,9 @@ public class TestSpecificBuilderTree {
     builderCopy.getNullableRecordBuilder();
   }
 
+  /**
+   * Copy builder with nullables and set to null.
+   */
   @Test
   public void copyBuilderWithNullablesAndSetToNull() {
     // Create builder with all values default to null, yet unset.
@@ -340,6 +364,9 @@ public class TestSpecificBuilderTree {
     assertTrue(builder.hasNullableArray ());
   }
 
+  /**
+   * Gets builder for record with null record.
+   */
   @Test
   public void getBuilderForRecordWithNullRecord() {
     // Create a record with all nullable fields set to the default value : null
@@ -352,12 +379,18 @@ public class TestSpecificBuilderTree {
     builder.getNullableRecordBuilder();
   }
 
+  /**
+   * Gets builder for null record.
+   */
   @Test
   public void getBuilderForNullRecord() {
     // In the past this caused an NPE
     RecordWithNullables.newBuilder((RecordWithNullables)null);
   }
 
+  /**
+   * Gets builder for null builder.
+   */
   @Test
   public void getBuilderForNullBuilder() {
     // In the past this caused an NPE

--- a/lang/java/ipc/src/test/java/org/apache/avro/specific/TestSpecificData.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/specific/TestSpecificData.java
@@ -47,8 +47,14 @@ import org.apache.avro.test.Reserved;
 
 import org.apache.avro.generic.GenericRecord;
 
+/**
+ * The type Test specific data.
+ */
 public class TestSpecificData {
 
+  /**
+   * Test hash code.
+   */
   @Test
   /** Make sure that even with nulls, hashCode() doesn't throw NPE. */
   public void testHashCode() {
@@ -56,6 +62,9 @@ public class TestSpecificData {
     SpecificData.get().hashCode(null, TestRecord.SCHEMA$);
   }
 
+  /**
+   * Test to string.
+   */
   @Test
   /** Make sure that even with nulls, toString() doesn't throw NPE. */
   public void testToString() {
@@ -63,14 +72,27 @@ public class TestSpecificData {
   }
 
   private static class X {
+    /**
+     * The Map.
+     */
     public Map<String,String> map;
   }
 
+  /**
+   * Test get map schema.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testGetMapSchema() throws Exception {
     SpecificData.get().getSchema(X.class.getField("map").getGenericType());
   }
 
+  /**
+   * Test specific within generic.
+   *
+   * @throws Exception the exception
+   */
   @Test
   /** Test nesting of specific data within generic. */
   public void testSpecificWithinGeneric() throws Exception {
@@ -102,6 +124,9 @@ public class TestSpecificData {
         new SpecificDatumReader<>());
 }
 
+  /**
+   * Test convert generic to specific.
+   */
   @Test public void testConvertGenericToSpecific() {
     GenericRecord generic = new GenericData.Record(TestRecord.SCHEMA$);
     generic.put("name", "foo");
@@ -112,12 +137,22 @@ public class TestSpecificData {
       (TestRecord)SpecificData.get().deepCopy(TestRecord.SCHEMA$, generic);
   }
 
+  /**
+   * Test get class schema.
+   *
+   * @throws Exception the exception
+   */
   @Test public void testGetClassSchema() throws Exception {
     Assert.assertEquals(TestRecord.getClassSchema(), TestRecord.SCHEMA$);
     Assert.assertEquals(MD5.getClassSchema(), MD5.SCHEMA$);
     Assert.assertEquals(Kind.getClassSchema(), Kind.SCHEMA$);
   }
 
+  /**
+   * Test specific record to string.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testSpecificRecordToString() throws IOException {
     FooBarSpecificRecord foo = FooBarSpecificRecord.newBuilder()
@@ -137,6 +172,11 @@ public class TestSpecificData {
     mapper.readTree(parser);
   }
 
+  /**
+   * Test externalizeable.
+   *
+   * @throws Exception the exception
+   */
   @Test public void testExternalizeable() throws Exception {
     TestRecord before = new TestRecord();
     before.setName("foo");
@@ -155,6 +195,11 @@ public class TestSpecificData {
 
   }
 
+  /**
+   * Test reserved enum symbol.
+   *
+   * @throws Exception the exception
+   */
   @Test public void testReservedEnumSymbol() throws Exception {
     Assert.assertEquals(Reserved.default$,
                         SpecificData.get().createEnum("default",

--- a/lang/java/ipc/src/test/java/org/apache/avro/specific/TestSpecificDatumReader.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/specific/TestSpecificDatumReader.java
@@ -37,8 +37,18 @@ import org.junit.Test;
 
 import test.StringablesRecord;
 
+/**
+ * The type Test specific datum reader.
+ */
 public class TestSpecificDatumReader {
 
+  /**
+   * Serialize record byte [ ].
+   *
+   * @param fooBarSpecificRecord the foo bar specific record
+   * @return the byte [ ]
+   * @throws IOException the io exception
+   */
   public static byte[] serializeRecord(FooBarSpecificRecord fooBarSpecificRecord) throws IOException {
     SpecificDatumWriter<FooBarSpecificRecord> datumWriter =
         new SpecificDatumWriter<>(FooBarSpecificRecord.SCHEMA$);
@@ -49,6 +59,13 @@ public class TestSpecificDatumReader {
     return byteArrayOutputStream.toByteArray();
   }
 
+  /**
+   * Serialize record byte [ ].
+   *
+   * @param stringablesRecord the stringables record
+   * @return the byte [ ]
+   * @throws IOException the io exception
+   */
   public static byte[] serializeRecord(StringablesRecord stringablesRecord) throws IOException {
     SpecificDatumWriter<StringablesRecord> datumWriter =
         new SpecificDatumWriter<>(StringablesRecord.SCHEMA$);
@@ -59,6 +76,11 @@ public class TestSpecificDatumReader {
     return byteArrayOutputStream.toByteArray();
   }
 
+  /**
+   * Test read.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testRead() throws IOException {
     Builder newBuilder = FooBarSpecificRecord.newBuilder();
@@ -78,6 +100,11 @@ public class TestSpecificDatumReader {
     assertEquals(specificRecord, deserialized);
   }
 
+  /**
+   * Test stringables.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testStringables() throws IOException {
     StringablesRecord.Builder newBuilder = StringablesRecord.newBuilder();

--- a/lang/java/ipc/src/test/java/org/apache/avro/specific/TestSpecificDatumWriter.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/specific/TestSpecificDatumWriter.java
@@ -29,7 +29,15 @@ import org.apache.avro.test.Kind;
 import org.apache.avro.test.TestRecordWithUnion;
 import org.junit.Test;
 
+/**
+ * The type Test specific datum writer.
+ */
 public class TestSpecificDatumWriter {
+  /**
+   * Test resolve union.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testResolveUnion() throws IOException {
     final SpecificDatumWriter<TestRecordWithUnion> writer = new SpecificDatumWriter<>();

--- a/lang/java/ipc/src/test/java/org/apache/avro/specific/TestSpecificErrorBuilder.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/specific/TestSpecificErrorBuilder.java
@@ -25,6 +25,9 @@ import org.junit.Test;
  * Unit test for the SpecificErrorBuilderBase class.
  */
 public class TestSpecificErrorBuilder {
+  /**
+   * Test specific error builder.
+   */
   @Test
   public void testSpecificErrorBuilder() {
     TestError.Builder testErrorBuilder = TestError.newBuilder().
@@ -67,6 +70,9 @@ public class TestSpecificErrorBuilder {
     Assert.assertNull(testErrorBuilder.getMessage$());
   }
 
+  /**
+   * Attempt to set non nullable field to null.
+   */
   @Test(expected=org.apache.avro.AvroRuntimeException.class)
   public void attemptToSetNonNullableFieldToNull() {
     TestError.newBuilder().setMessage$(null);

--- a/lang/java/ipc/src/test/java/org/apache/avro/specific/TestSpecificRecordBuilder.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/specific/TestSpecificRecordBuilder.java
@@ -40,6 +40,9 @@ import org.junit.Test;
  * Unit test for the SpecificRecordBuilder class.
  */
 public class TestSpecificRecordBuilder {
+  /**
+   * Test specific builder.
+   */
   @Test
   public void testSpecificBuilder() {
     // Create a new builder, and leave some fields with default values empty:
@@ -92,6 +95,9 @@ public class TestSpecificRecordBuilder {
     Assert.assertTrue(person2.getFriends().isEmpty());
   }
 
+  /**
+   * Test unions.
+   */
   @Test
   public void testUnions() {
     long datetime = 1234L;
@@ -116,6 +122,9 @@ public class TestSpecificRecordBuilder {
 
   }
 
+  /**
+   * Test interop.
+   */
   @Test
   public void testInterop() {
     Interop interop = Interop.newBuilder()
@@ -154,16 +163,25 @@ public class TestSpecificRecordBuilder {
     Assert.assertEquals(interop, copy);
   }
 
+  /**
+   * Attempt to set non nullable field to null.
+   */
   @Test(expected=org.apache.avro.AvroRuntimeException.class)
   public void attemptToSetNonNullableFieldToNull() {
     Person.newBuilder().setName(null);
   }
 
+  /**
+   * Build without setting required fields 1.
+   */
   @Test(expected=org.apache.avro.AvroRuntimeException.class)
   public void buildWithoutSettingRequiredFields1() {
     Person.newBuilder().build();
   }
 
+  /**
+   * Build without setting required fields 2.
+   */
   @Test
   public void buildWithoutSettingRequiredFields2() {
     // Omit required non-primitive field
@@ -176,6 +194,9 @@ public class TestSpecificRecordBuilder {
     }
   }
 
+  /**
+   * Build without setting required fields 3.
+   */
   @Test
   public void buildWithoutSettingRequiredFields3() {
     // Omit required primitive field
@@ -188,6 +209,9 @@ public class TestSpecificRecordBuilder {
     }
   }
 
+  /**
+   * Test builder performance.
+   */
   @Ignore
   @Test
   public void testBuilderPerformance() {
@@ -206,6 +230,9 @@ public class TestSpecificRecordBuilder {
         "ms/record");
   }
 
+  /**
+   * Test builder performance with default values.
+   */
   @Ignore
   @Test
   public void testBuilderPerformanceWithDefaultValues() {
@@ -221,6 +248,9 @@ public class TestSpecificRecordBuilder {
         "ms/record");
   }
 
+  /**
+   * Test manual build performance.
+   */
   @Ignore
   @Test
   @SuppressWarnings("deprecation")

--- a/lang/java/tools/src/main/java/org/apache/avro/tool/BinaryFragmentToJsonTool.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/BinaryFragmentToJsonTool.java
@@ -35,7 +35,9 @@ import org.apache.avro.io.JsonEncoder;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericDatumWriter;
 
-/** Converts an input file from Avro binary into JSON. */
+/**
+ * Converts an input file from Avro binary into JSON.
+ */
 public class BinaryFragmentToJsonTool implements Tool {
   @Override
   public int run(InputStream stdin, PrintStream out, PrintStream err,

--- a/lang/java/tools/src/main/java/org/apache/avro/tool/CatTool.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/CatTool.java
@@ -38,7 +38,9 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.Path;
 
-/** Tool to extract samples from an Avro data file. */
+/**
+ * Tool to extract samples from an Avro data file.
+ */
 public class CatTool implements Tool {
 
   private long totalCopied;

--- a/lang/java/tools/src/main/java/org/apache/avro/tool/CreateRandomFileTool.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/CreateRandomFileTool.java
@@ -30,7 +30,9 @@ import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.trevni.avro.RandomData;
 
-/** Creates a file filled with randomly-generated instances of a schema. */
+/**
+ * Creates a file filled with randomly-generated instances of a schema.
+ */
 public class CreateRandomFileTool implements Tool {
 
   @Override

--- a/lang/java/tools/src/main/java/org/apache/avro/tool/DataFileGetMetaTool.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/DataFileGetMetaTool.java
@@ -29,7 +29,9 @@ import org.apache.avro.file.DataFileReader;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.mapred.FsInput;
 
-/** Reads a data file to get its metadata. */
+/**
+ * Reads a data file to get its metadata.
+ */
 public class DataFileGetMetaTool implements Tool {
 
   @Override
@@ -82,7 +84,13 @@ public class DataFileGetMetaTool implements Tool {
     return 0;
   }
 
-  // escape TAB, NL and CR in keys, so that output can be reliably parsed
+  /**
+   * Escape key string.
+   *
+   * @param key the key
+   * @return the string
+   */
+// escape TAB, NL and CR in keys, so that output can be reliably parsed
   static String escapeKey(String key) {
     key = key.replace("\\","\\\\");               // escape backslashes first
     key = key.replace("\t","\\t");                // TAB

--- a/lang/java/tools/src/main/java/org/apache/avro/tool/DataFileGetSchemaTool.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/DataFileGetSchemaTool.java
@@ -24,7 +24,9 @@ import java.util.List;
 import org.apache.avro.file.DataFileReader;
 import org.apache.avro.generic.GenericDatumReader;
 
-/** Reads a data file to get its schema. */
+/**
+ * Reads a data file to get its schema.
+ */
 public class DataFileGetSchemaTool implements Tool {
 
   @Override

--- a/lang/java/tools/src/main/java/org/apache/avro/tool/DataFileReadTool.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/DataFileReadTool.java
@@ -34,7 +34,9 @@ import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.io.JsonEncoder;
 
-/** Reads a data file and dumps to JSON */
+/**
+ * Reads a data file and dumps to JSON
+ */
 public class DataFileReadTool implements Tool {
 
   @Override

--- a/lang/java/tools/src/main/java/org/apache/avro/tool/DataFileRepairTool.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/DataFileRepairTool.java
@@ -33,7 +33,9 @@ import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericDatumWriter;
 
-/** Recovers data from a corrupt Avro Data file */
+/**
+ * Recovers data from a corrupt Avro Data file
+ */
 public class DataFileRepairTool implements Tool {
 
   @Override

--- a/lang/java/tools/src/main/java/org/apache/avro/tool/DataFileWriteTool.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/DataFileWriteTool.java
@@ -36,7 +36,9 @@ import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
 
-/** Reads new-line delimited JSON records and writers an Avro data file. */
+/**
+ * Reads new-line delimited JSON records and writers an Avro data file.
+ */
 public class DataFileWriteTool implements Tool {
 
   @Override

--- a/lang/java/tools/src/main/java/org/apache/avro/tool/FromTextTool.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/FromTextTool.java
@@ -33,10 +33,12 @@ import org.apache.avro.file.CodecFactory;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericDatumWriter;
 
-/** Reads a text file into an Avro data file.
- *
+/**
+ * Reads a text file into an Avro data file.
+ * <p>
  * Can accept a file name, and HDFS file URI, or stdin. Can write to a file
- * name, an HDFS URI, or stdout.*/
+ * name, an HDFS URI, or stdout.
+ */
 public class FromTextTool implements Tool {
   private static final String TEXT_FILE_SCHEMA =
     "\"bytes\"";

--- a/lang/java/tools/src/main/java/org/apache/avro/tool/JsonToBinaryFragmentTool.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/JsonToBinaryFragmentTool.java
@@ -34,7 +34,9 @@ import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.JsonDecoder;
 
-/** Tool to convert JSON data into the binary form. */
+/**
+ * Tool to convert JSON data into the binary form.
+ */
 public class JsonToBinaryFragmentTool implements Tool {
   @Override
   public int run(InputStream stdin, PrintStream out, PrintStream err,

--- a/lang/java/tools/src/main/java/org/apache/avro/tool/Main.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/Main.java
@@ -25,15 +25,23 @@ import java.util.TreeMap;
 
 import java.io.InputStream;
 
-/** Command-line driver.*/
+/**
+ * Command-line driver.
+ */
 public class Main {
   /**
    * Available tools, initialized in constructor.
    */
   final Map<String, Tool> tools;
 
+  /**
+   * The Max len.
+   */
   int maxLen = 0;
 
+  /**
+   * Instantiates a new Main.
+   */
   Main() {
     tools = new TreeMap<>();
     for (Tool tool : new Tool[] {
@@ -72,6 +80,12 @@ public class Main {
     }
   }
 
+  /**
+   * The entry point of application.
+   *
+   * @param args the input arguments
+   * @throws Exception the exception
+   */
   public static void main(String[] args) throws Exception {
     int rc = new Main().run(args);
     System.exit(rc);

--- a/lang/java/tools/src/main/java/org/apache/avro/tool/RecodecTool.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/RecodecTool.java
@@ -35,7 +35,9 @@ import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 
-/** Tool to alter the codec of an Avro data file. */
+/**
+ * Tool to alter the codec of an Avro data file.
+ */
 public class RecodecTool implements Tool {
   @Override
   public int run(InputStream in, PrintStream out, PrintStream err,

--- a/lang/java/tools/src/main/java/org/apache/avro/tool/RpcReceiveTool.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/RpcReceiveTool.java
@@ -49,6 +49,9 @@ public class RpcReceiveTool implements Tool {
   /** Used to communicate between server thread (responder) and run() */
   private CountDownLatch latch;
   private Message expectedMessage;
+  /**
+   * The Server.
+   */
   Server server;
 
   @Override
@@ -63,6 +66,11 @@ public class RpcReceiveTool implements Tool {
 
   private class SinkResponder extends GenericResponder {
 
+    /**
+     * Instantiates a new Sink responder.
+     *
+     * @param local the local
+     */
     public SinkResponder(Protocol local) {
       super(local);
     }
@@ -114,6 +122,16 @@ public class RpcReceiveTool implements Tool {
     return run2(err);
   }
 
+  /**
+   * Run 1 int.
+   *
+   * @param in   the in
+   * @param out  the out
+   * @param err  the err
+   * @param args the args
+   * @return the int
+   * @throws Exception the exception
+   */
   int run1(InputStream in, PrintStream out, PrintStream err,
       List<String> args) throws Exception {
     OptionParser p = new OptionParser();
@@ -164,6 +182,13 @@ public class RpcReceiveTool implements Tool {
     return 0;
   }
 
+  /**
+   * Run 2 int.
+   *
+   * @param err the err
+   * @return the int
+   * @throws InterruptedException the interrupted exception
+   */
   int run2(PrintStream err) throws InterruptedException {
     latch.await();
     err.println("Closing server.");

--- a/lang/java/tools/src/main/java/org/apache/avro/tool/SpecificCompilerTool.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/SpecificCompilerTool.java
@@ -36,7 +36,6 @@ import org.apache.avro.compiler.specific.SpecificCompiler;
  * A Tool for compiling avro protocols or schemas to Java classes using the Avro
  * SpecificCompiler.
  */
-
 public class SpecificCompilerTool implements Tool {
   @Override
   public int run(InputStream in, PrintStream out, PrintStream err,

--- a/lang/java/tools/src/main/java/org/apache/avro/tool/TetherTool.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/TetherTool.java
@@ -40,8 +40,14 @@ import org.apache.commons.cli.GnuParser;
 import org.apache.commons.cli.HelpFormatter;
 
 
+/**
+ * The type Tether tool.
+ */
 @SuppressWarnings("deprecation")
 public class TetherTool implements Tool {
+  /**
+   * The Job.
+   */
   public TetherJob job;
 
   @Override

--- a/lang/java/tools/src/main/java/org/apache/avro/tool/ToTextTool.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/ToTextTool.java
@@ -31,7 +31,9 @@ import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileStream;
 import org.apache.avro.generic.GenericDatumReader;
 
-/** Reads an avro data file into a plain text file. */
+/**
+ * Reads an avro data file into a plain text file.
+ */
 public class ToTextTool implements Tool {
   private static final String TEXT_FILE_SCHEMA =
         "\"bytes\"";

--- a/lang/java/tools/src/main/java/org/apache/avro/tool/ToTrevniTool.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/ToTrevniTool.java
@@ -33,7 +33,9 @@ import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
 
 
-/** Reads an Avro data file and writes a Trevni file. */
+/**
+ * Reads an Avro data file and writes a Trevni file.
+ */
 public class ToTrevniTool implements Tool {
 
   @Override

--- a/lang/java/tools/src/main/java/org/apache/avro/tool/Tool.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/Tool.java
@@ -30,9 +30,9 @@ public interface Tool {
    * Runs the tool with supplied arguments.  Input and output streams
    * are customizable for easier testing.
    *
-   * @param in Input stream to read data (typically System.in).
-   * @param out Output of tool (typically System.out).
-   * @param err Error stream (typically System.err).
+   * @param in   Input stream to read data (typically System.in).
+   * @param out  Output of tool (typically System.out).
+   * @param err  Error stream (typically System.err).
    * @param args Non-null list of arguments.
    * @return result code (0 for success)
    * @throws Exception Just like main(), tools may throw Exception.
@@ -41,11 +41,15 @@ public interface Tool {
 
   /**
    * Name of tool, to be used in listings.
+   *
+   * @return the name
    */
   String getName();
 
   /**
    * 1-line description to be used in command listings.
+   *
+   * @return the short description
    */
   String getShortDescription();
 }

--- a/lang/java/tools/src/main/java/org/apache/avro/tool/TrevniCreateRandomTool.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/TrevniCreateRandomTool.java
@@ -27,7 +27,9 @@ import org.apache.trevni.ColumnFileMetaData;
 import org.apache.trevni.avro.AvroColumnWriter;
 import org.apache.trevni.avro.RandomData;
 
-/** Tool to create randomly populated Trevni file based on an Avro schema */
+/**
+ * Tool to create randomly populated Trevni file based on an Avro schema
+ */
 public class TrevniCreateRandomTool implements Tool {
 
   @Override

--- a/lang/java/tools/src/main/java/org/apache/avro/tool/TrevniMetadataTool.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/TrevniMetadataTool.java
@@ -33,8 +33,13 @@ import org.codehaus.jackson.JsonGenerator;
 import org.codehaus.jackson.JsonEncoding;
 import org.codehaus.jackson.util.MinimalPrettyPrinter;
 
-/** Tool to print Trevni file metadata as JSON. */
+/**
+ * Tool to print Trevni file metadata as JSON.
+ */
 public class TrevniMetadataTool implements Tool {
+  /**
+   * The Factory.
+   */
   static final JsonFactory FACTORY = new JsonFactory();
 
   private JsonGenerator generator;
@@ -70,7 +75,13 @@ public class TrevniMetadataTool implements Tool {
     return 0;
   }
 
-  /** Read a Trevni file and print each row as a JSON object. */
+  /**
+   * Read a Trevni file and print each row as a JSON object.  @param input the input
+   *
+   * @param out    the out
+   * @param pretty the pretty
+   * @throws IOException the io exception
+   */
   public void dump(Input input, PrintStream out, boolean pretty)
     throws IOException {
     this.generator = FACTORY.createJsonGenerator(out, JsonEncoding.UTF8);

--- a/lang/java/tools/src/main/java/org/apache/avro/tool/TrevniToJsonTool.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/TrevniToJsonTool.java
@@ -32,11 +32,15 @@ import org.codehaus.jackson.JsonGenerator;
 import org.codehaus.jackson.JsonEncoding;
 import org.codehaus.jackson.util.MinimalPrettyPrinter;
 
-/** Tool to read Trevni files and print them as JSON.
+/**
+ * Tool to read Trevni files and print them as JSON.
  * This can read any Trevni file.  Nested structure is reconstructed from the
  * columns rather than any schema information.
  */
 public class TrevniToJsonTool implements Tool {
+  /**
+   * The Factory.
+   */
   static final JsonFactory FACTORY = new JsonFactory();
 
   private JsonGenerator generator;
@@ -74,7 +78,13 @@ public class TrevniToJsonTool implements Tool {
     return 0;
   }
 
-  /** Read a Trevni file and print each row as a JSON object. */
+  /**
+   * Read a Trevni file and print each row as a JSON object.  @param input the input
+   *
+   * @param out    the out
+   * @param pretty the pretty
+   * @throws IOException the io exception
+   */
   public void toJson(Input input, PrintStream out, boolean pretty)
     throws IOException {
     this.generator = FACTORY.createJsonGenerator(out, JsonEncoding.UTF8);

--- a/lang/java/tools/src/main/java/org/apache/avro/tool/TrevniUtil.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/TrevniUtil.java
@@ -35,9 +35,18 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
-/** Static utility methods for tools. */
+/**
+ * Static utility methods for tools.
+ */
 class TrevniUtil {
 
+  /**
+   * Input input.
+   *
+   * @param filename the filename
+   * @return the input
+   * @throws IOException the io exception
+   */
   static Input input(String filename) throws IOException {
     if (filename.startsWith("hdfs://")) {
       return new HadoopInput(new Path(filename), new Configuration());
@@ -49,7 +58,11 @@ class TrevniUtil {
   /**
    * Returns stdin if filename is "-", else opens the local or HDFS file
    * and returns an InputStream for it.
-   * @throws IOException
+   *
+   * @param filename the filename
+   * @param stdin    the stdin
+   * @return the input stream
+   * @throws IOException the io exception
    */
   static InputStream input(String filename, InputStream stdin)
     throws IOException {
@@ -66,7 +79,11 @@ class TrevniUtil {
   /**
    * Returns stdout if filename is "-", else opens the local or HDFS file
    * and returns an OutputStream for it.
-   * @throws IOException
+   *
+   * @param filename the filename
+   * @param stdout   the stdout
+   * @return the output stream
+   * @throws IOException the io exception
    */
   static OutputStream output(String filename, OutputStream stdout)
     throws IOException {

--- a/lang/java/tools/src/main/java/org/apache/avro/tool/Util.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/Util.java
@@ -47,14 +47,19 @@ import joptsimple.OptionSet;
 import joptsimple.OptionParser;
 import joptsimple.OptionSpec;
 
-/** Static utility methods for tools. */
+/**
+ * Static utility methods for tools.
+ */
 class Util {
   /**
    * Returns stdin if filename is "-", else opens the File in the owning filesystem
    * and returns an InputStream for it.
    * Relative paths will be opened in the default filesystem.
+   *
    * @param filename The filename to be opened
-   * @throws IOException
+   * @param stdin    the stdin
+   * @return the buffered input stream
+   * @throws IOException the io exception
    */
   static BufferedInputStream fileOrStdin(String filename, InputStream stdin)
       throws IOException {
@@ -67,8 +72,11 @@ class Util {
    * Returns stdout if filename is "-", else opens the file from the owning filesystem
    * and returns an OutputStream for it.
    * Relative paths will be opened in the default filesystem.
+   *
    * @param filename The filename to be opened
-   * @throws IOException
+   * @param stdout   the stdout
+   * @return the buffered output stream
+   * @throws IOException the io exception
    */
   static BufferedOutputStream fileOrStdout(String filename, OutputStream stdout)
       throws IOException {
@@ -80,8 +88,10 @@ class Util {
   /**
    * Returns an InputStream for the file using the owning filesystem,
    * or the default if none is given.
+   *
    * @param filename The filename to be opened
-   * @throws IOException
+   * @return the input stream
+   * @throws IOException the io exception
    */
   static InputStream openFromFS(String filename)
       throws IOException {
@@ -92,8 +102,10 @@ class Util {
   /**
    * Returns an InputStream for the file using the owning filesystem,
    * or the default if none is given.
+   *
    * @param filename The filename to be opened
-   * @throws IOException
+   * @return the input stream
+   * @throws IOException the io exception
    */
   static InputStream openFromFS(Path filename)
       throws IOException {
@@ -103,8 +115,10 @@ class Util {
   /**
    * Returns a seekable FsInput using the owning filesystem,
    * or the default if none is given.
+   *
    * @param filename The filename to be opened
-   * @throws IOException
+   * @return the fs input
+   * @throws IOException the io exception
    */
   static FsInput openSeekableFromFS(String filename)
       throws IOException {
@@ -114,9 +128,10 @@ class Util {
   /**
    * Opens the file for writing in the owning filesystem,
    * or the default if none is given.
+   *
    * @param filename The filename to be opened.
    * @return An OutputStream to the specified file.
-   * @throws IOException
+   * @throws IOException the io exception
    */
   static OutputStream createFromFS(String filename)
       throws IOException {
@@ -127,6 +142,7 @@ class Util {
   /**
    * Closes the inputstream created from {@link Util.fileOrStdin}
    * unless it is System.in.
+   *
    * @param in The inputstream to be closed.
    */
   static void close(InputStream in) {
@@ -142,6 +158,7 @@ class Util {
   /**
    * Closes the outputstream created from {@link Util.fileOrStdout}
    * unless it is System.out.
+   *
    * @param out The outputStream to be closed.
    */
   static void close(OutputStream out) {
@@ -156,9 +173,10 @@ class Util {
 
   /**
    * Parses a schema from the specified file.
+   *
    * @param filename The file name to parse
    * @return The parsed schema
-   * @throws IOException
+   * @throws IOException the io exception
    */
   static Schema parseSchemaFromFS(String filename) throws IOException {
     InputStream stream = openFromFS(filename);
@@ -175,11 +193,12 @@ class Util {
    * this directory. Only files inside that directory are included, no subdirectories or files
    * in subdirectories will be added.
    * If pathname is a glob pattern, all files matching the pattern are included.
-   *
+   * <p>
    * The List is sorted alphabetically.
+   *
    * @param fileOrDirName filename, directoryname or a glob pattern
    * @return A Path List
-   * @throws IOException
+   * @throws IOException the io exception
    */
   static List<Path> getFiles(String fileOrDirName) throws IOException {
     List<Path> pathList = new ArrayList<>();
@@ -211,11 +230,12 @@ class Util {
   /**
    * Concatenate the result of {@link #getFiles(String)} applied to all file or directory names.
    * The list is sorted alphabetically and contains no subdirectories or files within those.
-   *
+   * <p>
    * The list is sorted alphabetically.
+   *
    * @param fileOrDirNames A list of filenames, directorynames or glob patterns
    * @return A list of Paths, one for each file
-   * @throws IOException
+   * @throws IOException the io exception
    */
   static List<Path> getFiles(List<String> fileOrDirNames)
       throws IOException {
@@ -229,9 +249,14 @@ class Util {
 
   /**
    * Converts a String JSON object into a generic datum.
-   *
+   * <p>
    * This is inefficient (creates extra objects), so should be used
    * sparingly.
+   *
+   * @param schema   the schema
+   * @param jsonData the json data
+   * @return the object
+   * @throws IOException the io exception
    */
   static Object jsonToGenericDatum(Schema schema, String jsonData)
       throws IOException {
@@ -241,7 +266,13 @@ class Util {
     return datum;
   }
 
-  /** Reads and returns the first datum in a data file. */
+  /**
+   * Reads and returns the first datum in a data file.  @param schema the schema
+   *
+   * @param file the file
+   * @return the object
+   * @throws IOException the io exception
+   */
   static Object datumFromFile(Schema schema, String file) throws IOException {
     DataFileReader<Object> in =
         new DataFileReader<>(new File(file),
@@ -253,6 +284,12 @@ class Util {
     }
   }
 
+  /**
+   * Compression codec option option spec.
+   *
+   * @param optParser the opt parser
+   * @return the option spec
+   */
   static OptionSpec<String> compressionCodecOption(OptionParser optParser) {
     return optParser
       .accepts("codec", "Compression codec")
@@ -261,6 +298,12 @@ class Util {
       .defaultsTo("null");
 }
 
+  /**
+   * Compression level option option spec.
+   *
+   * @param optParser the opt parser
+   * @return the option spec
+   */
   static OptionSpec<Integer> compressionLevelOption(OptionParser optParser) {
     return optParser
       .accepts("level", "Compression level (only applies to deflate and xz)")
@@ -269,10 +312,27 @@ class Util {
       .defaultsTo(Deflater.DEFAULT_COMPRESSION);
   }
 
+  /**
+   * Codec factory codec factory.
+   *
+   * @param opts  the opts
+   * @param codec the codec
+   * @param level the level
+   * @return the codec factory
+   */
   static CodecFactory codecFactory(OptionSet opts, OptionSpec<String> codec, OptionSpec<Integer> level) {
     return codecFactory(opts, codec, level, DEFLATE_CODEC);
   }
 
+  /**
+   * Codec factory codec factory.
+   *
+   * @param opts         the opts
+   * @param codec        the codec
+   * @param level        the level
+   * @param defaultCodec the default codec
+   * @return the codec factory
+   */
   static CodecFactory codecFactory(OptionSet opts, OptionSpec<String> codec, OptionSpec<Integer> level, String defaultCodec) {
       String codecName = opts.hasArgument(codec)
         ? codec.value(opts)

--- a/lang/java/tools/src/test/java/org/apache/avro/tool/TestCatTool.java
+++ b/lang/java/tools/src/test/java/org/apache/avro/tool/TestCatTool.java
@@ -45,6 +45,9 @@ import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.junit.Test;
 
+/**
+ * The type Test cat tool.
+ */
 public class TestCatTool {
   private static final int ROWS_IN_INPUT_FILES = 100000;
   private static final int OFFSET = 1000;
@@ -137,6 +140,11 @@ public class TestCatTool {
     return rowcount;
   }
 
+  /**
+   * Test cat.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testCat() throws Exception {
     Map<String, String> metadata = new HashMap<>();
@@ -197,6 +205,11 @@ public class TestCatTool {
   }
 
 
+  /**
+   * Test limit out of bounds.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testLimitOutOfBounds() throws Exception {
     Map<String, String> metadata = new HashMap<>();
@@ -220,6 +233,11 @@ public class TestCatTool {
     assertEquals(ROWS_IN_INPUT_FILES - OFFSET, numRowsInFile(output));
   }
 
+  /**
+   * Test samplerate accuracy.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testSamplerateAccuracy() throws Exception {
     Map<String, String> metadata = new HashMap<>();
@@ -246,6 +264,11 @@ public class TestCatTool {
     assertTrue("", (ROWS_IN_INPUT_FILES - OFFSET)*SAMPLERATE - numRowsInFile(output) > -2);
   }
 
+  /**
+   * Test off set accuracy.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testOffSetAccuracy() throws Exception {
     Map<String, String> metadata = new HashMap<>();
@@ -271,6 +294,11 @@ public class TestCatTool {
       OFFSET, getFirstIntDatum(output));
   }
 
+  /**
+   * Test offset bigger than input.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testOffsetBiggerThanInput() throws Exception{
     Map<String, String> metadata = new HashMap<>();
@@ -294,6 +322,11 @@ public class TestCatTool {
       0, numRowsInFile(output));
   }
 
+  /**
+   * Test samplerate smaller than input.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testSamplerateSmallerThanInput() throws Exception{
     Map<String, String> metadata = new HashMap<>();
@@ -320,6 +353,11 @@ public class TestCatTool {
   }
 
 
+  /**
+   * Test different schemas fail.
+   *
+   * @throws Exception the exception
+   */
   @Test(expected = IOException.class)
   public void testDifferentSchemasFail() throws Exception {
     Map<String, String> metadata = new HashMap<>();
@@ -342,6 +380,11 @@ public class TestCatTool {
       args);
   }
 
+  /**
+   * Test helpful message when no args given.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testHelpfulMessageWhenNoArgsGiven() throws Exception {
     ByteArrayOutputStream buffer = new ByteArrayOutputStream(1024);

--- a/lang/java/tools/src/test/java/org/apache/avro/tool/TestConcatTool.java
+++ b/lang/java/tools/src/test/java/org/apache/avro/tool/TestConcatTool.java
@@ -46,6 +46,9 @@ import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.junit.Test;
 
+/**
+ * The type Test concat tool.
+ */
 public class TestConcatTool {
   private static final int ROWS_IN_INPUT_FILES = 100000;
   private static final CodecFactory DEFLATE = CodecFactory.deflateCodec(9);
@@ -108,6 +111,11 @@ public class TestConcatTool {
     return rowcount;
   }
 
+  /**
+   * Test dir concat.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testDirConcat() throws Exception {
     Map<String, String> metadata = new HashMap<>();
@@ -137,6 +145,11 @@ public class TestConcatTool {
     assertEquals(ROWS_IN_INPUT_FILES * 3, numRowsInFile(output));
   }
 
+  /**
+   * Test glob pattern concat.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testGlobPatternConcat() throws Exception {
     Map<String, String> metadata = new HashMap<>();
@@ -166,6 +179,11 @@ public class TestConcatTool {
     assertEquals(ROWS_IN_INPUT_FILES * 3, numRowsInFile(output));
   }
 
+  /**
+   * Test file does not exist.
+   *
+   * @throws Exception the exception
+   */
   @Test(expected = FileNotFoundException.class)
   public void testFileDoesNotExist() throws Exception {
     Map<String, String> metadata = new HashMap<>();
@@ -185,6 +203,11 @@ public class TestConcatTool {
       args);
   }
 
+  /**
+   * Test concat.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testConcat() throws Exception {
     Map<String, String> metadata = new HashMap<>();
@@ -213,6 +236,11 @@ public class TestConcatTool {
     assertEquals(getCodec(input1).getClass(), getCodec(output).getClass());
   }
 
+  /**
+   * Test different schemas fail.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testDifferentSchemasFail() throws Exception {
     Map<String, String> metadata = new HashMap<>();
@@ -236,6 +264,11 @@ public class TestConcatTool {
     assertEquals(1, returnCode);
   }
 
+  /**
+   * Test different metadata fail.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testDifferentMetadataFail() throws Exception {
     Map<String, String> metadata1 = new HashMap<>();
@@ -261,6 +294,11 @@ public class TestConcatTool {
     assertEquals(2, returnCode);
   }
 
+  /**
+   * Test different codec fail.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testDifferentCodecFail() throws Exception {
     Map<String, String> metadata = new HashMap<>();
@@ -284,6 +322,11 @@ public class TestConcatTool {
     assertEquals(3, returnCode);
   }
 
+  /**
+   * Test helpful message when no args given.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testHelpfulMessageWhenNoArgsGiven() throws Exception {
     ByteArrayOutputStream buffer = new ByteArrayOutputStream(1024);

--- a/lang/java/tools/src/test/java/org/apache/avro/tool/TestCreateRandomFileTool.java
+++ b/lang/java/tools/src/test/java/org/apache/avro/tool/TestCreateRandomFileTool.java
@@ -39,6 +39,9 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+/**
+ * The type Test create random file tool.
+ */
 public class TestCreateRandomFileTool {
   private static final String COUNT = System.getProperty("test.count", "200");
   private static final File DIR
@@ -52,12 +55,20 @@ public class TestCreateRandomFileTool {
   private ByteArrayOutputStream out;
   private ByteArrayOutputStream err;
 
+  /**
+   * Before.
+   */
   @Before
   public void before() {
     out = new ByteArrayOutputStream();
     err = new ByteArrayOutputStream();
   }
 
+  /**
+   * After.
+   *
+   * @throws Exception the exception
+   */
   @After
   public void after() throws Exception {
     out.close();
@@ -111,21 +122,41 @@ public class TestCreateRandomFileTool {
     assertTrue(err.toString().contains("Need count (--count)"));
   }
 
+  /**
+   * Test simple.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testSimple() throws Exception {
     check();
   }
 
+  /**
+   * Test codec.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testCodec() throws Exception {
     check("--codec", "snappy");
   }
 
+  /**
+   * Test missing count parameter.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testMissingCountParameter() throws Exception {
     checkMissingCount();
   }
 
+  /**
+   * Test std out.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testStdOut() throws Exception {
     TestUtil.resetRandomSeed();

--- a/lang/java/tools/src/test/java/org/apache/avro/tool/TestDataFileRepairTool.java
+++ b/lang/java/tools/src/test/java/org/apache/avro/tool/TestDataFileRepairTool.java
@@ -42,6 +42,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+/**
+ * The type Test data file repair tool.
+ */
 public class TestDataFileRepairTool {
 
   private static final Schema SCHEMA = Schema.create(Schema.Type.STRING);
@@ -50,6 +53,11 @@ public class TestDataFileRepairTool {
 
   private File repairedFile;
 
+  /**
+   * Write corrupt file.
+   *
+   * @throws IOException the io exception
+   */
   @BeforeClass
   public static void writeCorruptFile() throws IOException {
     // Write a data file
@@ -100,11 +108,17 @@ public class TestDataFileRepairTool {
     out.close();
   }
 
+  /**
+   * Sets up.
+   */
   @Before
   public void setUp() {
     repairedFile = AvroTestUtil.tempFile(TestDataFileRepairTool.class, "repaired.avro");
   }
 
+  /**
+   * Tear down.
+   */
   @After
   public void tearDown() {
     repairedFile.delete();
@@ -125,6 +139,11 @@ public class TestDataFileRepairTool {
     return out.toString("UTF-8").replace("\r", "");
   }
 
+  /**
+   * Test report corrupt block.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testReportCorruptBlock() throws Exception {
     String output = run(new DataFileRepairTool(), "-o", "report", corruptBlockFile.getPath());
@@ -132,6 +151,11 @@ public class TestDataFileRepairTool {
     assertTrue(output, output.contains("Number of records: 5 Number of corrupt records: 0"));
   }
 
+  /**
+   * Test report corrupt record.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testReportCorruptRecord() throws Exception {
     String output = run(new DataFileRepairTool(), "-o", "report", corruptRecordFile.getPath());
@@ -139,6 +163,11 @@ public class TestDataFileRepairTool {
     assertTrue(output, output.contains("Number of records: 8 Number of corrupt records: 2"));
   }
 
+  /**
+   * Test repair all corrupt block.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testRepairAllCorruptBlock() throws Exception {
     String output = run(new DataFileRepairTool(), "-o", "all",
@@ -148,6 +177,11 @@ public class TestDataFileRepairTool {
     checkFileContains(repairedFile, "apple", "banana", "celery", "guava", "hazelnut");
   }
 
+  /**
+   * Test repair all corrupt record.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testRepairAllCorruptRecord() throws Exception {
     String output = run(new DataFileRepairTool(), "-o", "all",
@@ -158,6 +192,11 @@ public class TestDataFileRepairTool {
         "hazelnut");
   }
 
+  /**
+   * Test repair prior corrupt block.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testRepairPriorCorruptBlock() throws Exception {
     String output = run(new DataFileRepairTool(), "-o", "prior",
@@ -167,6 +206,11 @@ public class TestDataFileRepairTool {
     checkFileContains(repairedFile, "apple", "banana", "celery");
   }
 
+  /**
+   * Test repair prior corrupt record.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testRepairPriorCorruptRecord() throws Exception {
     String output = run(new DataFileRepairTool(), "-o", "prior",
@@ -176,6 +220,11 @@ public class TestDataFileRepairTool {
     checkFileContains(repairedFile, "apple", "banana", "celery", "date");
   }
 
+  /**
+   * Test repair after corrupt block.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testRepairAfterCorruptBlock() throws Exception {
     String output = run(new DataFileRepairTool(), "-o", "after",
@@ -185,6 +234,11 @@ public class TestDataFileRepairTool {
     checkFileContains(repairedFile, "guava", "hazelnut");
   }
 
+  /**
+   * Test repair after corrupt record.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testRepairAfterCorruptRecord() throws Exception {
     String output = run(new DataFileRepairTool(), "-o", "after",

--- a/lang/java/tools/src/test/java/org/apache/avro/tool/TestDataFileTools.java
+++ b/lang/java/tools/src/test/java/org/apache/avro/tool/TestDataFileTools.java
@@ -45,17 +45,40 @@ import org.apache.avro.generic.GenericDatumWriter;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+/**
+ * The type Test data file tools.
+ */
 @SuppressWarnings("deprecation")
 public class TestDataFileTools {
+  /**
+   * The Count.
+   */
   static final int COUNT = 10;
+  /**
+   * The Sample file.
+   */
   static File sampleFile;
+  /**
+   * The Json data.
+   */
   static String jsonData;
+  /**
+   * The Schema.
+   */
   static Schema schema;
+  /**
+   * The Schema file.
+   */
   static File schemaFile;
 
   private static final String KEY_NEEDING_ESCAPES = "trn\\\r\t\n";
   private static final String ESCAPED_KEY = "trn\\\\\\r\\t\\n";
 
+  /**
+   * Write sample file.
+   *
+   * @throws IOException the io exception
+   */
   @BeforeClass
   public static void writeSampleFile() throws IOException {
     sampleFile = AvroTestUtil.tempFile(TestDataFileTools.class,
@@ -99,24 +122,44 @@ public class TestDataFileTools {
     return baos.toString("UTF-8").replace("\r", "");
   }
 
+  /**
+   * Test read.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testRead() throws Exception {
     assertEquals(jsonData,
         run(new DataFileReadTool(), sampleFile.getPath()));
   }
 
+  /**
+   * Test read stdin.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testReadStdin() throws Exception {
     FileInputStream stdin = new FileInputStream(sampleFile);
     assertEquals(jsonData, run(new DataFileReadTool(), stdin, "-"));
   }
 
+  /**
+   * Test read to json pretty.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testReadToJsonPretty() throws Exception {
     assertEquals(jsonData,
         run(new DataFileReadTool(), "--pretty", sampleFile.getPath()));
   }
 
+  /**
+   * Test get meta.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testGetMeta() throws Exception {
     String output = run(new DataFileGetMetaTool(), sampleFile.getPath());
@@ -124,6 +167,11 @@ public class TestDataFileTools {
     assertTrue(output, output.contains(ESCAPED_KEY+"\t\n"));
   }
 
+  /**
+   * Test get meta for single key.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testGetMetaForSingleKey() throws Exception {
     assertEquals(schema.toString() + "\n",
@@ -131,27 +179,60 @@ public class TestDataFileTools {
             "avro.schema"));
   }
 
+  /**
+   * Test get schema.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testGetSchema() throws Exception {
     assertEquals(schema.toString() + "\n",
         run(new DataFileGetSchemaTool(), sampleFile.getPath()));
   }
 
+  /**
+   * Test write with deflate.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testWriteWithDeflate() throws Exception {
     testWrite("deflate", Arrays.asList("--codec", "deflate"), "deflate");
   }
 
+  /**
+   * Test write.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testWrite() throws Exception {
     testWrite("plain", Collections.emptyList(), "null");
   }
 
+  /**
+   * Test write.
+   *
+   * @param name          the name
+   * @param extra         the extra
+   * @param expectedCodec the expected codec
+   * @throws Exception the exception
+   */
   public void testWrite(String name, List<String> extra, String expectedCodec)
       throws Exception {
       testWrite(name, extra, expectedCodec, "-schema", schema.toString());
       testWrite(name, extra, expectedCodec, "-schema-file", schemaFile.toString());
   }
+
+  /**
+   * Test write.
+   *
+   * @param name          the name
+   * @param extra         the extra
+   * @param expectedCodec the expected codec
+   * @param extraArgs     the extra args
+   * @throws Exception the exception
+   */
   public void testWrite(String name, List<String> extra, String expectedCodec, String... extraArgs)
   throws Exception {
     File outFile = AvroTestUtil.tempFile(getClass(),
@@ -189,6 +270,11 @@ public class TestDataFileTools {
     assertEquals(expectedCodec, codecStr);
   }
 
+  /**
+   * Test failure on writing partial json values.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testFailureOnWritingPartialJSONValues() throws Exception {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -207,6 +293,11 @@ public class TestDataFileTools {
     }
   }
 
+  /**
+   * Test writing zero json values.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testWritingZeroJsonValues() throws Exception {
     File outFile = writeToAvroFile("zerojsonvalues",
@@ -226,6 +317,11 @@ public class TestDataFileTools {
     return i;
   }
 
+  /**
+   * Test different separators between json records.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testDifferentSeparatorsBetweenJsonRecords() throws Exception {
     File outFile = writeToAvroFile(
@@ -235,6 +331,15 @@ public class TestDataFileTools {
     assertEquals(5, countRecords(outFile));
   }
 
+  /**
+   * Write to avro file file.
+   *
+   * @param testName the test name
+   * @param schema   the schema
+   * @param json     the json
+   * @return the file
+   * @throws Exception the exception
+   */
   public File writeToAvroFile(String testName, String schema, String json) throws Exception {
     File outFile = AvroTestUtil.tempFile(getClass(),
         TestDataFileTools.class + "." + testName + ".avro");

--- a/lang/java/tools/src/test/java/org/apache/avro/tool/TestIdlToSchemataTool.java
+++ b/lang/java/tools/src/test/java/org/apache/avro/tool/TestIdlToSchemataTool.java
@@ -25,8 +25,16 @@ import java.util.List;
 
 import org.junit.Test;
 
+/**
+ * The type Test idl to schemata tool.
+ */
 public class TestIdlToSchemataTool {
 
+  /**
+   * Test split idl into schemata.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testSplitIdlIntoSchemata() throws Exception {
     String idl = "src/test/idl/protocol.avdl";

--- a/lang/java/tools/src/test/java/org/apache/avro/tool/TestJsonToFromBinaryFragmentTools.java
+++ b/lang/java/tools/src/test/java/org/apache/avro/tool/TestJsonToFromBinaryFragmentTools.java
@@ -47,41 +47,81 @@ public class TestJsonToFromBinaryFragmentTools {
   private static final String JSON =
     "\"Long string implies readable length encoding.\"\n";
 
+  /**
+   * Test binary to json.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testBinaryToJson() throws Exception {
     binaryToJson(AVRO, JSON, STRING_SCHEMA);
   }
 
+  /**
+   * Test json to binary.
+   *
+   * @throws Exception the exception
+   */
   @Test
     public void testJsonToBinary() throws Exception {
     jsonToBinary(JSON, AVRO, STRING_SCHEMA);
   }
 
+  /**
+   * Test multi binary to json.
+   *
+   * @throws Exception the exception
+   */
   @Test
     public void testMultiBinaryToJson() throws Exception {
     binaryToJson(AVRO + AVRO + AVRO, JSON + JSON + JSON, STRING_SCHEMA);
   }
 
+  /**
+   * Test multi json to binary.
+   *
+   * @throws Exception the exception
+   */
   @Test
     public void testMultiJsonToBinary() throws Exception {
     jsonToBinary(JSON + JSON + JSON, AVRO + AVRO + AVRO, STRING_SCHEMA);
   }
 
+  /**
+   * Test binary to no pretty json.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testBinaryToNoPrettyJson() throws Exception {
     binaryToJson(AVRO, JSON, "--no-pretty", STRING_SCHEMA);
   }
 
+  /**
+   * Test multi binary to no pretty json.
+   *
+   * @throws Exception the exception
+   */
   @Test
     public void testMultiBinaryToNoPrettyJson() throws Exception {
     binaryToJson(AVRO + AVRO + AVRO, JSON + JSON + JSON, "--no-pretty", STRING_SCHEMA);
   }
 
+  /**
+   * Test binary to json schema file.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testBinaryToJsonSchemaFile() throws Exception {
     binaryToJson(AVRO, JSON, "--schema-file", schemaFile());
   }
 
+  /**
+   * Test json to binary schema file.
+   *
+   * @throws Exception the exception
+   */
   @Test
     public void testJsonToBinarySchemaFile() throws Exception {
     jsonToBinary(JSON, AVRO, "--schema-file", schemaFile());

--- a/lang/java/tools/src/test/java/org/apache/avro/tool/TestMain.java
+++ b/lang/java/tools/src/test/java/org/apache/avro/tool/TestMain.java
@@ -21,7 +21,13 @@ import static org.junit.Assert.fail;
 
 import org.junit.Test;
 
+/**
+ * The type Test main.
+ */
 public class TestMain {
+  /**
+   * Test tool description length.
+   */
   @Test
   /** Make sure that tool descriptions fit in 80 characters. */
   public void testToolDescriptionLength() {

--- a/lang/java/tools/src/test/java/org/apache/avro/tool/TestRecodecTool.java
+++ b/lang/java/tools/src/test/java/org/apache/avro/tool/TestRecodecTool.java
@@ -34,7 +34,15 @@ import org.apache.avro.generic.GenericDatumWriter;
 import org.junit.Assert;
 import org.junit.Test;
 
+/**
+ * The type Test recodec tool.
+ */
 public class TestRecodecTool {
+  /**
+   * Test recodec.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testRecodec() throws Exception {
     String metaKey = "myMetaKey";

--- a/lang/java/tools/src/test/java/org/apache/avro/tool/TestRpcProtocolTool.java
+++ b/lang/java/tools/src/test/java/org/apache/avro/tool/TestRpcProtocolTool.java
@@ -33,11 +33,16 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 
 /**
- *
+ * The type Test rpc protocol tool.
  */
 @RunWith(Parameterized.class)
 public class TestRpcProtocolTool {
 
+  /**
+   * Data list.
+   *
+   * @return the list
+   */
   @Parameterized.Parameters(/*name = "{0}"*/)
   public static List<Object[]> data() {
     return Arrays.asList( new Object[]{"http"},
@@ -49,10 +54,20 @@ public class TestRpcProtocolTool {
 
   private String uriScheme ;
 
+  /**
+   * Instantiates a new Test rpc protocol tool.
+   *
+   * @param uriScheme the uri scheme
+   */
   public TestRpcProtocolTool(String uriScheme) {
     this.uriScheme = uriScheme;
   }
 
+  /**
+   * Sets up.
+   *
+   * @throws Exception the exception
+   */
   @Before
   public void setUp() throws Exception {
     String protocolFile =
@@ -70,12 +85,22 @@ public class TestRpcProtocolTool {
             "-data", "\"Hello!\""));
   }
 
+  /**
+   * Tear down.
+   *
+   * @throws Exception the exception
+   */
   @After
   public void tearDown() throws Exception {
     if( receive != null )
       receive.server.close(); // force the server to finish
   }
 
+  /**
+   * Test rpc protocol.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testRpcProtocol() throws Exception {
 

--- a/lang/java/tools/src/test/java/org/apache/avro/tool/TestRpcReceiveAndSendTools.java
+++ b/lang/java/tools/src/test/java/org/apache/avro/tool/TestRpcReceiveAndSendTools.java
@@ -26,10 +26,15 @@ import java.util.Arrays;
 
 import org.junit.Test;
 
+/**
+ * The type Test rpc receive and send tools.
+ */
 public class TestRpcReceiveAndSendTools {
 
   /**
    * Starts a server (using the tool) and sends a single message to it.
+   *
+   * @throws Exception the exception
    */
   @Test
   public void testServeAndSend() throws Exception {

--- a/lang/java/tools/src/test/java/org/apache/avro/tool/TestSpecificCompilerTool.java
+++ b/lang/java/tools/src/test/java/org/apache/avro/tool/TestSpecificCompilerTool.java
@@ -73,11 +73,19 @@ public class TestSpecificCompilerTool {
   private static final File TEST_OUTPUT_STRING_POSITION =
     new File(TEST_OUTPUT_STRING_DIR, "avro/examples/baseball/Position.java");
 
+  /**
+   * Sets up.
+   */
   @Before
   public void setUp() {
     TEST_OUTPUT_DIR.delete();
   }
 
+  /**
+   * Test compile schema single file.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testCompileSchemaSingleFile() throws Exception {
 
@@ -87,6 +95,11 @@ public class TestSpecificCompilerTool {
     assertFileMatch(TEST_EXPECTED_POSITION, TEST_OUTPUT_POSITION);
   }
 
+  /**
+   * Test compile schema two files.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testCompileSchemaTwoFiles() throws Exception {
 
@@ -98,6 +111,11 @@ public class TestSpecificCompilerTool {
     assertFileMatch(TEST_EXPECTED_PLAYER,   TEST_OUTPUT_PLAYER);
   }
 
+  /**
+   * Test compile schema file and directory.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testCompileSchemaFileAndDirectory() throws Exception {
 
@@ -109,6 +127,11 @@ public class TestSpecificCompilerTool {
     assertFileMatch(TEST_EXPECTED_PLAYER,   TEST_OUTPUT_PLAYER);
   }
 
+  /**
+   * Test compile schemas using string.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testCompileSchemasUsingString() throws Exception {
 

--- a/lang/java/tools/src/test/java/org/apache/avro/tool/TestTetherTool.java
+++ b/lang/java/tools/src/test/java/org/apache/avro/tool/TestTetherTool.java
@@ -40,13 +40,18 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.JobConf;
 import org.junit.Test;
 
+/**
+ * The type Test tether tool.
+ */
 public class TestTetherTool {
 
   /**
    * Test that the tether tool works with the mapreduce example
-   *
+   * <p>
    * TODO: How can we ensure that when we run, the WordCountTether example has
    * been properly compiled?
+   *
+   * @throws Exception the exception
    */
   @Test
   public void test() throws Exception {

--- a/lang/java/tools/src/test/java/org/apache/avro/tool/TestTextFileTools.java
+++ b/lang/java/tools/src/test/java/org/apache/avro/tool/TestTextFileTools.java
@@ -41,17 +41,37 @@ import org.junit.BeforeClass;
 import org.junit.AfterClass;
 import org.junit.Test;
 
+/**
+ * The type Test text file tools.
+ */
 @SuppressWarnings("deprecation")
 public class TestTextFileTools {
   private static final int COUNT =
     Integer.parseInt(System.getProperty("test.count", "10"));
 
   private static final byte[] LINE_SEP = System.getProperty("line.separator").getBytes();
+  /**
+   * The Lines file.
+   */
   static File linesFile;
+  /**
+   * The Lines.
+   */
   static ByteBuffer[] lines;
+  /**
+   * The Schema.
+   */
   static Schema schema;
+  /**
+   * The Schema file.
+   */
   static File schemaFile;
 
+  /**
+   * Write random file.
+   *
+   * @throws IOException the io exception
+   */
   @BeforeClass
   public static void writeRandomFile() throws IOException {
     schema = Schema.create(Type.BYTES);
@@ -99,6 +119,11 @@ public class TestTextFileTools {
     assertEquals(COUNT, i);
   }
 
+  /**
+   * Test from text.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void testFromText() throws Exception {
     fromText("null", "--codec", "null");
@@ -106,6 +131,11 @@ public class TestTextFileTools {
     fromText("snappy", "--codec", "snappy");
   }
 
+  /**
+   * Test to text.
+   *
+   * @throws Exception the exception
+   */
   @AfterClass
   public static void testToText() throws Exception {
     toText("null");

--- a/lang/java/tools/src/test/java/org/apache/avro/tool/TestToTrevniTool.java
+++ b/lang/java/tools/src/test/java/org/apache/avro/tool/TestToTrevniTool.java
@@ -32,6 +32,9 @@ import org.apache.trevni.avro.RandomData;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
+/**
+ * The type Test to trevni tool.
+ */
 public class TestToTrevniTool {
   private static final int COUNT =
     Integer.parseInt(System.getProperty("test.count", "200"));
@@ -49,6 +52,11 @@ public class TestToTrevniTool {
     return baos.toString("UTF-8").replace("\r", "");
   }
 
+  /**
+   * Test.
+   *
+   * @throws Exception the exception
+   */
   @Test
   public void test() throws Exception {
     Schema schema = Schema.parse(SCHEMA_FILE);


### PR DESCRIPTION
From Java 8 on the JavaDoc is being linted and it will fail early if there are issues with the JavaDoc: http://openjdk.java.net/jeps/172

This patch will add the missing Javadoc with some stubs. Additionally I updated the docs of some of the public API by hand to make the Javadoc more verbose.

The JavaDoc needs to be updated in the future, but this commit will let the compiler pass the javadoc check step.

Tested locally and it passes the tests. This patch only changes the Javadoc and does not change the logic of the code.

Cheers, Fokko