### PR TITLE
AVRO-2442: Set LANG variable for C# tests

### DIFF
--- a/lang/csharp/build.sh
+++ b/lang/csharp/build.sh
@@ -28,7 +28,9 @@ case "$1" in
   test)
     dotnet build --configuration Release --framework netcoreapp2.0 ./src/apache/codegen/Avro.codegen.csproj
     dotnet build --configuration Release --framework netstandard2.0 ./src/apache/msbuild/Avro.msbuild.csproj
-    dotnet test --configuration Release --framework netcoreapp2.0 ./src/apache/test/Avro.test.csproj
+
+    # AVRO-2442: Explictly set LANG to work around ICU bug in `dotnet test`
+    LANG=en_US.UTF-8 dotnet test --configuration Release --framework netcoreapp2.0 ./src/apache/test/Avro.test.csproj
     ;;
 
   perf)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2442
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x). **n/a**

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: **n/a**

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it. **n/a**
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
