### PR TITLE
AVRO-2291 - Make elements of an array reusable again

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/generic/GenericArray.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/generic/GenericArray.java
@@ -27,6 +27,14 @@ public interface GenericArray<T> extends List<T>, GenericContainer {
    * without allocating new objects. */
   T peek();
 
+  /** reset size counter of array to zero */
+  default void reset() {
+    clear();
+  }
+
+  /** clean up reusable objects from array (if reset didn't already) */
+  default void prune() {}
+
   /** Reverses the order of the elements in this array. */
   void reverse();
 }

--- a/lang/java/avro/src/main/java/org/apache/avro/generic/GenericData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/generic/GenericData.java
@@ -267,6 +267,19 @@ public class GenericData {
       Arrays.fill(elements, 0, size, null);
       size = 0;
     }
+
+    @Override
+    public void reset() {
+      size = 0;
+    }
+
+    @Override
+    public void prune() {
+      if (size<elements.length) {
+        Arrays.fill(elements, size, elements.length, null);
+      }
+    }
+
     @Override public Iterator<T> iterator() {
       return new Iterator<T>() {
         private int position = 0;

--- a/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericData.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericData.java
@@ -695,4 +695,26 @@ public class TestGenericData {
       fail("StackOverflowError occurred");
     }
   }
+
+  @Test
+  /** check that GenericArray.reset() retains reusable elements and that GenericArray.prune() cleans
+   * them up properly.
+   */
+  public void testGenericArrayPeek() {
+    Schema elementSchema = SchemaBuilder.record("element").fields().requiredString("value").endRecord();
+    Schema arraySchema = Schema.createArray(elementSchema);
+
+    GenericRecord record = new GenericData.Record( elementSchema );
+    record.put("value", "string");
+
+    GenericArray<GenericRecord> list = new GenericData.Array<GenericRecord>(1, arraySchema);
+    list.add(record);
+
+    list.reset();
+    assertTrue( record == list.peek() );
+
+    list.prune();
+    assertNull( list.peek() );
+  }
+
 }


### PR DESCRIPTION
The fix for AVRO-2050 effectively prevented array elements from ever being reused, thus making the implementation of array element reuse in GenericDatumReader.readArray() by means of GenericArray.peek() useless (GenericArray.peek() would ALWAYS return null).

With this PR, I suggest a means of retaining the behaviour of AVRO-2050 while also allowing GenericData.readArray() to work as it should, by reusing all required existing elements and only pruning the non-used ones to reduce allocation pressure.

A possible extension might even be to disable the pruning via a setting in GenericData/GenericDatumWriter to potentially reduce required allocations even more at the cost of potential zombie elements lurking in unused array cells.

Feedback and suggestions welcome.