### PR TITLE
AVRO-2354: Add CombineAvroKeyValueFileInputFormat in avro-mapred to combine small avro keyvalue files into combineSplit

### DIFF
--- a/lang/java/mapred/src/main/java/org/apache/avro/mapreduce/CombineAvroKeyValueFileInputFormat.java
+++ b/lang/java/mapred/src/main/java/org/apache/avro/mapreduce/CombineAvroKeyValueFileInputFormat.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.avro.mapreduce;
+
+import java.io.IOException;
+import org.apache.avro.mapred.AvroKey;
+import org.apache.avro.mapred.AvroValue;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.input.CombineFileInputFormat;
+import org.apache.hadoop.mapreduce.lib.input.CombineFileRecordReader;
+import org.apache.hadoop.mapreduce.lib.input.CombineFileRecordReaderWrapper;
+import org.apache.hadoop.mapreduce.lib.input.CombineFileSplit;
+
+/**
+ * A combine avro keyvalue file input format that can combine small avro files into mappers.
+ *
+ * @param <K> The type of the Avro key to read.
+ * @param <V> The type of the Avro value to read.
+ */
+public class CombineAvroKeyValueFileInputFormat<K, V> extends CombineFileInputFormat<AvroKey<K>, AvroValue<V>> {
+
+  @Override
+  public RecordReader<AvroKey<K>, AvroValue<V>> createRecordReader(InputSplit inputSplit, TaskAttemptContext taskAttemptContext) throws IOException {
+    return new CombineFileRecordReader((CombineFileSplit)inputSplit, taskAttemptContext,
+      CombineAvroKeyValueFileInputFormat.AvroKeyValueFileRecordReaderWrapper.class);
+  }
+
+  /**
+   * A record reader that may be passed to <code>CombineFileRecordReader</code>
+   * so that it can be used in a <code>CombineFileInputFormat</code>-equivalent
+   * for <code>AvroKeyValueInputFormat</code>.
+   *
+   * @see CombineFileRecordReader
+   * @see CombineFileInputFormat
+   * @see AvroKeyValueInputFormat
+   */
+  private static class AvroKeyValueFileRecordReaderWrapper<K,V>
+    extends CombineFileRecordReaderWrapper<AvroKey<K>, AvroValue<V>> {
+    // this constructor signature is required by CombineFileRecordReader
+    public AvroKeyValueFileRecordReaderWrapper(CombineFileSplit split,
+                                           TaskAttemptContext context, Integer idx)
+      throws IOException, InterruptedException {
+      super(new AvroKeyValueInputFormat<>(), split, context, idx);
+    }
+  }
+}

--- a/lang/java/mapred/src/test/java/org/apache/avro/mapreduce/TestCombineAvroKeyValueFileInputFormat.java
+++ b/lang/java/mapred/src/test/java/org/apache/avro/mapreduce/TestCombineAvroKeyValueFileInputFormat.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.avro.mapreduce;
+
+import org.apache.avro.Schema;
+import org.apache.avro.file.DataFileReader;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.hadoop.io.AvroKeyValue;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.mapred.AvroKey;
+import org.apache.avro.mapred.AvroValue;
+import org.apache.avro.specific.SpecificDatumReader;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class TestCombineAvroKeyValueFileInputFormat {
+
+  /** A temporary directory for test data. */
+  @Rule
+  public TemporaryFolder mTempDir = new TemporaryFolder();
+
+  /**
+   * Verifies that avro records can be read in multi files.
+   */
+  @Test
+  public void testReadRecords() throws IOException, InterruptedException, ClassNotFoundException {
+
+    Schema keyValueSchema = AvroKeyValue.getSchema(
+      Schema.create(Schema.Type.INT), Schema.create(Schema.Type.STRING));
+
+    AvroKeyValue<Integer, CharSequence> record1
+      = new AvroKeyValue<>(new GenericData.Record(keyValueSchema));
+    record1.setKey(1);
+    record1.setValue("apple banana carrot");
+    AvroFiles.createFile(new File(mTempDir.getRoot(), "combineSplit00.avro"), keyValueSchema, record1.get());
+
+    AvroKeyValue<Integer, CharSequence> record2
+      = new AvroKeyValue<>(new GenericData.Record(keyValueSchema));
+    record2.setKey(2);
+    record2.setValue("apple banana");
+
+    AvroFiles.createFile(new File(mTempDir.getRoot(), "combineSplit01.avro"), keyValueSchema, record2.get());
+
+    // Configure the job input.
+    Job job = Job.getInstance();
+    FileInputFormat.setInputPaths(job, new Path(mTempDir.getRoot().getAbsolutePath()));
+    job.setInputFormatClass(CombineAvroKeyValueFileInputFormat.class);
+    AvroJob.setInputKeySchema(job, Schema.create(Schema.Type.INT));
+    AvroJob.setInputValueSchema(job, Schema.create(Schema.Type.STRING));
+
+    // Configure the identity mapper.
+    AvroJob.setMapOutputKeySchema(job, Schema.create(Schema.Type.INT));
+    AvroJob.setMapOutputValueSchema(job, Schema.create(Schema.Type.STRING));
+
+    // Configure zero reducers.
+    job.setNumReduceTasks(0);
+    job.setOutputKeyClass(AvroKey.class);
+    job.setOutputValueClass(AvroValue.class);
+
+    // Configure the output format.
+    job.setOutputFormatClass(AvroKeyValueOutputFormat.class);
+    Path outputPath = new Path(mTempDir.getRoot().getPath(), "out");
+    FileOutputFormat.setOutputPath(job, outputPath);
+
+    // Run the job.
+    assertTrue(job.waitForCompletion(true));
+
+
+    // Verify that the output Avro container file has the expected data.
+    File avroFile = new File(outputPath.toString(), "part-m-00000.avro");
+    DatumReader<GenericRecord> datumReader = new SpecificDatumReader<>(
+      AvroKeyValue.getSchema(Schema.create(Schema.Type.INT),
+        Schema.create(Schema.Type.STRING)));
+    DataFileReader<GenericRecord> avroFileReader
+      = new DataFileReader<>(avroFile, datumReader);
+    assertTrue(avroFileReader.hasNext());
+
+    AvroKeyValue<Integer, CharSequence> mapRecord1
+      = new AvroKeyValue<>(avroFileReader.next());
+    assertNotNull(mapRecord1.get());
+    assertEquals(2, mapRecord1.getKey().intValue());
+    assertEquals("apple banana", mapRecord1.getValue().toString());
+
+    assertTrue(avroFileReader.hasNext());
+    AvroKeyValue<Integer, CharSequence> mapRecord2
+      = new AvroKeyValue<>(avroFileReader.next());
+    assertNotNull(mapRecord2.get());
+    assertEquals(1, mapRecord2.getKey().intValue());
+    assertEquals("apple banana carrot", mapRecord2.getValue().toString());
+  }
+}


### PR DESCRIPTION
In our production env, we generate avro files to track some user behavior events. Every hour, we will have several avro files created. And daily, we will run MR to do analysis, when using AvroKeyValueInputFormat, a lot of small mappers started due to we have small avro files. 

A combine file inputformat will be very helpful for such case. 

Hadoop already provided some implementation for sequencefile and text file. This Jira is propose a CombineAvroKeyValueFileInputFormat class to implement the same for avro keyvalue files.