### PR TITLE
Suppressed warning from m2e maven plugin

### DIFF
--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -103,58 +103,6 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.eclipse.m2e</groupId>
-          <artifactId>lifecycle-mapping</artifactId>
-          <version>1.0.0</version>
-          <configuration>
-            <lifecycleMappingMetadata>
-              <pluginExecutions>
-                <pluginExecution>
-                  <pluginExecutionFilter>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>javacc-maven-plugin</artifactId>
-                    <versionRange>[${javacc-plugin.version},)</versionRange>
-                    <goals>
-                      <goal>javacc</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <ignore />
-                  </action>
-                </pluginExecution>
-                <pluginExecution>
-                  <pluginExecutionFilter>
-                    <groupId>com.thoughtworks.paranamer</groupId>
-                    <artifactId>paranamer-maven-plugin</artifactId>
-                    <versionRange>[${paranamer.version},)</versionRange>
-                    <goals>
-                      <goal>generate</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <ignore />
-                  </action>
-                </pluginExecution>
-                <pluginExecution>
-                  <pluginExecutionFilter>
-                    <groupId>org.apache.avro</groupId>
-                    <artifactId>avro-maven-plugin</artifactId>
-                    <versionRange>[${project.version},)</versionRange>
-                    <goals>
-                      <goal>protocol</goal>
-                      <goal>idl-protocol</goal>
-                      <goal>schema</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <ignore />
-                  </action>
-                </pluginExecution>
-              </pluginExecutions>
-            </lifecycleMappingMetadata>
-          </configuration>
-        </plugin>
-        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${compiler-plugin.version}</version>
@@ -347,6 +295,97 @@
   </reporting>
 
   <profiles>
+    <profile>
+      <id>m2e</id>
+      <activation>
+        <property><name>m2e.version</name></property>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.eclipse.m2e</groupId>
+              <artifactId>lifecycle-mapping</artifactId>
+              <version>1.0.0</version>
+              <configuration>
+                <lifecycleMappingMetadata>
+                  <pluginExecutions>
+                    <pluginExecution>
+                      <pluginExecutionFilter>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-plugin-plugin</artifactId>
+                        <versionRange>[${plugin-plugin.version},)</versionRange>
+                        <goals>
+                          <goal>helpmojo</goal>
+                          <goal>descriptor</goal>
+                        </goals>
+                      </pluginExecutionFilter>
+                      <action>
+                        <ignore />
+                      </action>
+                    </pluginExecution>
+                    <pluginExecution>
+                      <pluginExecutionFilter>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <versionRange>[$${exec-plugin.version},)</versionRange>
+                        <goals>
+                          <goal>exec</goal>
+                        </goals>
+                      </pluginExecutionFilter>
+                      <action>
+                        <ignore />
+                      </action>
+                    </pluginExecution>
+                    <pluginExecution>
+                      <pluginExecutionFilter>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>javacc-maven-plugin</artifactId>
+                        <versionRange>[${javacc-plugin.version},)</versionRange>
+                        <goals>
+                          <goal>javacc</goal>
+                        </goals>
+                      </pluginExecutionFilter>
+                      <action>
+                        <ignore />
+                      </action>
+                    </pluginExecution>
+                    <pluginExecution>
+                      <pluginExecutionFilter>
+                        <groupId>com.thoughtworks.paranamer</groupId>
+                        <artifactId>paranamer-maven-plugin</artifactId>
+                        <versionRange>[${paranamer.version},)</versionRange>
+                        <goals>
+                          <goal>generate</goal>
+                        </goals>
+                      </pluginExecutionFilter>
+                      <action>
+                        <ignore />
+                      </action>
+                    </pluginExecution>
+                    <pluginExecution>
+                      <pluginExecutionFilter>
+                        <groupId>org.apache.avro</groupId>
+                        <artifactId>avro-maven-plugin</artifactId>
+                        <versionRange>[${project.version},)</versionRange>
+                        <goals>
+                          <goal>protocol</goal>
+                          <goal>idl-protocol</goal>
+                          <goal>schema</goal>
+                        </goals>
+                      </pluginExecutionFilter>
+                      <action>
+                        <ignore />
+                      </action>
+                    </pluginExecution>
+                  </pluginExecutions>
+                </lifecycleMappingMetadata>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
     <profile>
       <id>interop-data-test</id>
       <build>


### PR DESCRIPTION
m2e lifecycle plugin is used for building maven projects within Eclipse IDE. Since the plugin is in {{pluginManagement}} section and the plugin is never used in {{build/plugins}} or {{profiles/profile/build/plugins}} it is never used by normal Maven builds. It is used exclusively by Eclipse.

All that needed to done was to push the {{pluginManagement}} section into a profile that is triggered only when Eclipse invokes Maven. To get a better view of changes use {{?w=1}} in the URL for this pull request.

This does not have an impact on non-eclipse builds (except getting rid of the warning, of course). For Eclipse builds, this no worse than what we have been always having. I verified that with the latest Eclipse release Photon. There is a different problem (unrelated to m2e). It is related to {{test}} code being used by {{main}} code of a dependent module. I've filed a separate ticket AVRO-2267 for that issue.