### PR TITLE
AVRO-2363: bugfix, parsing is more restrictive in py3 than in java

### DIFF
--- a/lang/py3/avro/schema.py
+++ b/lang/py3/avro/schema.py
@@ -397,9 +397,6 @@ class Names(object):
     if schema.fullname in VALID_TYPES:
       raise SchemaParseException(
           '%s is a reserved type name.' % schema.fullname)
-    if schema.fullname in self.names:
-      raise SchemaParseException(
-          'Avro name %r already exists.' % schema.fullname)
 
     logger.log(DEBUG_VERBOSE, 'Register new name for %r', schema.fullname)
     self._names[schema.fullname] = schema

--- a/lang/py3/avro/tests/reusingSchema.avsc
+++ b/lang/py3/avro/tests/reusingSchema.avsc
@@ -23,6 +23,19 @@
         "name": "B",
         "type": "record"
       }
+    },
+    {
+      "name": "c",
+      "type": {
+        "fields": [
+          {
+            "name": "value",
+            "type":  "string"
+          }
+        ],
+        "name": "C",
+        "type": "record"
+      }
     }
   ],
   "name": "A",

--- a/lang/py3/avro/tests/reusingSchema.avsc
+++ b/lang/py3/avro/tests/reusingSchema.avsc
@@ -1,0 +1,31 @@
+{
+  "doc": "",
+  "fields": [
+    {
+      "name": "b",
+      "type": {
+        "fields": [
+          {
+            "name": "c",
+            "type": {
+              "fields": [
+                {
+                  "name": "value",
+                  "type":  "string"
+
+                }
+              ],
+              "name": "C",
+              "type": "record"
+            }
+          }
+        ],
+        "name": "B",
+        "type": "record"
+      }
+    }
+  ],
+  "name": "A",
+  "namespace": "namespace",
+  "type": "record"
+}

--- a/lang/py3/avro/tests/test_schema.py
+++ b/lang/py3/avro/tests/test_schema.py
@@ -20,7 +20,7 @@
 """
 Test the schema parsing logic.
 """
-
+import json
 import logging
 import traceback
 import unittest
@@ -645,6 +645,10 @@ class TestSchema(unittest.TestCase):
       schema.Parse(schema_string)
     self.assertRegexpMatches(str(e.exception), 'Duplicate.*field name.*foo')
 
+  def testDuplicateTypeOnDifferentLevels(self):
+    with open('avro/tests/reusingSchema.avsc') as f:
+      schema_string = json.dumps(json.load(f))
+    schema.Parse(schema_string)
 
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
This patch allows the same record type being used multiple times in same schema. 
Most languages have support to import schemas recursively whereas the python3 parser expects all schemas to consist of one flattened file. 

The test imports the schema `./lang/py3/avro/tests/reusingSchema.avsc`, which on two different levels refer to the record type C. 
Due to the SchemaParseException that is raised when `schema.fullname in self.names` python can not work in the same schema domains as other languages.

The origin story for this: 
https://issues.apache.org/jira/browse/AVRO-2363

