### PR TITLE
Fix undefined variable field_desc_list in RecordSchema._MakeFieldMap

### DIFF
--- a/lang/py3/avro/schema.py
+++ b/lang/py3/avro/schema.py
@@ -1001,7 +1001,7 @@ class RecordSchema(NamedSchema):
     for field in fields:
       if field.name in field_map:
         raise SchemaParseException(
-            'Duplicate field name %r in list %r.' % (field.name, field_desc_list))
+            'Duplicate record field name %r.' % field.name)
       field_map[field.name] = field
     return ImmutableDict(field_map)
 

--- a/lang/py3/avro/tests/test_schema.py
+++ b/lang/py3/avro/tests/test_schema.py
@@ -622,6 +622,16 @@ class TestSchema(unittest.TestCase):
         self.assertEqual(type(v), list)
     self.assertEqual(correct,len(OTHER_PROP_EXAMPLES))
 
+  def testDuplicateRecordField(self):
+    schema_string = """{
+      "type": "record",
+      "name": "Test",
+      "fields": [{"name": "foo", "type": "int"}, {"name": "foo", "type": "string"}]
+    }"""
+    with self.assertRaises(schema.SchemaParseException) as e:
+      schema.Parse(schema_string)
+    self.assertRegexpMatches(str(e.exception), 'Duplicate.*field name.*foo')
+
 
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes undefined variable issue in `RecordSchema._MakeFieldMap`:

```
File ".../avro/schema.py", line 1004, in _MakeFieldMap
    'Duplicate field name %r in list %r.' % (field.name, field_desc_list))
NameError: name 'field_desc_list' is not defined
```
