### PR TITLE
AVRO-2240 Fix py3 Setup

### DIFF
--- a/lang/py3/setup.py
+++ b/lang/py3/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- mode: python -*-
 # -*- coding: utf-8 -*-
 
@@ -17,6 +17,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""
+Provide the code necessary for packaging and installing avro-python3.
+
+The avro-python3 software is designed for Python 3, but this file and the packaging software supports Python 2.7.
+
+https://pypi.org/project/avro-python3/
+"""
+
 
 import os
 import shutil
@@ -142,11 +151,16 @@ def Main():
       license = 'Apache License 2.0',
       keywords = 'avro serialization rpc',
       url = 'http://avro.apache.org/',
-      classifiers=[
+      classifiers=(
           'License :: OSI Approved :: Apache Software License',
           'Programming Language :: Python :: 3 :: Only',
-      ],
-      python_requires='>=3',
+          'Programming Language :: Python :: 3.4',
+          'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3.6',
+          'Programming Language :: Python :: 3.7',
+          'Programming Language :: Python :: 3.8',
+      ),
+      python_requires='>=3.4',
   )
 
 

--- a/lang/py3/setup.py
+++ b/lang/py3/setup.py
@@ -34,14 +34,9 @@ import sys
 
 from setuptools import setup
 
-
 VERSION_FILE_NAME = 'VERSION.txt'
 LICENSE_FILE_NAME = 'LICENSE'
 NOTICE_FILE_NAME = 'NOTICE'
-
-# The following prevents distutils from using hardlinks (which may not always be
-# available, e.g. on a Docker volume). See http://bugs.python.org/issue8876
-del os.link
 
 def RunsFromSourceDist():
   """Tests whether setup.py is invoked from a source distribution.
@@ -101,11 +96,6 @@ def SetupSources():
       src=avsc_file_path,
       dst=os.path.join(py3_dir, 'avro', 'tests', 'interop.avsc'),
   )
-
-  # Make sure the avro shell script is executable:
-  script = os.path.join(py3_dir, 'scripts', 'avro')
-  os.chmod(script,
-           stat.S_IMODE(os.stat(script).st_mode) | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
 
 def ReadVersion():

--- a/lang/py3/setup.py
+++ b/lang/py3/setup.py
@@ -20,6 +20,7 @@
 
 import os
 import shutil
+import stat
 import sys
 
 from setuptools import setup
@@ -93,10 +94,9 @@ def SetupSources():
   )
 
   # Make sure the avro shell script is executable:
-  os.chmod(
-      path=os.path.join(py3_dir, 'scripts', 'avro'),
-      mode=0o777,
-  )
+  script = os.path.join(py3_dir, 'scripts', 'avro')
+  os.chmod(script,
+           stat.S_IMODE(os.stat(script).st_mode) | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
 
 def ReadVersion():
@@ -110,9 +110,6 @@ def ReadVersion():
 
 
 def Main():
-  assert (sys.version_info[0] >= 3), \
-      ('Python version >= 3 required, got %r' % sys.version_info)
-
   if not RunsFromSourceDist():
     SetupSources()
 
@@ -145,6 +142,11 @@ def Main():
       license = 'Apache License 2.0',
       keywords = 'avro serialization rpc',
       url = 'http://avro.apache.org/',
+      classifiers=[
+          'License :: OSI Approved :: Apache Software License',
+          'Programming Language :: Python :: 3 :: Only',
+      ],
+      python_requires='>=3',
   )
 
 


### PR DESCRIPTION
Removes the assert statement that prevents python2 from interacting with setup.py at all. Also fixes an incompatibility and apparent brokenness with chmod in the setup.py script.

https://issues.apache.org/jira/browse/AVRO-2240