### PR TITLE
AVRO-2386: Make customEncode and customDecode public

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificRecordBase.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificRecordBase.java
@@ -115,11 +115,11 @@ public abstract class SpecificRecordBase
     return false;
   }
 
-  protected void customEncode(Encoder out) throws IOException {
+  public void customEncode(Encoder out) throws IOException {
     throw new UnsupportedOperationException();
   }
 
-  protected void customDecode(ResolvingDecoder in) throws IOException {
+  public void customDecode(ResolvingDecoder in) throws IOException {
     throw new UnsupportedOperationException();
   }
 }

--- a/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/record.vm
+++ b/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/record.vm
@@ -536,7 +536,7 @@ static {
 #if ($this.isCustomCodable($schema))
   @Override protected boolean hasCustomCoders() { return true; }
 
-  @Override protected void customEncode(org.apache.avro.io.Encoder out)
+  @Override public void customEncode(org.apache.avro.io.Encoder out)
     throws java.io.IOException
   {
 #set ($nv = 0)## Counter to ensure unique var-names
@@ -550,7 +550,7 @@ static {
 #end
   }
 
-  @Override protected void customDecode(org.apache.avro.io.ResolvingDecoder in)
+  @Override public void customDecode(org.apache.avro.io.ResolvingDecoder in)
     throws java.io.IOException
   {
     org.apache.avro.Schema.Field[] fieldOrder = in.readFieldOrderIfDiff();

--- a/lang/java/integration-test/codegen-test/src/test/java/org/apache/avro/codegentest/TestNestedRecordsWithDifferentNamespaces.java
+++ b/lang/java/integration-test/codegen-test/src/test/java/org/apache/avro/codegentest/TestNestedRecordsWithDifferentNamespaces.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.avro.codegentest;
+
+import org.apache.avro.codegentest.other.NestedOtherNamespaceRecord;
+import org.apache.avro.codegentest.some.NestedSomeNamespaceRecord;
+import org.junit.Test;
+
+public class TestNestedRecordsWithDifferentNamespaces extends AbstractSpecificRecordTest {
+
+  @Test
+  public void testNestedRecordsWithDifferentNamespaces() {
+    NestedSomeNamespaceRecord instanceOfGeneratedClass = NestedSomeNamespaceRecord.newBuilder()
+        .setNestedRecordBuilder(NestedOtherNamespaceRecord.newBuilder().setSomeField(1)).build();
+    verifySerDeAndStandardMethods(instanceOfGeneratedClass);
+  }
+
+}

--- a/lang/java/integration-test/codegen-test/src/test/resources/avro/nested_records_different_namespace.avsc
+++ b/lang/java/integration-test/codegen-test/src/test/resources/avro/nested_records_different_namespace.avsc
@@ -1,0 +1,23 @@
+{"namespace": "org.apache.avro.codegentest.some",
+  "type": "record",
+  "name": "NestedSomeNamespaceRecord",
+  "doc" : "Test nested types with different namespace than the outer type",
+  "fields": [
+    {
+      "name": "nestedRecord",
+      "type": {
+        "namespace": "org.apache.avro.codegentest.other",
+        "type": "record",
+        "name": "NestedOtherNamespaceRecord",
+        "fields": [
+          {
+            "name": "someField",
+            "type": "int"
+          }
+        ]
+      }
+    }]
+}
+
+
+

--- a/lang/java/tools/src/test/compiler/output-string/avro/examples/baseball/Player.java
+++ b/lang/java/tools/src/test/compiler/output-string/avro/examples/baseball/Player.java
@@ -493,7 +493,7 @@ public class Player extends org.apache.avro.specific.SpecificRecordBase implemen
 
   @Override protected boolean hasCustomCoders() { return true; }
 
-  @Override protected void customEncode(org.apache.avro.io.Encoder out)
+  @Override public void customEncode(org.apache.avro.io.Encoder out)
     throws java.io.IOException
   {
     out.writeInt(this.number);
@@ -517,7 +517,7 @@ public class Player extends org.apache.avro.specific.SpecificRecordBase implemen
 
   }
 
-  @Override protected void customDecode(org.apache.avro.io.ResolvingDecoder in)
+  @Override public void customDecode(org.apache.avro.io.ResolvingDecoder in)
     throws java.io.IOException
   {
     org.apache.avro.Schema.Field[] fieldOrder = in.readFieldOrderIfDiff();

--- a/lang/java/tools/src/test/compiler/output/Player.java
+++ b/lang/java/tools/src/test/compiler/output/Player.java
@@ -493,7 +493,7 @@ public class Player extends org.apache.avro.specific.SpecificRecordBase implemen
 
   @Override protected boolean hasCustomCoders() { return true; }
 
-  @Override protected void customEncode(org.apache.avro.io.Encoder out)
+  @Override public void customEncode(org.apache.avro.io.Encoder out)
     throws java.io.IOException
   {
     out.writeInt(this.number);
@@ -517,7 +517,7 @@ public class Player extends org.apache.avro.specific.SpecificRecordBase implemen
 
   }
 
-  @Override protected void customDecode(org.apache.avro.io.ResolvingDecoder in)
+  @Override public void customDecode(org.apache.avro.io.ResolvingDecoder in)
     throws java.io.IOException
   {
     org.apache.avro.Schema.Field[] fieldOrder = in.readFieldOrderIfDiff();


### PR DESCRIPTION
The problem was that the generated Java code did not compile for records with nested records in different namespaces. The reason is that these two methods were protected.

The suggested fix is to simply make the methods public, which gets rid of the regression. I realize that this is not good for other reasons (it is after all an internal method), so other suggestions are more than welcome.

This PR also includes a test that reproduced the problem.