### PR TITLE
AVRO-1981: Catch exceptions loading types from assemblies in C#

### DIFF
--- a/lang/csharp/src/apache/main/Specific/ObjectCreator.cs
+++ b/lang/csharp/src/apache/main/Specific/ObjectCreator.cs
@@ -138,7 +138,16 @@ namespace Avro.Specific
                     if (assembly.FullName.StartsWith("MonoDevelop.NUnit"))
                         continue;
 
-                    types = assembly.GetTypes();
+                    // Loading all types from all assemblies could fail for a variety of non-fatal
+                    // reasons. If we fail to load types from an assembly, continue.
+                    try
+                    {
+                        types = assembly.GetTypes();
+                    }
+                    catch
+                    {
+                        continue;
+                    }
 
                     // Change the search to look for Types by both NAME and FULLNAME
                     foreach (Type t in types)


### PR DESCRIPTION
Loading all types from all assemblies in the current domain
could throw an exception for a variety of non-fatal reasons.
Simply catch these exceptions and continue.