### PR TITLE
AVRO-2440: Decode messages by their write schema

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/message/BinaryMessageDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/message/BinaryMessageDecoder.java
@@ -16,12 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.avro.message;
 
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaNormalization;
 import org.apache.avro.generic.GenericData;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
@@ -66,12 +66,15 @@ public class BinaryMessageDecoder<D> extends MessageDecoder.BaseDecoder<D> {
    * {@link Schema schema}.
    * <p>
    * The {@code readSchema} is as used the expected schema (read schema). Datum
-   * instances created by this class will are described by the expected schema.
+   * instances created by this class will be described by the expected schema.
+   * <p>
+   * If {@code readSchema} is {@code null}, the write schema of an incoming buffer
+   * is used as read schema for that datum instance.
    * <p>
    * The schema used to decode incoming buffers is determined by the schema
    * fingerprint encoded in the message header. This class can decode messages
-   * that were encoded using the {@code readSchema} and other schemas that are
-   * added using {@link #addSchema(Schema)}.
+   * that were encoded using the {@code readSchema} (if any) and other schemas
+   * that are added using {@link #addSchema(Schema)}.
    *
    * @param model      the {@link GenericData data model} for datum instances
    * @param readSchema the {@link Schema} used to construct datum instances
@@ -86,12 +89,15 @@ public class BinaryMessageDecoder<D> extends MessageDecoder.BaseDecoder<D> {
    * {@link Schema schema}.
    * <p>
    * The {@code readSchema} is used as the expected schema (read schema). Datum
-   * instances created by this class will are described by the expected schema.
+   * instances created by this class will be described by the expected schema.
+   * <p>
+   * If {@code readSchema} is {@code null}, the write schema of an incoming buffer
+   * is used as read schema for that datum instance.
    * <p>
    * The schema used to decode incoming buffers is determined by the schema
    * fingerprint encoded in the message header. This class can decode messages
-   * that were encoded using the {@code readSchema}, other schemas that are added
-   * using {@link #addSchema(Schema)}, or schemas returned by the
+   * that were encoded using the {@code readSchema} (if any), other schemas that
+   * are added using {@link #addSchema(Schema)}, or schemas returned by the
    * {@code resolver}.
    *
    * @param model      the {@link GenericData data model} for datum instances
@@ -102,7 +108,9 @@ public class BinaryMessageDecoder<D> extends MessageDecoder.BaseDecoder<D> {
     this.model = model;
     this.readSchema = readSchema;
     this.resolver = resolver;
-    addSchema(readSchema);
+    if (readSchema != null) {
+      addSchema(readSchema);
+    }
   }
 
   /**
@@ -112,7 +120,8 @@ public class BinaryMessageDecoder<D> extends MessageDecoder.BaseDecoder<D> {
    */
   public void addSchema(Schema writeSchema) {
     long fp = SchemaNormalization.parsingFingerprint64(writeSchema);
-    codecByFingerprint.put(fp, new RawMessageDecoder<>(model, writeSchema, readSchema));
+    final Schema actualReadSchema = this.readSchema != null ? this.readSchema : writeSchema;
+    codecByFingerprint.put(fp, new RawMessageDecoder<D>(model, writeSchema, actualReadSchema));
   }
 
   private RawMessageDecoder<D> getDecoder(long fp) {

--- a/lang/java/avro/src/test/java/org/apache/avro/message/TestBinaryMessageEncoding.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/message/TestBinaryMessageEncoding.java
@@ -139,6 +139,21 @@ public class TestBinaryMessageEncoding {
   }
 
   @Test
+  public void testIdenticalReadWithSchemaFromLookup() throws Exception {
+    MessageEncoder<Record> v1Encoder = new BinaryMessageEncoder<>(GenericData.get(), SCHEMA_V1);
+
+    SchemaStore.Cache schemaCache = new SchemaStore.Cache();
+    schemaCache.addSchema(SCHEMA_V1);
+    BinaryMessageDecoder<Record> genericDecoder = new BinaryMessageDecoder<>(GenericData.get(), null, schemaCache);
+
+    ByteBuffer v1Buffer = v1Encoder.encode(V1_RECORDS.get(2));
+
+    Record record = genericDecoder.decode(v1Buffer);
+
+    Assert.assertEquals(V1_RECORDS.get(2), record);
+  }
+
+  @Test
   public void testBufferReuse() throws Exception {
     // This test depends on the serialized version of record 1 being smaller or
     // the same size as record 0 so that the reused ByteArrayOutputStream won't

--- a/lang/java/avro/src/test/java/org/apache/avro/message/TestBinaryMessageEncoding.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/message/TestBinaryMessageEncoding.java
@@ -144,6 +144,8 @@ public class TestBinaryMessageEncoding {
 
     SchemaStore.Cache schemaCache = new SchemaStore.Cache();
     schemaCache.addSchema(SCHEMA_V1);
+    // The null readSchema should not throw an NPE, but trigger the
+    // BinaryMessageEncoder to use the write schema as read schema
     BinaryMessageDecoder<Record> genericDecoder = new BinaryMessageDecoder<>(GenericData.get(), null, schemaCache);
 
     ByteBuffer v1Buffer = v1Encoder.encode(V1_RECORDS.get(2));


### PR DESCRIPTION
This implements AVRO-2440 by allowing a null value for the readSchema
field in the BinaryMessageDecoder. It is interpreted as "no preference",
and makes the decoder use the write schema of an incoming buffer as its
read schema.

Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title:
  - https://issues.apache.org/jira/browse/AVRO-2440

### Tests

- [X] My PR adds the following unit test:
`org.apache.avro.message.TestBinaryMessageEncoding#testIdenticalReadWithSchemaFromLookup`

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
