### PR TITLE
AVRO-2448: Make test for leaking FileDescriptors more resilient

### DIFF
--- a/lang/java/avro/src/test/java/org/apache/avro/TestDataFileReader.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestDataFileReader.java
@@ -17,7 +17,7 @@
  */
 package org.apache.avro;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
@@ -47,8 +47,11 @@ public class TestDataFileReader {
     }
     Files.delete(emptyFile);
 
-    assertEquals("File descriptor leaked from new DataFileReader()", openFilesBeforeOperation,
-        getNumberOfOpenFileDescriptors());
+    long openFilesAfterOperation = getNumberOfOpenFileDescriptors();
+
+    // Sometimes we have less open files because of a GC run during the test cycle.
+    assertTrue("File descriptor leaked from new DataFileReader() (expected:" + openFilesBeforeOperation + " actual:"
+        + openFilesAfterOperation + ")", openFilesBeforeOperation >= openFilesAfterOperation);
   }
 
   private long getNumberOfOpenFileDescriptors() {


### PR DESCRIPTION
Lets the test for leaking FileDescriptors pass if the number of open descriptors has gone down.
https://issues.apache.org/jira/browse/AVRO-2448