### PR TITLE
AVRO-2297: Re-enable ruby build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -56,8 +56,7 @@ do
       (cd lang/c++; ./build.sh test)
       (cd lang/csharp; ./build.sh test)
       (cd lang/js; ./build.sh test)
-# Disabling until the issue triggered by ruby bundler is fixed: AVRO-2297
-#      (cd lang/ruby; ./build.sh test)
+      (cd lang/ruby; ./build.sh test)
       (cd lang/php; ./build.sh test)
       (cd lang/perl; ./build.sh test)
 

--- a/lang/ruby/build.sh
+++ b/lang/ruby/build.sh
@@ -25,7 +25,7 @@ export GEM_HOME=.gem/
 export PATH="$PATH:.gem/bin"
 
 # bootstrap bundler
-gem install --no-rdoc --no-ri bundler
+gem install --no-document -v 1.17.3 bundler
 bundle install
 
 case "$1" in

--- a/share/docker/run-tests.sh
+++ b/share/docker/run-tests.sh
@@ -15,6 +15,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+headline(){
+  echo -e "\e[1;34m#################################################################"
+  echo -e "##### $1 \e[1;37m"
+  echo -e "\e[1;34m#################################################################\e[0m"
+}
+
 set -e
 
-./build.sh test
+for lang in /avro/lang/*/
+do
+  headline "Run tests: $lang"
+  cd "$lang"
+  ./build.sh test
+done


### PR DESCRIPTION
This reverts the changes from https://github.com/apache/avro/pull/422 and fixes the build by installing the latest bundler (1.17.3) that is compatible with the ruby version (2.1.5) from the Docker image.`