### PR TITLE
AVRO-2397 Implement Alias Support for C++

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test-output
 /lang/java/compiler/nb-configuration.xml
 /lang/java/compiler/nbproject/
 **/.vscode/**/*
+/lang/c++/CMakeResult

--- a/lang/c++/CMakeLists.txt
+++ b/lang/c++/CMakeLists.txt
@@ -44,12 +44,7 @@ if (WIN32 AND NOT CYGWIN AND NOT MSYS)
     add_definitions (/EHa)
     add_definitions (
         -DNOMINMAX
-        -DBOOST_REGEX_DYN_LINK
-        -DBOOST_FILESYSTEM_DYN_LINK
-        -DBOOST_SYSTEM_DYN_LINK
-        -DBOOST_IOSTREAMS_DYN_LINK
-        -DBOOST_PROGRAM_OPTIONS_DYN_LINK
-        -DBOOST_ALL_NO_LIB)
+		)
 else()
 # Replease c++11 with c++17 below in case C++ 17 should be used
     add_definitions(-std=c++11 -fPIC)
@@ -68,7 +63,7 @@ endif ()
 
 
 find_package (Boost 1.38 REQUIRED
-    COMPONENTS filesystem iostreams program_options regex system)
+    COMPONENTS zlib filesystem iostreams program_options regex system)
 
 find_package(Snappy)
 if (SNAPPY_FOUND)

--- a/lang/c++/api/Node.hh
+++ b/lang/c++/api/Node.hh
@@ -40,6 +40,7 @@ typedef std::shared_ptr<Node> NodePtr;
 class AVRO_DECL Name {
     std::string ns_;
     std::string simpleName_;
+	 std::vector<std::string> aliases_;
 public:
     Name() { }
     Name(const std::string& fullname);
@@ -52,6 +53,8 @@ public:
     void ns(const std::string& n) { ns_ = n; }
     void simpleName(const std::string& n) { simpleName_ = n; }
     void fullname(const std::string& n);
+	 void addAlias(const std::string& alias);
+	 bool hasAlias();
 
     bool operator < (const Name& n) const;
     void check() const;
@@ -147,8 +150,8 @@ class AVRO_DECL Node : private boost::noncopyable
         doAddName(name);
     }
     virtual size_t names() const = 0;
-    virtual const std::string &nameAt(int index) const = 0;
-    virtual bool nameIndex(const std::string &name, size_t &index) const = 0;
+    virtual const Name &nameAt(int index) const = 0;
+    virtual bool nameIndex(const Name &name, size_t &index) const = 0;
 
     void setFixedSize(int size) {
         checkLock();
@@ -187,7 +190,7 @@ class AVRO_DECL Node : private boost::noncopyable
     virtual void doSetDoc(const std::string &name) = 0;
 
     virtual void doAddLeaf(const NodePtr &newLeaf) = 0;
-    virtual void doAddName(const std::string &name) = 0;
+    virtual void doAddName(const Name &name) = 0;
     virtual void doSetFixedSize(int size) = 0;
 
   private:

--- a/lang/c++/api/NodeConcepts.hh
+++ b/lang/c++/api/NodeConcepts.hh
@@ -178,23 +178,23 @@ struct MultiAttribute
 template<typename T>
 struct NameIndexConcept {
 
-    bool lookup(const std::string &name, size_t &index) const {
+    bool lookup(const Name &name, size_t &index) const {
         throw Exception("Name index does not exist");
         return 0;
     }
 
-    bool add(const::std::string &name, size_t index) {
+    bool add(const Name &name, size_t index) {
         throw Exception("Name index does not exist");
         return false;
     }
 };
 
 template<>
-struct NameIndexConcept < MultiAttribute<std::string> > 
+struct NameIndexConcept < MultiAttribute<Name> > 
 {
-    typedef std::map<std::string, size_t> IndexMap;
+    typedef std::map<Name, size_t> IndexMap;
 
-    bool lookup(const std::string &name, size_t &index) const {
+    bool lookup(const Name &name, size_t &index) const {
         IndexMap::const_iterator iter = map_.find(name); 
         if(iter == map_.end()) {
             return false;
@@ -203,7 +203,7 @@ struct NameIndexConcept < MultiAttribute<std::string> >
         return true;
     }
 
-    bool add(const::std::string &name, size_t index) {
+    bool add(const Name &name, size_t index) {
         bool added = false;
         IndexMap::iterator lb = map_.lower_bound(name); 
         if(lb == map_.end() || map_.key_comp()(name, lb->first)) {

--- a/lang/c++/api/NodeImpl.hh
+++ b/lang/c++/api/NodeImpl.hh
@@ -128,7 +128,7 @@ class NodeImpl : public Node
         return leafAttributes_.get(index);
     }
 
-    void doAddName(const std::string &name) {
+    void doAddName(const Name &name) {
         if (! nameIndex_.add(name, leafNameAttributes_.size())) {
             throw Exception(boost::format("Cannot add duplicate name: %1%") % name);
         }
@@ -139,11 +139,11 @@ class NodeImpl : public Node
         return leafNameAttributes_.size();
     }
 
-    const std::string &nameAt(int index) const {
+    const Name &nameAt(int index) const {
         return leafNameAttributes_.get(index);
     }
 
-    bool nameIndex(const std::string &name, size_t &index) const {
+    bool nameIndex(const Name &name, size_t &index) const {
         return nameIndex_.lookup(name, index);
     }
 
@@ -218,8 +218,8 @@ typedef concepts::NoAttribute<NodePtr>      NoLeaves;
 typedef concepts::SingleAttribute<NodePtr>  SingleLeaf;
 typedef concepts::MultiAttribute<NodePtr>   MultiLeaves;
 
-typedef concepts::NoAttribute<std::string>     NoLeafNames;
-typedef concepts::MultiAttribute<std::string>  LeafNames;
+typedef concepts::NoAttribute<Name>     NoLeafNames;
+typedef concepts::MultiAttribute<Name>  LeafNames;
 
 typedef concepts::NoAttribute<int>     NoSize;
 typedef concepts::SingleAttribute<int> HasSize;

--- a/lang/c++/impl/Node.cc
+++ b/lang/c++/impl/Node.cc
@@ -50,6 +50,16 @@ void Name::fullname(const string& name)
     check();
 }
 
+void Name::addAlias(const std::string& alias)
+{
+	aliases_.emplace_back(alias);
+}
+
+bool Name::hasAlias()
+{
+	return aliases_.size() > 0;
+}
+
 bool Name::operator < (const Name& n) const
 {
     return (ns_ < n.ns_) ? true :
@@ -79,7 +89,30 @@ void Name::check() const
 
 bool Name::operator == (const Name& n) const
 {
-    return ns_ == n.ns_ && simpleName_ == n.simpleName_;
+	if (ns_ == n.ns_ && simpleName_ == n.simpleName_)
+		return true;
+
+	const std::string& myFullName = fullname();
+	const std::string& theirFullName = n.fullname();
+
+	for (const auto& theirAlias : n.aliases_)
+	{
+		if (myFullName == theirAlias)
+			return true;
+	}
+
+	for (const auto &myAlias : aliases_)
+	{
+		if (myAlias == theirFullName)
+			return true;
+		for (const auto& theirAlias : n.aliases_)
+		{
+			if (myAlias == theirAlias)
+				return true;
+		}
+	}
+
+	return false;
 }
 
 void Node::setLogicalType(LogicalType logicalType) {

--- a/lang/c++/impl/parsing/ResolvingDecoder.cc
+++ b/lang/c++/impl/parsing/ResolvingDecoder.cc
@@ -70,8 +70,8 @@ class ResolvingGrammarGenerator : public ValidatingGrammarGenerator {
         const NodePtr& reader, map<NodePair, ProductionPtr> &m,
         map<NodePtr, ProductionPtr> &m2);
 
-    static vector<pair<string, size_t> > fields(const NodePtr& n) {
-        vector<pair<string, size_t> > result;
+    static vector<pair<Name, size_t> > fields(const NodePtr& n) {
+        vector<pair<Name, size_t> > result;
         size_t c = n->names();
         for (size_t i = 0; i < c; ++i) {
             result.push_back(make_pair(n->nameAt(i), i));
@@ -191,8 +191,8 @@ ProductionPtr ResolvingGrammarGenerator::resolveRecords(
 {
     ProductionPtr result = make_shared<Production>();
 
-    vector<pair<string, size_t> > wf = fields(writer);
-    vector<pair<string, size_t> > rf = fields(reader);
+    vector<pair<Name, size_t> > wf = fields(writer);
+    vector<pair<Name, size_t> > rf = fields(reader);
     vector<size_t> fieldOrder;
     fieldOrder.reserve(reader->names());
 
@@ -202,11 +202,11 @@ ProductionPtr ResolvingGrammarGenerator::resolveRecords(
      * If no matching field is found for reader, arrange to skip the writer
      * field.
      */
-    for (vector<pair<string, size_t> >::const_iterator it = wf.begin();
+    for (vector<pair<Name, size_t> >::const_iterator it = wf.begin();
         it != wf.end(); ++it) {
-        vector<pair<string, size_t> >::iterator it2 =
+        vector<pair<Name, size_t> >::iterator it2 =
             find_if(rf.begin(), rf.end(),
-                equalsFirst<string, size_t>(it->first));
+                equalsFirst<Name, size_t>(it->first));
         if (it2 != rf.end()) {
             ProductionPtr p = doGenerate2(writer->leafAt(it->second),
                 reader->leafAt(it2->second), m, m2);
@@ -229,7 +229,7 @@ ProductionPtr ResolvingGrammarGenerator::resolveRecords(
      * Examine the reader fields left out, (i.e. those didn't have corresponding
      * writer field).
      */
-    for (vector<pair<string, size_t> >::const_iterator it = rf.begin();
+    for (vector<pair<Name, size_t> >::const_iterator it = rf.begin();
         it != rf.end(); ++it) {
 
         NodePtr s = reader->leafAt(it->second);

--- a/lang/c++/jsonschemas/bigrecord_r
+++ b/lang/c++/jsonschemas/bigrecord_r
@@ -1,9 +1,11 @@
 {
     "type": "record",
-    "name": "RootRecord",
+    "name": "RootRecordAliased",
+	"aliases": ["RootRecord"],
     "fields": [
         {
-            "name": "mylong",
+            "name": "mylongAliased",
+			"aliases": ["mylong"],
             "type": "long"
         },
         {

--- a/lang/c++/test/AvrogencppTests.cc
+++ b/lang/c++/test/AvrogencppTests.cc
@@ -134,7 +134,39 @@ void checkRecord(const T1& r1, const T2& r2)
     BOOST_CHECK_EQUAL(static_cast<unsigned int>(r1.myenum), static_cast<unsigned int>(r2.myenum));
 }
 
-void checkDefaultValues(const testgen_r::RootRecord& r)
+template <typename T1, typename T2>
+void checkRecordAliased(const T1& r1, const T2& r2)
+{
+	BOOST_CHECK_EQUAL(r1.mylongAliased, r2.mylong);
+	BOOST_CHECK_EQUAL(r1.nestedrecord.inval1, r2.nestedrecord.inval1);
+	BOOST_CHECK_EQUAL(r1.nestedrecord.inval2, r2.nestedrecord.inval2);
+	BOOST_CHECK_EQUAL(r1.nestedrecord.inval3, r2.nestedrecord.inval3);
+	BOOST_CHECK(r1.mymap == r2.mymap);
+	BOOST_CHECK(r1.myarray == r2.myarray);
+	BOOST_CHECK_EQUAL(r1.myunion.idx(), r2.myunion.idx());
+	BOOST_CHECK(r1.myunion.get_map() == r2.myunion.get_map());
+	BOOST_CHECK_EQUAL(r1.anotherunion.idx(), r2.anotherunion.idx());
+	BOOST_CHECK(r1.anotherunion.get_bytes() == r2.anotherunion.get_bytes());
+	BOOST_CHECK_EQUAL(r1.mybool, r2.mybool);
+	BOOST_CHECK_EQUAL(r1.anothernested.inval1, r2.anothernested.inval1);
+	BOOST_CHECK_EQUAL(r1.anothernested.inval2, r2.anothernested.inval2);
+	BOOST_CHECK_EQUAL(r1.anothernested.inval3, r2.anothernested.inval3);
+	BOOST_CHECK_EQUAL_COLLECTIONS(r1.myfixed.begin(), r1.myfixed.end(),
+		 r2.myfixed.begin(), r2.myfixed.end());
+	BOOST_CHECK_EQUAL(r1.anotherint, r2.anotherint);
+	BOOST_CHECK_EQUAL(r1.bytes.size(), r2.bytes.size());
+	BOOST_CHECK_EQUAL_COLLECTIONS(r1.bytes.begin(), r1.bytes.end(),
+		 r2.bytes.begin(), r2.bytes.end());
+	/**
+	 * Usually, comparing two different enums is not reliable. But here it fine because we
+	 * know the generated code and are merely checking if Avro did the right job.
+	 * Also, converting enum into unsigned int is not always safe. There are cases there could be
+	 * truncation. Again, we have a controlled situation and it is safe here.
+	 */
+	BOOST_CHECK_EQUAL(static_cast<unsigned int>(r1.myenum), static_cast<unsigned int>(r2.myenum));
+}
+
+void checkDefaultValues(const testgen_r::RootRecordAliased& r)
 {
     BOOST_CHECK_EQUAL(r.withDefaultValue.s1, "\"sval\\u8352\"");
     BOOST_CHECK_EQUAL(r.withDefaultValue.i1, 99);
@@ -189,18 +221,18 @@ void testResolution()
     unique_ptr<InputStream> is = memoryInputStream(*os);
     dd->init(*is);
     DecoderPtr rd = resolvingDecoder(s_w, s_r, dd);
-    testgen_r::RootRecord t2;
+    testgen_r::RootRecordAliased t2;
     avro::decode(*rd, t2);
 
-    checkRecord(t2, t1);
+	 checkRecordAliased(t2, t1);
     checkDefaultValues(t2);
 
     //Re-use the resolving decoder to decode again.
     unique_ptr<InputStream> is1 = memoryInputStream(*os);
     rd->init(*is1);
-    testgen_r::RootRecord t3;
+    testgen_r::RootRecordAliased t3;
     avro::decode(*rd, t3);
-    checkRecord(t3, t1);
+	 checkRecordAliased(t3, t1);
     checkDefaultValues(t3);
 
     // Test serialization of default values.
@@ -212,7 +244,7 @@ void testResolution()
     std::unique_ptr<InputStream> is2 = memoryInputStream(*os);
     dd->init(*is2);
     rd = resolvingDecoder(s_w, s_rs, dd);
-    testgen_r::RootRecord t4;
+    testgen_r::RootRecordAliased t4;
     avro::decode(*rd, t4);
     checkDefaultValues(t4);
 

--- a/lang/c++/test/unittest.cc
+++ b/lang/c++/test/unittest.cc
@@ -140,30 +140,30 @@ struct TestSchema
         NodePtr node = schema_.root();
 
         size_t index = 0;
-        bool found = node->nameIndex("mylongxxx", index);
+        bool found = node->nameIndex(std::string("mylongxxx"), index);
         BOOST_CHECK_EQUAL(found, false);
 
-        found = node->nameIndex("mylong", index);
+        found = node->nameIndex(std::string("mylong"), index);
         BOOST_CHECK_EQUAL(found, true);
         BOOST_CHECK_EQUAL(index, 0U);
 
-        found = node->nameIndex("mylong2", index);
+        found = node->nameIndex(std::string("mylong2"), index);
         BOOST_CHECK_EQUAL(found, true);
         BOOST_CHECK_EQUAL(index, 8U);
 
-        found = node->nameIndex("myenum", index);
+        found = node->nameIndex(std::string("myenum"), index);
         BOOST_CHECK_EQUAL(found, true);
         NodePtr enumNode = node->leafAt(index);
 
-        found = enumNode->nameIndex("one", index);
+        found = enumNode->nameIndex(std::string("one"), index);
         BOOST_CHECK_EQUAL(found, true);
         BOOST_CHECK_EQUAL(index, 1U);
 
-        found = enumNode->nameIndex("three", index);
+        found = enumNode->nameIndex(std::string("three"), index);
         BOOST_CHECK_EQUAL(found, true);
         BOOST_CHECK_EQUAL(index, 3U);
 
-        found = enumNode->nameIndex("four", index);
+        found = enumNode->nameIndex(std::string("four"), index);
         BOOST_CHECK_EQUAL(found, false);
     }
 


### PR DESCRIPTION
This provided code here should implement alias support for the C++ implementation of AVRO. 

You may or may not wish to include the CMake changes - they were required on my machine to build in VS2017 Windows. 

Note: One of the parts of the edited tests still fails as it relies on converting the schema to canonical form and re-running resolution. As the canonical form removes aliases its expected to fail.  I will leave it to the maintainers to decide how to handle that. 

See bug entry here: https://issues.apache.org/jira/browse/AVRO-2397 