### PR TITLE
AVRO-2364 Use Jackson TokenBuffer in JsonDecoder

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/io/JsonDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/JsonDecoder.java
@@ -20,13 +20,9 @@ package org.apache.avro.io;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Stack;
 
@@ -36,14 +32,10 @@ import org.apache.avro.io.parsing.JsonGrammarGenerator;
 import org.apache.avro.io.parsing.Parser;
 import org.apache.avro.io.parsing.Symbol;
 import org.apache.avro.util.Utf8;
-import com.fasterxml.jackson.core.Base64Variant;
 import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonLocation;
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonStreamContext;
 import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.core.ObjectCodec;
-import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.util.TokenBuffer;
 
 /**
  * A {@link Decoder} for Avro's JSON data encoding.
@@ -59,7 +51,7 @@ public class JsonDecoder extends ParsingDecoder implements Parser.ActionHandler 
   ReorderBuffer currentReorderBuffer;
 
   private static class ReorderBuffer {
-    public Map<String, List<JsonElement>> savedFields = new HashMap<>();
+    public Map<String, TokenBuffer> savedFields = new HashMap<>();
     public JsonParser origParser = null;
   }
 
@@ -453,11 +445,12 @@ public class JsonDecoder extends ParsingDecoder implements Parser.ActionHandler 
       Symbol.FieldAdjustAction fa = (Symbol.FieldAdjustAction) top;
       String name = fa.fname;
       if (currentReorderBuffer != null) {
-        List<JsonElement> node = currentReorderBuffer.savedFields.get(name);
-        if (node != null) {
+        TokenBuffer tokenBuffer = currentReorderBuffer.savedFields.get(name);
+        if (tokenBuffer != null) {
           currentReorderBuffer.savedFields.remove(name);
           currentReorderBuffer.origParser = in;
-          in = makeParser(node);
+          in = tokenBuffer.asParser();
+          in.nextToken();
           return null;
         }
       }
@@ -471,7 +464,11 @@ public class JsonDecoder extends ParsingDecoder implements Parser.ActionHandler 
             if (currentReorderBuffer == null) {
               currentReorderBuffer = new ReorderBuffer();
             }
-            currentReorderBuffer.savedFields.put(fn, getValueAsTree(in));
+            TokenBuffer tokenBuffer = new TokenBuffer(in);
+            // Moves the parser to the end of the current event e.g. END_OBJECT
+            tokenBuffer.copyCurrentStructure(in);
+            currentReorderBuffer.savedFields.put(fn, tokenBuffer);
+            in.nextToken();
           }
         } while (in.getCurrentToken() == JsonToken.FIELD_NAME);
         throw new AvroTypeException("Expected field name not found: " + fa.fname);
@@ -509,248 +506,6 @@ public class JsonDecoder extends ParsingDecoder implements Parser.ActionHandler 
       throw new AvroTypeException("Unknown action symbol " + top);
     }
     return null;
-  }
-
-  private static class JsonElement {
-    public final JsonToken token;
-    public final String value;
-
-    public JsonElement(JsonToken t, String value) {
-      this.token = t;
-      this.value = value;
-    }
-
-    public JsonElement(JsonToken t) {
-      this(t, null);
-    }
-  }
-
-  private static List<JsonElement> getValueAsTree(JsonParser in) throws IOException {
-    int level = 0;
-    List<JsonElement> result = new ArrayList<>();
-    do {
-      JsonToken t = in.getCurrentToken();
-      switch (t) {
-      case START_OBJECT:
-      case START_ARRAY:
-        level++;
-        result.add(new JsonElement(t));
-        break;
-      case END_OBJECT:
-      case END_ARRAY:
-        level--;
-        result.add(new JsonElement(t));
-        break;
-      case FIELD_NAME:
-      case VALUE_STRING:
-      case VALUE_NUMBER_INT:
-      case VALUE_NUMBER_FLOAT:
-      case VALUE_TRUE:
-      case VALUE_FALSE:
-      case VALUE_NULL:
-        result.add(new JsonElement(t, in.getText()));
-        break;
-      }
-      in.nextToken();
-    } while (level != 0);
-    result.add(new JsonElement(null));
-    return result;
-  }
-
-  private JsonParser makeParser(final List<JsonElement> elements) throws IOException {
-    return new JsonParser() {
-      int pos = 0;
-
-      @Override
-      public ObjectCodec getCodec() {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public void setCodec(ObjectCodec c) {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public void close() throws IOException {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public JsonToken nextToken() throws IOException {
-        pos++;
-        return elements.get(pos).token;
-      }
-
-      @Override
-      public JsonParser skipChildren() throws IOException {
-        JsonToken tkn = elements.get(pos).token;
-        int level = (tkn == JsonToken.START_ARRAY || tkn == JsonToken.END_ARRAY) ? 1 : 0;
-        while (level > 0) {
-          switch (elements.get(++pos).token) {
-          case START_ARRAY:
-          case START_OBJECT:
-            level++;
-            break;
-          case END_ARRAY:
-          case END_OBJECT:
-            level--;
-            break;
-          }
-        }
-        return this;
-      }
-
-      @Override
-      public boolean isClosed() {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public String getCurrentName() throws IOException {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public JsonStreamContext getParsingContext() {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public JsonLocation getTokenLocation() {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public JsonLocation getCurrentLocation() {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public String getText() throws IOException {
-        return elements.get(pos).value;
-      }
-
-      @Override
-      public char[] getTextCharacters() throws IOException {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public int getTextLength() throws IOException {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public int getTextOffset() throws IOException {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public Number getNumberValue() throws IOException {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public NumberType getNumberType() throws IOException {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public int getIntValue() throws IOException {
-        return Integer.parseInt(getText());
-      }
-
-      @Override
-      public long getLongValue() throws IOException {
-        return Long.parseLong(getText());
-      }
-
-      @Override
-      public BigInteger getBigIntegerValue() throws IOException {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public float getFloatValue() throws IOException {
-        return Float.parseFloat(getText());
-      }
-
-      @Override
-      public double getDoubleValue() throws IOException {
-        return Double.parseDouble(getText());
-      }
-
-      @Override
-      public BigDecimal getDecimalValue() throws IOException {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public byte[] getBinaryValue(Base64Variant b64variant) throws IOException {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public JsonToken getCurrentToken() {
-        return elements.get(pos).token;
-      }
-
-      @Override
-      public Version version() {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public JsonToken nextValue() throws IOException {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public int getCurrentTokenId() {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public boolean hasCurrentToken() {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public boolean hasTokenId(int id) {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public boolean hasToken(JsonToken t) {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public void clearCurrentToken() {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public JsonToken getLastClearedToken() {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public void overrideCurrentName(String name) {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public boolean hasTextCharacters() {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public String getValueAsString(String def) throws IOException {
-        throw new UnsupportedOperationException();
-      }
-    };
   }
 
   private AvroTypeException error(String type) {


### PR DESCRIPTION
[issue link](https://issues.apache.org/jira/browse/AVRO-2364)

The JsonDecoder implements the parsing interfacing for replaying parts of the JSON stream while accessing fields out of order. This PR rewrites the ReorderBuffer to use [TokenBuffers](http://static.javadoc.io/com.fasterxml.jackson.core/jackson-databind/2.9.8/com/fasterxml/jackson/databind/util/TokenBuffer.html) from Jackson's data binding library. 