### PR TITLE
AVRO-1658 Added license to AvroDoc.java

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/AvroDoc.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/AvroDoc.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.avro.reflect;
 
 import java.lang.annotation.ElementType;


### PR DESCRIPTION
License file for org.apache.avro.reflect.AvroDoc was missing a license, breaking the build.  This patch adds the standard lic header.
