### PR TITLE
AVRO-2415 - Union resolver regression when dealing with arrays

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/io/parsing/ResolvingGrammarGenerator.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/parsing/ResolvingGrammarGenerator.java
@@ -91,6 +91,11 @@ public class ResolvingGrammarGenerator extends ValidatingGrammarGenerator {
     } else if (action instanceof Resolver.Promote) {
       return Symbol.resolve(simpleGen(action.writer, seen), simpleGen(action.reader, seen));
 
+    } else if (action instanceof Resolver.ReaderUnion) {
+      Resolver.ReaderUnion ru = (Resolver.ReaderUnion) action;
+      Symbol s = generate(ru.actualAction, seen);
+      return Symbol.seq(Symbol.unionAdjustAction(ru.firstMatch, s), Symbol.UNION);
+
     } else if (action.writer.getType() == Schema.Type.ARRAY) {
       Symbol es = generate(((Resolver.Container) action).elementAction, seen);
       return Symbol.seq(Symbol.repeat(Symbol.ARRAY_END, es), Symbol.ARRAY_START);
@@ -112,12 +117,6 @@ public class ResolvingGrammarGenerator extends ValidatingGrammarGenerator {
         i++;
       }
       return Symbol.seq(Symbol.alt(symbols, labels), Symbol.WRITER_UNION_ACTION);
-
-    }
-    if (action instanceof Resolver.ReaderUnion) {
-      Resolver.ReaderUnion ru = (Resolver.ReaderUnion) action;
-      Symbol s = generate(ru.actualAction, seen);
-      return Symbol.seq(Symbol.unionAdjustAction(ru.firstMatch, s), Symbol.UNION);
 
     } else if (action instanceof Resolver.EnumAdjust) {
       Resolver.EnumAdjust e = (Resolver.EnumAdjust) action;

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemaValidation.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemaValidation.java
@@ -76,6 +76,8 @@ public class TestSchemaValidation {
       new ReaderWriter(BYTES_UNION_SCHEMA, EMPTY_UNION_SCHEMA),
       new ReaderWriter(BYTES_UNION_SCHEMA, STRING_UNION_SCHEMA),
       new ReaderWriter(DOUBLE_UNION_SCHEMA, INT_FLOAT_UNION_SCHEMA),
+      
+      new ReaderWriter(NULL_INT_ARRAY_UNION_SCHEMA, INT_ARRAY_SCHEMA),
 
       // Readers capable of reading all branches of a union are compatible
       new ReaderWriter(FLOAT_SCHEMA, INT_FLOAT_UNION_SCHEMA), new ReaderWriter(LONG_SCHEMA, INT_LONG_UNION_SCHEMA),

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemaValidation.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemaValidation.java
@@ -76,7 +76,7 @@ public class TestSchemaValidation {
       new ReaderWriter(BYTES_UNION_SCHEMA, EMPTY_UNION_SCHEMA),
       new ReaderWriter(BYTES_UNION_SCHEMA, STRING_UNION_SCHEMA),
       new ReaderWriter(DOUBLE_UNION_SCHEMA, INT_FLOAT_UNION_SCHEMA),
-      
+
       new ReaderWriter(NULL_INT_ARRAY_UNION_SCHEMA, INT_ARRAY_SCHEMA),
 
       // Readers capable of reading all branches of a union are compatible

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemaValidation.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemaValidation.java
@@ -78,6 +78,7 @@ public class TestSchemaValidation {
       new ReaderWriter(DOUBLE_UNION_SCHEMA, INT_FLOAT_UNION_SCHEMA),
 
       new ReaderWriter(NULL_INT_ARRAY_UNION_SCHEMA, INT_ARRAY_SCHEMA),
+      new ReaderWriter(NULL_INT_MAP_UNION_SCHEMA, INT_MAP_SCHEMA),
 
       // Readers capable of reading all branches of a union are compatible
       new ReaderWriter(FLOAT_SCHEMA, INT_FLOAT_UNION_SCHEMA), new ReaderWriter(LONG_SCHEMA, INT_LONG_UNION_SCHEMA),

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemas.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemas.java
@@ -81,6 +81,7 @@ public class TestSchemas {
       .createUnion(list(INT_SCHEMA, LONG_SCHEMA, FLOAT_SCHEMA, DOUBLE_SCHEMA));
 
   static final Schema NULL_INT_ARRAY_UNION_SCHEMA = Schema.createUnion(list(NULL_SCHEMA, INT_ARRAY_SCHEMA));
+  static final Schema NULL_INT_MAP_UNION_SCHEMA = Schema.createUnion(list(NULL_SCHEMA, INT_MAP_SCHEMA));
 
   // Non recursive records:
   static final Schema EMPTY_RECORD1 = Schema.createRecord("Record1", null, null, false);

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemas.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemas.java
@@ -80,6 +80,8 @@ public class TestSchemas {
   static final Schema INT_LONG_FLOAT_DOUBLE_UNION_SCHEMA = Schema
       .createUnion(list(INT_SCHEMA, LONG_SCHEMA, FLOAT_SCHEMA, DOUBLE_SCHEMA));
 
+  static final Schema NULL_INT_ARRAY_UNION_SCHEMA = Schema.createUnion(list(NULL_SCHEMA,INT_ARRAY_SCHEMA));
+
   // Non recursive records:
   static final Schema EMPTY_RECORD1 = Schema.createRecord("Record1", null, null, false);
   static final Schema EMPTY_RECORD2 = Schema.createRecord("Record2", null, null, false);

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemas.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemas.java
@@ -80,7 +80,7 @@ public class TestSchemas {
   static final Schema INT_LONG_FLOAT_DOUBLE_UNION_SCHEMA = Schema
       .createUnion(list(INT_SCHEMA, LONG_SCHEMA, FLOAT_SCHEMA, DOUBLE_SCHEMA));
 
-  static final Schema NULL_INT_ARRAY_UNION_SCHEMA = Schema.createUnion(list(NULL_SCHEMA,INT_ARRAY_SCHEMA));
+  static final Schema NULL_INT_ARRAY_UNION_SCHEMA = Schema.createUnion(list(NULL_SCHEMA, INT_ARRAY_SCHEMA));
 
   // Non recursive records:
   static final Schema EMPTY_RECORD1 = Schema.createRecord("Record1", null, null, false);


### PR DESCRIPTION
Fix error with resolution with

writer = array<int>
reader = union { null, array<int> }

Resolution works fine in 1.8.2 and got broken with the new Resolver code.

https://issues.apache.org/jira/browse/AVRO-2415