### PR TITLE
Update surefire to version 3.0.0-M1 and enable parallel tests for some modules

### DIFF
--- a/lang/java/avro/pom.xml
+++ b/lang/java/avro/pom.xml
@@ -66,6 +66,27 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <parallel>none</parallel>
+        </configuration>
+        <executions>
+          <execution>
+            <id>test-with-custom-coders</id>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <systemPropertyVariables>
+                <org.apache.avro.specific.use_custom_coders>true</org.apache.avro.specific.use_custom_coders>
+              </systemPropertyVariables>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/lang/java/compiler/pom.xml
+++ b/lang/java/compiler/pom.xml
@@ -137,6 +137,16 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <!-- some tests hang if not run in a separate JVM -->
+          <forkCount>1</forkCount>
+          <reuseForks>false</reuseForks>
+          <parallel>none</parallel>
+        </configuration>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>

--- a/lang/java/ipc/pom.xml
+++ b/lang/java/ipc/pom.xml
@@ -55,6 +55,16 @@
     </resources>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <!-- some tests hang if not run in a separate JVM -->
+          <forkCount>1</forkCount>
+          <reuseForks>false</reuseForks>
+           <parallel>none</parallel>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>${project.groupId}</groupId>
         <artifactId>avro-maven-plugin</artifactId>
         <version>${project.version}</version>

--- a/lang/java/mapred/pom.xml
+++ b/lang/java/mapred/pom.xml
@@ -61,6 +61,16 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <!-- some IPC tests hang if not run in a separate JVM -->
+          <forkCount>1</forkCount>
+          <reuseForks>false</reuseForks>
+          <parallel>none</parallel>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>${project.groupId}</groupId>
         <artifactId>avro-maven-plugin</artifactId>
         <version>${project.version}</version>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -76,7 +76,7 @@
     <maven-site-plugin.version>3.7.1</maven-site-plugin.version>
     <plugin-plugin.version>3.6.0</plugin-plugin.version>
     <source-plugin.version>3.0.1</source-plugin.version>
-    <surefire-plugin.version>2.22.1</surefire-plugin.version>
+    <surefire-plugin.version>3.0.0-M3</surefire-plugin.version>
     <file-management.version>1.2.1</file-management.version>
     <shade-plugin.version>3.2.0</shade-plugin.version>
     <archetype-plugin.version>3.0.1</archetype-plugin.version>
@@ -119,7 +119,6 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
           <version>${jar-plugin.version}</version>
-
           <!--We want to be able to resuse the test-jars for mapred
               to test avro-tool
               see http://maven.apache.org/guides/mini/guide-attached-tests.html
@@ -144,6 +143,13 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${surefire-plugin.version}</version>
+          <dependencies>
+            <dependency>
+              <groupId>org.apache.maven.surefire</groupId>
+              <artifactId>surefire-junit47</artifactId>
+              <version>${surefire-plugin.version}</version>
+            </dependency>
+          </dependencies>
           <executions>
             <execution>
               <id>test-with-custom-coders</id>
@@ -171,9 +177,12 @@
               <exclude>**/apache/avro/test/**</exclude>
             </excludes>
             <enableAssertions>false</enableAssertions>
-            <!-- some IPC tests hang if not run in a separate JVM -->
-            <forkCount>1</forkCount>
-            <reuseForks>false</reuseForks>
+            <trimStackTrace>false</trimStackTrace>
+            <runOrder>random</runOrder>
+            <parallel>all</parallel>
+            <useUnlimitedThreads>true</useUnlimitedThreads>
+            <!--<perCoreThreadCount>true</perCoreThreadCount>-->
+
             <!-- TestSpecificCompiler instantiates a Java compiler to test output results,
                  this does not work with a manifest-only-jar to set the classpath for the javac.
                  This may cause problems on some platforms.

--- a/lang/java/tools/pom.xml
+++ b/lang/java/tools/pom.xml
@@ -170,6 +170,17 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${surefire-plugin.version}</version>
+        <configuration>
+          <!-- some tests hang if not run in a separate JVM -->
+          <forkCount>1</forkCount>
+          <reuseForks>false</reuseForks>
+          <parallel>none</parallel>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 
@@ -283,6 +294,4 @@
     </dependency>
   </dependencies>
 
-
 </project>
-

--- a/lang/java/trevni/pom.xml
+++ b/lang/java/trevni/pom.xml
@@ -49,6 +49,10 @@
           <version>${surefire-plugin.version}</version>
           <configuration>
             <failIfNoTests>false</failIfNoTests>
+            <!-- some tests hang if not run in a separate JVM -->
+            <forkCount>1</forkCount>
+            <reuseForks>false</reuseForks>
+            <parallel>none</parallel>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
This also disables the double execution of the tests mentioned in the mailing list for all modules apart of the core module.
I think we could eventually enable parallel tests run for the core module but we need to fix some flaky tests, in the meantime I think this is a worth improvement, in particular now that we need to run the Java 11 tests too.