### PR TITLE
Provide Schema when 'writeEnum' fails

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/generic/GenericDatumWriter.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/generic/GenericDatumWriter.java
@@ -215,7 +215,7 @@ public class GenericDatumWriter<D> implements DatumWriter<D> {
    */
   protected void writeEnum(Schema schema, Object datum, Encoder out) throws IOException {
     if (!data.isEnum(datum))
-      throw new AvroTypeException("Not an enum: " + dataum + " for schema: " + schema);
+      throw new AvroTypeException("Not an enum: " + datum + " for schema: " + schema);
     out.writeEnum(schema.getEnumOrdinal(datum.toString()));
   }
 

--- a/lang/java/avro/src/main/java/org/apache/avro/generic/GenericDatumWriter.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/generic/GenericDatumWriter.java
@@ -215,7 +215,7 @@ public class GenericDatumWriter<D> implements DatumWriter<D> {
    */
   protected void writeEnum(Schema schema, Object datum, Encoder out) throws IOException {
     if (!data.isEnum(datum))
-      throw new AvroTypeException("Not an enum: " + datum);
+      error(schema, datum);
     out.writeEnum(schema.getEnumOrdinal(datum.toString()));
   }
 

--- a/lang/java/avro/src/main/java/org/apache/avro/generic/GenericDatumWriter.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/generic/GenericDatumWriter.java
@@ -215,7 +215,7 @@ public class GenericDatumWriter<D> implements DatumWriter<D> {
    */
   protected void writeEnum(Schema schema, Object datum, Encoder out) throws IOException {
     if (!data.isEnum(datum))
-      error(schema, datum);
+      throw new AvroTypeException("Not an enum: " + dataum + " for schema: " + schema);
     out.writeEnum(schema.getEnumOrdinal(datum.toString()));
   }
 


### PR DESCRIPTION
Current state:
 If datum is null and the schema enum does not accept null, then the exception message is "Not an enum: null". This makes it difficult for debugging or failing gracefully with automated solutions if records have multiple schemas using enums.

With this change, the schema will be included in the 'AvroTypeException' with the potential to provide acceptable enum values from the schema's properties.