### PR TITLE
AVRO-2421 Allow multiple @AvroAliases annotations on classes and fields

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/AvroAlias.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/AvroAlias.java
@@ -18,6 +18,7 @@
 package org.apache.avro.reflect;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -28,6 +29,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE, ElementType.FIELD })
+@Repeatable(AvroAliases.class)
 public @interface AvroAlias {
   String NULL = "NOT A VALID NAMESPACE";
 

--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/AvroAliases.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/AvroAliases.java
@@ -1,0 +1,12 @@
+package org.apache.avro.reflect;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.FIELD })
+public @interface AvroAliases {
+  AvroAlias[] value();
+}

--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/AvroAliases.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/AvroAliases.java
@@ -5,6 +5,22 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE, ElementType.FIELD })
 public @interface AvroAliases {

--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/AvroAliases.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/AvroAliases.java
@@ -1,10 +1,3 @@
-package org.apache.avro.reflect;
-
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-
 /**
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this
@@ -21,6 +14,13 @@ import java.lang.annotation.Target;
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+package org.apache.avro.reflect;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE, ElementType.FIELD })
 public @interface AvroAliases {

--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectData.java
@@ -875,8 +875,8 @@ public class ReflectData extends SpecificData {
   }
 
   private void consumeAvroAliasAnnotation(Class<?> c, Schema schema) {
-    AvroAlias alias = c.getAnnotation(AvroAlias.class);
-    if (alias != null) {
+    AvroAlias[] aliases = c.getAnnotationsByType(AvroAlias.class);
+    for (AvroAlias alias : aliases) {
       String space = alias.space();
       if (AvroAlias.NULL.equals(space))
         space = null;
@@ -885,8 +885,8 @@ public class ReflectData extends SpecificData {
   }
 
   private void consumeFieldAlias(Field field, Schema.Field recordField) {
-    AvroAlias alias = field.getAnnotation(AvroAlias.class);
-    if (alias != null) {
+    AvroAlias[] aliases = field.getAnnotationsByType(AvroAlias.class);
+    for (AvroAlias alias : aliases) {
       if (!alias.space().equals(AvroAlias.NULL)) {
         throw new AvroRuntimeException(
             "Namespaces are not allowed on field aliases. " + "Offending field: " + recordField.name());

--- a/lang/java/avro/src/test/java/org/apache/avro/reflect/TestReflect.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/reflect/TestReflect.java
@@ -1192,6 +1192,19 @@ public class TestReflect {
         "{\"type\":\"record\",\"name\":\"AliasC\",\"namespace\":\"org.apache.avro.reflect.TestReflect\",\"fields\":[],\"aliases\":[\"a\"]}");
   }
 
+  @AvroAlias(alias = "alias1", space = "space1")
+  @AvroAlias(alias = "alias2", space = "space2")
+  private static class MultipleAliasRecord {
+
+  }
+
+  @Test
+  public void testMultipleAliasAnnotationsOnClass() {
+    check(MultipleAliasRecord.class,
+        "{\"type\":\"record\",\"name\":\"MultipleAliasRecord\",\"namespace\":\"org.apache.avro.reflect.TestReflect\",\"fields\":[],\"aliases\":[\"space1.alias1\",\"space2.alias2\"]}");
+
+  }
+
   private static class Z {
   }
 
@@ -1206,6 +1219,12 @@ public class TestReflect {
 
   private static class ClassWithAliasOnField {
     @AvroAlias(alias = "aliasName")
+    int primitiveField;
+  }
+
+  private static class ClassWithMultipleAliasesOnField {
+    @AvroAlias(alias = "alias1")
+    @AvroAlias(alias = "alias2")
     int primitiveField;
   }
 
@@ -1227,6 +1246,16 @@ public class TestReflect {
   @Test(expected = AvroRuntimeException.class)
   public void namespaceDefinitionOnFieldAliasMustThrowException() {
     ReflectData.get().getSchema(ClassWithAliasAndNamespaceOnField.class);
+  }
+
+  @Test
+  public void testMultipleFieldAliases() {
+
+    Schema expectedSchema = SchemaBuilder.record(ClassWithMultipleAliasesOnField.class.getSimpleName())
+        .namespace("org.apache.avro.reflect.TestReflect").fields().name("primitiveField").aliases("alias1", "alias2")
+        .type(Schema.create(org.apache.avro.Schema.Type.INT)).noDefault().endRecord();
+
+    check(ClassWithMultipleAliasesOnField.class, expectedSchema.toString());
   }
 
   private static class DefaultTest {


### PR DESCRIPTION
[AVRO-2421](https://issues.apache.org/jira/browse/AVRO-2421)

Add all @AvroAlias present on classes and fields to the schema