### PR TITLE
AVRO-2241. Fix Jsr310/Joda datetime tests

### DIFF
--- a/lang/java/avro/src/test/java/org/apache/avro/specific/TestSpecificLogicalTypes.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/specific/TestSpecificLogicalTypes.java
@@ -40,6 +40,8 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -103,8 +105,8 @@ public class TestSpecificLogicalTypes {
         3019.34,
         null,
         java.time.LocalDate.now(),
-        java.time.LocalTime.now(),
-        java.time.Instant.now(),
+        java.time.LocalTime.now().truncatedTo(ChronoUnit.MILLIS),
+        java.time.Instant.now().truncatedTo(ChronoUnit.MILLIS),
         new BigDecimal(123.45f).setScale(2, BigDecimal.ROUND_HALF_DOWN)
     );
 
@@ -160,8 +162,8 @@ public class TestSpecificLogicalTypes {
             3019.34,
             null,
             java.time.LocalDate.now(),
-            java.time.LocalTime.now(),
-            java.time.Instant.now(),
+            java.time.LocalTime.now().truncatedTo(ChronoUnit.MILLIS),
+            java.time.Instant.now().truncatedTo(ChronoUnit.MILLIS),
             new BigDecimal(123.45f).setScale(2, BigDecimal.ROUND_HALF_DOWN)
     );
 


### PR DESCRIPTION
Whe comparing Instant, DateTime, LocalTime with its Joda equivalents the tests fail since the java.time.* adds support for microseconds, and Joda only miliseconds. For example:

```
Failed tests:
  TestSpecificLogicalTypes.testAbilityToReadJodaRecordWrittenAsJsr310Record:183
Expected: is "11:45:07.170331"
     but: was "11:45:07.170"
  TestSpecificLogicalTypes.testRecordWithJsr310LogicalTypes:115 Should match written record expected:

<{"b": true, "i32": 34, "i64": 35, "f32": 3.14, "f64": 3019.34, "s": null, "d": 2018-10-11, "t": 11:45:06.513252, "ts": 2018-10-11T11:45:06.513358Z, "dec": 123.45}>

but was:

<{"b": true, "i32": 34, "i64": 35, "f32": 3.14, "f64": 3019.34, "s": null, "d": 2018-10-11, "t": 11:45:06.513, "ts": 2018-10-11T11:45:06.513Z, "dec": 123.45}>
```