### PR TITLE
AVRO-2239: Fix RPC interop tests for Ruby

### DIFF
--- a/lang/ruby/lib/avro/schema_validator.rb
+++ b/lang/ruby/lib/avro/schema_validator.rb
@@ -130,6 +130,7 @@ module Avro
       end
 
       def validate_map(expected_schema, datum, path, result)
+        fail TypeMismatchError unless datum.is_a?(Hash)
         datum.keys.each do |k|
           result.add_error(path, "unexpected key type '#{ruby_to_avro_type(k.class)}' in map") unless k.is_a?(String)
         end

--- a/lang/ruby/test/test_schema_validator.rb
+++ b/lang/ruby/test/test_schema_validator.rb
@@ -301,6 +301,10 @@ class TestSchema < Test::Unit::TestCase
     assert_failed_validation("at . unexpected key type 'Symbol' in map") do
       validate!(schema, some: 1)
     end
+
+    assert_failed_validation('at . expected type map, got null') do
+      validate!(schema, nil)
+    end
   end
 
   def test_validate_deep_record

--- a/share/test/interop/bin/test_rpc_interop.sh
+++ b/share/test/interop/bin/test_rpc_interop.sh
@@ -29,15 +29,13 @@ java_server="java -jar lang/java/tools/target/avro-tools-$VERSION.jar rpcreceive
 py_client="python lang/py/build/src/avro/tool.py rpcsend"
 py_server="python lang/py/build/src/avro/tool.py rpcreceive"
 
-#ruby_client="ruby -rubygems -Ilang/ruby/lib lang/ruby/test/tool.rb rpcsend"
-#ruby_server="ruby -rubygems -Ilang/ruby/lib lang/ruby/test/tool.rb rpcreceive"
+ruby_client="ruby -rubygems -Ilang/ruby/lib lang/ruby/test/tool.rb rpcsend"
+ruby_server="ruby -rubygems -Ilang/ruby/lib lang/ruby/test/tool.rb rpcreceive"
 
 export PYTHONPATH=lang/py/build/src      # path to avro Python module
 
-#clients=("$java_client" "$py_client" "$ruby_client")
-#servers=("$java_server" "$py_server" "$ruby_server")
-clients=("$java_client" "$py_client")
-servers=("$java_server" "$py_server")
+clients=("$java_client" "$py_client" "$ruby_client")
+servers=("$java_server" "$py_server" "$ruby_server")
 
 proto=share/test/schemas/simple.avpr
 


### PR DESCRIPTION
This fixes https://issues.apache.org/jira/browse/AVRO-2239 and re-enables RPC interop tests for Ruby.

The fix is to check that a datum is a Ruby Hash before validating it as a map.

The fix for this was already in https://github.com/apache/avro/pull/230, but I can rebase that PR if this makes it to master first.
