### PR TITLE
AVRO-2426: Add zstd support to Python2 bindings

### DIFF
--- a/lang/py/src/avro/datafile.py
+++ b/lang/py/src/avro/datafile.py
@@ -28,6 +28,11 @@ try:
   has_snappy = True
 except ImportError:
   has_snappy = False
+try:
+  import zstandard as zstd
+  has_zstandard = True
+except ImportError:
+  has_zstandard = False
 #
 # Constants
 #
@@ -47,6 +52,8 @@ META_SCHEMA = schema.parse("""\
 VALID_CODECS = ['null', 'deflate']
 if has_snappy:
     VALID_CODECS.append('snappy')
+if has_zstandard:
+    VALID_CODECS.append('zstandard')
 VALID_ENCODINGS = ['binary'] # not used yet
 
 CODEC_KEY = "avro.codec"
@@ -170,6 +177,9 @@ class DataFileWriter(object):
       elif self.get_meta(CODEC_KEY) == 'snappy':
         compressed_data = snappy.compress(uncompressed_data)
         compressed_data_length = len(compressed_data) + 4 # crc32
+      elif self.get_meta(CODEC_KEY) == 'zstandard':
+        compressed_data = zstd.ZstdCompressor().compress(uncompressed_data)
+        compressed_data_length = len(compressed_data)
       else:
         fail_msg = '"%s" codec is not supported.' % self.get_meta(CODEC_KEY)
         raise DataFileException(fail_msg)
@@ -331,6 +341,19 @@ class DataFileReader(object):
       uncompressed = snappy.decompress(data)
       self._datum_decoder = io.BinaryDecoder(StringIO(uncompressed))
       self.raw_decoder.check_crc32(uncompressed);
+    elif self.codec == 'zstandard':
+      length = self.raw_decoder.read_long()
+      data = self.raw_decoder.read(length)
+      uncompressed = bytearray()
+      dctx = zstd.ZstdDecompressor()
+      with dctx.stream_reader(StringIO(data)) as reader:
+        while True:
+          chunk = reader.read(16384)
+          if not chunk:
+            break
+          else:
+            uncompressed.extend(chunk)
+      self._datum_decoder = io.BinaryDecoder(StringIO(uncompressed))
     else:
       raise DataFileException("Unknown codec: %r" % self.codec)
 

--- a/lang/py/src/avro/datafile.py
+++ b/lang/py/src/avro/datafile.py
@@ -351,8 +351,7 @@ class DataFileReader(object):
           chunk = reader.read(16384)
           if not chunk:
             break
-          else:
-            uncompressed.extend(chunk)
+          uncompressed.extend(chunk)
       self._datum_decoder = io.BinaryDecoder(StringIO(uncompressed))
     else:
       raise DataFileException("Unknown codec: %r" % self.codec)

--- a/lang/py/test/test_datafile.py
+++ b/lang/py/test/test_datafile.py
@@ -60,6 +60,11 @@ try:
   CODECS_TO_VALIDATE += ('snappy',)
 except ImportError:
   print 'Snappy not present, will skip testing it.'
+try:
+  import zstandard
+  CODECS_TO_VALIDATE += ('zstandard',)
+except ImportError:
+  print 'Zstandard not present, will skip testing it.'
 
 # TODO(hammer): clean up written files with ant, not os.remove
 class TestDataFile(unittest.TestCase):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2426
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

I added new codec (zstandard) to CODECS_TO_VALIDATE in test_datafile.py, so if the zstandard python package is installed, read/write are tested in test_round_trip and test_append.
In addition, as an interoperability test, I generated a zstd-compressed Avro file using Java bindings manually and confirmed it can be read from Python2 bindings.

```
$ cd lang/java/tools
$ mvn dependency:copy-dependencies
$ java -cp 'target/avro-tools-1.10.0-SNAPSHOT.jar:target/dependency/*' org.apache.avro.tool.Main fromjson --codec zstandard --schema-file ../../../share/test/schemas/weather.avsc ../../../share/test/data/weather.json > /tmp/zstandard.avro
```

```
In [1]: from avro.schema import parse

In [2]: with open("../../share/test/schemas/weather.avsc") as f:
   ...:     s = parse(f.read())
   ...:     

In [3]: from avro.datafile import DataFileReader

In [4]: from avro.io import DatumReader

In [5]: with open("/tmp/zstandard.avro", "rb") as f:
   ...:     r = DataFileReader(f, DatumReader())
   ...:     for i in r:
   ...:         print(i)
   ...:         
{u'station': u'011990-99999', u'temp': 0, u'time': -619524000000}
{u'station': u'011990-99999', u'temp': 22, u'time': -619506000000}
{u'station': u'011990-99999', u'temp': -11, u'time': -619484400000}
{u'station': u'012650-99999', u'temp': 111, u'time': -655531200000}
{u'station': u'012650-99999', u'temp': 78, u'time': -655509600000}

In [6]: r.codec
Out[6]: 'zstandard'
```

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
