### PR TITLE
AVRO-2400: Make schema resolution behave the same as previous versions

### DIFF
--- a/doc/src/content/xdocs/spec.xml
+++ b/doc/src/content/xdocs/spec.xml
@@ -1129,9 +1129,9 @@
           <ul>
             <li>both schemas are arrays whose item types match</li>
             <li>both schemas are maps whose value types match</li>
-            <li>both schemas are enums whose names match</li>
-            <li>both schemas are fixed whose sizes and names match</li>
-            <li>both schemas are records with the same name</li>
+            <li>both schemas are enums whose (unqualified) names match</li>
+            <li>both schemas are fixed whose sizes and (unqualified) names match</li>
+            <li>both schemas are records with the same (unqualified) name</li>
             <li>either schema is a union</li>
             <li>both schemas have same primitive type</li>
             <li>the writer's schema may be <em>promoted</em> to the

--- a/lang/java/avro/src/main/java/org/apache/avro/Resolver.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Resolver.java
@@ -691,8 +691,12 @@ public class Resolver {
     Schema.Type wt = w.getType();
     if (wt != r.getType())
       return false;
+
+    // Previously, the spec was somewhat ambiguous as to whether getFullName or
+    // getName should be used here. Using name rather than fully qualified name
+    // maintains backwards compatibility.
     if ((wt == Schema.Type.RECORD || wt == Schema.Type.FIXED || wt == Schema.Type.ENUM)
-        && !(w.getFullName() == null || w.getFullName().equals(r.getFullName())))
+        && !(w.getName() == null || w.getName().equals(r.getName())))
       return false;
 
     switch (w.getType()) {

--- a/lang/java/avro/src/main/java/org/apache/avro/SchemaCompatibility.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/SchemaCompatibility.java
@@ -94,12 +94,11 @@ public class SchemaCompatibility {
    * @return whether the names of the named schemas match or not.
    */
   public static boolean schemaNameEquals(final Schema reader, final Schema writer) {
-    final String writerFullName = writer.getFullName();
-    if (objectsEqual(reader.getFullName(), writerFullName)) {
+    if (objectsEqual(reader.getName(), writer.getName())) {
       return true;
     }
     // Apply reader aliases:
-    return reader.getAliases().contains(writerFullName);
+    return reader.getAliases().contains(writer.getFullName());
   }
 
   /**

--- a/lang/java/avro/src/main/java/org/apache/avro/io/parsing/ResolvingGrammarGenerator.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/parsing/ResolvingGrammarGenerator.java
@@ -113,8 +113,7 @@ public class ResolvingGrammarGenerator extends ValidatingGrammarGenerator {
       }
       return Symbol.seq(Symbol.alt(symbols, labels), Symbol.WRITER_UNION_ACTION);
 
-    }
-    if (action instanceof Resolver.ReaderUnion) {
+    } else if (action instanceof Resolver.ReaderUnion) {
       Resolver.ReaderUnion ru = (Resolver.ReaderUnion) action;
       Symbol s = generate(ru.actualAction, seen);
       return Symbol.seq(Symbol.unionAdjustAction(ru.firstMatch, s), Symbol.UNION);

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemaCompatibility.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemaCompatibility.java
@@ -239,8 +239,7 @@ public class TestSchemaCompatibility {
 
       // This is comparing two records that have an inner array of records with
       // different namespaces.
-      new ReaderWriter(NS_RECORD1, NS_RECORD2)
-  );
+      new ReaderWriter(NS_RECORD1, NS_RECORD2));
 
   // -----------------------------------------------------------------------------------------------
 

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemaCompatibility.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemaCompatibility.java
@@ -235,8 +235,11 @@ public class TestSchemaCompatibility {
 
       new ReaderWriter(NULL_SCHEMA, NULL_SCHEMA),
       new ReaderWriter(ENUM_AB_ENUM_DEFAULT_A_RECORD, ENUM_ABC_ENUM_DEFAULT_A_RECORD),
-      new ReaderWriter(ENUM_AB_FIELD_DEFAULT_A_ENUM_DEFAULT_B_RECORD, ENUM_ABC_FIELD_DEFAULT_B_ENUM_DEFAULT_A_RECORD)
+      new ReaderWriter(ENUM_AB_FIELD_DEFAULT_A_ENUM_DEFAULT_B_RECORD, ENUM_ABC_FIELD_DEFAULT_B_ENUM_DEFAULT_A_RECORD),
 
+      // This is comparing two records that have an inner array of records with
+      // different namespaces.
+      new ReaderWriter(NS_RECORD1, NS_RECORD2)
   );
 
   // -----------------------------------------------------------------------------------------------

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemaCompatibilityMultiple.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemaCompatibilityMultiple.java
@@ -101,16 +101,16 @@ public class TestSchemaCompatibilityMultiple {
         SchemaIncompatibilityType.NAME_MISMATCH, SchemaIncompatibilityType.TYPE_MISMATCH,
         SchemaIncompatibilityType.READER_FIELD_MISSING_DEFAULT_VALUE, SchemaIncompatibilityType.FIXED_SIZE_MISMATCH,
         SchemaIncompatibilityType.MISSING_UNION_BRANCH, SchemaIncompatibilityType.MISSING_UNION_BRANCH,
-        SchemaIncompatibilityType.MISSING_UNION_BRANCH, SchemaIncompatibilityType.NAME_MISMATCH,
+        SchemaIncompatibilityType.MISSING_UNION_BRANCH,
         SchemaIncompatibilityType.TYPE_MISMATCH);
     List<String> details = Arrays.asList("[B, D]", "expected: check_enum_name_type_ERR",
         "reader type: STRING not compatible with writer type: LONG", "extra_no_default_field", "expected: 8, found: 4",
         "reader union lacking writer type: DOUBLE", "reader union lacking writer type: STRING",
-        "reader union lacking writer type: LONG", "expected: nsA.recordA",
+        "reader union lacking writer type: LONG",
         "reader type: STRING not compatible with writer type: BOOLEAN");
     List<String> location = Arrays.asList("/fields/0/type/symbols", "/fields/1/type/name", "/fields/2/type",
         "/fields/3/type/fields/1", "/fields/3/type/fields/2/type/size", "/fields/3/type/fields/3/type/1",
-        "/fields/3/type/fields/3/type/2", "/fields/3/type/fields/4/type", "/fields/3/type/fields/5/type/name",
+        "/fields/3/type/fields/3/type/2", "/fields/3/type/fields/4/type",
         "/fields/3/type/fields/5/type/fields/1/type/items");
 
     validateIncompatibleSchemas(reader, writer, types, details, location);

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemaCompatibilityMultiple.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemaCompatibilityMultiple.java
@@ -101,13 +101,11 @@ public class TestSchemaCompatibilityMultiple {
         SchemaIncompatibilityType.NAME_MISMATCH, SchemaIncompatibilityType.TYPE_MISMATCH,
         SchemaIncompatibilityType.READER_FIELD_MISSING_DEFAULT_VALUE, SchemaIncompatibilityType.FIXED_SIZE_MISMATCH,
         SchemaIncompatibilityType.MISSING_UNION_BRANCH, SchemaIncompatibilityType.MISSING_UNION_BRANCH,
-        SchemaIncompatibilityType.MISSING_UNION_BRANCH,
-        SchemaIncompatibilityType.TYPE_MISMATCH);
+        SchemaIncompatibilityType.MISSING_UNION_BRANCH, SchemaIncompatibilityType.TYPE_MISMATCH);
     List<String> details = Arrays.asList("[B, D]", "expected: check_enum_name_type_ERR",
         "reader type: STRING not compatible with writer type: LONG", "extra_no_default_field", "expected: 8, found: 4",
         "reader union lacking writer type: DOUBLE", "reader union lacking writer type: STRING",
-        "reader union lacking writer type: LONG",
-        "reader type: STRING not compatible with writer type: BOOLEAN");
+        "reader union lacking writer type: LONG", "reader type: STRING not compatible with writer type: BOOLEAN");
     List<String> location = Arrays.asList("/fields/0/type/symbols", "/fields/1/type/name", "/fields/2/type",
         "/fields/3/type/fields/1", "/fields/3/type/fields/2/type/size", "/fields/3/type/fields/3/type/1",
         "/fields/3/type/fields/3/type/2", "/fields/3/type/fields/4/type",

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemaCompatibilityNameMismatch.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemaCompatibilityNameMismatch.java
@@ -33,10 +33,6 @@ import org.junit.runners.Parameterized.Parameters;
 public class TestSchemaCompatibilityNameMismatch {
 
   private static final Schema FIXED_4_ANOTHER_NAME = Schema.createFixed("AnotherName", null, null, 4);
-  private static final Schema FIXED_4_NAMESPACE_V1 = Schema.createFixed("Fixed", null, "org.apache.avro.tests.v_1_0",
-      4);
-  private static final Schema FIXED_4_NAMESPACE_V2 = Schema.createFixed("Fixed", null, "org.apache.avro.tests.v_2_0",
-      4);
 
   @Parameters(name = "r: {0} | w: {1}")
   public static Iterable<Object[]> data() {
@@ -44,7 +40,6 @@ public class TestSchemaCompatibilityNameMismatch {
         { ENUM1_AB_SCHEMA, ENUM2_AB_SCHEMA, "expected: Enum2", "/name" },
         { EMPTY_RECORD2, EMPTY_RECORD1, "expected: Record1", "/name" },
         { FIXED_4_BYTES, FIXED_4_ANOTHER_NAME, "expected: AnotherName", "/name" },
-        { FIXED_4_NAMESPACE_V1, FIXED_4_NAMESPACE_V2, "expected: org.apache.avro.tests.v_2_0.Fixed", "/name" },
         { A_DINT_B_DENUM_1_RECORD1, A_DINT_B_DENUM_2_RECORD1, "expected: Enum2", "/fields/1/type/name" } };
     return Arrays.asList(fields);
   }

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemaValidation.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemaValidation.java
@@ -107,7 +107,13 @@ public class TestSchemaValidation {
       // new ReaderWriter(LONG_LIST_RECORD, LONG_LIST_RECORD),
       // new ReaderWriter(LONG_LIST_RECORD, INT_LIST_RECORD),
 
-      new ReaderWriter(NULL_SCHEMA, NULL_SCHEMA));
+      new ReaderWriter(NULL_SCHEMA, NULL_SCHEMA),
+
+      // Only included here for now. SchemaCompatibility and Resolver have
+      // a different idea of what schemas are compatible. See AVRO-2400.
+      // This is comparing two records that have an inner array of records with
+      // different namespaces.
+      new ReaderWriter(NS_RECORD1, NS_RECORD2));
 
   /** Collection of reader/writer schema pair that are incompatible. */
   public static final List<ReaderWriter> INCOMPATIBLE_READER_WRITER_TEST_CASES = list(

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemaValidation.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemaValidation.java
@@ -109,8 +109,6 @@ public class TestSchemaValidation {
 
       new ReaderWriter(NULL_SCHEMA, NULL_SCHEMA),
 
-      // Only included here for now. SchemaCompatibility and Resolver have
-      // a different idea of what schemas are compatible. See AVRO-2400.
       // This is comparing two records that have an inner array of records with
       // different namespaces.
       new ReaderWriter(NS_RECORD1, NS_RECORD2));

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemas.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemas.java
@@ -100,6 +100,11 @@ public class TestSchemas {
   static final Schema FIXED_4_BYTES = Schema.createFixed("Fixed", null, null, 4);
   static final Schema FIXED_8_BYTES = Schema.createFixed("Fixed", null, null, 8);
 
+  static final Schema NS_RECORD1 = Schema.createRecord("Record1", null, null, false);
+  static final Schema NS_RECORD2 = Schema.createRecord("Record1", null, null, false);
+  static final Schema NS_INNER_RECORD1 = Schema.createRecord("InnerRecord1", null, "ns1", false);
+  static final Schema NS_INNER_RECORD2 = Schema.createRecord("InnerRecord1", null, "ns2", false);
+
   static {
     EMPTY_RECORD1.setFields(Collections.emptyList());
     EMPTY_RECORD2.setFields(Collections.emptyList());
@@ -121,6 +126,14 @@ public class TestSchemas {
         .setFields(list(new Field("a", INT_SCHEMA, null, 0), new Field("b", ENUM1_AB_SCHEMA, null, null)));
     A_DINT_B_DENUM_2_RECORD1
         .setFields(list(new Field("a", INT_SCHEMA, null, 0), new Field("b", ENUM2_AB_SCHEMA, null, null)));
+
+    NS_INNER_RECORD1.setFields(list(new Schema.Field("a", INT_SCHEMA)));
+    NS_INNER_RECORD2.setFields(list(new Schema.Field("a", INT_SCHEMA)));
+
+    NS_RECORD1
+        .setFields(list(new Schema.Field("f1", Schema.createUnion(NULL_SCHEMA, Schema.createArray(NS_INNER_RECORD1)))));
+    NS_RECORD2
+        .setFields(list(new Schema.Field("f1", Schema.createUnion(NULL_SCHEMA, Schema.createArray(NS_INNER_RECORD2)))));
   }
 
   // Recursive records


### PR DESCRIPTION
Make 1.9.x behavior when parsing qualified names match prior versions.

See https://issues.apache.org/jira/browse/AVRO-2400