### PR TITLE
AVRO-2279: Fix broken java build on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test-output
 /lang/java/compiler/nbactions.xml
 /lang/java/compiler/nb-configuration.xml
 /lang/java/compiler/nbproject/
+**/.vscode/**/*

--- a/lang/java/grpc/pom.xml
+++ b/lang/java/grpc/pom.xml
@@ -77,6 +77,11 @@
   <dependencies>
     <dependency>
       <groupId>io.grpc</groupId>
+      <artifactId>grpc-core</artifactId>
+      <version>${grpc.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
       <version>${grpc.version}</version>
     </dependency>
@@ -85,6 +90,12 @@
       <artifactId>grpc-netty</artifactId>
       <version>${grpc.version}</version>
       <!-- use netty only for tests as user can use grpc transports other than Netty -->
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-http2</artifactId>
+      <version>${netty-codec-http2.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/lang/java/maven-plugin/pom.xml
+++ b/lang/java/maven-plugin/pom.xml
@@ -33,10 +33,6 @@
   <name>Apache Avro Maven Plugin</name>
   <description>Maven plugin for Avro IDL and Specific API Compilers</description>
 
-  <prerequisites>
-    <maven>${maven.version}</maven>
-  </prerequisites>
-
   <properties>
     <pluginTestingVersion>1.3</pluginTestingVersion>
   </properties>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -62,6 +62,7 @@
     <hamcrest.version>1.3</hamcrest.version>
     <joda.version>2.10.1</joda.version>
     <grpc.version>1.16.1</grpc.version>
+    <netty-codec-http2.version>4.1.30.Final</netty-codec-http2.version>
     <findbugs-annotations.version>1.3.9-1</findbugs-annotations.version>
     <zstd-jni.version>1.3.7-1</zstd-jni.version>
 
@@ -79,7 +80,7 @@
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
     <file-management.version>1.2.1</file-management.version>
     <shade-plugin.version>3.2.0</shade-plugin.version>
-    <archetype-plugin.version>2.4</archetype-plugin.version>
+    <archetype-plugin.version>3.0.1</archetype-plugin.version>
   </properties>
 
   <modules>
@@ -515,6 +516,11 @@
       </dependency>
       <dependency>
         <groupId>io.grpc</groupId>
+        <artifactId>grpc-core</artifactId>
+        <version>${grpc.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.grpc</groupId>
         <artifactId>grpc-stub</artifactId>
         <version>${grpc.version}</version>
       </dependency>
@@ -522,6 +528,11 @@
         <groupId>io.grpc</groupId>
         <artifactId>grpc-netty</artifactId>
         <version>${grpc.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-http2</artifactId>
+        <version>${netty-codec-http2.version}</version>
       </dependency>
       <dependency>
         <groupId>com.github.luben</groupId>

--- a/lang/java/protobuf/pom.xml
+++ b/lang/java/protobuf/pom.xml
@@ -50,6 +50,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-antrun-plugin</artifactId>
+            <version>${antrun-plugin.version}</version>
             <executions>
               <execution>
                 <phase>generate-test-sources</phase>

--- a/lang/java/thrift/pom.xml
+++ b/lang/java/thrift/pom.xml
@@ -50,6 +50,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-antrun-plugin</artifactId>
+            <version>${antrun-plugin.version}</version>
             <executions>
               <execution>
                 <phase>generate-test-sources</phase>

--- a/lang/java/tools/pom.xml
+++ b/lang/java/tools/pom.xml
@@ -50,6 +50,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
+          <version>${source-plugin.version}</version>
           <configuration>
             <excludes>
               <exclude>META-INF/LICENSE</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <prerequisites>
-    <maven>2.2.1</maven>
+    <maven>3.0.5</maven>
   </prerequisites>
 
   <parent>
@@ -51,10 +51,13 @@
     <apache-rat-tasks.version>0.7</apache-rat-tasks.version>
 
     <!-- plugin versions -->
-    <antrun-plugin.version>1.7</antrun-plugin.version>
+    <antrun-plugin.version>1.8</antrun-plugin.version>
     <enforcer-plugin.version>1.3.1</enforcer-plugin.version>
     <rat.version>0.13</rat.version>
-    <checkstyle-plugin.version>2.17</checkstyle-plugin.version>
+    <checkstyle-plugin.version>3.0.0</checkstyle-plugin.version>
+    <gpg-plugin.version>1.6</gpg-plugin.version>
+    <javadoc-plugin.version>3.0.1</javadoc-plugin.version>
+    <source-plugin.version>3.0.1</source-plugin.version>
   </properties>
 
   <modules>
@@ -132,6 +135,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
+            <version>${javadoc-plugin.version}</version>
             <executions>
               <execution>
                 <!-- build javadoc jars per jar for publishing to maven -->
@@ -157,6 +161,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
+            <version>${source-plugin.version}</version>
             <executions>
               <execution>
                 <!-- builds source jars and attaches them to the project for publishing -->
@@ -190,6 +195,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
+            <version>${gpg-plugin.version}</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -272,6 +278,7 @@
                 <exclude>lang/c/tests/schema_tests/fail/*</exclude> <!-- C test cases -->
                 <exclude>lang/c/tests/schema_tests/pass/*</exclude> <!-- C test cases -->
                 <exclude>lang/c++/jsonschemas/*</exclude> <!-- C++ test cases -->
+                <exclude>lang/js/test/dat/**</exclude>
                 <!-- IDE settings and files -->
                 <exclude>**/.classpath</exclude>
                 <exclude>**/.project</exclude>


### PR DESCRIPTION
I also includes fixes for most of the warnings reported via `mvn versions:display-plugin-updates`