### PR TITLE
Fix crash of DataFileReader with gcc 4.8

### DIFF
--- a/lang/c++/impl/DataFile.cc
+++ b/lang/c++/impl/DataFile.cc
@@ -272,7 +272,7 @@ DataFileReaderBase::DataFileReaderBase(const char* filename) :
 }
 
 DataFileReaderBase::DataFileReaderBase(std::unique_ptr<InputStream> inputStream) :
-    filename_(NULL), stream_(std::move(inputStream)),
+    filename_(""), stream_(std::move(inputStream)),
     decoder_(binaryDecoder()), objectCount_(0), eof_(false)
 {
     readHeader();


### PR DESCRIPTION
While using DataFileReader (C++) through InputStream,
the following error encountered in Ubuntu 14.04, gcc 4.8:
```
terminate called after throwing an instance of 'std::logic_error'
  what():  basic_string::_S_construct null not valid
Aborted (core dumped)
```

The reason is that gcc 4.8 does not allow string(NULL) for initialization.

This fix fixes the issue on gcc 4.8 (Ubuntu 14.04).

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>