### PR TITLE
Exclude generated Protobuf file from spotless check

### DIFF
--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -316,6 +316,9 @@
               <version>4.10.0</version>
             </eclipse>
             <removeUnusedImports/>
+            <excludes>
+              <exclude>src/test/java/org/apache/avro/protobuf/Test.java</exclude>
+            </excludes>
           </java>
         </configuration>
         <executions>


### PR DESCRIPTION
Test.java in Protobuf test folder is a generated file, and should not be inspected by Spotless.