### PR TITLE
AVRO-2288: Trevni’s OutputBuffer signature clashes with new ByteArrayOutputStream#writeBytes method

### DIFF
--- a/lang/java/avro/src/test/java/org/apache/avro/specific/TestSpecificLogicalTypes.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/specific/TestSpecificLogicalTypes.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.*;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
@@ -100,7 +101,7 @@ public class TestSpecificLogicalTypes {
         LocalDate.now(),
         LocalTime.now(),
         DateTime.now().withZone(DateTimeZone.UTC),
-        new BigDecimal(123.45f).setScale(2, BigDecimal.ROUND_HALF_DOWN)
+        new BigDecimal(123.45f).setScale(2, RoundingMode.HALF_DOWN)
     );
 
     File data = write(TestRecordWithLogicalTypes.getClassSchema(), record);
@@ -121,7 +122,7 @@ public class TestSpecificLogicalTypes {
         java.time.LocalDate.now(),
         java.time.LocalTime.now(),
         java.time.Instant.now(),
-        new BigDecimal(123.45f).setScale(2, BigDecimal.ROUND_HALF_DOWN)
+        new BigDecimal(123.45f).setScale(2, RoundingMode.HALF_DOWN)
     );
 
     File data = write(TestRecordWithJsr310LogicalTypes.getClassSchema(), record);
@@ -147,7 +148,7 @@ public class TestSpecificLogicalTypes {
             // for granularity less than one second second.
             new DateTime((System.currentTimeMillis() / 1000) * 1000,
                     ISOChronology.getInstance()).withZone(DateTimeZone.UTC),
-            new BigDecimal(123.45f).setScale(2, BigDecimal.ROUND_HALF_DOWN)
+            new BigDecimal(123.45f).setScale(2, RoundingMode.HALF_DOWN)
     );
 
     File data = write(TestRecordWithLogicalTypes.getClassSchema(), withJoda);
@@ -182,7 +183,7 @@ public class TestSpecificLogicalTypes {
             java.time.LocalDate.now(),
             java.time.LocalTime.now(),
             java.time.Instant.now(),
-            new BigDecimal(123.45f).setScale(2, BigDecimal.ROUND_HALF_DOWN)
+            new BigDecimal(123.45f).setScale(2, RoundingMode.HALF_DOWN)
     );
 
     File data = write(TestRecordWithJsr310LogicalTypes.getClassSchema(), withJsr310);
@@ -225,7 +226,7 @@ public class TestSpecificLogicalTypes {
         new TimestampConversion().toLong(
             DateTime.now().withZone(DateTimeZone.UTC), null, null),
         new Conversions.DecimalConversion().toBytes(
-            new BigDecimal(123.45f).setScale(2, BigDecimal.ROUND_HALF_DOWN), null,
+            new BigDecimal(123.45f).setScale(2, RoundingMode.HALF_DOWN), null,
             LogicalTypes.decimal(9, 2))
     );
 
@@ -241,7 +242,7 @@ public class TestSpecificLogicalTypes {
     LocalDate date = LocalDate.now();
     LocalTime time = LocalTime.now();
     DateTime timestamp = DateTime.now().withZone(DateTimeZone.UTC);
-    BigDecimal decimal = new BigDecimal(123.45f).setScale(2, BigDecimal.ROUND_HALF_DOWN);
+    BigDecimal decimal = new BigDecimal(123.45f).setScale(2, RoundingMode.HALF_DOWN);
 
     TestRecordWithoutLogicalTypes record = new TestRecordWithoutLogicalTypes(
         true,
@@ -282,7 +283,7 @@ public class TestSpecificLogicalTypes {
     LocalDate date = LocalDate.now();
     LocalTime time = LocalTime.now();
     DateTime timestamp = DateTime.now().withZone(DateTimeZone.UTC);
-    BigDecimal decimal = new BigDecimal(123.45f).setScale(2, BigDecimal.ROUND_HALF_DOWN);
+    BigDecimal decimal = new BigDecimal(123.45f).setScale(2, RoundingMode.HALF_DOWN);
 
     TestRecordWithLogicalTypes record = new TestRecordWithLogicalTypes(
         true,

--- a/lang/java/integration-test/test-custom-conversions/src/main/java/org.apache.avro.codegentest/CustomDecimal.java
+++ b/lang/java/integration-test/test-custom-conversions/src/main/java/org.apache.avro.codegentest/CustomDecimal.java
@@ -20,6 +20,7 @@ package org.apache.avro.codegentest;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.math.RoundingMode;
 
 /**
  * Wraps a BigDecimal just to demonstrate that it is possible to use custom implementation classes with custom conversions.
@@ -35,7 +36,7 @@ public class CustomDecimal implements Comparable<CustomDecimal> {
     public byte[] toByteArray(int scale) {
         final BigDecimal correctlyScaledValue;
         if (scale != internalValue.scale()) {
-            correctlyScaledValue = internalValue.setScale(scale, BigDecimal.ROUND_HALF_UP);
+            correctlyScaledValue = internalValue.setScale(scale, RoundingMode.HALF_UP);
         } else {
             correctlyScaledValue = internalValue;
         }

--- a/lang/java/trevni/core/src/main/java/org/apache/trevni/OutputBuffer.java
+++ b/lang/java/trevni/core/src/main/java/org/apache/trevni/OutputBuffer.java
@@ -92,18 +92,18 @@ class OutputBuffer extends ByteArrayOutputStream {
     write(bytes, 0, bytes.length);
   }
 
-  public void writeBytes(ByteBuffer bytes) throws IOException {
+  public void writeBytes(ByteBuffer bytes) {
     int pos = bytes.position();
     int start = bytes.arrayOffset() + pos;
     int len = bytes.limit() - pos;
     writeBytes(bytes.array(), start, len);
   }
 
-  public void writeBytes(byte[] bytes) throws IOException {
+  public void writeBytes(byte[] bytes) {
     writeBytes(bytes, 0, bytes.length);
   }
 
-  public void writeBytes(byte[] bytes, int start, int len) throws IOException {
+  public void writeBytes(byte[] bytes, int start, int len) {
     writeInt(len);
     write(bytes, start, len);
   }
@@ -140,7 +140,7 @@ class OutputBuffer extends ByteArrayOutputStream {
     count += 8;
   }
 
-  public void writeInt(int n) throws IOException {
+  public void writeInt(int n) {
     ensure(5);
     n = (n << 1) ^ (n >> 31);                     // move sign to low-order bit
     if ((n & ~0x7F) != 0) {


### PR DESCRIPTION
It also fixes a deprecation warning for `RoundingMode` on Java 11 in a backwards compatible way.