### PR TITLE
AVRO-1810: Fix GenericDatumWriter w/ enums

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/generic/GenericData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/generic/GenericData.java
@@ -397,7 +397,7 @@ public class GenericData {
 
   /** Default implementation of {@link GenericEnumSymbol}. */
   public static class EnumSymbol
-      implements GenericEnumSymbol, Comparable<GenericEnumSymbol>  {
+      implements GenericEnumSymbol<EnumSymbol> {
     private Schema schema;
     private String symbol;
 
@@ -430,7 +430,7 @@ public class GenericData {
     public String toString() { return symbol; }
 
     @Override
-    public int compareTo(GenericEnumSymbol that) {
+    public int compareTo(EnumSymbol that) {
       return GenericData.get().compare(this, that, schema);
     }
   }

--- a/lang/java/avro/src/main/java/org/apache/avro/generic/GenericEnumSymbol.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/generic/GenericEnumSymbol.java
@@ -18,8 +18,8 @@
 package org.apache.avro.generic;
 
 /** An enum symbol. */
-public interface GenericEnumSymbol
-    extends GenericContainer, Comparable<GenericEnumSymbol> {
+public interface GenericEnumSymbol<E extends GenericEnumSymbol<E>>
+    extends GenericContainer, Comparable<E> {
   /** Return the symbol. */
   String toString();
 }

--- a/lang/java/avro/src/test/java/org/apache/avro/TypeEnum.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TypeEnum.java
@@ -22,8 +22,9 @@
 package org.apache.avro;
 @SuppressWarnings("all")
 @org.apache.avro.specific.AvroGenerated
-public enum TypeEnum {
+public enum TypeEnum implements org.apache.avro.generic.GenericEnumSymbol<TypeEnum> {
   a, b, c  ;
   public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"enum\",\"name\":\"TypeEnum\",\"namespace\":\"org.apache.avro\",\"symbols\":[\"a\",\"b\",\"c\"]}");
   public static org.apache.avro.Schema getClassSchema() { return SCHEMA$; }
+  public org.apache.avro.Schema getSchema() { return SCHEMA$; }
 }

--- a/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericConcreteEnum.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericConcreteEnum.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.avro.generic;
+
+import org.apache.avro.FooBarSpecificRecord;
+import org.apache.avro.TypeEnum;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.specific.SpecificDatumReader;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * See AVRO-1810: GenericDatumWriter broken with Enum
+ */
+public class TestGenericConcreteEnum {
+
+  private static byte[] serializeRecord(FooBarSpecificRecord fooBarSpecificRecord) throws IOException {
+    GenericDatumWriter<FooBarSpecificRecord> datumWriter =
+      new GenericDatumWriter<>(FooBarSpecificRecord.SCHEMA$);
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    Encoder encoder = EncoderFactory.get().binaryEncoder(byteArrayOutputStream, null);
+    datumWriter.write(fooBarSpecificRecord, encoder);
+    encoder.flush();
+    return byteArrayOutputStream.toByteArray();
+  }
+
+  @Test
+  public void testGenericWriteAndRead() throws IOException {
+    FooBarSpecificRecord specificRecord = getRecord();
+
+    byte[] bytes = serializeRecord(specificRecord);
+
+    Decoder decoder = DecoderFactory.get().binaryDecoder(bytes, null);
+
+    GenericDatumReader<IndexedRecord> genericDatumReader = new GenericDatumReader<>(FooBarSpecificRecord.SCHEMA$);
+    IndexedRecord deserialized = new GenericData.Record(FooBarSpecificRecord.SCHEMA$);
+    genericDatumReader.read(deserialized, decoder);
+
+    assertEquals(0, GenericData.get().compare(specificRecord, deserialized, FooBarSpecificRecord.SCHEMA$));
+  }
+
+  @Test
+  public void testGenericWriteSpecificRead() throws IOException {
+    FooBarSpecificRecord specificRecord = getRecord();
+
+    byte[] bytes = serializeRecord(specificRecord);
+
+    Decoder decoder = DecoderFactory.get().binaryDecoder(bytes, null);
+
+    SpecificDatumReader<FooBarSpecificRecord> specificDatumReader = new SpecificDatumReader<>(FooBarSpecificRecord.SCHEMA$);
+    FooBarSpecificRecord deserialized = new FooBarSpecificRecord();
+    specificDatumReader.read(deserialized, decoder);
+
+    assertEquals(specificRecord, deserialized);
+  }
+
+  private FooBarSpecificRecord getRecord() {
+    return FooBarSpecificRecord.newBuilder()
+      .setId(42)
+      .setName("foo")
+      .setNicknames(Collections.singletonList("bar"))
+      .setRelatedids(Collections.singletonList(3))
+      .setTypeEnum(TypeEnum.a)
+      .build();
+  }
+}

--- a/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/enum.vm
+++ b/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/enum.vm
@@ -25,9 +25,10 @@ package $schema.getNamespace();
 @$annotation
 #end
 @org.apache.avro.specific.AvroGenerated
-public enum ${this.mangle($schema.getName())} {
+public enum ${this.mangle($schema.getName())} implements org.apache.avro.generic.GenericEnumSymbol<${this.mangle($schema.getName())}> {
   #foreach ($symbol in ${schema.getEnumSymbols()})${this.mangle($symbol)}#if ($foreach.hasNext), #end#end
   ;
   public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("${this.javaEscape($schema.toString())}");
   public static org.apache.avro.Schema getClassSchema() { return SCHEMA$; }
+  public org.apache.avro.Schema getSchema() { return SCHEMA$; }
 }

--- a/lang/java/tools/src/test/compiler/output-string/Position.java
+++ b/lang/java/tools/src/test/compiler/output-string/Position.java
@@ -5,8 +5,9 @@
  */
 package avro.examples.baseball;
 @org.apache.avro.specific.AvroGenerated
-public enum Position {
+public enum Position implements org.apache.avro.generic.GenericEnumSymbol<Position> {
   P, C, B1, B2, B3, SS, LF, CF, RF, DH  ;
   public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"enum\",\"name\":\"Position\",\"namespace\":\"avro.examples.baseball\",\"symbols\":[\"P\",\"C\",\"B1\",\"B2\",\"B3\",\"SS\",\"LF\",\"CF\",\"RF\",\"DH\"]}");
   public static org.apache.avro.Schema getClassSchema() { return SCHEMA$; }
+  public org.apache.avro.Schema getSchema() { return SCHEMA$; }
 }

--- a/lang/java/tools/src/test/compiler/output-string/avro/examples/baseball/Position.java
+++ b/lang/java/tools/src/test/compiler/output-string/avro/examples/baseball/Position.java
@@ -5,8 +5,9 @@
  */
 package avro.examples.baseball;
 @org.apache.avro.specific.AvroGenerated
-public enum Position {
+public enum Position implements org.apache.avro.generic.GenericEnumSymbol<Position> {
   P, C, B1, B2, B3, SS, LF, CF, RF, DH  ;
   public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"enum\",\"name\":\"Position\",\"namespace\":\"avro.examples.baseball\",\"symbols\":[\"P\",\"C\",\"B1\",\"B2\",\"B3\",\"SS\",\"LF\",\"CF\",\"RF\",\"DH\"]}");
   public static org.apache.avro.Schema getClassSchema() { return SCHEMA$; }
+  public org.apache.avro.Schema getSchema() { return SCHEMA$; }
 }

--- a/lang/java/tools/src/test/compiler/output/Position.java
+++ b/lang/java/tools/src/test/compiler/output/Position.java
@@ -5,8 +5,9 @@
  */
 package avro.examples.baseball;
 @org.apache.avro.specific.AvroGenerated
-public enum Position {
+public enum Position implements org.apache.avro.generic.GenericEnumSymbol<Position> {
   P, C, B1, B2, B3, SS, LF, CF, RF, DH  ;
   public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"enum\",\"name\":\"Position\",\"namespace\":\"avro.examples.baseball\",\"symbols\":[\"P\",\"C\",\"B1\",\"B2\",\"B3\",\"SS\",\"LF\",\"CF\",\"RF\",\"DH\"]}");
   public static org.apache.avro.Schema getClassSchema() { return SCHEMA$; }
+  public org.apache.avro.Schema getSchema() { return SCHEMA$; }
 }


### PR DESCRIPTION
Generated enum classes will implement GenericEnumSymbol so that they may be written with GenericDatumWriter. This narrows the Comparable scope of GenericEnumSymbol to the class that implements it because java.lang.Enum already implements Comparable. However it seems the broader comparable scope was unused or at least untested.

testGenericWriteAndRead reads into an IndexedRecord because there is no GenericDatumReader support for setting an instance of an Enum into a SpecificRecord (but this seems to make sense and SpecificDatumReader should be used in that instance anyway).

https://issues.apache.org/jira/browse/AVRO-1810