### PR TITLE
Fix javadoc link

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/io/ResolvingDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/ResolvingDecoder.java
@@ -37,7 +37,7 @@ import org.apache.avro.util.Utf8;
  * clients handle fields that appear to be coming out of order, this class
  * defines the method {@link #readFieldOrder}.
  *
- * <p>See the <a href="doc-files/parsing.html">parser documentation</a> for
+ * <p>See the <a href="parsing/doc-files/parsing.html">parser documentation</a> for
  *  information on how this works.
  */
 public class ResolvingDecoder extends ValidatingDecoder {


### PR DESCRIPTION
Current docs: https://avro.apache.org/docs/1.8.2/api/java/org/apache/avro/io/parsing/doc-files/parsing.html

Right now, this links to https://avro.apache.org/docs/1.8.2/api/java/org/apache/avro/io/doc-files/parsing.html

The link should actually be to https://avro.apache.org/docs/1.8.2/api/java/org/apache/avro/io/parsing/doc-files/parsing.html