### PR TITLE
C#: Fixing avro signature reading in DataFileReader

### DIFF
--- a/lang/csharp/src/apache/main/File/DataFileReader.cs
+++ b/lang/csharp/src/apache/main/File/DataFileReader.cs
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -100,7 +100,7 @@ namespace Avro.File
             // verify magic header
             byte[] magic = new byte[DataFileConstants.Magic.Length];
             inStream.Seek(0, SeekOrigin.Begin);
-            for (int c = 0; c < magic.Length; c = inStream.Read(magic, c, magic.Length - c)) { }
+            for (int c = 0; c < magic.Length; c += inStream.Read(magic, c, magic.Length - c)) { }
             inStream.Seek(0, SeekOrigin.Begin);
 
             if (magic.SequenceEqual(DataFileConstants.Magic))   // current format


### PR DESCRIPTION
Stream.Read method returns the amount of read bytes, not the offset (`c` variable), so the value must be added to the offset, not simply assigned.