### PR TITLE
[AVRO-2314] Bump protobuf to 3.6.1

### DIFF
--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -44,7 +44,7 @@
     <jopt-simple.version>5.0.4</jopt-simple.version>
     <junit.version>4.12</junit.version>
     <netty.version>3.10.6.Final</netty.version>
-    <protobuf.version>2.6.1</protobuf.version>
+    <protobuf.version>3.6.1</protobuf.version>
     <thrift.version>0.11.0</thrift.version>
     <slf4j.version>1.7.25</slf4j.version>
     <snappy.version>1.1.7.2</snappy.version>


### PR DESCRIPTION
https://jira.apache.org/jira/browse/AVRO-2314

There is an outstanding CVE on 3.4.0+
https://ossindex.sonatype.org/vuln/d47d20ab-eb2a-4cfd-8064-bbf6283649cb