### PR TITLE
AVRO-2303 Build and test against .NET SDK instead of Mono

### DIFF
--- a/lang/csharp/README.md
+++ b/lang/csharp/README.md
@@ -7,20 +7,17 @@
 1. Install [Microsoft Visual Studio Community 2017](https://www.visualstudio.com/downloads/)
 2. `./build.ps1 Test`
 
+### Linux with .NET SDK
+
+1. Install [.NET Core SDK 2.1+](https://www.microsoft.com/net/download/linux)
+2. `./build.sh test`
+
 ### Linux with Mono
 
 1. Install [Mono v5.18+](https://www.mono-project.com/download/stable/). Install the **mono-devel**
    and **mono-complete** packages.
-2. `./build.sh test`
-
-### Linux with .NET Core SDK
-
-1. Install [.NET Core SDK 2.1+](https://www.microsoft.com/net/download/linux)
-2. Build and run unit tests:
-    ```
-    cd src/apache/test
-    dotnet test --framework netcoreapp2.0
-    ```
+2. Build: `msbuild /t:"restore;build" /p:"Configuration=Release"`
+3. Test: `mono ~/.nuget/packages/nunit.consolerunner/3.9.0/tools/nunit3-console.exe src/apache/test/bin/Release/net40/Avro.test.dll`
 
 ## Target Frameworks
 

--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -26,14 +26,17 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Add the repository for node.js 4.x
 RUN curl -sL https://deb.nodesource.com/setup_4.x | bash -
 
+# Register Microsoft key and feed for .NET SDK
+# https://dotnet.microsoft.com/download/linux-package-manager/debian8/sdk-current
+RUN wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.asc.gpg && \
+  mv microsoft.asc.gpg /etc/apt/trusted.gpg.d/ && \
+  wget -q https://packages.microsoft.com/config/debian/8/prod.list && \
+  mv prod.list /etc/apt/sources.list.d/microsoft-prod.list && \
+  chown root:root /etc/apt/trusted.gpg.d/microsoft.asc.gpg && \
+  chown root:root /etc/apt/sources.list.d/microsoft-prod.list
+
 # Install dependencies from packages
 RUN apt-get -qq update && \
-  # Add the repository for Mono (https://www.mono-project.com/download/stable/#download-lin-debian)
-  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
-  apt-get -qq install -y apt-transport-https && \
-  echo "deb https://download.mono-project.com/repo/debian stable-jessie main" | tee /etc/apt/sources.list.d/mono-official-stable.list && \
-  apt-get -qq update && \
-  # END Add the repository for Mono
   apt-get -qq install --no-install-recommends -y \
     ant \
     asciidoc \
@@ -41,6 +44,7 @@ RUN apt-get -qq update && \
     bzip2 \
     cmake \
     curl \
+    dotnet-sdk-2.1 \
     doxygen \
     flex \
     g++ \
@@ -55,8 +59,6 @@ RUN apt-get -qq update && \
     libsnappy1 \
     make \
     maven \
-    mono-devel \
-    mono-complete \
     nodejs \
     perl \
     php5 \


### PR DESCRIPTION
Fixes [AVRO-2303](https://issues.apache.org/jira/browse/AVRO-2303)

Tests against .NET SDK instead of Mono. Still requires Mono for the `./build.sh dist` command.