### PR TITLE
WIP: AVRO-2393: Add C# example code

### DIFF
--- a/lang/csharp/README.md
+++ b/lang/csharp/README.md
@@ -1,4 +1,22 @@
-# Avro C#
+# Avro C# [![Build Status](https://travis-ci.org/apache/avro.svg?branch=master)](https://travis-ci.org/apache/avro) [![NuGet Package](https://img.shields.io/nuget/v/Apache.Avro.svg)](https://www.nuget.org/packages/Apache.Avro)
+
+[![Avro](http://avro.apache.org/images/avro-logo.png)](http://avro.apache.org/)
+
+## Install
+
+Install the Apache.Avro package from NuGet
+
+```
+Install-Package Apache.Avro
+```
+
+## Usage
+
+See the examples in [`src/apache/test/Examples`](./src/apache/test/Examples). The best place to
+start is the [Generic Examples](./src/apache/test/Examples/Generic.cs);
+
+Why are the examples implemented as unit tests? This helps us to ensure that our examples work
+properly and stay up-to-date.
 
 ## Build & Test
 

--- a/lang/csharp/src/apache/test/Avro.test.csproj
+++ b/lang/csharp/src/apache/test/Avro.test.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
@@ -22,6 +22,21 @@
     <AssemblyName>Avro.test</AssemblyName>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="..\..\..\..\..\share\test\data\weather.json" Link="Examples\Content\weather.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\..\..\..\share\test\data\weather.avro" Link="Examples\Content\weather.avro">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\..\..\..\share\test\schemas\weather.avsc" Link="Examples\Content\weather.avsc">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="nunit">
@@ -49,6 +64,10 @@
 
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Examples\Content\" />
   </ItemGroup>
 
 </Project>

--- a/lang/csharp/src/apache/test/Examples/Generic.cs
+++ b/lang/csharp/src/apache/test/Examples/Generic.cs
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 using Avro.File;
 using Avro.Generic;
 using NUnit.Framework;

--- a/lang/csharp/src/apache/test/Examples/Generic.cs
+++ b/lang/csharp/src/apache/test/Examples/Generic.cs
@@ -1,0 +1,130 @@
+using Avro.File;
+using Avro.Generic;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Avro.test.Examples
+{
+    /// <summary>
+    /// This class contains example usages of the Avro.Generic namespace.
+    /// </summary>
+    [TestFixture]
+    [Parallelizable(ParallelScope.All)]
+    public class Generic
+    {
+        /// <summary>
+        /// Create some <see cref="GenericRecord"/>s containing weather reports and write them to
+        /// an Avro data file using the <see cref="DataFileWriter{T}"/>.
+        ///
+        /// In this example we are creating an Avro data file whose content matches that of the
+        /// `weather.json` sample file.
+        /// </summary>
+        [Test]
+        public void Generic_DataFileWriter()
+        {
+            var schemaPath = GetExampleContentPath("weather.avsc");
+
+            // Load the schema used for weather report records.
+            var schema = (RecordSchema)Schema.Parse(System.IO.File.ReadAllText(schemaPath));
+
+            // Create each record and populate its fields.
+            var record0 = new GenericRecord(schema);
+            var record1 = new GenericRecord(schema);
+            var record2 = new GenericRecord(schema);
+            var record3 = new GenericRecord(schema);
+            var record4 = new GenericRecord(schema);
+
+            record0.Add("station", "011990-99999");
+            record0.Add("time", -619524000000);
+            record0.Add("temp", 0);
+            record1.Add("station", "011990-99999");
+            record1.Add("time", -619506000000);
+            record1.Add("temp", 22);
+            record2.Add("station","011990-99999");
+            record2.Add("time", -619484400000);
+            record2.Add("temp", -11);
+            record3.Add("station","012650-99999");
+            record3.Add("time", -655531200000);
+            record3.Add("temp", 111);
+            record4.Add("station","012650-99999");
+            record4.Add("time", -655509600000);
+            record4.Add("temp", 78);
+
+            var dataFilePath = GetExampleContentPath(Path.GetRandomFileName() + ".avro");
+
+            try
+            {
+                // This writer serializes the records according to the schema.
+                var datumWriter = new GenericDatumWriter<GenericRecord>(schema);
+
+                // Create a DataFileWriter that uses the GenericDatumWriter to serialize
+                // records to an Avro data file.
+                using (var writer = DataFileWriter<GenericRecord>.OpenWriter(
+                    datumWriter, dataFilePath))
+                {
+                    writer.Append(record0);
+                    writer.Append(record1);
+                    writer.Append(record2);
+                    writer.Append(record3);
+                    writer.Append(record4);
+                }
+
+                // TODO: This Avro data file *should* be identical to the weather.avro data file.
+                // If they were identical, we would compare the two files here to confirm
+                // everything worked as expected. However, due to a bug in the C# implementation,
+                // the schema written to the Avro data file does not contain the documentation
+                // for the record. This results in two files that are not identical.
+            }
+            finally
+            {
+                // Clean up our test file.
+                if (System.IO.File.Exists(dataFilePath))
+                {
+                    System.IO.File.Delete(dataFilePath);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Read an Avro data file, `weather.avro`, using a <see cref="DataFileReader{T}"/>.
+        /// Store the result in a <see cref="GenericRecord"/>. See `weather.json` for the
+        /// JSON representation of this data file.
+        /// </summary>
+        [Test]
+        public void Generic_DataFileReader()
+        {
+            var dataFilePath = GetExampleContentPath("weather.avro");
+            var records = new List<GenericRecord>();
+
+            // weather.avro is an Avro data file. To get a better idea of what it contains,
+            // see weather.json, which is the JSON representation of that data file.
+            // DataFileReader uses the schema embedded in the weather.avro data file to
+            // parse the records in the file.
+            using (var reader = DataFileReader<GenericRecord>.OpenReader(dataFilePath))
+            {
+                while (reader.HasNext())
+                {
+                    records.Add(reader.Next());
+                }
+            }
+
+            // This file contains 5 records.
+            Assert.AreEqual(5, records.Count);
+
+            var firstRecord = records[0];
+
+            // Use dictionary-like syntax to access fields in the records.
+            Assert.AreEqual("011990-99999", firstRecord["station"]);
+            Assert.AreEqual(-619524000000, firstRecord["time"]);
+            Assert.AreEqual(0, firstRecord["temp"]);
+        }
+
+        private static string GetExampleContentPath(string fileName)
+        {
+            return Path.Combine(TestContext.CurrentContext.TestDirectory,
+                "Examples", "Content", fileName);
+        }
+    }
+}


### PR DESCRIPTION
This is a proposal to add C# API examples. This approach adds new unit tests that are designed to introduce new developers to the C# Avro API.

So far, I have only added two examples. I would like to know whether or not others are happy with this approach before I continue adding more examples.

See [AVRO-2393](https://issues.apache.org/jira/browse/AVRO-2393) for more details on this approach and other approaches considered.