### PR TITLE
AVRO-2309: Conversions.java - Use JDK Array Manipulations

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/Conversions.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Conversions.java
@@ -114,13 +114,9 @@ public class Conversions {
       byte[] bytes = new byte[schema.getFixedSize()];
       int offset = bytes.length - unscaled.length;
 
-      for (int i = 0; i < bytes.length; i += 1) {
-        if (i < offset) {
-          bytes[i] = fillByte;
-        } else {
-          bytes[i] = unscaled[i - offset];
-        }
-      }
+      // Fill the front of the array and copy remaining with unscaled values
+      Arrays.fill(bytes, 0, offset, fillByte);
+      System.arraycopy(unscaled, 0, bytes, offset, bytes.length - offset);
 
       return new GenericData.Fixed(schema, bytes);
     }


### PR DESCRIPTION
```
-- Code currently in master branch
TestFill.fill_master  thrpt   30  72819605.046 ±  283321.097  ops/s

-- Use Arrays.fill for prefix and a basic for-loop to copy the unscaled data
TestFill.fill_fill_loop  thrpt   30  84733757.365 ±  585261.934  ops/s

-- Use Arrays.fill for prefix and a System.arraycopy to copy the unscaled data
TestFill.fill_fill_copy  thrpt   30  92483842.121 ± 1288416.561  ops/s
```

Interestingly, my JMH testing showed that it might be faster too.