### PR TITLE
AVRO-2345: Export getSchema() to bypass using reflection

### DIFF
--- a/lang/java/protobuf/src/main/java/org/apache/avro/protobuf/ProtobufData.java
+++ b/lang/java/protobuf/src/main/java/org/apache/avro/protobuf/ProtobufData.java
@@ -197,7 +197,7 @@ public class ProtobufData extends GenericData {
     }
   };
 
-  private Schema getSchema(Descriptor descriptor) {
+  public Schema getSchema(Descriptor descriptor) {
     Map<Descriptor,Schema> seen = SEEN.get();
     if (seen.containsKey(descriptor))             // stop recursion
       return seen.get(descriptor);
@@ -299,7 +299,7 @@ public class ProtobufData extends GenericData {
     }
   }
 
-  private Schema getSchema(EnumDescriptor d) {
+  public Schema getSchema(EnumDescriptor d) {
     List<String> symbols = new ArrayList<>();
     for (EnumValueDescriptor e : d.getValues()) {
       symbols.add(e.getName());


### PR DESCRIPTION
https://issues.apache.org/jira/browse/AVRO-2345

I'd like to use `getSchema(descriptor)` directly to enable 1) to get schema from protobuf instance doesn't have `getDescriptor()` created from reflection and 2) to pass not protoc-java classes e.g. Scala classes generated by [ScalaPB](https://github.com/scalapb/ScalaPB) has `javaDescriptor()` instread of `getDescriptor()`.