### PR TITLE
AVRO-2436: Add snappy packages for python2/3 to Dockerfile

### DIFF
--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -68,7 +68,9 @@ RUN apt-get -qq update && \
     php5.6-gmp \
     python \
     python-setuptools \
+    python-snappy \
     python3-setuptools \
+    python3-snappy \
     rake \
     ruby \
     ruby-dev \


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2436
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No additional test, since it's a fix for the test itself. Instead, I ran `./build.sh docker-test` with the revised Dockerfile and confirmed the following message was never shown.

```
  [py-test] Snappy not present, will skip testing it.
```

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
