### PR TITLE
AVRO-2306: Fix data corruption issue with snappy in Python 3

### DIFF
--- a/lang/py3/avro/datafile.py
+++ b/lang/py3/avro/datafile.py
@@ -283,7 +283,7 @@ class DataFileWriter(object):
     self.writer.write(compressed_data)
 
     # Write CRC32 checksum for Snappy
-    if self.GetMeta(CODEC_KEY) == 'snappy':
+    if codec == 'snappy':
       self.encoder.write_crc32(uncompressed_data)
 
     # write sync marker


### PR DESCRIPTION
This change fixes https://issues.apache.org/jira/browse/AVRO-2306, which is a data corruption bug encountered when using Avro with the snappy codec in Python 3.

CC: @aaltay @chamikaramj @valentyn