### PR TITLE
Register enum names when they are added via .type(schema)

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/SchemaBuilder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/SchemaBuilder.java
@@ -2139,7 +2139,12 @@ public class SchemaBuilder {
       Field field = new Field(name(), schema, doc(), defaultVal, order);
       addPropsTo(field);
       addAliasesTo(field);
-      names().put(schema);
+      if (schema.getType() == Schema.Type.ENUM) {
+        try {
+          names().put(schema);
+        } catch (Exception ignored) {
+        }
+      }
       return fields.addField(field);
     }
 

--- a/lang/java/avro/src/main/java/org/apache/avro/SchemaBuilder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/SchemaBuilder.java
@@ -2139,6 +2139,7 @@ public class SchemaBuilder {
       Field field = new Field(name(), schema, doc(), defaultVal, order);
       addPropsTo(field);
       addAliasesTo(field);
+      names().put(schema);
       return fields.addField(field);
     }
 


### PR DESCRIPTION
I'm working on an Avro schema generator and found a subtle bug in the `SchemaBuilder` code. For context, I'm dealing with schemas that have multiple fields with the same enum. This is the schema I'm trying to generate:

```
{
    {
      "name": "some_name",
      "type": {
        "type": "enum",
        "name": "Gender",
        "namespace": "some.ns.inner",
        "symbols": [
          "male",
          "female"
        ]
      }
    },
    {
      "name": "some_other_name",
      "type": "some.ns.Gender",
      "default": null
    },
}
```

It works fine if I build it this way:

```java
fieldBuilder.name("some_name")
  .enumeration("some.ns.Gender")
  .symbols("male", "female")
  .noDefault()

fieldBuilder.name(prop.snakeCaseName)
  .type("some.ns.Gender")
  .withDefault("male")
```

However, if I try this (which in theory is equivalent):

```java
enumSchema = Schema.createEnum("some.ns.Gender", null, null, values)

fieldBuilder.name("some_name")
  .type(enumSchema)
  .noDefault()

fieldBuilder.name(prop.snakeCaseName)
  .type("some.ns.Gender")
  .withDefault("male")
```

I get:

```
Undefined name: some.ns.Gender
org.apache.avro.SchemaParseException: Undefined name: some.ns.Gender
	at org.apache.avro.SchemaBuilder$NameContext.getFullname(SchemaBuilder.java:928)
	at org.apache.avro.SchemaBuilder$NameContext.get(SchemaBuilder.java:922)
	at org.apache.avro.SchemaBuilder$NameContext.access$1200(SchemaBuilder.java:884)
	at org.apache.avro.SchemaBuilder$BaseTypeBuilder.type(SchemaBuilder.java:1007)
	at org.apache.avro.SchemaBuilder$BaseTypeBuilder.type(SchemaBuilder.java:994)
```

The reason I'm trying to do it in this alternative form is because it will make for a nicer, more reusable code (since I can use the same template for any type, not just enumerations).