### PR TITLE
AVRO-2318: Add a new hadoop3 profile and include it in test execution

### DIFF
--- a/lang/java/build.sh
+++ b/lang/java/build.sh
@@ -44,6 +44,8 @@ function do_dist() {
 case "$target" in
   test)
     mvn -B test
+    # Test the modules that depend on hadoop using Hadoop 3
+    mvn -B test -Phadoop3
     ;;
 
   dist)

--- a/lang/java/ipc-jetty/pom.xml
+++ b/lang/java/ipc-jetty/pom.xml
@@ -109,6 +109,10 @@
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-servlet</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -475,6 +475,12 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>hadoop3</id>
+      <properties>
+        <hadoop.version>3.2.0</hadoop.version>
+      </properties>
+    </profile>
   </profiles>
 
   <!-- dependencyManagement can be used to define dependency versions, scopes, and
@@ -507,6 +513,11 @@
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-servlet</artifactId>
           <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-util</artifactId>
+        <version>${jetty.version}</version>
       </dependency>
       <dependency>
           <groupId>javax.servlet</groupId>


### PR DESCRIPTION
As explained in #448 Avro's hadoop dependencies are provided/runtime so we can ensure our compatibility just by running tests against Hadoop 3 to ensure no change breaks compatibility with both versions, given that tests pass fully we may not need to release extra artifacts.

Notice that hadoop 3 uses a version of jetty that does not depend on jetty-util so we need to explictly add it to ipc-jetty to avoid runtime issues (ClassNotFoundException) in Avro's tools when using Hadoop 3.

R: @Fokko @dkulp 
CC: @scottcarey
