### PR TITLE
AVRO-2398 Bump Jackson to 2.9.9

### DIFF
--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -40,7 +40,7 @@
     <!-- version properties for dependencies -->
 
     <hadoop.version>2.7.3</hadoop.version>
-    <jackson.version>2.9.8</jackson.version>
+    <jackson.version>2.9.9</jackson.version>
     <servlet-api.version>3.1.0</servlet-api.version>
     <jetty.version>9.4.15.v20190215</jetty.version>
     <jopt-simple.version>5.0.4</jopt-simple.version>


### PR DESCRIPTION
This fixes CVE-2019-12086 on Databind:
https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.9