### PR TITLE
Renamed BUILD.txt to BUILD.md in RAT-task exclusions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -280,7 +280,7 @@
                 <exclude>**/*.iml</exclude>
                 <exclude>lang/csharp/Avro.sln</exclude> <!-- visual studio -->
                 <!-- build-related files -->
-                <exclude>BUILD.txt</exclude>
+                <exclude>BUILD.md</exclude>
                 <exclude>**/VERSION.txt</exclude>
                 <exclude>**/dependency-reduced-pom.xml</exclude>
                 <exclude>lang/perl/.shipit</exclude>


### PR DESCRIPTION
A recent commit (perhaps a11bd49e86d50f5a840ab2cdfe4f6927bedb4f93) renamed BUILD.txt to BUILD.md.  BUILD.txt was excluded from license checking in a RAT exclusion.  This pull request renames the exclusion in pom.xml so the validation phases passes.