### PR TITLE
AVRO-2428: Update Hadoop version in the MR document

### DIFF
--- a/doc/examples/mr-example/pom.xml
+++ b/doc/examples/mr-example/pom.xml
@@ -40,7 +40,7 @@
       <plugin>
         <groupId>org.apache.avro</groupId>
         <artifactId>avro-maven-plugin</artifactId>
-        <version>1.7.5</version>
+        <version>1.9.0</version>
         <executions>
           <execution>
             <phase>generate-sources</phase>
@@ -61,17 +61,17 @@
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
-      <version>1.7.5</version>
+      <version>1.9.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro-mapred</artifactId>
-      <version>1.7.5</version>
+      <version>1.9.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-core</artifactId>
-      <version>1.1.0</version>
+      <artifactId>hadoop-client</artifactId>
+      <version>3.1.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/doc/src/content/xdocs/mr.xml
+++ b/doc/src/content/xdocs/mr.xml
@@ -64,8 +64,8 @@
 &#60;/dependency&#62;
 &#60;dependency&#62;
   &#60;groupId&#62;org.apache.hadoop&#60;/groupId&#62;
-  &#60;artifactId&#62;hadoop-core&#60;/artifactId&#62;
-  &#60;version&#62;1.1.0&#60;/version&#62;
+  &#60;artifactId&#62;hadoop-client&#60;/artifactId&#62;
+  &#60;version&#62;3.1.2&#60;/version&#62;
 &#60;/dependency&#62;
       </source>
       <p>


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2428
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No additional test since it's mainly a documentation fix. Instead, I walked through the MR document (http://avro.apache.org/docs/current/mr.html) and confirmed all of the commands in that document (`mvn compile` and `mvn exec:java`) worked with the updated pom.xml. Also, I ran `./build.sh dist`
 and confirmed that avro-doc-1.10.0-SNAPSHOT was successfully generated.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
