### PR TITLE
AVRO-2234 Use MappingProxyType, not ImmutableDict

### DIFF
--- a/lang/py3/avro/schema.py
+++ b/lang/py3/avro/schema.py
@@ -38,6 +38,7 @@ A schema may be one of:
  - Null.
 """
 
+from types import MappingProxyType
 
 import abc
 import collections
@@ -45,7 +46,7 @@ import json
 import logging
 import re
 
-logger = logging.getLogger(__name__) 
+logger = logging.getLogger(__name__)
 
 # ------------------------------------------------------------------------------
 # Constants
@@ -149,49 +150,13 @@ class SchemaParseException(AvroException):
   """Error while parsing a JSON schema descriptor."""
   pass
 
-
 # ------------------------------------------------------------------------------
-
-
-class ImmutableDict(dict):
-  """Dictionary guaranteed immutable.
-
-  All mutations raise an exception.
-  Behaves exactly as a dict otherwise.
-  """
-
-  def __init__(self, items=None, **kwargs):
-    if items is not None:
-      super(ImmutableDict, self).__init__(items)
-      assert (len(kwargs) == 0)
-    else:
-      super(ImmutableDict, self).__init__(**kwargs)
-
-  def __setitem__(self, key, value):
-    raise Exception(
-        'Attempting to map key %r to value %r in ImmutableDict %r'
-        % (key, value, self))
-
-  def __delitem__(self, key):
-    raise Exception(
-        'Attempting to remove mapping for key %r in ImmutableDict %r'
-        % (key, self))
-
-  def clear(self):
-    raise Exception('Attempting to clear ImmutableDict %r' % self)
-
-  def update(self, items=None, **kwargs):
-    raise Exception(
-        'Attempting to update ImmutableDict %r with items=%r, kwargs=%r'
-        % (self, args, kwargs))
-
-  def pop(self, key, default=None):
-    raise Exception(
-        'Attempting to pop key %r from ImmutableDict %r' % (key, self))
-
-  def popitem(self):
-    raise Exception('Attempting to pop item from ImmutableDict %r' % self)
-
+# Utilities
+class MappingProxyEncoder(json.JSONEncoder):
+  def default(self, obj):
+    if isinstance(obj, MappingProxyType):
+      return obj.copy()
+    return json.JSONEncoder.default(self, obj)
 
 # ------------------------------------------------------------------------------
 
@@ -255,7 +220,7 @@ class Schema(object, metaclass=abc.ABCMeta):
     Returns:
       A read-only dictionary of properties associated to this schema.
     """
-    return ImmutableDict(self._props)
+    return MappingProxyType(self._props)
 
   @property
   def other_props(self):
@@ -264,7 +229,7 @@ class Schema(object, metaclass=abc.ABCMeta):
 
   def __str__(self):
     """Returns: the JSON representation of this schema."""
-    return json.dumps(self.to_json())
+    return json.dumps(self.to_json(), cls=MappingProxyEncoder)
 
   @abc.abstractmethod
   def to_json(self, names):
@@ -620,7 +585,7 @@ class Field(object):
     return FilterKeysOut(items=self._props, keys=FIELD_RESERVED_PROPS)
 
   def __str__(self):
-    return json.dumps(self.to_json())
+    return json.dumps(self.to_json(), cls=MappingProxyEncoder)
 
   def to_json(self, names=None):
     if names is None:
@@ -1003,7 +968,7 @@ class RecordSchema(NamedSchema):
         raise SchemaParseException(
             'Duplicate field name %r in list %r.' % (field.name, field_desc_list))
       field_map[field.name] = field
-    return ImmutableDict(field_map)
+    return MappingProxyType(field_map)
 
   def __init__(
       self,


### PR DESCRIPTION
Per the Rejection Notice of PEP-416, use MappingProxyType instead of
creating our own implementation of ImmutableDict.