### PR TITLE
AVRO-2450 log message about failure to load SnappyCodec

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/file/CodecFactory.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/file/CodecFactory.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import java.util.zip.Deflater;
 
 import org.apache.avro.AvroRuntimeException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Encapsulates the ability to specify and configure a compression codec.
@@ -38,6 +40,8 @@ import org.apache.avro.AvroRuntimeException;
  * {@link #addCodec(String, CodecFactory)}.
  */
 public abstract class CodecFactory {
+  private static final Logger LOG = LoggerFactory.getLogger(CodecFactory.class);
+
   /** Null codec, for no compression. */
   public static CodecFactory nullCodec() {
     return NullCodec.OPTION;
@@ -64,7 +68,7 @@ public abstract class CodecFactory {
     try {
       return new SnappyCodec.Option();
     } catch (Throwable t) {
-      // snappy not available
+      LOG.debug("Snappy was not available", t);
       return null;
     }
   }


### PR DESCRIPTION
Tested the Codec related unit tests locally. as expected a new log message doesn't impact them.