### PR TITLE
AVRO-2275 Refactor schema-resolution code from grammar-generation

### DIFF
--- a/doc/src/content/mddocs/refactoring-resolution.md
+++ b/doc/src/content/mddocs/refactoring-resolution.md
@@ -1,0 +1,143 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+# Refactoring Resolution
+by Raymie Stata
+
+
+## Problem statement
+
+In the early days of Avro, Schema resolution was implemented in a
+number of places, e.g., `GenericDatumReader` as well as
+`ResolvingGrammarGenerator`.  However, Schema resolution is
+complicated and thus error prone.  Multiple implementations were hard
+to maintain, both for correctness and for updates to the
+schema-resolution spec.
+
+To address the problems of multiple implementations, we converged on
+the implementation found in `ResolvingGrammarGenerator` (together with
+`ResolvingDecoder`) as the single implementation, and refactored other
+parts of Avro to depend on this implementation.
+
+Converging on a single implementation solved the maintenance problem,
+and has served well for a number of years.  However, the logic in
+`ResolvingGrammarGenerator` does _two_ things: it contains the logic
+for _schema resolution_ itself, and it contains the logic for
+embedding that logic into a grammar that can be used by
+`ResolvingDecoder`.
+
+Recently, Avro contributors have wanted access to the logic of schema
+resolution _apart from_ `ResolvingDecoder`.  For example,
+[AVRO-2247](https://issues.apache.org/jira/browse/AVRO-2247) proposes
+a new, faster approach to implementing `DatumReaders`.  The initial
+implementation of AVRO-2247 was forced to reimplement Schema
+resolution -- going back to the world of multiple implementations --
+because there isn't a reusable implementation of our resolution logic.
+
+Similarly, as I've been working on extending the performance
+improvements of
+[AVRO-2090](https://issues.apache.org/jira/browse/AVRO-2090) when
+writing data, I've been thinking about the possibilities of dynamic
+code generation.  Here too, I can't reuse `ResolvingGrammarGenerator`,
+which would force me to reimplement the schema-resolution logic.
+
+
+## Proposed solution
+
+We introduce a new class to encapsulate the logic of schema resolution
+independent from the logic of implementing schema resolution as a
+`ResolvingDecoder` grammar.  In particular, we introduce a new class
+`org.apache.avro.Resolver` with the following key function:
+
+    public static Resolver.Action resolve(Schema writer, Schema reader);
+
+The subclasses of `Resolver.Action` encapsulate various ways to
+resolve schemas.  The `resolve` function walks the reader's and
+writer's schema parse trees together, and generate a tree of
+`Resolver.Action` nodes indicating how to resolve each subtree of the
+writer's schema into the corresponding subtree of the reader's.
+
+`Resolve.Action` has the following subclasses:
+
+   * `DoNothing` -- nothing needs to be done to resolve the writer's
+     data into the reader's schema.  That is, the reader should read
+     the data written by the writer as if it were written using the
+     reader's own schema.  This can be generated for any kind of
+     schema -- for example, if the reader's and writer's schemas are
+     the exact same union schema, a `DoNothing` will be generated --
+     so consumers of `Resolver` need to be able to handle `DoNothing`
+     for all schemas.
+
+   * `Promote` -- the writer's value needs to be promoted to the
+     reader's schema.  Generated only for numeric and byte/string
+     types.
+
+   * `ContainerAction` -- no resolution is needed directly on
+     container schemas, but a `ContainerAction` contains the `Action`
+     needed for the contained schema
+
+   * `EnumAdjust` -- resolution involves dealing with reordering of
+     symbols and symbols that have been removed from the enumeration.
+     An `EnumAdjust` object contains the information needed to do so.
+
+   * `RecordAdjust` -- resolution involves recursively resolving the
+     schemas for each field, and dealing with reordering and removal
+     of fields.  An `EnumAdjust` object contains the information
+     needed to do so.
+
+   * `SkipAction` -- only generated as a sub-action of a
+     `RecordAdjust` action.  Used to indicate that a writer's field
+     does not appear in the reader's schema and thus should be
+     skipped.
+
+   * `WriterUnion` -- generated when the writer's schema is a union
+     and the reader's schema is not the identical union.  Has
+     subactions for resolving each branch of the writer's union
+     against the reader's schema.
+
+   * `ReaderUnion` -- generated when the reader's schema is a union
+     and the writer's was not.  Had information indicating which of
+     the reader's union-branch was the best fit for the writer's
+     schema, and a subaction for resolving the schema of that branch
+     against the writer's schema.
+
+   * `ErrorAction` -- generated when the (sub)schemas can't be
+     resolved.
+
+These new classes aresimilar to the family of `Symbol` objects we've
+defined for `ResolvingGrammarGenerator`.  For example,
+`Action.RecordAdjust` is similar to `Symbol.FieldOrderAction`, and
+`Action.EnumAdjust` in `Symbol.EnumAdjustAction`.  This similarity is
+not surprising, since those `Symbol` objects were design to
+encapsulate the logic of schema resolution as well.
+
+However, where `ResolvingGrammarGenerator` embeds those `Symbol`
+objects into flattened productions highly optimized for the LL(1)
+parser implemented by `ResolvingDecoder`.  The `Resolver`, in
+contrast, captures the schema-resolution logic in a tree-like
+structure that closely mirrors the syntax-tree of the schemas being
+resolved.  This tree-like representation is easily consumed by
+multiple implementations of resolution -- be it the grammar-based
+implementation of `ResolvingDecoder`, the "action-sequence"-based
+implementation of AVRO-2247, or the dynamic code-gen implementation
+being considered as an extension to AVRO-2090.
+
+We have reimplemented `ResolvingGrammarGenerator` to eliminate it's
+implementaiton of schema-resolution logic and instead consume the
+output of `Resolver.resolve`.  Thus, it might be helpful to study
+`ResolvingGrammarGenerator` to better understand how to consume this
+output in other circumstances.

--- a/lang/java/avro/src/main/java/org/apache/avro/Resolver.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Resolver.java
@@ -27,44 +27,39 @@ import org.apache.avro.Schema.SeenPair;
 import org.apache.avro.Resolver.ErrorAction.ErrorType;
 
 /**
- * Encapsulate schema-resolution logic in an easy-to-consume
- * representation.  See {@link #resolve} and also the separate
- * document entitled <tt>refactoring-resolution</tt> for more
- * information.  It might also be helpful to study {@link
- * org.apache.avro.io.parsing.ResolvingGrammarGenerator} as an example
- * of how to use this class.
+ * Encapsulate schema-resolution logic in an easy-to-consume representation. See
+ * {@link #resolve} and also the separate document entitled
+ * <tt>refactoring-resolution</tt> for more information. It might also be
+ * helpful to study {@link org.apache.avro.io.parsing.ResolvingGrammarGenerator}
+ * as an example of how to use this class.
  */
 public class Resolver {
   /**
-   * Returns a {@link Resolver.Action} tree for resolving the writer
-   * schema <tt>writer</tt> and the reader schema <tt>reader</tt>.
+   * Returns a {@link Resolver.Action} tree for resolving the writer schema
+   * <tt>writer</tt> and the reader schema <tt>reader</tt>.
    *
-   * This method walks the reader's and writer's schemas together,
-   * generating an appropriate subclass of {@link Action} to
-   * encapsulate the information needed to resolve the corresponding
-   * parts of each schema tree.  For convience, every {@link Action}
-   * object has a pointer to the corresponding parts of the reader's
-   * and writer's trees being resolved by the action.  Each subclass
-   * of {@link Action} has additional information needed for different
-   * types of schema, e.g., the {@link EnumAdjust} subclass has
-   * information about re-ordering and deletion of enumeration
-   * symbols, while {@link RecordAdjust} has information about
-   * re-ordering and deletion of record fields.
+   * This method walks the reader's and writer's schemas together, generating an
+   * appropriate subclass of {@link Action} to encapsulate the information needed
+   * to resolve the corresponding parts of each schema tree. For convience, every
+   * {@link Action} object has a pointer to the corresponding parts of the
+   * reader's and writer's trees being resolved by the action. Each subclass of
+   * {@link Action} has additional information needed for different types of
+   * schema, e.g., the {@link EnumAdjust} subclass has information about
+   * re-ordering and deletion of enumeration symbols, while {@link RecordAdjust}
+   * has information about re-ordering and deletion of record fields.
    *
-   * Note that aliases are applied to the writer's schema before
-   * resolution actually takes place.  This means that the
-   * <tt>writer</tt> field of the resulting {@link Action} objects
-   * will not be the same schema as provided to this method.  However,
-   * the <tt>reader</tt> field will be.
+   * Note that aliases are applied to the writer's schema before resolution
+   * actually takes place. This means that the <tt>writer</tt> field of the
+   * resulting {@link Action} objects will not be the same schema as provided to
+   * this method. However, the <tt>reader</tt> field will be.
    *
-   * @param writer    The schema used by the writer
-   * @param reader    The schema used by the reader
-   * @param data      Used for <tt>getDefaultValue</tt> and getting conversions
-   * @return          Nested actions for resolving the two
+   * @param writer The schema used by the writer
+   * @param reader The schema used by the reader
+   * @param data   Used for <tt>getDefaultValue</tt> and getting conversions
+   * @return Nested actions for resolving the two
    */
   public static Action resolve(Schema writer, Schema reader, GenericData data) {
-    return resolve(Schema.applyAliases(writer, reader),
-                   reader, data, new HashMap<>());
+    return resolve(Schema.applyAliases(writer, reader), reader, data, new HashMap<>());
   }
 
   /**
@@ -74,9 +69,7 @@ public class Resolver {
     return resolve(writer, reader, GenericData.get());
   }
 
-  private static Action resolve(Schema w, Schema r, GenericData d,
-                                Map<SeenPair, Action> seen)
-  {
+  private static Action resolve(Schema w, Schema r, GenericData d, Map<SeenPair, Action> seen) {
     final Schema.Type wType = w.getType();
     final Schema.Type rType = r.getType();
 
@@ -85,17 +78,23 @@ public class Resolver {
 
     if (wType == rType) {
       switch (wType) {
-      case NULL: case BOOLEAN:
-      case INT: case LONG: case FLOAT: case DOUBLE:
-      case STRING: case BYTES:
+      case NULL:
+      case BOOLEAN:
+      case INT:
+      case LONG:
+      case FLOAT:
+      case DOUBLE:
+      case STRING:
+      case BYTES:
         return new DoNothing(w, r, d);
 
       case FIXED:
-        if (w.getFullName() != null && ! w.getFullName().equals(r.getFullName()))
+        if (w.getFullName() != null && !w.getFullName().equals(r.getFullName()))
           return new ErrorAction(w, r, d, ErrorType.NAMES_DONT_MATCH);
         else if (w.getFixedSize() != r.getFixedSize())
           return new ErrorAction(w, r, d, ErrorType.SIZES_DONT_MATCH);
-        else return new DoNothing(w, r, d);
+        else
+          return new DoNothing(w, r, d);
 
       case ARRAY:
         Action et = resolve(w.getElementType(), r.getElementType(), d, seen);
@@ -114,37 +113,38 @@ public class Resolver {
       default:
         throw new IllegalArgumentException("Unknown type for schema: " + wType);
       }
-    } else if (rType == Schema.Type.UNION) return ReaderUnion.resolve(w, r, d, seen);
-    else return Promote.resolve(w, r, d);
+    } else if (rType == Schema.Type.UNION)
+      return ReaderUnion.resolve(w, r, d, seen);
+    else
+      return Promote.resolve(w, r, d);
   }
 
   /**
-   * An abstract class for an action to be taken to resolve a writer's
-   * schema (found in public instance variable <tt>writer</tt>)
-   * against a reader's schema (in <tt>reader</tt>).  Ordinarily,
-   * neither field can be <tt>null</tt>, except that the
-   * <tt>reader</tt> field can be <tt>null</tt> in a {@link
-   * Skip}, which is used to skip a field in a writer's record
-   * that doesn't exist in the reader's (and thus there is no reader
-   * schema to resolve to).
+   * An abstract class for an action to be taken to resolve a writer's schema
+   * (found in public instance variable <tt>writer</tt>) against a reader's schema
+   * (in <tt>reader</tt>). Ordinarily, neither field can be <tt>null</tt>, except
+   * that the <tt>reader</tt> field can be <tt>null</tt> in a {@link Skip}, which
+   * is used to skip a field in a writer's record that doesn't exist in the
+   * reader's (and thus there is no reader schema to resolve to).
    */
   public static abstract class Action {
     /** Helps us traverse faster. */
     public static enum Type {
-      DO_NOTHING, ERROR, PROMOTE, CONTAINER, ENUM, SKIP, RECORD,
-      WRITER_UNION, READER_UNION
+      DO_NOTHING, ERROR, PROMOTE, CONTAINER, ENUM, SKIP, RECORD, WRITER_UNION, READER_UNION
     };
 
     public final Schema writer, reader;
     public final Type type;
 
-    /** If the reader has a logical type, it's stored here for fast
-     * access, otherwise this will be null.
+    /**
+     * If the reader has a logical type, it's stored here for fast access, otherwise
+     * this will be null.
      */
     public final LogicalType logicalType;
 
-    /** If the reader has a conversion that needs to be applied, it's
-     * stored here for fast access, otherwise this will be null.
+    /**
+     * If the reader has a conversion that needs to be applied, it's stored here for
+     * fast access, otherwise this will be null.
      */
     public final Conversion<?> conversion;
 
@@ -163,44 +163,52 @@ public class Resolver {
   }
 
   /**
-   * In this case, there's nothing to be done for resolution: the two
-   * schemas are effectively the same.  This action will be generated
-   * <em>only</em> for primitive types and fixed types, and not for
-   * any other kind of schema. */
+   * In this case, there's nothing to be done for resolution: the two schemas are
+   * effectively the same. This action will be generated <em>only</em> for
+   * primitive types and fixed types, and not for any other kind of schema.
+   */
   public static class DoNothing extends Action {
-    public DoNothing(Schema w, Schema r, GenericData d)
-    { super(w, r, d, Action.Type.DO_NOTHING); }
+    public DoNothing(Schema w, Schema r, GenericData d) {
+      super(w, r, d, Action.Type.DO_NOTHING);
+    }
   }
 
   /**
-   * In this case there is an error.  We put error Actions into trees
-   * because Avro reports these errors in a lazy fashion: if a
-   * particular input doesn't "tickle" the error (typically because
-   * it's in a branch of a union that isn't found in the data being
-   * read), then it's safe to ignore it.
+   * In this case there is an error. We put error Actions into trees because Avro
+   * reports these errors in a lazy fashion: if a particular input doesn't
+   * "tickle" the error (typically because it's in a branch of a union that isn't
+   * found in the data being read), then it's safe to ignore it.
    */
   public static class ErrorAction extends Action {
     public static enum ErrorType {
-        /** Use when Schema types don't match and can't be converted.  For
-         * example, resolving "int" and "enum". */
-        INCOMPATIBLE_SCHEMA_TYPES,
+      /**
+       * Use when Schema types don't match and can't be converted. For example,
+       * resolving "int" and "enum".
+       */
+      INCOMPATIBLE_SCHEMA_TYPES,
 
-        /** Use when Schema types match but, in the case of record, enum,
-         * or fixed, the names don't match. */
-        NAMES_DONT_MATCH,
+      /**
+       * Use when Schema types match but, in the case of record, enum, or fixed, the
+       * names don't match.
+       */
+      NAMES_DONT_MATCH,
 
-        /** Use when two fixed types match and their names match by their
-         * sizes don't. */
-        SIZES_DONT_MATCH,
+      /**
+       * Use when two fixed types match and their names match by their sizes don't.
+       */
+      SIZES_DONT_MATCH,
 
-        /** Use when matching two records and the reader has a field
-         * with no default value and that field is missing in the
-         * writer.. */
-        MISSING_REQUIRED_FIELD,
+      /**
+       * Use when matching two records and the reader has a field with no default
+       * value and that field is missing in the writer..
+       */
+      MISSING_REQUIRED_FIELD,
 
-        /** Use when matching a reader's union against a non-union and
-         * can't find a branch that matches. */
-        NO_MATCHING_BRANCH
+      /**
+       * Use when matching a reader's union against a non-union and can't find a
+       * branch that matches.
+       */
+      NO_MATCHING_BRANCH
     }
 
     public final ErrorType error;
@@ -226,9 +234,8 @@ public class Resolver {
         for (Field rf : rfields)
           if (writer.getField(rf.name()) == null && rf.defaultValue() == null)
             fname = rf.name();
-        return ("Found " + writer.getFullName()
-                + ", expecting " + reader.getFullName()
-                + ", missing required field " + fname);
+        return ("Found " + writer.getFullName() + ", expecting " + reader.getFullName() + ", missing required field "
+            + fname);
       }
       default:
         throw new IllegalArgumentException("Unknown error.");
@@ -237,34 +244,37 @@ public class Resolver {
   }
 
   /**
-   * In this case, the writer's type needs to be promoted to the
-   * reader's.  These are constructed by {@link Promote.resolve},
-   * which will only construct one when the writer's and reader's
-   * schemas are different (ie, no "self promotion"), and whent the
-   * promotion is one allowed by the Avro spec.
+   * In this case, the writer's type needs to be promoted to the reader's. These
+   * are constructed by {@link Promote.resolve}, which will only construct one
+   * when the writer's and reader's schemas are different (ie, no "self
+   * promotion"), and whent the promotion is one allowed by the Avro spec.
    */
   public static class Promote extends Action {
-    private Promote(Schema w, Schema r, GenericData d)
-    { super(w, r, d, Action.Type.PROMOTE); }
-
-    /**
-     * Return a promotion.
-     * @param w Writer's schema
-     * @param r Rearder's schema
-     * @result a {@link Promote} schema if the two schemas are compatible,
-     * or {@link ErrorType.INCOMPATIBLE_SCHEMA_TYPE} if they are not.
-     * @throws IllegalArgumentException if <em>getType()</em> of the two schemas
-     * are not different.
-     */
-    public static Action resolve(Schema w, Schema r, GenericData d) {
-      if (isValid(w, r)) return new Promote(w, r, d);
-      else return new ErrorAction(w, r, d, ErrorType.INCOMPATIBLE_SCHEMA_TYPES);
+    private Promote(Schema w, Schema r, GenericData d) {
+      super(w, r, d, Action.Type.PROMOTE);
     }
 
     /**
-     * Returns true iff <tt>w</tt> and <tt>r</tt> are both primitive
-     * types and either they are the same type or <tt>w</tt> is
-     * promotable to <tt>r</tt>.  Should
+     * Return a promotion.
+     * 
+     * @param w Writer's schema
+     * @param r Rearder's schema
+     * @result a {@link Promote} schema if the two schemas are compatible, or
+     *         {@link ErrorType.INCOMPATIBLE_SCHEMA_TYPE} if they are not.
+     * @throws IllegalArgumentException if <em>getType()</em> of the two schemas are
+     *                                  not different.
+     */
+    public static Action resolve(Schema w, Schema r, GenericData d) {
+      if (isValid(w, r))
+        return new Promote(w, r, d);
+      else
+        return new ErrorAction(w, r, d, ErrorType.INCOMPATIBLE_SCHEMA_TYPES);
+    }
+
+    /**
+     * Returns true iff <tt>w</tt> and <tt>r</tt> are both primitive types and
+     * either they are the same type or <tt>w</tt> is promotable to <tt>r</tt>.
+     * Should
      */
     public static boolean isValid(Schema w, Schema r) {
       if (w.getType() == r.getType())
@@ -272,20 +282,42 @@ public class Resolver {
       Schema.Type wt = w.getType();
       switch (r.getType()) {
       case INT:
-        switch (wt) { case INT: return true; }
+        switch (wt) {
+        case INT:
+          return true;
+        }
         break;
       case LONG:
-        switch (wt) { case INT: case LONG: return true; }
+        switch (wt) {
+        case INT:
+        case LONG:
+          return true;
+        }
         break;
       case FLOAT:
-        switch (wt) { case INT: case LONG: case FLOAT: return true; }
+        switch (wt) {
+        case INT:
+        case LONG:
+        case FLOAT:
+          return true;
+        }
         break;
       case DOUBLE:
-        switch (wt) { case INT: case LONG: case FLOAT: case DOUBLE: return true; }
+        switch (wt) {
+        case INT:
+        case LONG:
+        case FLOAT:
+        case DOUBLE:
+          return true;
+        }
         break;
       case BYTES:
       case STRING:
-        switch (wt) { case STRING: case BYTES: return true; }
+        switch (wt) {
+        case STRING:
+        case BYTES:
+          return true;
+        }
         break;
       }
       return false;
@@ -294,11 +326,12 @@ public class Resolver {
 
   /**
    * Used for array and map schemas: the public instance variable
-   * <tt>elementAction</tt> contains the resolving action needed for
-   * the element type of an array or value top of a map.
+   * <tt>elementAction</tt> contains the resolving action needed for the element
+   * type of an array or value top of a map.
    */
   public static class Container extends Action {
     public final Action elementAction;
+
     public Container(Schema w, Schema r, GenericData d, Action e) {
       super(w, r, d, Action.Type.CONTAINER);
       this.elementAction = e;
@@ -306,27 +339,24 @@ public class Resolver {
   }
 
   /**
-   * Contains information needed to resolve enumerations.  When
-   * resolving enums, adjustments need to be made in two scenarios:
-   * the index for an enum symbol might be different in the reader or
-   * writer, or the reader might not have a symbol that was written
-   * out for the writer (which is an error, but one we can only detect
-   * when decoding data).
+   * Contains information needed to resolve enumerations. When resolving enums,
+   * adjustments need to be made in two scenarios: the index for an enum symbol
+   * might be different in the reader or writer, or the reader might not have a
+   * symbol that was written out for the writer (which is an error, but one we can
+   * only detect when decoding data).
    *
    * These adjustments are reflected in the instance variable
-   * <tt>adjustments</tt>.  For the symbol with index <tt>i</tt> in
-   * the writer's enum definition, <tt>adjustments[i]</tt> -- and
-   * integer -- contains the adjustment for that symbol.  If the
-   * integer is positive, then reader also has the symbol and the
-   * integer is its index in the reader's schema.  If
-   * <tt>adjustment[i]</tt> is negative, then the reader does
-   * <em>not</em> have the corresponding symbol (which is the error case).
+   * <tt>adjustments</tt>. For the symbol with index <tt>i</tt> in the writer's
+   * enum definition, <tt>adjustments[i]</tt> -- and integer -- contains the
+   * adjustment for that symbol. If the integer is positive, then reader also has
+   * the symbol and the integer is its index in the reader's schema. If
+   * <tt>adjustment[i]</tt> is negative, then the reader does <em>not</em> have
+   * the corresponding symbol (which is the error case).
    *
-   * Sometimes there's no adjustments needed: all symbols in the
-   * reader have the same index in the reader's and writer's schema.
-   * This is a common case, and it allows for some optimization.  To
-   * signal that this is the case, <tt>noAdjustmentsNeeded</tt> is set
-   * to true.
+   * Sometimes there's no adjustments needed: all symbols in the reader have the
+   * same index in the reader's and writer's schema. This is a common case, and it
+   * allows for some optimization. To signal that this is the case,
+   * <tt>noAdjustmentsNeeded</tt> is set to true.
    */
   public static class EnumAdjust extends Action {
     public final int[] adjustments;
@@ -345,18 +375,17 @@ public class Resolver {
     }
 
     /**
-     * If writer and reader don't have same name, a {@link
-     * ErrorAction.Type.NAMES_DONT_MATCH} is returned, otherwise an
+     * If writer and reader don't have same name, a
+     * {@link ErrorAction.Type.NAMES_DONT_MATCH} is returned, otherwise an
      * appropriate {@link EnumAdjust} is.
      */
     public static Action resolve(Schema w, Schema r, GenericData d) {
-      if (w.getFullName() != null && ! w.getFullName().equals(r.getFullName()))
+      if (w.getFullName() != null && !w.getFullName().equals(r.getFullName()))
         return new ErrorAction(w, r, d, ErrorType.NAMES_DONT_MATCH);
 
       final List<String> wsymbols = w.getEnumSymbols();
       final List<String> rsymbols = r.getEnumSymbols();
-      final int defaultIndex
-        = (r.getEnumDefault() == null ? -1 : rsymbols.indexOf(r.getEnumDefault()));
+      final int defaultIndex = (r.getEnumDefault() == null ? -1 : rsymbols.indexOf(r.getEnumDefault()));
       int[] adjustments = new int[wsymbols.size()];
       for (int i = 0; i < adjustments.length; i++) {
         int j = rsymbols.indexOf(wsymbols.get(i));
@@ -367,67 +396,61 @@ public class Resolver {
   }
 
   /**
-   * This only appears inside {@link RecordAdjust.fieldActions}, i.e.,
-   * the actions for adjusting the fields of a record.  This action
-   * indicates that the writer's schema has a field that the reader's
-   * does <em>not</em> have, and thus the field should be skipped.
-   * Since there is no corresponding reader's schema for the writer's
-   * in this case, the {@link Action.reader} field is <tt>null</tt>
+   * This only appears inside {@link RecordAdjust.fieldActions}, i.e., the actions
+   * for adjusting the fields of a record. This action indicates that the writer's
+   * schema has a field that the reader's does <em>not</em> have, and thus the
+   * field should be skipped. Since there is no corresponding reader's schema for
+   * the writer's in this case, the {@link Action.reader} field is <tt>null</tt>
    * for this subclass.
    */
   public static class Skip extends Action {
-    public Skip(Schema w, GenericData d) { super(w, null, d, Action.Type.SKIP); }
+    public Skip(Schema w, GenericData d) {
+      super(w, null, d, Action.Type.SKIP);
+    }
   }
 
   /**
-   * Instructions for resolving two record schemas.  Includes
-   * instructions on how to recursively resolve each field, an
-   * indication of when to skip (writer fields), plus information
-   * about which reader fields should be populated by defaults
-   * (because the writer doesn't have corresponding fields).
+   * Instructions for resolving two record schemas. Includes instructions on how
+   * to recursively resolve each field, an indication of when to skip (writer
+   * fields), plus information about which reader fields should be populated by
+   * defaults (because the writer doesn't have corresponding fields).
    */
   public static class RecordAdjust extends Action {
     /**
-     * An action for each field of the writer.  If the corresponding
-     * field is to be skipped during reading, then this will contain a
-     * {@link Skip}.  For fields to be read into the reading
-     * datum, will contain a regular action for resolving the
-     * writer/reader schemas of the matching fields.
+     * An action for each field of the writer. If the corresponding field is to be
+     * skipped during reading, then this will contain a {@link Skip}. For fields to
+     * be read into the reading datum, will contain a regular action for resolving
+     * the writer/reader schemas of the matching fields.
      */
     public final Action[] fieldActions;
 
     /**
-     * Contains (all of) the reader's fields.  The first <i>n</i> of
-     * these are the fields that will be read from the writer: these
-     * <i>n</i> are in the order dictated by writer's schema.  The
-     * remaining <i>m</i> fields will be read from default values
-     * (actions for these default values are found in {@link
-     * defaults}.
+     * Contains (all of) the reader's fields. The first <i>n</i> of these are the
+     * fields that will be read from the writer: these <i>n</i> are in the order
+     * dictated by writer's schema. The remaining <i>m</i> fields will be read from
+     * default values (actions for these default values are found in
+     * {@link defaults}.
      */
     public final Field[] readerOrder;
 
     /**
-     * Pointer into {@link readerOrder} of the first reader field
-     * whose value comes from a default value.  Set to length of
-     * {@link readerOrder} if there are none.
+     * Pointer into {@link readerOrder} of the first reader field whose value comes
+     * from a default value. Set to length of {@link readerOrder} if there are none.
      */
     public final int firstDefault;
 
     /**
      * Contains the default values to be used for the last
-     * <tt>readerOrder.length-firstDefault</tt> fields in
-     * rearderOrder.  The <tt>i</tt>th element of <tt>defaults</tt> is
-     * the default value for the <tt>i+firstDefault</tt> member of
-     * <tt>readerOrder</tt>.
+     * <tt>readerOrder.length-firstDefault</tt> fields in rearderOrder. The
+     * <tt>i</tt>th element of <tt>defaults</tt> is the default value for the
+     * <tt>i+firstDefault</tt> member of <tt>readerOrder</tt>.
      */
     public final Object[] defaults;
 
     /**
-     * Returns true iff
-     * <code>i&nbsp;==&nbsp;readerOrder[i].pos()</code> for all
-     * indices <code>i</code>.  Which is to say: the order of the
-     * reader's fields is the same in both the reader's and writer's
-     * schema.
+     * Returns true iff <code>i&nbsp;==&nbsp;readerOrder[i].pos()</code> for all
+     * indices <code>i</code>. Which is to say: the order of the reader's fields is
+     * the same in both the reader's and writer's schema.
      */
     public boolean noReorder() {
       boolean result = true;
@@ -436,9 +459,7 @@ public class Resolver {
       return result;
     }
 
-    private RecordAdjust(Schema w, Schema r, GenericData d,
-                         Action[] fa, Field[] ro, int firstD, Object[] defaults)
-    {
+    private RecordAdjust(Schema w, Schema r, GenericData d, Action[] fa, Field[] ro, int firstD, Object[] defaults) {
       super(w, r, d, Action.Type.RECORD);
       this.fieldActions = fa;
       this.readerOrder = ro;
@@ -447,44 +468,47 @@ public class Resolver {
     }
 
     /**
-     * Returns a {@link RecordAdjust} for the two schemas, or an
-     * {@link ErrorAction} if there was a problem resolving.  An
-     * {@link ErrorAction} is returned when either the two
-     * record-schemas don't have the same name, or if the writer is
-     * missing a field for which the reader does not have a default
-     * value.
+     * Returns a {@link RecordAdjust} for the two schemas, or an {@link ErrorAction}
+     * if there was a problem resolving. An {@link ErrorAction} is returned when
+     * either the two record-schemas don't have the same name, or if the writer is
+     * missing a field for which the reader does not have a default value.
+     * 
      * @throws RuntimeException if writer and reader schemas are not both records
      */
     static Action resolve(Schema w, Schema r, GenericData d, Map<SeenPair, Action> seen) {
       SeenPair wr = new SeenPair(w, r);
       Action result = seen.get(wr);
-      if (result != null) return result;
-
-/* Current implementation doesn't do this check.  To pass regressions tests, we can't either.
-      if (w.getFullName() != null && ! w.getFullName().equals(r.getFullName())) {
-        result = new ErrorAction(w, r, d, ErrorType.NAMES_DONT_MATCH);
-        seen.put(wr, result);
+      if (result != null)
         return result;
-      }
-*/
+
+      /*
+       * Current implementation doesn't do this check. To pass regressions tests, we
+       * can't either. if (w.getFullName() != null && !
+       * w.getFullName().equals(r.getFullName())) { result = new ErrorAction(w, r, d,
+       * ErrorType.NAMES_DONT_MATCH); seen.put(wr, result); return result; }
+       */
       List<Field> wfields = w.getFields();
       List<Field> rfields = r.getFields();
 
       int firstDefault = 0;
       for (Schema.Field wf : wfields)
-        if (r.getField(wf.name()) != null) firstDefault++;
+        if (r.getField(wf.name()) != null)
+          firstDefault++;
       Action[] actions = new Action[wfields.size()];
       Field[] reordered = new Field[rfields.size()];
       Object[] defaults = new Object[reordered.length - firstDefault];
       result = new RecordAdjust(w, r, d, actions, reordered, firstDefault, defaults);
       seen.put(wr, result); // Insert early to handle recursion
 
-      int i = 0; int ridx = 0; for (Field wField : wfields) {
+      int i = 0;
+      int ridx = 0;
+      for (Field wField : wfields) {
         Field rField = r.getField(wField.name());
         if (rField != null) {
           reordered[ridx++] = rField;
           actions[i++] = Resolver.resolve(wField.schema(), rField.schema(), d, seen);
-        } else actions[i++] = new Skip(wField.schema(), d);
+        } else
+          actions[i++] = new Skip(wField.schema(), d);
       }
       for (Field rf : rfields)
         if (w.getField(rf.name()) == null)
@@ -493,7 +517,7 @@ public class Resolver {
             seen.put(wr, result);
             return result;
           } else {
-            defaults[ridx-firstDefault] = d.getDefaultValue(rf);
+            defaults[ridx - firstDefault] = d.getDefaultValue(rf);
             reordered[ridx++] = rf;
           }
       return result;
@@ -501,31 +525,28 @@ public class Resolver {
   }
 
   /**
-   * In this case, the writer was a union.  There are two subcases
-   * here:
+   * In this case, the writer was a union. There are two subcases here:
    *
-   * If the reader and writer are the same union, then the
-   * <tt>unionEquiv</tt> variable is set to true and the
-   * <tt>actions</tt> list holds the resolutions of each branch of the
-   * writer against the corresponding branch of the reader (which will
-   * result in no material resolution work, because the branches will
-   * be equivalent).  If they reader is not a union or is a different
-   * union, then <tt>unionEquiv</tt> is false and the <tt>actions</tt>
-   * list holds the resolution of each of the writer's branches
-   * against the entire schema of the reader (if the reader is a
-   * union, that will result in ReaderUnion actions). */
+   * If the reader and writer are the same union, then the <tt>unionEquiv</tt>
+   * variable is set to true and the <tt>actions</tt> list holds the resolutions
+   * of each branch of the writer against the corresponding branch of the reader
+   * (which will result in no material resolution work, because the branches will
+   * be equivalent). If they reader is not a union or is a different union, then
+   * <tt>unionEquiv</tt> is false and the <tt>actions</tt> list holds the
+   * resolution of each of the writer's branches against the entire schema of the
+   * reader (if the reader is a union, that will result in ReaderUnion actions).
+   */
   public static class WriterUnion extends Action {
     public final Action[] actions;
     public final boolean unionEquiv;
+
     private WriterUnion(Schema w, Schema r, GenericData d, boolean ue, Action[] a) {
       super(w, r, d, Action.Type.WRITER_UNION);
       unionEquiv = ue;
       actions = a;
     }
 
-    public static Action resolve(Schema w, Schema r, GenericData d,
-                                 Map<SeenPair,Action> seen)
-    {
+    public static Action resolve(Schema w, Schema r, GenericData d, Map<SeenPair, Action> seen) {
       boolean ueqv = unionEquiv(w, r, new HashMap<>());
       List<Schema> wb = w.getTypes();
       List<Schema> rb = (ueqv ? r.getTypes() : null);
@@ -538,16 +559,15 @@ public class Resolver {
   }
 
   /**
-   * In this case, the reader is a union and the writer is not.  For
-   * this case, we need to pick the first branch of the reader that
-   * matches the writer and pretend to the reader that the index of
-   * this branch was found in the writer's data stream.
+   * In this case, the reader is a union and the writer is not. For this case, we
+   * need to pick the first branch of the reader that matches the writer and
+   * pretend to the reader that the index of this branch was found in the writer's
+   * data stream.
    *
-   * To support this case, the {@link ReaderUnion} object has two
-   * (public) fields: <tt>firstMatch</tt> gives the index of the first
-   * matching branch in the reader's schema, and
-   * <tt>actualResolution</tt> is the {@link Action} that resolves the
-   * writer's schema with the schema found in the <tt>firstMatch</tt>
+   * To support this case, the {@link ReaderUnion} object has two (public) fields:
+   * <tt>firstMatch</tt> gives the index of the first matching branch in the
+   * reader's schema, and <tt>actualResolution</tt> is the {@link Action} that
+   * resolves the writer's schema with the schema found in the <tt>firstMatch</tt>
    * branch of the reader's schema.
    */
   public static class ReaderUnion extends Action {
@@ -561,15 +581,14 @@ public class Resolver {
     }
 
     /**
-     * Returns a {@link ReaderUnion} action for resolving <tt>w</tt>
-     * and <tt>r</tt>, or an {@link ErrorAction} if there is no branch
-     * in the reader that matches the writer.
-     * @throws RuntimeException if <tt>r</tt> is not a union schema or
-     * <tt>w</tt> <em>is</em> a union schema
+     * Returns a {@link ReaderUnion} action for resolving <tt>w</tt> and <tt>r</tt>,
+     * or an {@link ErrorAction} if there is no branch in the reader that matches
+     * the writer.
+     * 
+     * @throws RuntimeException if <tt>r</tt> is not a union schema or <tt>w</tt>
+     *                          <em>is</em> a union schema
      */
-    public static Action resolve(Schema w, Schema r, GenericData d,
-                                 Map<SeenPair,Action> seen)
-    {
+    public static Action resolve(Schema w, Schema r, GenericData d, Map<SeenPair, Action> seen) {
       if (w.getType() == Schema.Type.UNION)
         throw new IllegalArgumentException("Writer schema is union.");
       int i = firstMatchingBranch(w, r, d, seen);
@@ -578,33 +597,30 @@ public class Resolver {
       return new ErrorAction(w, r, d, ErrorType.NO_MATCHING_BRANCH);
     }
 
-    // Note: This code was taken verbatim from the 1.8.x branch of Avro.  It implements
-    // a "soft match" algorithm that seems to disagree with the spec.  However, in the
+    // Note: This code was taken verbatim from the 1.8.x branch of Avro. It
+    // implements
+    // a "soft match" algorithm that seems to disagree with the spec. However, in
+    // the
     // interest of "bug-for-bug" compatibility, we imported the old algorithm.
-    private static int firstMatchingBranch(Schema w, Schema r, GenericData d,
-                                           Map<SeenPair, Action> seen)
-    {
+    private static int firstMatchingBranch(Schema w, Schema r, GenericData d, Map<SeenPair, Action> seen) {
       Schema.Type vt = w.getType();
       // first scan for exact match
       int j = 0;
       int structureMatch = -1;
       for (Schema b : r.getTypes()) {
         if (vt == b.getType())
-          if (vt == Schema.Type.RECORD || vt == Schema.Type.ENUM ||
-              vt == Schema.Type.FIXED) {
+          if (vt == Schema.Type.RECORD || vt == Schema.Type.ENUM || vt == Schema.Type.FIXED) {
             String vname = w.getFullName();
             String bname = b.getFullName();
             // return immediately if the name matches exactly according to spec
             if (vname != null && vname.equals(bname))
               return j;
 
-            if (vt == Schema.Type.RECORD &&
-                !hasMatchError(RecordAdjust.resolve(w, b, d, seen))) {
+            if (vt == Schema.Type.RECORD && !hasMatchError(RecordAdjust.resolve(w, b, d, seen))) {
               String vShortName = w.getName();
               String bShortName = b.getName();
               // use the first structure match or one where the name matches
-              if ((structureMatch < 0) ||
-                  (vShortName != null && vShortName.equals(bShortName))) {
+              if ((structureMatch < 0) || (vShortName != null && vShortName.equals(bShortName))) {
                 structureMatch = j;
               }
             }
@@ -639,9 +655,9 @@ public class Resolver {
         case FLOAT:
           switch (b.getType()) {
           case DOUBLE:
-              return j;
+            return j;
           }
-        break;
+          break;
         case STRING:
           switch (b.getType()) {
           case BYTES:
@@ -664,60 +680,77 @@ public class Resolver {
       if (action instanceof ErrorAction)
         return true;
       else
-        for (Action a : ((RecordAdjust)action).fieldActions)
-          if (a instanceof ErrorAction) return true;
+        for (Action a : ((RecordAdjust) action).fieldActions)
+          if (a instanceof ErrorAction)
+            return true;
       return false;
     }
   }
 
   private static boolean unionEquiv(Schema w, Schema r, Map<SeenPair, Boolean> seen) {
     Schema.Type wt = w.getType();
-    if (wt != r.getType()) return false;
+    if (wt != r.getType())
+      return false;
     if ((wt == Schema.Type.RECORD || wt == Schema.Type.FIXED || wt == Schema.Type.ENUM)
-        && ! (w.getFullName() == null || w.getFullName().equals(r.getFullName())))
+        && !(w.getFullName() == null || w.getFullName().equals(r.getFullName())))
       return false;
 
     switch (w.getType()) {
-    case NULL: case BOOLEAN: case INT: case LONG: case FLOAT: case DOUBLE:
-    case STRING: case BYTES:
+    case NULL:
+    case BOOLEAN:
+    case INT:
+    case LONG:
+    case FLOAT:
+    case DOUBLE:
+    case STRING:
+    case BYTES:
       return true;
 
-    case ARRAY: return unionEquiv(w.getElementType(), r.getElementType(), seen);
-    case MAP: return unionEquiv(w.getValueType(), r.getValueType(), seen);
+    case ARRAY:
+      return unionEquiv(w.getElementType(), r.getElementType(), seen);
+    case MAP:
+      return unionEquiv(w.getValueType(), r.getValueType(), seen);
 
-    case FIXED: return w.getFixedSize() == r.getFixedSize();
+    case FIXED:
+      return w.getFixedSize() == r.getFixedSize();
 
     case ENUM: {
       List<String> ws = w.getEnumSymbols();
       List<String> rs = r.getEnumSymbols();
-      if (ws.size() != rs.size()) return false;
+      if (ws.size() != rs.size())
+        return false;
       int i = 0;
       for (i = 0; i < ws.size(); i++)
-        if (! ws.get(i).equals(rs.get(i))) break;
+        if (!ws.get(i).equals(rs.get(i)))
+          break;
       return i == ws.size();
     }
 
     case UNION: {
       List<Schema> wb = w.getTypes();
       List<Schema> rb = r.getTypes();
-      if (wb.size() != rb.size()) return false;
+      if (wb.size() != rb.size())
+        return false;
       int i = 0;
       for (i = 0; i < wb.size(); i++)
-        if (! unionEquiv(wb.get(i), rb.get(i), seen)) break;
+        if (!unionEquiv(wb.get(i), rb.get(i), seen))
+          break;
       return i == wb.size();
     }
 
     case RECORD: {
       SeenPair wsc = new SeenPair(w, r);
-      if (! seen.containsKey(wsc)) {
+      if (!seen.containsKey(wsc)) {
         seen.put(wsc, true); // Be optimistic, but we may change our minds
         List<Field> wb = w.getFields();
         List<Field> rb = r.getFields();
-        if (wb.size() != rb.size()) seen.put(wsc, false);
+        if (wb.size() != rb.size())
+          seen.put(wsc, false);
         else {
           int i = 0;
           for (i = 0; i < wb.size(); i++)
-            if (! unionEquiv(wb.get(i).schema(), rb.get(i).schema(), seen)) break;
+            if (!unionEquiv(wb.get(i).schema(), rb.get(i).schema(), seen))
+              break;
           seen.put(wsc, (i == wb.size()));
         }
       }

--- a/lang/java/avro/src/main/java/org/apache/avro/Resolver.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Resolver.java
@@ -51,20 +51,27 @@ public class Resolver {
    * symbols, while {@link RecordAdjust} has information about
    * re-ordering and deletion of record fields.
    *
+   * Note that aliases are applied to the writer's schema before
+   * resolution actually takes place.  This means that the
+   * <tt>writer</tt> field of the resulting {@link Action} objects
+   * will not be the same schema as provided to this method.  However,
+   * the <tt>reader</tt> field will be.
+   *
    * @param writer    The schema used by the writer
    * @param reader    The schema used by the reader
    * @param data      Used for <tt>getDefaultValue</tt> and getting conversions
    * @return          Nested actions for resolving the two
    */
   public static Action resolve(Schema writer, Schema reader, GenericData data) {
-      return resolve(writer, reader, data, new HashMap<>());
+    return resolve(Schema.applyAliases(writer, reader),
+                   reader, data, new HashMap<>());
   }
 
   /**
    * Uses <tt>GenericData.get()</tt> for the <tt>data</tt> param.
    */
   public static Action resolve(Schema writer, Schema reader) {
-    return resolve(writer, reader, GenericData.get(), new HashMap<>());
+    return resolve(writer, reader, GenericData.get());
   }
 
   private static Action resolve(Schema w, Schema r, GenericData d,

--- a/lang/java/avro/src/main/java/org/apache/avro/Resolver.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Resolver.java
@@ -1,0 +1,673 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.avro;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.avro.Schema.Field;
+import org.apache.avro.Resolver.ErrorAction.ErrorType;
+
+/**
+ * Encapsulate schema-resolution logic in an easy-to-consume
+ * representation.  See {@link #resolve} and also the separate
+ * document entitled <tt>refactoring-resolution</tt> for more
+ * information.  It might also be helpful to study {@link
+ * org.apache.avro.io.parsing.ResolvingGrammarGenerator} as an example
+ * of how to use this class.
+ */
+public class Resolver {
+  /**
+   * Returns a {@link Resolver.Action} tree for resolving the writer
+   * schema <tt>writer</tt> and the reader schema <tt>reader</tt>.
+   *
+   * This method walks the reader's and writer's schemas together,
+   * generating an appropriate subclass of {@link Action} to
+   * encapsulate the information needed to resolve the corresponding
+   * parts of each schema tree.  For convience, every {@link Action}
+   * object has a pointer to the corresponding parts of the reader's
+   * and writer's trees being resolved by the action.  Each subclass
+   * of {@link Action} has additional information needed for different
+   * types of schema, e.g., the {@link EnumAdjust} subclass has
+   * information about re-ordering and deletion of enumeration
+   * symbols, while {@link RecordAdjust} has information about
+   * re-ordering and deletion of record fields.
+   *
+   * @param writer    The schema used by the writer
+   * @param reader    The schema used by the reader
+   * @return          Nested actions for resolving the two
+   */
+  public static Action resolve(Schema writer, Schema reader) {
+    return resolve(writer, reader, new HashMap<>());
+  }
+
+  private static Action resolve(Schema w, Schema r, Map<Pair, Action> seen) {
+    final Schema.Type wType = w.getType();
+    final Schema.Type rType = r.getType();
+
+    if (wType == Schema.Type.UNION) {
+      if (unionEquiv(w, r, new HashMap<>())) {
+        return new DoNothing(w, r);
+      } else {
+        List<Schema> branches = w.getTypes();
+        int sz = branches.size();
+        Action[] actions = new Action[sz];
+        for (int i = 0; i < sz; i++) actions[i] = resolve(branches.get(i), r, seen);
+        return new WriterUnion(w, r, actions);
+      }
+    }
+
+    if (wType == rType) {
+      switch (wType) {
+      case NULL: case BOOLEAN:
+      case INT: case LONG: case FLOAT: case DOUBLE:
+      case STRING: case BYTES:
+        return new DoNothing(w, r);
+
+      case FIXED:
+        if (w.getFullName() != null && ! w.getFullName().equals(r.getFullName()))
+          return new ErrorAction(w, r, ErrorType.NAMES_DONT_MATCH);
+        else if (w.getFixedSize() != r.getFixedSize())
+          return new ErrorAction(w, r, ErrorType.SIZES_DONT_MATCH);
+        else return new DoNothing(w, r);
+
+      case ARRAY:
+        Action et = resolve(w.getElementType(), r.getElementType(), seen);
+        return new ContainerAction(w, r, et);
+
+      case MAP:
+        Action vt = resolve(w.getValueType(), r.getValueType(), seen);
+        return new ContainerAction(w, r, vt);
+
+      case ENUM:
+        return EnumAdjust.resolve(w, r);
+
+      case RECORD:
+        return RecordAdjust.resolve(w, r, seen);
+
+      default:
+        throw new IllegalArgumentException("Unknown type for schema: " + wType);
+      }
+    } else if (rType == Schema.Type.UNION) return ReaderUnion.resolve(w, r, seen);
+    else return Promote.resolve(w, r);
+  }
+
+  /**
+   * An abstract class for an action to be taken to resolve a writer's
+   * schema (found in public instance variable <tt>writer</tt>)
+   * against a reader's schema (in <tt>reader</tt>).  Ordinarily,
+   * neither field can be <tt>null</tt>, except that the
+   * <tt>reader</tt> field can be <tt>null</tt> in a {@link
+   * SkipAction}, which is used to skip a field in a writer's record
+   * that doesn't exist in the reader's (and thus there is no reader
+   * schema to resolve to).
+   */
+  public static abstract class Action {
+    public final Schema writer, reader;
+    protected Action(Schema w, Schema r) { writer = w; reader = r; }
+  }
+
+  /**
+   * In this case, there's nothing to be done for resolution: the two
+   * schemas are effectively the same.  This action may be generated
+   * for any type of schema (including union schemas, for example):
+   * resolvers must be able to handle all these cases.
+   */
+  public static class DoNothing extends Action {
+    public DoNothing(Schema w, Schema r) { super(w, r); }
+  }
+
+  /**
+   * In this case there is an error.  We put error Actions into trees
+   * because Avro reports these errors in a lazy fashion: if a
+   * particular input doesn't "tickle" the error (typically because
+   * it's in a branch of a union that isn't found in the data being
+   * read), then it's safe to ignore it.
+   */
+  public static class ErrorAction extends Action {
+    public static enum ErrorType {
+        /** Use when Schema types don't match and can't be converted.  For
+         * example, resolving "int" and "enum". */
+        INCOMPATIBLE_SCHEMA_TYPES,
+
+        /** Use when Schema types match but, in the case of record, enum,
+         * or fixed, the names don't match. */
+        NAMES_DONT_MATCH,
+
+        /** Use when two fixed types match and their names match by their
+         * sizes don't. */
+        SIZES_DONT_MATCH,
+
+        /** Use when matching two records and the reader has a field
+         * with no default value and that field is missing in the
+         * writer.. */
+        MISSING_REQUIRED_FIELD,
+
+        /** Use when matching a reader's union against a non-union and
+         * can't find a branch that matches. */
+        NO_MATCHING_BRANCH
+    }
+
+    public final ErrorType error;
+
+    public ErrorAction(Schema w, Schema r, ErrorType e) {
+      super(w,r);
+      this.error = e;
+    }
+
+    public String toString() {
+      String result;
+      switch (this.error) {
+      case INCOMPATIBLE_SCHEMA_TYPES:
+      case NAMES_DONT_MATCH:
+      case SIZES_DONT_MATCH:
+      case NO_MATCHING_BRANCH:
+        return "Found " + writer.getFullName() + ", expecting " + reader.getFullName();
+
+      case MISSING_REQUIRED_FIELD: {
+        List<Field> wfields = writer.getFields();
+        List<Field> rfields = reader.getFields();
+        String fname = "<oops>";
+        for (Field rf : rfields)
+          if (writer.getField(rf.name()) == null && rf.defaultValue() == null)
+            fname = rf.name();
+        return ("Found " + writer.getFullName()
+                + ", expecting " + reader.getFullName()
+                + ", missing required field " + fname);
+      }
+      default:
+        throw new IllegalArgumentException("Unknown error.");
+      }
+    }
+  }
+
+  /**
+   * In this case, the writer's type needs to be promoted to the
+   * reader's.  These are constructed by {@link Promote.resolve},
+   * which will only construct one when the writer's and reader's
+   * schemas are different (ie, no "self promotion"), and whent the
+   * promotion is one allowed by the Avro spec.
+   */
+  public static class Promote extends Action {
+    private Promote(Schema w, Schema r) { super(w, r); }
+
+    /**
+     * Return a promotion.
+     * @param w Writer's schema
+     * @param r Rearder's schema
+     * @result a {@link Promote} schema if the two schemas are compatible,
+     * or {@link ErrorType.INCOMPATIBLE_SCHEMA_TYPE} if they are not.
+     * @throws IllegalArgumentException if <em>getType()</em> of the two schemas
+     * are not different.
+     */
+    public static Action resolve(Schema w, Schema r) {
+      if (isValid(w, r)) return new Promote(w,r);
+      else return new ErrorAction(w, r, ErrorType.INCOMPATIBLE_SCHEMA_TYPES);
+    }
+
+    /**
+     * Returns true iff <tt>w</tt> and <tt>r</tt> are both primitive
+     * types and either they are the same type or <tt>w</tt> is
+     * promotable to <tt>r</tt>.  Should
+     */
+    public static boolean isValid(Schema w, Schema r) {
+      if (w.getType() == r.getType())
+        throw new IllegalArgumentException("Only use when reader and writer are different.");
+      Schema.Type wt = w.getType();
+      switch (r.getType()) {
+      case INT:
+        switch (wt) { case INT: return true; }
+        break;
+      case LONG:
+        switch (wt) { case INT: case LONG: return true; }
+        break;
+      case FLOAT:
+        switch (wt) { case INT: case LONG: case FLOAT: return true; }
+        break;
+      case DOUBLE:
+        switch (wt) { case INT: case LONG: case FLOAT: case DOUBLE: return true; }
+        break;
+      case BYTES:
+      case STRING:
+        switch (wt) { case STRING: case BYTES: return true; }
+        break;
+      }
+      return false;
+    }
+  }
+
+  /**
+   * Used for array and map schemas: the public instance variable
+   * <tt>elementAction</tt> contains the resolving action needed for
+   * the element type of an array or value top of a map.
+   */
+  public static class ContainerAction extends Action {
+    public final Action elementAction;
+    public ContainerAction(Schema w, Schema r, Action e) {
+      super(w, r);
+      this.elementAction = e;
+    }
+  }
+
+  /**
+   * Contains information needed to resolve enumerations.  When
+   * resolving enums, adjustments need to be made in two scenarios:
+   * the index for an enum symbol might be different in the reader or
+   * writer, or the reader might not have a symbol that was written
+   * out for the writer (which is an error, but one we can only detect
+   * when decoding data).
+   *
+   * These adjustments are reflected in the instance variable
+   * <tt>adjustments</tt>.  For the symbol with index <tt>i</tt> in
+   * the writer's enum definition, <tt>adjustments[i]</tt> -- and
+   * integer -- contains the adjustment for that symbol.  If the
+   * integer is positive, then reader also has the symbol and the
+   * integer is its index in the reader's schema.  If
+   * <tt>adjustment[i]</tt> is negative, then the reader does
+   * <em>not</em> have the corresponding symbol (which is the error case).
+   *
+   * Sometimes there's no adjustments needed: all symbols in the
+   * reader have the same index in the reader's and writer's schema.
+   * This is a common case, and it allows for some optimization.  To
+   * signal that this is the case, <tt>noAdjustmentsNeeded</tt> is set
+   * to true.
+   */
+  public static class EnumAdjust extends Action {
+    public final int[] adjustments;
+    public final boolean noAdjustmentsNeeded;
+
+    private EnumAdjust(Schema w, Schema r, int[] adj) {
+      super(w, r);
+      this.adjustments = adj;
+      boolean noAdj = true;
+      int rsymCount = r.getEnumSymbols().size();
+      int count = Math.min(rsymCount, adj.length);
+      noAdj = (adj.length <= rsymCount);
+      for (int i = 0; noAdj && i < count; i++)
+        noAdj &= (i == adj[i]);
+      this.noAdjustmentsNeeded = noAdj;
+    }
+
+    /**
+     * If writer and reader don't have same name, a {@link
+     * ErrorAction.Type.NAMES_DONT_MATCH} is returned, otherwise an
+     * appropriate {@link EnumAdjust} is.
+     */
+    public static Action resolve(Schema w, Schema r) {
+      if (w.getFullName() != null && ! w.getFullName().equals(r.getFullName()))
+        return new ErrorAction(w, r, ErrorType.NAMES_DONT_MATCH);
+
+      final List<String> wsymbols = w.getEnumSymbols();
+      final List<String> rsymbols = r.getEnumSymbols();
+      final int defaultIndex
+        = (r.getEnumDefault() == null ? -1 : rsymbols.indexOf(r.getEnumDefault()));
+      int[] adjustments = new int[wsymbols.size()];
+      for (int i = 0; i < adjustments.length; i++) {
+        int j = rsymbols.indexOf(wsymbols.get(i));
+        adjustments[i] = (0 <= j ? j : defaultIndex);
+      }
+      return new EnumAdjust(w, r, adjustments);
+    }
+  }
+
+  /**
+   * This only appears inside {@link RecordAdjust.fieldActions}, i.e.,
+   * the actions for adjusting the fields of a record.  This action
+   * indicates that the writer's schema has a field that the reader's
+   * does <em>not</em> have, and thus the field should be skipped.
+   * Since there is no corresponding reader's schema for the writer's
+   * in this case, the {@link Action.reader} field is <tt>null</tt>
+   * for this subclass.
+   */
+  public static class SkipAction extends Action {
+    public SkipAction(Schema w) { super(w, null); }
+  }
+
+  /**
+   * Instructions for resolving two record schemas.  Includes
+   * instructions on how to recursively resolve each field, an
+   * indication of when to skip (writer fields), plus information
+   * about which reader fields should be populated by defaults
+   * (because the writer doesn't have corresponding fields).
+   */
+  public static class RecordAdjust extends Action {
+    /**
+     * An action for each field of the writer.  If the corresponding
+     * field is to be skipped during reading, then this will contain a
+     * {@link SkipAction}.  For fields to be read into the reading
+     * datum, will contain a regular action for resolving the
+     * writer/reader schemas of the matching fields.
+     */
+    public final Action[] fieldActions;
+
+    /**
+     * Contains (all of) the reader's fields.  The first <i>n</i> of
+     * these are the fields that will be read from the writer: these
+     * <i>n</i> are in the order dictated by writer's schema.  The
+     * remaining <i>m</i> fields will be read from default values
+     * (actions for these default values are found in {@link
+     * defaults}.
+     */
+    public final Field[] readerOrder;
+
+    /**
+     * Pointer into {@link readerOrder} of the first reader field
+     * whose value comes from a default value.
+     */
+    public final int firstDefault;
+
+    /**
+     * Returns true iff
+     * <code>i&nbsp;==&nbsp;readerOrder[i].pos()</code> for all
+     * indices <code>i</code>.  Which is to say: the order of the
+     * reader's fields is the same in both the reader's and writer's
+     * schema.
+     */
+    public boolean noReorder() {
+      boolean result = true;
+      for (int i = 0; result && i < readerOrder.length; i++)
+        result &= (i == readerOrder[i].pos());
+      return result;
+    }
+
+    private RecordAdjust(Schema w, Schema r, Action[] fa, Field[] ro, int firstD) {
+      super(w, r);
+      this.fieldActions = fa;
+      this.readerOrder = ro;
+      this.firstDefault = firstD;
+    }
+
+    /**
+     * Returns a {@link RecordAdjust} for the two schemas, or an
+     * {@link ErrorAction} if there was a problem resolving.  An
+     * {@link ErrorAction} is returned when either the two
+     * record-schemas don't have the same name, or if the writer is
+     * missing a field for which the reader does not have a default
+     * value.
+     * @throws RuntimeException if writer and reader schemas are not both records
+     */
+    static Action resolve(Schema w, Schema r, Map<Pair, Action> seen) {
+      Pair wr = new Pair(w, r);
+      Action result = seen.get(wr);
+      if (result != null) return result;
+
+/* Current implementation doesn't do this check.  To pass regressions tests, we can't either.
+      if (w.getFullName() != null && ! w.getFullName().equals(r.getFullName())) {
+        result = new ErrorAction(w, r, ErrorType.NAMES_DONT_MATCH);
+        seen.put(wr, result);
+        return result;
+      }
+*/
+      List<Field> wfields = w.getFields();
+      List<Field> rfields = r.getFields();
+
+      Action[] actions = new Action[wfields.size()];
+      Field[] reordered = new Field[rfields.size()];
+      int firstDefault = 0;
+      for (Schema.Field wf : wfields)
+        if (r.getField(wf.name()) != null) firstDefault++;
+      result = new RecordAdjust(w, r, actions, reordered, firstDefault);
+      seen.put(wr, result); // Insert early to handle recursion
+
+      int i = 0; int ridx = 0; for (Field wField : wfields) {
+        Field rField = r.getField(wField.name());
+        if (rField != null) {
+          reordered[ridx++] = rField;
+          actions[i++] = Resolver.resolve(wField.schema(), rField.schema(), seen);
+        } else actions[i++] = new SkipAction(wField.schema());
+      }
+      for (Field rf : rfields)
+        if (w.getField(rf.name()) == null)
+          if (rf.defaultValue() == null) {
+            result = new ErrorAction(w, r, ErrorType.MISSING_REQUIRED_FIELD);
+            seen.put(wr, result);
+            return result;
+          } else reordered[ridx++] = rf;
+      return result;
+    }
+  }
+
+  /**
+   * In this case, the writer was a union and the reader was either
+   * not a union, or was a union that was different from the writer.
+   * In this case, we resolve the entire reader schema with _each_
+   * branch of the writer schema (stored in <tt>actions</tt>).  Based
+   * on the tag we see in the data stream, we pick the resolution
+   * branch selected by that tag.
+   *
+   * (Note, if both the reader and writer are the same union, the
+   * reading process can read the input according to its own schema
+   * with no need for further resolution.  In this case, a {@link
+   * DoNothing} action is generated instead of a {@link WriterUnion}.
+   * This is an optimization for the common-case where an evolved
+   * schema containing a union does not actually change the schema of
+   * the contained union, e.g., nullable fields in a record).
+   */
+  public static class WriterUnion extends Action {
+    public final Action[] actions;
+    public WriterUnion(Schema w, Schema r, Action[] a) { super(w,r); actions = a; }
+  }
+
+  /**
+   * In this case, the reader is a union and the writer is not.  For
+   * this case, we need to pick the first branch of the reader that
+   * matches the writer and pretend to the reader that the index of
+   * this branch was found in the writer's data stream.
+   *
+   * To support this case, the {@link ReaderUnion} object has two
+   * (public) fields: <tt>firstMatch</tt> gives the index of the first
+   * matching branch in the reader's schema, and
+   * <tt>actualResolution</tt> is the {@link Action} that resolves the
+   * writer's schema with the schema found in the <tt>firstMatch</tt>
+   * branch of the reader's schema.
+   */
+  public static class ReaderUnion extends Action {
+    public final int firstMatch;
+    public final Action actualAction;
+
+    public ReaderUnion(Schema w, Schema r, int firstMatch, Action actual) {
+      super(w, r);
+      this.firstMatch = firstMatch;
+      this.actualAction = actual;
+    }
+
+    /**
+     * Returns a {@link ReaderUnion} action for resolving <tt>w</tt>
+     * and <tt>r</tt>, or an {@link ErrorAction} if there is no branch
+     * in the reader that matches the writer.
+     * @throws RuntimeException if <tt>r</tt> is not a union schema or
+     * <tt>w</tt> <em>is</em> a union schema
+     */
+    public static Action resolve(Schema w, Schema r, Map<Pair,Action> seen) {
+      if (w.getType() == Schema.Type.UNION)
+        throw new IllegalArgumentException("Writer schema is union.");
+      int i = firstMatchingBranch(w, r, seen);
+      if (0 <= i)
+        return new ReaderUnion(w, r, i, Resolver.resolve(w, r.getTypes().get(i), seen));
+      return new ErrorAction(w, r, ErrorType.NO_MATCHING_BRANCH);
+    }
+
+    // Note: This code was taken verbatim from the 1.8.x branch of Avro.  It implements
+    // a "soft match" algorithm that seems to disagree with the spec.  However, in the
+    // interest of "bug-for-bug" compatibility, we imported the old algorithm.
+    private static int firstMatchingBranch(Schema w, Schema r, Map<Pair, Action> seen) {
+      Schema.Type vt = w.getType();
+      // first scan for exact match
+      int j = 0;
+      int structureMatch = -1;
+      for (Schema b : r.getTypes()) {
+        if (vt == b.getType())
+          if (vt == Schema.Type.RECORD || vt == Schema.Type.ENUM ||
+              vt == Schema.Type.FIXED) {
+            String vname = w.getFullName();
+            String bname = b.getFullName();
+            // return immediately if the name matches exactly according to spec
+            if (vname != null && vname.equals(bname))
+              return j;
+
+            if (vt == Schema.Type.RECORD &&
+                !hasMatchError(RecordAdjust.resolve(w, b, seen))) {
+              String vShortName = w.getName();
+              String bShortName = b.getName();
+              // use the first structure match or one where the name matches
+              if ((structureMatch < 0) ||
+                  (vShortName != null && vShortName.equals(bShortName))) {
+                structureMatch = j;
+              }
+            }
+          } else
+            return j;
+        j++;
+      }
+
+      // if there is a record structure match, return it
+      if (structureMatch >= 0)
+        return structureMatch;
+
+      // then scan match via numeric promotion
+      j = 0;
+      for (Schema b : r.getTypes()) {
+        switch (vt) {
+        case INT:
+          switch (b.getType()) {
+          case LONG:
+          case DOUBLE:
+          case FLOAT:
+            return j;
+          }
+          break;
+        case LONG:
+          switch (b.getType()) {
+          case DOUBLE:
+          case FLOAT:
+            return j;
+          }
+          break;
+        case FLOAT:
+          switch (b.getType()) {
+          case DOUBLE:
+              return j;
+          }
+        break;
+        case STRING:
+          switch (b.getType()) {
+          case BYTES:
+            return j;
+          }
+          break;
+        case BYTES:
+          switch (b.getType()) {
+          case STRING:
+            return j;
+          }
+          break;
+        }
+        j++;
+      }
+      return -1;
+    }
+
+    private static boolean hasMatchError(Action action) {
+      if (action instanceof ErrorAction)
+        return true;
+      else
+        for (Action a : ((RecordAdjust)action).fieldActions)
+          if (a instanceof ErrorAction) return true;
+      return false;
+    }
+  }
+
+  private static boolean unionEquiv(Schema w, Schema r, Map<Pair, Boolean> seen) {
+    Schema.Type wt = w.getType();
+    if (wt != r.getType()) return false;
+    if ((wt == Schema.Type.RECORD || wt == Schema.Type.FIXED || wt == Schema.Type.ENUM)
+        && ! (w.getFullName() == null || w.getFullName().equals(r.getFullName())))
+      return false;
+
+    switch (w.getType()) {
+    case NULL: case BOOLEAN: case INT: case LONG: case FLOAT: case DOUBLE:
+    case STRING: case BYTES:
+      return true;
+
+    case ARRAY: return unionEquiv(w.getElementType(), r.getElementType(), seen);
+    case MAP: return unionEquiv(w.getValueType(), r.getValueType(), seen);
+
+    case FIXED: return w.getFixedSize() == r.getFixedSize();
+
+    case ENUM: {
+      List<String> ws = w.getEnumSymbols();
+      List<String> rs = r.getEnumSymbols();
+      if (ws.size() != rs.size()) return false;
+      int i = 0;
+      for (i = 0; i < ws.size(); i++)
+        if (! ws.get(i).equals(rs.get(i))) break;
+      return i == ws.size();
+    }
+
+    case UNION: {
+      List<Schema> wb = w.getTypes();
+      List<Schema> rb = r.getTypes();
+      if (wb.size() != rb.size()) return false;
+      int i = 0;
+      for (i = 0; i < wb.size(); i++)
+        if (! unionEquiv(wb.get(i), rb.get(i), seen)) break;
+      return i == wb.size();
+    }
+
+    case RECORD: {
+      Pair wsc = new Pair(w, r);
+      if (! seen.containsKey(wsc)) {
+        seen.put(wsc, true); // Be optimistic, but we may change our minds
+        List<Field> wb = w.getFields();
+        List<Field> rb = r.getFields();
+        if (wb.size() != rb.size()) seen.put(wsc, false);
+        else {
+          int i = 0;
+          for (i = 0; i < wb.size(); i++)
+            if (! unionEquiv(wb.get(i).schema(), rb.get(i).schema(), seen)) break;
+          seen.put(wsc, (i == wb.size()));
+        }
+      }
+      return seen.get(wsc);
+    }
+    default:
+      throw new IllegalArgumentException("Unknown schema type: " + w.getType());
+    }
+  }
+
+  private static class Pair {
+    public Schema writer;
+    public Schema reader;
+    Pair(Schema w, Schema r) { writer = w; reader = r; }
+
+    /**
+     * Two Pairs are equal if and only if their underlying schema is
+     * the same (not merely equal).
+     */
+    public boolean equals(Object o) {
+      if (! (o instanceof Pair)) return false;
+      Pair p = (Pair)o;
+      return writer == p.writer && reader == p.reader;
+    }
+
+    public int hashCode() {
+      return writer.hashCode() + reader.hashCode();
+    }
+  }
+}

--- a/lang/java/avro/src/main/java/org/apache/avro/Schema.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Schema.java
@@ -781,16 +781,12 @@ public abstract class Schema extends JsonProperties {
 
   }
 
-  private static class SeenPair {
-    private Object s1;
-    private Object s2;
-
-    private SeenPair(Object s1, Object s2) {
-      this.s1 = s1;
-      this.s2 = s2;
-    }
-
-    @Override
+  /** Useful as key of {@link Map}s when traversing two schemas at the
+   * same time and need to watch for recursion.
+   */
+  public static class SeenPair {
+    private Object s1; private Object s2;
+    public SeenPair(Object s1, Object s2) { this.s1 = s1; this.s2 = s2; }
     public boolean equals(Object o) {
       if (!(o instanceof SeenPair))
         return false;

--- a/lang/java/avro/src/main/java/org/apache/avro/Schema.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Schema.java
@@ -781,12 +781,19 @@ public abstract class Schema extends JsonProperties {
 
   }
 
-  /** Useful as key of {@link Map}s when traversing two schemas at the
-   * same time and need to watch for recursion.
+  /**
+   * Useful as key of {@link Map}s when traversing two schemas at the same time
+   * and need to watch for recursion.
    */
   public static class SeenPair {
-    private Object s1; private Object s2;
-    public SeenPair(Object s1, Object s2) { this.s1 = s1; this.s2 = s2; }
+    private Object s1;
+    private Object s2;
+
+    public SeenPair(Object s1, Object s2) {
+      this.s1 = s1;
+      this.s2 = s2;
+    }
+
     public boolean equals(Object o) {
       if (!(o instanceof SeenPair))
         return false;

--- a/lang/java/avro/src/main/java/org/apache/avro/io/parsing/ResolvingGrammarGenerator.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/parsing/ResolvingGrammarGenerator.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.avro.AvroTypeException;
+import org.apache.avro.Resolver;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field;
 import org.apache.avro.io.Encoder;
@@ -60,314 +61,153 @@ public class ResolvingGrammarGenerator extends ValidatingGrammarGenerator {
    * @throws IOException
    */
   public final Symbol generate(Schema writer, Schema reader) throws IOException {
-    return Symbol.root(generate(writer, reader, new HashMap<>()));
+    Resolver.Action r = Resolver.resolve(writer, reader);
+    return Symbol.root(generate(r, new HashMap<>()));
   }
 
   /**
-   * Resolves the writer schema <tt>writer</tt> and the reader schema
-   * <tt>reader</tt> and returns the start symbol for the grammar generated. If
-   * there is already a symbol in the map <tt>seen</tt> for resolving the two
-   * schemas, then that symbol is returned. Otherwise a new symbol is generated
-   * and returned.
-   * 
-   * @param writer The schema used by the writer
-   * @param reader The schema used by the reader
-   * @param seen   The &lt;reader-schema, writer-schema&gt; to symbol map of start
-   *               symbols of resolving grammars so far.
-   * @return The start symbol for the resolving grammar
+   * Takes a {@link Resolver.Action} for resolving two schemas and
+   * returns the start symbol for a grammar that implements that
+   * resolution.  If the action is for a record and there's already a
+   * symbol for that record in <tt>seen</tt>, then that symbol is
+   * returned. Otherwise a new symbol is generated and returned.
+   *
+   * @param action    The resolver to be implemented
+   * @param seen      The &lt;Action&gt; to symbol
+   * map of start symbols of resolving grammars so far.
+   * @return          The start symbol for the resolving grammar
    * @throws IOException
    */
-  private Symbol generate(Schema writer, Schema reader, Map<LitS, Symbol> seen) throws IOException {
-    final Schema.Type writerType = writer.getType();
-    final Schema.Type readerType = reader.getType();
+  private Symbol generate(Resolver.Action action, Map<Object, Symbol> seen)
+      throws IOException
+  {
+    if (action instanceof Resolver.DoNothing) {
+      return simpleGen(action.writer, seen);
 
-    if (writerType == readerType) {
-      switch (writerType) {
-      case NULL:
-        return Symbol.NULL;
-      case BOOLEAN:
-        return Symbol.BOOLEAN;
-      case INT:
-        return Symbol.INT;
-      case LONG:
-        return Symbol.LONG;
-      case FLOAT:
-        return Symbol.FLOAT;
-      case DOUBLE:
-        return Symbol.DOUBLE;
-      case STRING:
-        return Symbol.STRING;
-      case BYTES:
-        return Symbol.BYTES;
-      case FIXED:
-        if (writer.getFullName().equals(reader.getFullName()) && writer.getFixedSize() == reader.getFixedSize()) {
-          return Symbol.seq(Symbol.intCheckAction(writer.getFixedSize()), Symbol.FIXED);
-        }
-        break;
+    } else if (action instanceof Resolver.ErrorAction) {
+      return Symbol.error(action.toString());
 
-      case ENUM:
-        if (writer.getFullName() == null || writer.getFullName().equals(reader.getFullName())) {
-          return Symbol.seq(mkEnumAdjust(writer.getEnumSymbols(), reader.getEnumSymbols(), reader.getEnumDefault()),
-              Symbol.ENUM);
-        }
-        break;
+    } else if (action instanceof Resolver.SkipAction) {
+      return Symbol.skipAction(simpleGen(action.writer, seen));
 
-      case ARRAY:
-        return Symbol.seq(
-            Symbol.repeat(Symbol.ARRAY_END, generate(writer.getElementType(), reader.getElementType(), seen)),
-            Symbol.ARRAY_START);
+    } else if (action instanceof Resolver.Promote) {
+      return Symbol.resolve(simpleGen(action.writer, seen), simpleGen(action.reader, seen));
 
-      case MAP:
-        return Symbol.seq(
-            Symbol.repeat(Symbol.MAP_END, generate(writer.getValueType(), reader.getValueType(), seen), Symbol.STRING),
-            Symbol.MAP_START);
-      case RECORD:
-        return resolveRecords(writer, reader, seen);
-      case UNION:
-        return resolveUnion(writer, reader, seen);
-      default:
-        throw new AvroTypeException("Unknown type for schema: " + writerType);
+    } else if (action.writer.getType() == Schema.Type.ARRAY) {
+      Symbol es = generate(((Resolver.ContainerAction)action).elementAction, seen);
+      return Symbol.seq(Symbol.repeat(Symbol.ARRAY_END, es), Symbol.ARRAY_START);
+
+    } else if (action.writer.getType() == Schema.Type.MAP) {
+      Symbol es = generate(((Resolver.ContainerAction)action).elementAction, seen);
+      return Symbol.seq(Symbol.repeat(Symbol.MAP_END, es, Symbol.STRING), Symbol.MAP_START);
+
+    } else if (action.writer.getType() == Schema.Type.UNION) {
+      Resolver.Action[] branches = ((Resolver.WriterUnion) action).actions;
+      Symbol[] symbols = new Symbol[branches.length];
+      String[] labels = new String[branches.length];
+      int i = 0; for (Resolver.Action branch : branches) {
+        symbols[i] = generate(branch, seen);
+        labels[i] = action.writer.getTypes().get(i).getFullName();
+        i++;
       }
-    } else { // writer and reader are of different types
-      if (writerType == Schema.Type.UNION) {
-        return resolveUnion(writer, reader, seen);
-      }
+      return Symbol.seq(Symbol.alt(symbols, labels), Symbol.WRITER_UNION_ACTION);
 
-      switch (readerType) {
-      case LONG:
-        switch (writerType) {
-        case INT:
-          return Symbol.resolve(super.generate(writer, seen), Symbol.LONG);
-        }
-        break;
+    } if (action instanceof Resolver.ReaderUnion) {
+      Resolver.ReaderUnion ru = (Resolver.ReaderUnion) action;
+      Symbol s = generate(ru.actualAction, seen);
+      return Symbol.seq(Symbol.unionAdjustAction(ru.firstMatch, s), Symbol.UNION);
 
-      case FLOAT:
-        switch (writerType) {
-        case INT:
-        case LONG:
-          return Symbol.resolve(super.generate(writer, seen), Symbol.FLOAT);
-        }
-        break;
+    } else if (action instanceof Resolver.EnumAdjust) {
+      Resolver.EnumAdjust e = (Resolver.EnumAdjust)action;
+      Object[] adjs = new Object[e.adjustments.length];
+      for (int i = 0; i < adjs.length; i++)
+        adjs[i] = (0 <= e.adjustments[i] ? new Integer(e.adjustments[i])
+                   : "No match for " + e.writer.getEnumSymbols().get(i));
+      return  Symbol.seq(Symbol.enumAdjustAction(e.reader.getEnumSymbols().size(),
+                                                 adjs), Symbol.ENUM);
 
-      case DOUBLE:
-        switch (writerType) {
-        case INT:
-        case LONG:
-        case FLOAT:
-          return Symbol.resolve(super.generate(writer, seen), Symbol.DOUBLE);
-        }
-        break;
-
-      case BYTES:
-        switch (writerType) {
-        case STRING:
-          return Symbol.resolve(super.generate(writer, seen), Symbol.BYTES);
-        }
-        break;
-
-      case STRING:
-        switch (writerType) {
-        case BYTES:
-          return Symbol.resolve(super.generate(writer, seen), Symbol.STRING);
-        }
-        break;
-
-      case UNION:
-        int j = firstMatchingBranch(reader, writer, seen);
-        if (j >= 0) {
-          Symbol s = generate(writer, reader.getTypes().get(j), seen);
-          return Symbol.seq(Symbol.unionAdjustAction(j, s), Symbol.UNION);
-        }
-        break;
-      case NULL:
-      case BOOLEAN:
-      case INT:
-      case ENUM:
-      case ARRAY:
-      case MAP:
-      case RECORD:
-      case FIXED:
-        break;
-      default:
-        throw new RuntimeException("Unexpected schema type: " + readerType);
-      }
-    }
-    return Symbol.error("Found " + writer.getFullName() + ", expecting " + reader.getFullName());
-  }
-
-  private Symbol resolveUnion(Schema writer, Schema reader, Map<LitS, Symbol> seen) throws IOException {
-    boolean needsAdj = !unionEquiv(writer, reader, new HashMap<>());
-    List<Schema> alts2 = (!needsAdj ? reader.getTypes() : null);
-
-    List<Schema> alts = writer.getTypes();
-    final int size = alts.size();
-    Symbol[] symbols = new Symbol[size];
-    String[] labels = new String[size];
-
-    /**
-     * We construct a symbol without filling the arrays. Please see
-     * {@link Symbol#production} for the reason.
-     */
-    int i = 0;
-    for (Schema w : alts) {
-      symbols[i] = generate(w, (needsAdj ? reader : alts2.get(i)), seen);
-      labels[i] = w.getFullName();
-      i++;
-    }
-    if (!needsAdj)
-      return Symbol.seq(Symbol.alt(symbols, labels), Symbol.UNION);
-    return Symbol.seq(Symbol.alt(symbols, labels), Symbol.WRITER_UNION_ACTION);
-  }
-
-  private static boolean unionEquiv(Schema w, Schema r, Map<LitS, Boolean> seen) {
-    Schema.Type wt = w.getType();
-    if (wt != r.getType())
-      return false;
-    if ((wt == Schema.Type.RECORD || wt == Schema.Type.FIXED || wt == Schema.Type.ENUM)
-        && !(w.getFullName() == null || w.getFullName().equals(r.getFullName())))
-      return false;
-
-    switch (w.getType()) {
-    case NULL:
-    case BOOLEAN:
-    case INT:
-    case LONG:
-    case FLOAT:
-    case DOUBLE:
-    case STRING:
-    case BYTES:
-      return true;
-
-    case ARRAY:
-      return unionEquiv(w.getElementType(), r.getElementType(), seen);
-    case MAP:
-      return unionEquiv(w.getValueType(), r.getValueType(), seen);
-
-    case FIXED:
-      return w.getFixedSize() == r.getFixedSize();
-
-    case ENUM: {
-      List<String> ws = w.getEnumSymbols();
-      List<String> rs = r.getEnumSymbols();
-      if (ws.size() != rs.size())
-        return false;
-      int i = 0;
-      for (i = 0; i < ws.size(); i++)
-        if (!ws.get(i).equals(rs.get(i)))
-          break;
-      return i == ws.size();
-    }
-
-    case UNION: {
-      List<Schema> wb = w.getTypes();
-      List<Schema> rb = r.getTypes();
-      if (wb.size() != rb.size())
-        return false;
-      int i = 0;
-      for (i = 0; i < wb.size(); i++)
-        if (!unionEquiv(wb.get(i), rb.get(i), seen))
-          break;
-      return i == wb.size();
-    }
-
-    case RECORD: {
-      LitS wsc = new LitS2(w, r);
-      if (!seen.containsKey(wsc)) {
-        seen.put(wsc, true); // Be optimistic, but we may change our minds
-        List<Field> wb = w.getFields();
-        List<Field> rb = r.getFields();
-        if (wb.size() != rb.size())
-          seen.put(wsc, false);
-        else {
-          int i = 0;
-          for (i = 0; i < wb.size(); i++)
-            if (!unionEquiv(wb.get(i).schema(), rb.get(i).schema(), seen))
-              break;
-          seen.put(wsc, (i == wb.size()));
-        }
-      }
-      return seen.get(wsc);
-    }
-    default:
-      throw new IllegalArgumentException("Unknown schema type: " + w.getType());
-    }
-  }
-
-  private Symbol resolveRecords(Schema writer, Schema reader, Map<LitS, Symbol> seen) throws IOException {
-    LitS wsc = new LitS2(writer, reader);
-    Symbol result = seen.get(wsc);
-    if (result == null) {
-      List<Field> wfields = writer.getFields();
-      List<Field> rfields = reader.getFields();
-
-      // First, compute reordering of reader fields, plus
-      // number elements in the result's production
-      Field[] reordered = new Field[rfields.size()];
-      int ridx = 0;
-      int count = 1 + wfields.size();
-
-      for (Field f : wfields) {
-        Field rdrField = reader.getField(f.name());
-        if (rdrField != null) {
-          reordered[ridx++] = rdrField;
-        }
-      }
-
-      for (Field rf : rfields) {
-        String fname = rf.name();
-        if (writer.getField(fname) == null) {
-          if (rf.defaultVal() == null) {
-            result = Symbol.error("Found " + writer.getFullName() + ", expecting " + reader.getFullName()
-                + ", missing required field " + fname);
-            seen.put(wsc, result);
-            return result;
-          } else {
-            reordered[ridx++] = rf;
-            count += 3;
-          }
-        }
-      }
-
-      Symbol[] production = new Symbol[count];
-      production[--count] = Symbol.fieldOrderAction(reordered);
-
-      /**
-       * We construct a symbol without filling the array. Please see
-       * {@link Symbol#production} for the reason.
-       */
-      result = Symbol.seq(production);
-      seen.put(wsc, result);
-
-      /*
-       * For now every field in read-record with no default value must be in
-       * write-record. Write record may have additional fields, which will be skipped
-       * during read.
-       */
-
-      // Handle all the writer's fields
-      for (Field wf : wfields) {
-        String fname = wf.name();
-        Field rf = reader.getField(fname);
-        if (rf == null) {
-          production[--count] = Symbol.skipAction(generate(wf.schema(), wf.schema(), seen));
-        } else {
-          production[--count] = generate(wf.schema(), rf.schema(), seen);
-        }
-      }
-
-      // Add default values for fields missing from Writer
-      for (Field rf : rfields) {
-        String fname = rf.name();
-        Field wf = writer.getField(fname);
-        if (wf == null) {
+    } else if (action instanceof Resolver.RecordAdjust) {
+      Symbol result = seen.get(action);
+      if (result == null) {
+        final Resolver.RecordAdjust ra = (Resolver.RecordAdjust)action;
+        int defaultCount = ra.readerOrder.length - ra.firstDefault;
+        int count = 1 + ra.fieldActions.length + 3*defaultCount;
+        Symbol[] production = new Symbol[count];
+        result = Symbol.seq(production);
+        seen.put(action, result);
+        production[--count] = Symbol.fieldOrderAction(ra.readerOrder);
+        for (Resolver.Action wfa : ra.fieldActions) production[--count] = generate(wfa, seen);
+        for (int i = ra.firstDefault; i < ra.readerOrder.length; i++) {
+          Schema.Field rf = ra.readerOrder[i];
           byte[] bb = getBinary(rf.schema(), Accessor.defaultValue(rf));
           production[--count] = Symbol.defaultStartAction(bb);
-          production[--count] = generate(rf.schema(), rf.schema(), seen);
+          production[--count] = simpleGen(rf.schema(), seen);
           production[--count] = Symbol.DEFAULT_END_ACTION;
         }
       }
+      return result;
     }
-    return result;
+
+    throw new IllegalArgumentException("Unrecognized Resolver.Action: " + action);
+  }
+
+  private Symbol simpleGen(Schema s, Map<Object, Symbol> seen) {
+    switch (s.getType()) {
+    case NULL: return Symbol.NULL;
+    case BOOLEAN: return Symbol.BOOLEAN;
+    case INT: return Symbol.INT;
+    case LONG: return Symbol.LONG;
+    case FLOAT: return Symbol.FLOAT;
+    case DOUBLE: return Symbol.DOUBLE;
+    case BYTES: return Symbol.BYTES;
+    case STRING: return Symbol.STRING;
+
+    case FIXED:
+      return Symbol.seq(new Symbol.IntCheckAction(s.getFixedSize()), Symbol.FIXED);
+
+    case ENUM:
+      return Symbol.seq(Symbol.enumAdjustAction(s.getEnumSymbols().size(), null), Symbol.ENUM);
+
+    case ARRAY:
+      return Symbol.seq(Symbol.repeat(Symbol.ARRAY_END, simpleGen(s.getElementType(), seen)),
+                        Symbol.ARRAY_START);
+
+    case MAP:
+      return Symbol.seq(Symbol.repeat(Symbol.MAP_END, simpleGen(s.getValueType(), seen),
+                                      Symbol.STRING), Symbol.MAP_START);
+
+    case UNION: {
+      List<Schema> subs = s.getTypes();
+      Symbol[] symbols = new Symbol[subs.size()];
+      String[] labels = new String[subs.size()];
+      int i = 0; for (Schema b : s.getTypes()) {
+        symbols[i] = simpleGen(b, seen);
+        labels[i++] = b.getFullName();
+      }
+      return Symbol.seq(Symbol.alt(symbols, labels), Symbol.UNION);
+    }
+
+    case RECORD: {
+      Symbol result = seen.get(s);
+      if (result == null) {
+        Symbol[] production = new Symbol[s.getFields().size()+1];
+        result = Symbol.seq(production);
+        seen.put(s, result);
+        int i = production.length;
+        production[--i] =
+          Symbol.fieldOrderAction(s.getFields().toArray(new Schema.Field[0]));
+        for (Field f : s.getFields())
+          production[--i] = simpleGen(f.schema(), seen);
+        // FieldOrderAction is needed even though the field-order hasn't changed,
+        // because the _reader_ doesn't know the field order hasn't changed, and
+        // thus it will probably call {@ ResolvingDecoder.fieldOrder} to find out.
+      }
+      return result;
+    }
+
+    default:
+      throw new IllegalArgumentException("Unexpected schema: " + s);
+    }
   }
 
   private static EncoderFactory factory = new EncoderFactory().configureBufferSize(32);
@@ -491,144 +331,6 @@ public class ResolvingGrammarGenerator extends ValidatingGrammarGenerator {
         throw new AvroTypeException("Non-null default value for null type: " + n);
       e.writeNull();
       break;
-    }
-  }
-
-  private static Symbol mkEnumAdjust(List<String> wsymbols, List<String> rsymbols, Object rEnumDefault) {
-    Object[] adjustments = new Object[wsymbols.size()];
-    for (int i = 0; i < adjustments.length; i++) {
-      int j = rsymbols.indexOf(wsymbols.get(i));
-      if (j == -1) {
-        if (rEnumDefault instanceof String) {
-          j = rsymbols.indexOf(rEnumDefault);
-        }
-      }
-      adjustments[i] = (j == -1 ? "No match for " + wsymbols.get(i) : new Integer(j));
-    }
-    return Symbol.enumAdjustAction(rsymbols.size(), adjustments);
-  }
-
-  /**
-   * This checks if the symbol itself is an error or if there is an error in its
-   * production.
-   *
-   * When the symbol is created for a record, this checks whether the record
-   * fields are present (the symbol is not an error action) and that all of the
-   * fields have a non-error action. Record fields may have nested error actions.
-   *
-   * @return true if the symbol is an error or if its production has an error
-   */
-  private boolean hasMatchError(Symbol sym) {
-    if (sym instanceof Symbol.ErrorAction) {
-      return true;
-    } else {
-      for (int i = 0; i < sym.production.length; i += 1) {
-        if (sym.production[i] instanceof Symbol.ErrorAction) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
-  private int firstMatchingBranch(Schema r, Schema w, Map<LitS, Symbol> seen) throws IOException {
-    Schema.Type vt = w.getType();
-    // first scan for exact match
-    int j = 0;
-    int structureMatch = -1;
-    for (Schema b : r.getTypes()) {
-      if (vt == b.getType())
-        if (vt == Schema.Type.RECORD || vt == Schema.Type.ENUM || vt == Schema.Type.FIXED) {
-          String vname = w.getFullName();
-          String bname = b.getFullName();
-          // return immediately if the name matches exactly according to spec
-          if (vname != null && vname.equals(bname))
-            return j;
-
-          if (vt == Schema.Type.RECORD && !hasMatchError(resolveRecords(w, b, seen))) {
-            String vShortName = w.getName();
-            String bShortName = b.getName();
-            // use the first structure match or one where the name matches
-            if ((structureMatch < 0) || (vShortName != null && vShortName.equals(bShortName))) {
-              structureMatch = j;
-            }
-          }
-        } else
-          return j;
-      j++;
-    }
-
-    // if there is a record structure match, return it
-    if (structureMatch >= 0)
-      return structureMatch;
-
-    // then scan match via numeric promotion
-    j = 0;
-    for (Schema b : r.getTypes()) {
-      switch (vt) {
-      case INT:
-        switch (b.getType()) {
-        case LONG:
-        case DOUBLE:
-        case FLOAT:
-          return j;
-        }
-        break;
-      case LONG:
-        switch (b.getType()) {
-        case DOUBLE:
-        case FLOAT:
-          return j;
-        }
-        break;
-      case FLOAT:
-        switch (b.getType()) {
-        case DOUBLE:
-          return j;
-        }
-        break;
-      case STRING:
-        switch (b.getType()) {
-        case BYTES:
-          return j;
-        }
-        break;
-      case BYTES:
-        switch (b.getType()) {
-        case STRING:
-          return j;
-        }
-        break;
-      }
-      j++;
-    }
-    return -1;
-  }
-
-  /**
-   * Clever trick which differentiates items put into <code>seen</code> by
-   * {@link ValidatingGrammarGenerator#validating validating()} from those put in
-   * by {@link ValidatingGrammarGenerator#resolving resolving()}.
-   */
-  static class LitS2 extends ValidatingGrammarGenerator.LitS {
-    public Schema expected;
-
-    public LitS2(Schema actual, Schema expected) {
-      super(actual);
-      this.expected = expected;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (!(o instanceof LitS2))
-        return false;
-      LitS2 other = (LitS2) o;
-      return actual == other.actual && expected == other.expected;
-    }
-
-    @Override
-    public int hashCode() {
-      return super.hashCode() + expected.hashCode();
     }
   }
 }

--- a/lang/java/avro/src/main/java/org/apache/avro/io/parsing/ResolvingGrammarGenerator.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/parsing/ResolvingGrammarGenerator.java
@@ -87,21 +87,23 @@ public class ResolvingGrammarGenerator extends ValidatingGrammarGenerator {
     } else if (action instanceof Resolver.ErrorAction) {
       return Symbol.error(action.toString());
 
-    } else if (action instanceof Resolver.SkipAction) {
+    } else if (action instanceof Resolver.Skip) {
       return Symbol.skipAction(simpleGen(action.writer, seen));
 
     } else if (action instanceof Resolver.Promote) {
       return Symbol.resolve(simpleGen(action.writer, seen), simpleGen(action.reader, seen));
 
     } else if (action.writer.getType() == Schema.Type.ARRAY) {
-      Symbol es = generate(((Resolver.ContainerAction)action).elementAction, seen);
+      Symbol es = generate(((Resolver.Container)action).elementAction, seen);
       return Symbol.seq(Symbol.repeat(Symbol.ARRAY_END, es), Symbol.ARRAY_START);
 
     } else if (action.writer.getType() == Schema.Type.MAP) {
-      Symbol es = generate(((Resolver.ContainerAction)action).elementAction, seen);
+      Symbol es = generate(((Resolver.Container)action).elementAction, seen);
       return Symbol.seq(Symbol.repeat(Symbol.MAP_END, es, Symbol.STRING), Symbol.MAP_START);
 
     } else if (action.writer.getType() == Schema.Type.UNION) {
+      if (((Resolver.WriterUnion)action).unionEquiv)
+        return simpleGen(action.writer, seen);
       Resolver.Action[] branches = ((Resolver.WriterUnion) action).actions;
       Symbol[] symbols = new Symbol[branches.length];
       String[] labels = new String[branches.length];

--- a/lang/java/avro/src/test/java/org/apache/avro/io/TestBlockingIO2.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/io/TestBlockingIO2.java
@@ -53,7 +53,7 @@ public class TestBlockingIO2 {
 
     decoder = DecoderFactory.get().binaryDecoder(bb, null);
     this.calls = calls;
-    this.msg = "Case: { "+bufferSize+", "+skipLevel+", \""+calls+"\" }";
+    this.msg = "Case: { " + bufferSize + ", " + skipLevel + ", \"" + calls + "\" }";
   }
 
   @Test

--- a/lang/java/avro/src/test/java/org/apache/avro/io/TestBlockingIO2.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/io/TestBlockingIO2.java
@@ -37,6 +37,7 @@ public class TestBlockingIO2 {
   private final Decoder decoder;
   private final String calls;
   private Object[] values;
+  private String msg;
 
   public TestBlockingIO2(int bufferSize, int skipLevel, String calls) throws IOException {
 
@@ -52,11 +53,12 @@ public class TestBlockingIO2 {
 
     decoder = DecoderFactory.get().binaryDecoder(bb, null);
     this.calls = calls;
+    this.msg = "Case: { "+bufferSize+", "+skipLevel+", \""+calls+"\" }";
   }
 
   @Test
   public void testScan() throws IOException {
-    TestValidatingIO.check(decoder, calls, values, -1);
+    TestValidatingIO.check(msg, decoder, calls, values, -1);
   }
 
   @Parameterized.Parameters

--- a/lang/java/avro/src/test/java/org/apache/avro/io/TestResolvingIO.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/io/TestResolvingIO.java
@@ -96,7 +96,8 @@ public class TestResolvingIO {
       break;
     }
     Decoder vi = new ResolvingDecoder(wsc, rsc, bvi);
-    TestValidatingIO.check(vi, calls, values, skipLevel);
+    String msg = "Error in resolving case: w="+wsc+", r="+rsc;
+    TestValidatingIO.check(msg, vi, calls, values, skipLevel);
   }
 
   @Parameterized.Parameters

--- a/lang/java/avro/src/test/java/org/apache/avro/io/TestResolvingIO.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/io/TestResolvingIO.java
@@ -96,7 +96,7 @@ public class TestResolvingIO {
       break;
     }
     Decoder vi = new ResolvingDecoder(wsc, rsc, bvi);
-    String msg = "Error in resolving case: w="+wsc+", r="+rsc;
+    String msg = "Error in resolving case: w=" + wsc + ", r=" + rsc;
     TestValidatingIO.check(msg, vi, calls, values, skipLevel);
   }
 

--- a/lang/java/avro/src/test/java/org/apache/avro/io/TestValidatingIO.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/io/TestValidatingIO.java
@@ -297,11 +297,12 @@ public class TestValidatingIO {
       bvi = new JsonDecoder(sc, in);
     }
     Decoder vi = new ValidatingDecoder(sc, bvi);
-    String msg = "Error in validating case: "+sc;
+    String msg = "Error in validating case: " + sc;
     check(msg, vi, calls, values, skipLevel);
   }
 
-  public static void check(Decoder vi, String calls, Object[] values, final int skipLevel) throws IOException {
+  public static void check(String msg, Decoder vi, String calls, Object[] values, final int skipLevel)
+      throws IOException {
     InputScanner cs = new InputScanner(calls.toCharArray());
     int p = 0;
     int level = 0;
@@ -326,12 +327,14 @@ public class TestValidatingIO {
           assertEquals(msg, values[p++], vi.readLong());
           break;
         case 'F':
-          if (!(values[p] instanceof Float)) fail();
+          if (!(values[p] instanceof Float))
+            fail();
           float f = (Float) values[p++];
           assertEquals(msg, f, vi.readFloat(), Math.abs(f / 1000));
           break;
         case 'D':
-          if (!(values[p] instanceof Double)) fail();
+          if (!(values[p] instanceof Double))
+            fail();
           double d = (Double) values[p++];
           assertEquals(msg, d, vi.readDouble(), Math.abs(d / 1000));
           break;
@@ -364,27 +367,24 @@ public class TestValidatingIO {
             byte[] bb = (byte[]) values[p++];
             ByteBuffer bb2 = vi.readBytes(null);
             byte[] actBytes = new byte[bb2.remaining()];
-            System.arraycopy(bb2.array(), bb2.position(), actBytes,
-                0, bb2.remaining());
+            System.arraycopy(bb2.array(), bb2.position(), actBytes, 0, bb2.remaining());
             assertArrayEquals(msg, bb, actBytes);
           }
           break;
-        case 'f':
-          {
-            int len = extractInt(cs);
-            if (level == skipLevel) {
-              vi.skipFixed(len);
-              p++;
-            } else {
-              byte[] bb = (byte[]) values[p++];
-              byte[] actBytes = new byte[len];
-              vi.readFixed(actBytes);
-              assertArrayEquals(msg, bb, actBytes);
-            }
+        case 'f': {
+          int len = extractInt(cs);
+          if (level == skipLevel) {
+            vi.skipFixed(len);
+            p++;
+          } else {
+            byte[] bb = (byte[]) values[p++];
+            byte[] actBytes = new byte[len];
+            vi.readFixed(actBytes);
+            assertArrayEquals(msg, bb, actBytes);
           }
+        }
           break;
-        case 'e':
-        {
+        case 'e': {
           int e = extractInt(cs);
           if (level == skipLevel) {
             vi.readEnum();
@@ -392,7 +392,7 @@ public class TestValidatingIO {
             assertEquals(msg, e, vi.readEnum());
           }
         }
-        break;
+          break;
         case '[':
           if (level == skipLevel) {
             p += skip(msg, cs, vi, true);
@@ -417,14 +417,14 @@ public class TestValidatingIO {
           }
         case ']':
           assertEquals(msg, 0, counts[level]);
-          if (! isEmpty[level]) {
+          if (!isEmpty[level]) {
             assertEquals(msg, 0, vi.arrayNext());
           }
           level--;
           break;
         case '}':
           assertEquals(0, counts[level]);
-          if (! isEmpty[level]) {
+          if (!isEmpty[level]) {
             assertEquals(msg, 0, vi.mapNext());
           }
           level--;
@@ -442,15 +442,14 @@ public class TestValidatingIO {
         case 'c':
           extractInt(cs);
           continue;
-        case 'U':
-          {
-            int idx = extractInt(cs);
-            assertEquals(msg, idx, vi.readIndex());
-            continue;
-          }
+        case 'U': {
+          int idx = extractInt(cs);
+          assertEquals(msg, idx, vi.readIndex());
+          continue;
+        }
         case 'R':
-            ((ResolvingDecoder) vi).readFieldOrder();
-            continue;
+          ((ResolvingDecoder) vi).readFieldOrder();
+          continue;
         default:
           fail(msg);
         }
@@ -461,12 +460,11 @@ public class TestValidatingIO {
     assertEquals(msg, values.length, p);
   }
 
-  private static int skip(String msg, InputScanner cs, Decoder vi, boolean isArray)
-    throws IOException {
+  private static int skip(String msg, InputScanner cs, Decoder vi, boolean isArray) throws IOException {
     final char end = isArray ? ']' : '}';
     if (isArray) {
       assertEquals(msg, 0, vi.skipArray());
-    } else if (end == '}'){
+    } else if (end == '}') {
       assertEquals(msg, 0, vi.skipMap());
     }
     int level = 0;

--- a/lang/java/avro/src/test/java/org/apache/avro/io/TestValidatingIO.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/io/TestValidatingIO.java
@@ -297,7 +297,8 @@ public class TestValidatingIO {
       bvi = new JsonDecoder(sc, in);
     }
     Decoder vi = new ValidatingDecoder(sc, bvi);
-    check(vi, calls, values, skipLevel);
+    String msg = "Error in validating case: "+sc;
+    check(msg, vi, calls, values, skipLevel);
   }
 
   public static void check(Decoder vi, String calls, Object[] values, final int skipLevel) throws IOException {
@@ -310,156 +311,163 @@ public class TestValidatingIO {
     while (!cs.isDone()) {
       final char c = cs.cur();
       cs.next();
-      switch (c) {
-      case 'N':
-        vi.readNull();
-        break;
-      case 'B':
-        assertEquals(values[p++], vi.readBoolean());
-        break;
-      case 'I':
-        assertEquals(values[p++], vi.readInt());
-        break;
-      case 'L':
-        assertEquals(values[p++], vi.readLong());
-        break;
-      case 'F':
-        if (!(values[p] instanceof Float))
-          fail();
-        float f = (Float) values[p++];
-        assertEquals(f, vi.readFloat(), Math.abs(f / 1000));
-        break;
-      case 'D':
-        if (!(values[p] instanceof Double))
-          fail();
-        double d = (Double) values[p++];
-        assertEquals(d, vi.readDouble(), Math.abs(d / 1000));
-        break;
-      case 'S':
-        extractInt(cs);
-        if (level == skipLevel) {
-          vi.skipString();
-          p++;
-        } else {
-          String s = (String) values[p++];
-          assertEquals(new Utf8(s), vi.readString(null));
-        }
-        break;
-      case 'K':
-        extractInt(cs);
-        if (level == skipLevel) {
-          vi.skipString();
-          p++;
-        } else {
-          String s = (String) values[p++];
-          assertEquals(new Utf8(s), vi.readString(null));
-        }
-        break;
-      case 'b':
-        extractInt(cs);
-        if (level == skipLevel) {
-          vi.skipBytes();
-          p++;
-        } else {
-          byte[] bb = (byte[]) values[p++];
-          ByteBuffer bb2 = vi.readBytes(null);
-          byte[] actBytes = new byte[bb2.remaining()];
-          System.arraycopy(bb2.array(), bb2.position(), actBytes, 0, bb2.remaining());
-          assertArrayEquals(bb, actBytes);
-        }
-        break;
-      case 'f': {
-        int len = extractInt(cs);
-        if (level == skipLevel) {
-          vi.skipFixed(len);
-          p++;
-        } else {
-          byte[] bb = (byte[]) values[p++];
-          byte[] actBytes = new byte[len];
-          vi.readFixed(actBytes);
-          assertArrayEquals(bb, actBytes);
-        }
-      }
-        break;
-      case 'e': {
-        int e = extractInt(cs);
-        if (level == skipLevel) {
-          vi.readEnum();
-        } else {
-          assertEquals(e, vi.readEnum());
-        }
-      }
-        break;
-      case '[':
-        if (level == skipLevel) {
-          p += skip(cs, vi, true);
+      try {
+        switch (c) {
+        case 'N':
+          vi.readNull();
           break;
-        } else {
-          level++;
-          counts[level] = vi.readArrayStart();
-          isArray[level] = true;
-          isEmpty[level] = counts[level] == 0;
-          continue;
-        }
-      case '{':
-        if (level == skipLevel) {
-          p += skip(cs, vi, false);
+        case 'B':
+          assertEquals(msg, values[p++], vi.readBoolean());
           break;
-        } else {
-          level++;
-          counts[level] = vi.readMapStart();
-          isArray[level] = false;
-          isEmpty[level] = counts[level] == 0;
-          continue;
-        }
-      case ']':
-        assertEquals(0, counts[level]);
-        if (!isEmpty[level]) {
-          assertEquals(0, vi.arrayNext());
-        }
-        level--;
-        break;
-      case '}':
-        assertEquals(0, counts[level]);
-        if (!isEmpty[level]) {
-          assertEquals(0, vi.mapNext());
-        }
-        level--;
-        break;
-      case 's':
-        if (counts[level] == 0) {
-          if (isArray[level]) {
-            counts[level] = vi.arrayNext();
+        case 'I':
+          assertEquals(msg, values[p++], vi.readInt());
+          break;
+        case 'L':
+          assertEquals(msg, values[p++], vi.readLong());
+          break;
+        case 'F':
+          if (!(values[p] instanceof Float)) fail();
+          float f = (Float) values[p++];
+          assertEquals(msg, f, vi.readFloat(), Math.abs(f / 1000));
+          break;
+        case 'D':
+          if (!(values[p] instanceof Double)) fail();
+          double d = (Double) values[p++];
+          assertEquals(msg, d, vi.readDouble(), Math.abs(d / 1000));
+          break;
+        case 'S':
+          extractInt(cs);
+          if (level == skipLevel) {
+            vi.skipString();
+            p++;
           } else {
-            counts[level] = vi.mapNext();
+            String s = (String) values[p++];
+            assertEquals(msg, new Utf8(s), vi.readString(null));
+          }
+          break;
+        case 'K':
+          extractInt(cs);
+          if (level == skipLevel) {
+            vi.skipString();
+            p++;
+          } else {
+            String s = (String) values[p++];
+            assertEquals(msg, new Utf8(s), vi.readString(null));
+          }
+          break;
+        case 'b':
+          extractInt(cs);
+          if (level == skipLevel) {
+            vi.skipBytes();
+            p++;
+          } else {
+            byte[] bb = (byte[]) values[p++];
+            ByteBuffer bb2 = vi.readBytes(null);
+            byte[] actBytes = new byte[bb2.remaining()];
+            System.arraycopy(bb2.array(), bb2.position(), actBytes,
+                0, bb2.remaining());
+            assertArrayEquals(msg, bb, actBytes);
+          }
+          break;
+        case 'f':
+          {
+            int len = extractInt(cs);
+            if (level == skipLevel) {
+              vi.skipFixed(len);
+              p++;
+            } else {
+              byte[] bb = (byte[]) values[p++];
+              byte[] actBytes = new byte[len];
+              vi.readFixed(actBytes);
+              assertArrayEquals(msg, bb, actBytes);
+            }
+          }
+          break;
+        case 'e':
+        {
+          int e = extractInt(cs);
+          if (level == skipLevel) {
+            vi.readEnum();
+          } else {
+            assertEquals(msg, e, vi.readEnum());
           }
         }
-        counts[level]--;
-        continue;
-      case 'c':
-        extractInt(cs);
-        continue;
-      case 'U': {
-        int idx = extractInt(cs);
-        assertEquals(idx, vi.readIndex());
-        continue;
-      }
-      case 'R':
-        ((ResolvingDecoder) vi).readFieldOrder();
-        continue;
-      default:
-        fail();
+        break;
+        case '[':
+          if (level == skipLevel) {
+            p += skip(msg, cs, vi, true);
+            break;
+          } else {
+            level++;
+            counts[level] = vi.readArrayStart();
+            isArray[level] = true;
+            isEmpty[level] = counts[level] == 0;
+            continue;
+          }
+        case '{':
+          if (level == skipLevel) {
+            p += skip(msg, cs, vi, false);
+            break;
+          } else {
+            level++;
+            counts[level] = vi.readMapStart();
+            isArray[level] = false;
+            isEmpty[level] = counts[level] == 0;
+            continue;
+          }
+        case ']':
+          assertEquals(msg, 0, counts[level]);
+          if (! isEmpty[level]) {
+            assertEquals(msg, 0, vi.arrayNext());
+          }
+          level--;
+          break;
+        case '}':
+          assertEquals(0, counts[level]);
+          if (! isEmpty[level]) {
+            assertEquals(msg, 0, vi.mapNext());
+          }
+          level--;
+          break;
+        case 's':
+          if (counts[level] == 0) {
+            if (isArray[level]) {
+              counts[level] = vi.arrayNext();
+            } else {
+              counts[level] = vi.mapNext();
+            }
+          }
+          counts[level]--;
+          continue;
+        case 'c':
+          extractInt(cs);
+          continue;
+        case 'U':
+          {
+            int idx = extractInt(cs);
+            assertEquals(msg, idx, vi.readIndex());
+            continue;
+          }
+        case 'R':
+            ((ResolvingDecoder) vi).readFieldOrder();
+            continue;
+        default:
+          fail(msg);
+        }
+      } catch (RuntimeException e) {
+        throw new RuntimeException(msg, e);
       }
     }
-    assertEquals(values.length, p);
+    assertEquals(msg, values.length, p);
   }
 
-  private static int skip(InputScanner cs, Decoder vi, boolean isArray) throws IOException {
+  private static int skip(String msg, InputScanner cs, Decoder vi, boolean isArray)
+    throws IOException {
     final char end = isArray ? ']' : '}';
     if (isArray) {
-      assertEquals(0, vi.skipArray());
-    } else if (end == '}') {
-      assertEquals(0, vi.skipMap());
+      assertEquals(msg, 0, vi.skipArray());
+    } else if (end == '}'){
+      assertEquals(msg, 0, vi.skipMap());
     }
     int level = 0;
     int p = 0;

--- a/lang/java/avro/src/test/java/org/apache/avro/reflect/TestNonStringMapKeys.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/reflect/TestNonStringMapKeys.java
@@ -249,7 +249,7 @@ public class TestNonStringMapKeys {
     List<GenericRecord> records = new ArrayList<>();
     while (fileReader.hasNext()) {
       try {
-        records.add (fileReader.next(record));
+        records.add(fileReader.next(record));
       } catch (Exception e) {
         fail("Fail with schema: " + schema);
       }

--- a/lang/java/avro/src/test/java/org/apache/avro/reflect/TestNonStringMapKeys.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/reflect/TestNonStringMapKeys.java
@@ -248,7 +248,11 @@ public class TestNonStringMapKeys {
     GenericRecord record = null;
     List<GenericRecord> records = new ArrayList<>();
     while (fileReader.hasNext()) {
-      records.add(fileReader.next(record));
+      try {
+        records.add (fileReader.next(record));
+      } catch (Exception e) {
+        fail("Fail with schema: " + schema);
+      }
     }
     return records;
   }


### PR DESCRIPTION
Efforts to improve performance by code-generation and other means have been hampered by the fact that our schema-resolution logic is embedded in resolving-grammar-generation logic (see [AVRO-2275](https://issues.apache.org/jira/browse/AVRO-2275)).  This patch factors the resolution logic out from the grammar-generation logic, so the resolution logic can be more easily reused.  See the design document included in this patch for more information.

This patch consists of the following pieces:
* A design/user-guide document (`refactoring-resolution.md`).
* Core changes: a new file, `Resolver.java`, containing the extracted resolution logic, and a rewrite of `ResolvingGrammarGenerator.java` based on the new `Resolver.java`.
* Changes to resolution-related tests.  These changes do not change the tests themselves, but rather output more diagnostic information upon failure to help developers resolve bugs.