### PR TITLE
AVRO-2365 Enhancements to maven-plugin induce goal

### DIFF
--- a/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/InduceMojo.java
+++ b/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/InduceMojo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -22,8 +22,10 @@ import java.io.File;
 import java.io.PrintWriter;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.charset.Charset;
 import java.util.List;
 
+import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.reflect.ReflectData;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -38,20 +40,34 @@ import org.apache.maven.project.MavenProject;
  */
 public class InduceMojo extends AbstractMojo {
   /**
-   * The source directory of Java classes.
+   * The Java source directories.
    *
-   * @parameter property="sourceDirectory"
+   * @parameter property="javaSourceDirectories"
    *            default-value="${basedir}/src/main/java"
    */
-  private File sourceDirectory;
+  private File[] javaSourceDirectories;
 
   /**
    * Directory where to output Avro schemas (.avsc) or protocols (.avpr).
    *
-   * @parameter property="outputDirectory"
-   *            default-value="${basedir}/generated-resources/avro"
+   * @parameter property="avroOutputDirectory"
+   *            default-value="${project.build.directory}/generated-resources/avro"
    */
-  private File outputDirectory;
+  private File avroOutputDirectory;
+
+  /**
+   * The output encoding.
+   *
+   * @parameter default-value="${project.build.sourceEncoding}"
+   */
+  private String encoding;
+
+  /**
+   * Whether to use ReflectData.AllowNull.
+   *
+   * @parameter default-value="false"
+   */
+  private boolean allowNull;
 
   /**
    * The current Maven project.
@@ -62,60 +78,89 @@ public class InduceMojo extends AbstractMojo {
    */
   protected MavenProject project;
 
-  public void execute() throws MojoExecutionException {
-    ClassLoader classLoader = getClassLoader();
+  private ClassLoader classLoader;
+  private ReflectData reflectData;
 
-    for (File inputFile : sourceDirectory.listFiles()) {
+  public void execute() throws MojoExecutionException {
+    classLoader = getClassLoader();
+    reflectData = allowNull ? ReflectData.AllowNull.get() : ReflectData.get();
+
+    if (encoding == null) {
+      encoding = Charset.defaultCharset().name();
+      getLog().warn("Property project.build.sourceEncoding not set, using system default " + encoding);
+    }
+
+    for (File sourceDirectory : javaSourceDirectories) {
+      induceClasses(sourceDirectory);
+    }
+  }
+
+  private void induceClasses(File sourceDirectory) throws MojoExecutionException {
+    File[] files = sourceDirectory.listFiles();
+    if (files == null) {
+      throw new MojoExecutionException("Unable to list files from directory: " + sourceDirectory.getName());
+    }
+
+    for (File inputFile : files) {
+      if (inputFile.isDirectory()) {
+        induceClasses(inputFile);
+        continue;
+      }
+
       String className = parseClassName(inputFile.getPath());
+      if (className == null) {
+        continue; // Not a java file, continue
+      }
+
       Class<?> klass = loadClass(classLoader, className);
-      String fileName = outputDirectory.getPath() + "/" + parseFileName(klass);
+      String fileName = getOutputFileName(klass);
       File outputFile = new File(fileName);
       outputFile.getParentFile().mkdirs();
-      try {
-        PrintWriter writer = new PrintWriter(fileName, "UTF-8");
+      try (PrintWriter writer = new PrintWriter(fileName, encoding)) {
         if (klass.isInterface()) {
-          writer.println(ReflectData.get().getProtocol(klass).toString(true));
+          writer.println(reflectData.getProtocol(klass).toString(true));
         } else {
-          writer.println(ReflectData.get().getSchema(klass).toString(true));
+          writer.println(reflectData.getSchema(klass).toString(true));
         }
-        writer.close();
+      } catch (AvroRuntimeException e) {
+        throw new MojoExecutionException("Failed to resolve schema or protocol for class " + klass.getCanonicalName(),
+            e);
       } catch (Exception e) {
-        e.printStackTrace();
+        throw new MojoExecutionException("Failed to write output file for class " + klass.getCanonicalName(), e);
       }
     }
   }
 
   private String parseClassName(String fileName) {
-    String indentifier = "java/";
+    String indentifier = "java" + File.separator;
     int index = fileName.lastIndexOf(indentifier);
     String namespacedFileName = fileName.substring(index + indentifier.length());
+    if (!namespacedFileName.endsWith(".java")) {
+      return null;
+    }
 
-    return namespacedFileName.replace("/", ".").replace(".java", "");
+    return namespacedFileName.replace(File.separator, ".").replaceFirst("\\.java$", "");
   }
 
-  private String parseFileName(Class klass) {
-    String className = klass.getName().replace(".", "/");
+  private String getOutputFileName(Class klass) {
+    String filename = avroOutputDirectory.getPath() + File.separator + klass.getName().replace(".", File.separator);
     if (klass.isInterface()) {
-      return className.concat(".avpr");
+      return filename.concat(".avpr");
     } else {
-      return className.concat(".avsc");
+      return filename.concat(".avsc");
     }
   }
 
-  private Class<?> loadClass(ClassLoader classLoader, String className) {
-    Class<?> klass = null;
-
+  private Class<?> loadClass(ClassLoader classLoader, String className) throws MojoExecutionException {
     try {
-      klass = classLoader.loadClass(className);
+      return classLoader.loadClass(className);
     } catch (ClassNotFoundException e) {
-      e.printStackTrace();
+      throw new MojoExecutionException("Failed to load class " + className, e);
     }
-
-    return klass;
   }
 
-  private ClassLoader getClassLoader() {
-    ClassLoader classLoader = null;
+  private ClassLoader getClassLoader() throws MojoExecutionException {
+    ClassLoader classLoader;
 
     try {
       List<String> classpathElements = project.getRuntimeClasspathElements();
@@ -129,7 +174,7 @@ public class InduceMojo extends AbstractMojo {
       }
       classLoader = new URLClassLoader(urls, getClass().getClassLoader());
     } catch (Exception e) {
-      e.printStackTrace();
+      throw new MojoExecutionException("Failed to obtain ClassLoader", e);
     }
 
     return classLoader;

--- a/lang/java/maven-plugin/src/test/java/org/apache/avro/mojo/TestInduceMojo.java
+++ b/lang/java/maven-plugin/src/test/java/org/apache/avro/mojo/TestInduceMojo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -19,7 +19,13 @@
 package org.apache.avro.mojo;
 
 import java.io.File;
+import java.util.Arrays;
 
+import org.apache.avro.Protocol;
+import org.apache.avro.Schema;
+import org.apache.avro.entities.Person;
+import org.apache.avro.protocols.Remote;
+import org.apache.avro.reflect.ReflectData;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 
 public class TestInduceMojo extends AbstractMojoTestCase {
@@ -51,6 +57,9 @@ public class TestInduceMojo extends AbstractMojoTestCase {
 
     File outputDir = new File(getBasedir(), "target/test-harness/schemas/org/apache/avro/entities");
     assertTrue(outputDir.listFiles().length != 0);
+    File personSchemaFile = Arrays.stream(outputDir.listFiles()).filter(file -> file.getName().endsWith("Person.avsc"))
+        .findFirst().orElseThrow(AssertionError::new);
+    assertEquals(ReflectData.get().getSchema(Person.class), new Schema.Parser().parse(personSchemaFile));
   }
 
   public void testInducedSchemasFileExtension() throws Exception {
@@ -67,6 +76,9 @@ public class TestInduceMojo extends AbstractMojoTestCase {
 
     File outputDir = new File(getBasedir(), "target/test-harness/protocol/org/apache/avro/protocols");
     assertTrue(outputDir.listFiles().length != 0);
+    File remoteProtocolFile = Arrays.stream(outputDir.listFiles())
+        .filter(file -> file.getName().endsWith("Remote.avpr")).findFirst().orElseThrow(AssertionError::new);
+    assertEquals(ReflectData.get().getProtocol(Remote.class), Protocol.parse(remoteProtocolFile));
   }
 
   public void testInducedProtocolsFileExtension() throws Exception {

--- a/lang/java/maven-plugin/src/test/resources/unit/protocol/induce-pom.xml
+++ b/lang/java/maven-plugin/src/test/resources/unit/protocol/induce-pom.xml
@@ -37,8 +37,10 @@
           </execution>
         </executions>
         <configuration>
-          <sourceDirectory>${basedir}/src/test/java/org/apache/avro/protocols</sourceDirectory>
-          <outputDirectory>${basedir}/target/test-harness/protocol</outputDirectory>
+          <javaSourceDirectories>
+            <directory>${basedir}/src/test/java/org/apache/avro/protocols</directory>
+          </javaSourceDirectories>
+          <avroOutputDirectory>${basedir}/target/test-harness/protocol</avroOutputDirectory>
           <project implementation="org.apache.maven.plugin.testing.stubs.MavenProjectStub"/>
         </configuration>
       </plugin>

--- a/lang/java/maven-plugin/src/test/resources/unit/schema/induce-pom.xml
+++ b/lang/java/maven-plugin/src/test/resources/unit/schema/induce-pom.xml
@@ -37,8 +37,10 @@
           </execution>
         </executions>
         <configuration>
-          <sourceDirectory>${basedir}/src/test/java/org/apache/avro/entities</sourceDirectory>
-          <outputDirectory>${basedir}/target/test-harness/schemas</outputDirectory>
+          <javaSourceDirectories>
+            <directory>${basedir}/src/test/java/org/apache/avro/entities</directory>
+          </javaSourceDirectories>
+          <avroOutputDirectory>${basedir}/target/test-harness/schemas</avroOutputDirectory>
           <project implementation="org.apache.maven.plugin.testing.stubs.MavenProjectStub"/>
         </configuration>
       </plugin>


### PR DESCRIPTION
- Change `sourceDirectory` to `javaSourceDirectories`. This will ensure we don't clash with the regular 'sourceDirectory' configuration of the other goals, and allows the user to specify multiple source directories.
- Change `outputDirectory` to `avroOutputDirectory`. Unsure if this is really the best name but wanted to avoid clashing with the other goals.
- Add encoding option, which will default to `${project.build.sourceEncoding}` (Maven standard), or fall back to the JVM default with a warning.
- Recursively descend file structure to find all source files under the configured root(s)
- Add `allowNull` option, whether to use ReflectData.AllowNull or just ReflectData.
- Throw MojoExecutionException in exceptional situations.
- Use try-with-resources for PrintWriter to ensure it gets closed.
- Use `File.separator` rather than '/'.
- Enhance tests: assert that the output files contain the expected schema or protocol.

https://issues.apache.org/jira/browse/AVRO-2365