### PR TITLE
AVRO-2256 Prevent error checking compatibility of a record reading a union in Ruby

### DIFF
--- a/lang/ruby/lib/avro/schema_compatibility.rb
+++ b/lang/ruby/lib/avro/schema_compatibility.rb
@@ -141,6 +141,8 @@ module Avro
       end
 
       def match_record_schemas(writers_schema, readers_schema)
+        return false if writers_schema.type_sym == :union
+
         writer_fields_hash = writers_schema.fields_hash
         readers_schema.fields.each do |field|
           if writer_fields_hash.key?(field.name)

--- a/lang/ruby/test/test_schema_compatibility.rb
+++ b/lang/ruby/test/test_schema_compatibility.rb
@@ -75,7 +75,9 @@ class TestSchemaCompatibility < Test::Unit::TestCase
       long_list_record_schema, long_list_record_schema,
       long_list_record_schema, int_list_record_schema,
 
-      null_schema, null_schema
+      null_schema, null_schema,
+
+      nested_optional_record, nested_record
     ].each_slice(2) do |(reader, writer)|
       assert_true(can_read?(writer, reader), "expecting #{reader} to read #{writer}")
     end
@@ -130,7 +132,9 @@ class TestSchemaCompatibility < Test::Unit::TestCase
 
       int_list_record_schema, long_list_record_schema,
 
-      null_schema, int_schema
+      null_schema, int_schema,
+
+      nested_record, nested_optional_record
     ].each_slice(2) do |(reader, writer)|
       assert_false(can_read?(writer, reader), "expecting #{reader} not to read #{writer}")
     end
@@ -411,6 +415,14 @@ class TestSchemaCompatibility < Test::Unit::TestCase
 
   def a_dint_b_dint_record1_schema
     Avro::Schema.parse('{"type":"record", "name":"Record1", "fields":[{"name":"a", "type":"int", "default":0}, {"name":"b", "type":"int", "default":0}]}')
+  end
+
+  def nested_record
+    Avro::Schema.parse('{"type":"record","name":"parent","fields":[{"name":"attribute","type":{"type":"record","name":"child","fields":[{"name":"id","type":"string"}]}}]}')
+  end
+
+  def nested_optional_record
+    Avro::Schema.parse('{"type":"record","name":"parent","fields":[{"name":"attribute","type":["null",{"type":"record","name":"child","fields":[{"name":"id","type":"string"}]}],"default":null}]}')
   end
 
   def int_list_record_schema


### PR DESCRIPTION
This change fixes an error in Schema Compatibility checking in ruby: https://github.com/apache/avro/pull/170

Previously this raised a missing method error because the comparison is invalid.

With this change, the correct result returned that a record schema for a reader is incompatible with a union schema for the writer.

Test coverage is also increased for the cases of:
- a union schema for a reader with an included record schema for the writer (compatible)
- a record schema for a reader with a union schema for the writer (incompatible)

JIRA issue: https://issues.apache.org/jira/browse/AVRO-2256