### PR TITLE
AVRO-1989: Ruby schema validation should  use bytesize in error msg

### DIFF
--- a/lang/ruby/lib/avro/schema_validator.rb
+++ b/lang/ruby/lib/avro/schema_validator.rb
@@ -149,7 +149,7 @@ module Avro
       end
 
       def fixed_string_message(size, datum)
-        "expected fixed with size #{size}, got \"#{datum}\" with size #{datum.size}"
+        "expected fixed with size #{size}, got \"#{datum}\" with size #{datum.bytesize}"
       end
 
       def enum_message(symbols, datum)

--- a/lang/ruby/test/test_schema_validator.rb
+++ b/lang/ruby/test/test_schema_validator.rb
@@ -110,6 +110,13 @@ class TestSchema < Test::Unit::TestCase
     assert_failed_validation('at . expected fixed with size 3, got null') do
       validate_simple!(schema, nil)
     end
+
+    assert_failed_validation("at . expected fixed with size 3, got \"a\u2014b\" with size 5") do
+      validate!(schema, "a\u2014b")
+    end
+    assert_failed_validation("at . expected fixed with size 3, got \"a\u2014b\" with size 5") do
+      validate_simple!(schema, "a\u2014b")
+    end
   end
 
   def test_original_validate_nil
@@ -460,14 +467,5 @@ class TestSchema < Test::Unit::TestCase
       "at .[0] expected type int, got null\nat .[1] expected type int, got string with value \"e\"",
       exception.to_s
     )
-  end
-
-  def test_fixed_size_string
-    assert_failed_validation("at . expected fixed with size 3, got \"a\u2014b\" with size 5") do
-      validate!(schema, "a\u2014b")
-    end
-    assert_failed_validation("at . expected fixed with size 3, got \"a\u2014b\" with size 5") do
-      validate_simple!(schema, "a\u2014b")
-    end
   end
 end

--- a/lang/ruby/test/test_schema_validator.rb
+++ b/lang/ruby/test/test_schema_validator.rb
@@ -461,4 +461,13 @@ class TestSchema < Test::Unit::TestCase
       exception.to_s
     )
   end
+
+  def test_fixed_size_string
+    assert_failed_validation("at . expected fixed with size 3, got \"a\u2014b\" with size 5") do
+      validate!(schema, "a\u2014b")
+    end
+    assert_failed_validation("at . expected fixed with size 3, got \"a\u2014b\" with size 5") do
+      validate_simple!(schema, "a\u2014b")
+    end
+  end
 end


### PR DESCRIPTION
Ruby schema validation for fixed types should use bytesize in error message.

Minor change based on https://issues.apache.org/jira/browse/AVRO-1989

Create a new PR based on the patch file: https://issues.apache.org/jira/secure/attachment/12849804/AVRO-1989.0.patch