### PR TITLE
AVRO-2268 Fix FooBarSpecificRecord case

### DIFF
--- a/lang/java/ipc/src/test/java/org/apache/avro/io/Perf.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/io/Perf.java
@@ -1484,9 +1484,10 @@ public class Perf {
       }
 
       try {
+        String[] nicknames = { randomString(r), randomString(r) };
         return FooBarSpecificRecord.newBuilder().setId(r.nextInt())
             .setName(randomString(r))
-            .setNicknames(Arrays.asList(randomString(r), randomString(r)))
+            .setNicknames(new ArrayList<String>(Arrays.asList(nicknames)))
             .setTypeEnum(typeEnums[r.nextInt(typeEnums.length)])
             .setRelatedids(relatedIds).build();
       } catch (Exception e) {


### PR DESCRIPTION
Array fields for specific records should be given `List<>` implementations that support the `List.clear` operation.  The class returned by `Arrays.asList` does not support `clear`, so use an `ArrayList` instead.