### PR TITLE
AVRO-2357: Allow generic types in reflect protos

### DIFF
--- a/lang/java/avro/src/test/java/org/apache/avro/reflect/TestReflectData.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/reflect/TestReflectData.java
@@ -18,11 +18,15 @@
 
 package org.apache.avro.reflect;
 
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertThat;
 
 import java.util.Collections;
 
+import org.apache.avro.Protocol;
 import org.apache.avro.Schema;
 import org.junit.Test;
 
@@ -45,5 +49,45 @@ public class TestReflectData {
     System.gc(); // Not guaranteed, but seems to be reliable enough
 
     assertThat("ReflectData cache should release references", classData.bySchema.size(), lessThan(numSchemas));
+  }
+
+  @Test
+  public void testGenericProtocol() {
+    Protocol protocol = ReflectData.get().getProtocol(FooBarProtocol.class);
+    Schema recordSchema = ReflectData.get().getSchema(FooBarReflectiveRecord.class);
+
+    assertThat(protocol.getTypes(), contains(recordSchema));
+
+    assertThat(protocol.getMessages().keySet(), containsInAnyOrder("store", "findById", "exists"));
+
+    Schema.Field storeArgument = protocol.getMessages().get("store").getRequest().getFields().get(0);
+    assertThat(storeArgument.schema(), equalTo(recordSchema));
+
+    Schema.Field findByIdArgument = protocol.getMessages().get("findById").getRequest().getFields().get(0);
+    assertThat(findByIdArgument.schema(), equalTo(Schema.create(Schema.Type.STRING)));
+
+    Schema findByIdResponse = protocol.getMessages().get("findById").getResponse();
+    assertThat(findByIdResponse, equalTo(recordSchema));
+
+    Schema.Field existsArgument = protocol.getMessages().get("exists").getRequest().getFields().get(0);
+    assertThat(existsArgument.schema(), equalTo(Schema.create(Schema.Type.STRING)));
+  }
+
+  private interface CrudProtocol<R, I> extends OtherProtocol<I> {
+    void store(R record);
+
+    R findById(I id);
+  }
+
+  private interface OtherProtocol<G> {
+    boolean exists(G id);
+  }
+
+  private interface FooBarProtocol extends OtherProtocol<String>, CrudProtocol<FooBarReflectiveRecord, String> {
+  }
+
+  private static class FooBarReflectiveRecord {
+    private String bar;
+    private int baz;
   }
 }


### PR DESCRIPTION
Adds support for generic types in ReflectData for Protocols.

I also took the liberty of cleaning up the iteration over Parameters; the multi-dimensional array style is no longer really necessary with the new methods on Parameter.

https://issues.apache.org/jira/browse/AVRO-2357