### PR TITLE
AVRO-2277: Clean up Ruby warnings

### DIFF
--- a/lang/ruby/lib/avro/io.rb
+++ b/lang/ruby/lib/avro/io.rb
@@ -175,7 +175,6 @@ module Avro
       # int and long values are written using variable-length,
       # zig-zag coding.
       def write_long(n)
-        foo = n
         n = (n << 1) ^ (n >> 63)
         while (n & ~0x7F) != 0
           @writer.write(((n & 0x7f) | 0x80).chr)
@@ -299,7 +298,7 @@ module Avro
         while block_count != 0
           if block_count < 0
             block_count = -block_count
-            block_size = decoder.read_long
+            _block_size = decoder.read_long
           end
           block_count.times do
             read_items << read_data(writers_schema.items,
@@ -318,7 +317,7 @@ module Avro
         while block_count != 0
           if block_count < 0
             block_count = -block_count
-            block_size = decoder.read_long
+            _block_size = decoder.read_long
           end
           block_count.times do
             key = decoder.read_string
@@ -483,7 +482,7 @@ module Avro
           if block_count < 0
             decoder.skip(decoder.read_long)
           else
-            block_count.times &blk
+            block_count.times(&blk)
           end
           block_count = decoder.read_long
         end

--- a/lang/ruby/lib/avro/ipc.rb
+++ b/lang/ruby/lib/avro/ipc.rb
@@ -5,9 +5,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -74,10 +74,10 @@ module Avro::IPC
 
   class ConnectionClosedException < Avro::AvroError; end
 
+  # Base class for the client side of a protocol interaction.
   class Requestor
-    """Base class for the client side of a protocol interaction."""
-    attr_reader :local_protocol, :transport
-    attr_accessor :remote_protocol, :remote_hash, :send_protocol
+    attr_reader :local_protocol, :transport, :remote_protocol, :remote_hash
+    attr_accessor :send_protocol
 
     def initialize(local_protocol, transport)
       @local_protocol = local_protocol
@@ -193,9 +193,9 @@ module Avro::IPC
       #   * a one-byte error flag boolean, followed by either:
       #     * if the error flag is false,
       #       the message response, serialized per the message's response schema.
-      #     * if the error flag is true, 
+      #     * if the error flag is true,
       #       the error, serialized per the message's error union schema.
-      response_metadata = META_READER.read(decoder)
+      _response_metadata = META_READER.read(decoder)
 
       # remote response schema
       remote_message_schema = remote_protocol.messages[message_name]
@@ -257,7 +257,7 @@ module Avro::IPC
         end
 
         # read request using remote protocol
-        request_metadata = META_READER.read(buffer_decoder)
+        _request_metadata = META_READER.read(buffer_decoder)
         remote_message_name = buffer_decoder.read_string
 
         # get remote and local request schemas so we can do

--- a/lang/ruby/lib/avro/protocol.rb
+++ b/lang/ruby/lib/avro/protocol.rb
@@ -69,7 +69,6 @@ module Avro
 
     private
     def parse_types(types, type_names)
-      type_objects = []
       types.collect do |type|
         # FIXME adding type.name to type_names is not defined in the
         # spec. Possible bug in the python impl and the spec.

--- a/lang/ruby/lib/avro/schema.rb
+++ b/lang/ruby/lib/avro/schema.rb
@@ -231,6 +231,8 @@ module Avro
         if schema_type == :request || schema_type == 'request'
           @type_sym = schema_type.to_sym
           @namespace = namespace
+          @name = nil
+          @doc = nil
         else
           super(schema_type, name, namespace, names, doc)
         end
@@ -315,7 +317,7 @@ module Avro
 
       def initialize(name, space, symbols, names=nil, doc=nil)
         if symbols.uniq.length < symbols.length
-          fail_msg = 'Duplicate symbol: %s' % symbols
+          fail_msg = "Duplicate symbol: #{symbols}"
           raise Avro::SchemaParseError, fail_msg
         end
         super(:enum, name, space, names, doc)

--- a/lang/ruby/test/test_io.rb
+++ b/lang/ruby/test/test_io.rb
@@ -181,8 +181,8 @@ EOS
 
   def test_enum_with_duplicate
     str = '{"type": "enum", "name": "Test","symbols" : ["AA", "AA"]}'
-    assert_raises(Avro::SchemaParseError) do
-      schema = Avro::Schema.parse str
+    assert_raises(Avro::SchemaParseError.new('Duplicate symbol: ["AA", "AA"]')) do
+      Avro::Schema.parse str
     end
   end
 
@@ -289,7 +289,7 @@ EOS
   end
 
   def test_skip_long
-    for value_to_skip, hex_encoding in BINARY_INT_ENCODINGS
+    for value_to_skip, _hex_encoding in BINARY_INT_ENCODINGS
       value_to_read = 6253
 
       # write some data in binary to string buffer
@@ -314,7 +314,7 @@ EOS
   end
 
   def test_skip_int
-    for value_to_skip, hex_encoding in BINARY_INT_ENCODINGS
+    for value_to_skip, _hex_encoding in BINARY_INT_ENCODINGS
       value_to_read = 6253
 
       writer = StringIO.new
@@ -364,7 +364,7 @@ EOS
       datum_to_write = 219
       for rs in promotable_schemas[(i + 1)..-1]
         readers_schema = Avro::Schema.parse(rs)
-        writer, enc, dw = write_datum(datum_to_write, writers_schema)
+        writer, _enc, _dw = write_datum(datum_to_write, writers_schema)
         datum_read = read_datum(writer, writers_schema, readers_schema)
         if datum_read != datum_to_write
           incorrect += 1

--- a/lang/ruby/test/test_logical_types.rb
+++ b/lang/ruby/test/test_logical_types.rb
@@ -34,7 +34,7 @@ class TestLogicalTypes < Test::Unit::TestCase
 
     assert_equal 5, type.encode(Date.new(1970, 1, 6))
     assert_equal 0, type.encode(Date.new(1970, 1, 1))
-    assert_equal -5, type.encode(Date.new(1969, 12, 27))
+    assert_equal(-5, type.encode(Date.new(1969, 12, 27)))
 
     assert_equal Date.new(1970, 1, 6), type.decode(5)
     assert_equal Date.new(1970, 1, 1), type.decode(0)

--- a/lang/ruby/test/test_schema.rb
+++ b/lang/ruby/test/test_schema.rb
@@ -274,7 +274,7 @@ class TestSchema < Test::Unit::TestCase
     assert_equal enum_schema_hash, enum_schema_json.to_avro
   end
 
-def test_empty_record
+  def test_empty_record
     schema = Avro::Schema.parse('{"type":"record", "name":"Empty"}')
     assert_empty(schema.fields)
   end


### PR DESCRIPTION
This cleans up all of the warnings with Ruby versions 2.0 through 2.5.

There are still some warnings with Ruby 1.9.3 because it does not recognize the underscore (_) prefix convention for an unused variable.

Tested against:
  - 1.9.3-p551
  - 2.0.0-p648
  - 2.1.10
  - 2.2.8
  - 2.3.8
  - 2.4.5
  - 2.5.3

JIRA issue: https://issues.apache.org/jira/browse/AVRO-2277