### PR TITLE
[AVRO-2381] Ruby: set logical type for fixed

### DIFF
--- a/lang/ruby/lib/avro/schema.rb
+++ b/lang/ruby/lib/avro/schema.rb
@@ -355,7 +355,7 @@ module Avro
         unless size.is_a?(Integer)
           raise AvroError, 'Fixed Schema requires a valid integer for size property.'
         end
-        super(:fixed, name, space, names, logical_type)
+        super(:fixed, name, space, names, nil, logical_type)
         @size = size
       end
 

--- a/lang/ruby/test/test_logical_types.rb
+++ b/lang/ruby/test/test_logical_types.rb
@@ -90,6 +90,14 @@ class TestLogicalTypes < Test::Unit::TestCase
     assert_equal Time.utc(2015, 5, 28, 21, 46, 53, 221843), type.decode(1432849613221843)
   end
 
+  def test_parse_fixed_duration
+    schema = Avro::Schema.parse <<-SCHEMA
+      { "type": "fixed", "size": 12, "name": "fixed_dur", "logicalType": "duration" }
+    SCHEMA
+
+    assert_equal 'duration', schema.logical_type
+  end
+
   def encode(datum, schema)
     buffer = StringIO.new("")
     encoder = Avro::IO::BinaryEncoder.new(buffer)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/AVRO-2381

In the Ruby implementation, a logical type associated with a fixed type is incorrectly parsed as a doc attribute (and doc is not supported for a fixed type according to the spec).