### PR TITLE
[AVRO-2326] Bump netty-codec-http2 from 4.1.30.Final to 4.1.33.Final

### DIFF
--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -62,7 +62,7 @@
     <hamcrest.version>2.1</hamcrest.version>
     <joda.version>2.10.1</joda.version>
     <grpc.version>1.18.0</grpc.version>
-    <netty-codec-http2.version>4.1.30.Final</netty-codec-http2.version>
+    <netty-codec-http2.version>4.1.33.Final</netty-codec-http2.version>
     <zstd-jni.version>1.3.8-3</zstd-jni.version>
 
     <!-- version properties for plugins -->


### PR DESCRIPTION
https://jira.apache.org/jira/browse/AVRO-2326
