### PR TITLE
AVRO-2230 Assignable line_ in Entity

### DIFF
--- a/lang/c++/impl/json/JsonDom.hh
+++ b/lang/c++/impl/json/JsonDom.hh
@@ -64,7 +64,7 @@ const char* typeToString(EntityType t);
 class AVRO_DECL Entity {
     EntityType type_;
     boost::any value_;
-    const size_t line_;
+    size_t line_;
 
     void ensureType(EntityType) const;
 public:


### PR DESCRIPTION
Fixes AVRO-2230 by making the line_ assignable. The line_ in JsonDom.hh is only used for reporting the line an error occurs on (AVRO-2113), and does not need to be const.