### PR TITLE
AVRO-2425: CMake error message for C bindings is misleading

### DIFF
--- a/lang/c/docs/CMakeLists.txt
+++ b/lang/c/docs/CMakeLists.txt
@@ -48,6 +48,6 @@ if (ASCIIDOC_EXECUTABLE AND SOURCE_HIGHLIGHT_EXECUTABLE)
         add_custom_target(docs DEPENDS "${_html_out}")
     endforeach(_file)
 else(ASCIIDOC_EXECUTABLE AND SOURCE_HIGHLIGHT_EXECUTABLE)
-    message(WARNING "asciidoc not found. HTML documentation will *NOT* be built.")
+    message(WARNING "asciidoc and/or source-highlight not found. HTML documentation will *NOT* be built.")
 endif(ASCIIDOC_EXECUTABLE AND SOURCE_HIGHLIGHT_EXECUTABLE)
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2425
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

This change is for the build process, so it's difficult to write unit tests. Instead, I removed the source-highlight package from my OS and ran `./build.sh dist` in the lang/c directory, and confirmed the expected message was shown.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
