### PR TITLE
AVRO-2286 fix and regression test

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/file/DataFileWriter.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/file/DataFileWriter.java
@@ -40,6 +40,7 @@ import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.EncoderFactory;
+import org.apache.commons.compress.utils.IOUtils;
 
 /** Stores in a file a sequence of data conforming to a schema.  The schema is
  * stored in the file with the data.  Each datum in a file is of the same
@@ -126,7 +127,13 @@ public class DataFileWriter<D> implements Closeable, Flushable {
 
   /** Open a new file for data matching a schema with a random sync. */
   public DataFileWriter<D> create(Schema schema, File file) throws IOException {
-    return create(schema, new SyncableFileOutputStream(file), null);
+    SyncableFileOutputStream sfos = new SyncableFileOutputStream(file);
+    try {
+      return create(schema, sfos, null);
+    } catch (final Throwable e) {
+      IOUtils.closeQuietly(sfos);
+      throw e;
+    }
   }
 
   /** Open a new file for data matching a schema with a random sync. */

--- a/lang/java/avro/src/test/java/org/apache/avro/TestDataFileReader.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestDataFileReader.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.avro;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.lang.management.OperatingSystemMXBean;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.avro.file.DataFileReader;
+import org.apache.avro.generic.GenericDatumReader;
+import org.junit.Test;
+import com.sun.management.UnixOperatingSystemMXBean;
+
+@SuppressWarnings("restriction")
+public class TestDataFileReader {
+
+  @Test
+  // regression test for bug AVRO-2286
+  public void testForLeakingFileDescriptors() throws IOException {
+    Path emptyFile = Files.createTempFile("empty", ".avro");
+    Files.deleteIfExists(emptyFile);
+    Files.createFile(emptyFile);
+
+    long openFilesBeforeOperation = getNumberOfOpenFileDescriptors();
+    try (DataFileReader<Object> reader = new DataFileReader<>(emptyFile.toFile(), new GenericDatumReader<>())) {
+      fail("Reading on empty file is supposed to fail.");
+    } catch (IOException e) {
+      // everything going as supposed to
+    }
+    Files.delete(emptyFile);
+
+    assertEquals("File descriptor leaked from new DataFileReader()", openFilesBeforeOperation, getNumberOfOpenFileDescriptors());
+  }
+
+  private long getNumberOfOpenFileDescriptors() {
+    OperatingSystemMXBean osMxBean = ManagementFactory.getOperatingSystemMXBean();
+    if (osMxBean instanceof UnixOperatingSystemMXBean) {
+      return ((UnixOperatingSystemMXBean)osMxBean).getOpenFileDescriptorCount();
+    }
+    return 0;
+  }
+
+
+}


### PR DESCRIPTION
Suggested fix for AVRO-2286.
The test case only checks for the file handle leaking; inability to delete the file is not reproducible on most unix systems (although the resources may remain blocked, of course), so is not included in the test.