### PR TITLE
AVRO-2452: Interop tests should check the number of records

### DIFF
--- a/lang/java/ipc/src/test/java/org/apache/avro/DataFileInteropTest.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/DataFileInteropTest.java
@@ -80,9 +80,12 @@ public class DataFileInteropTest {
     for (File f : Objects.requireNonNull(DATAFILE_DIR.listFiles())) {
       System.out.println("Reading: " + f.getName());
       try (FileReader<? extends Object> reader = DataFileReader.openReader(f, provider.get())) {
+        int i = 0;
         for (Object datum : reader) {
+          i++;
           Assert.assertNotNull(datum);
         }
+        Assert.assertNotEquals(0, i);
       }
     }
   }

--- a/lang/py/test/test_datafile_interop.py
+++ b/lang/py/test/test_datafile_interop.py
@@ -35,8 +35,11 @@ class TestDataFileInterop(unittest.TestCase):
       reader = open(os.path.join('@INTEROP_DATA_DIR@', f), 'rb')
       datum_reader = io.DatumReader()
       dfr = datafile.DataFileReader(reader, datum_reader)
+      i = 0
       for datum in dfr:
+        i += 1
         assert datum is not None
+      assert 0 < i
 
 if __name__ == '__main__':
   unittest.main()

--- a/lang/py/test/test_datafile_interop.py
+++ b/lang/py/test/test_datafile_interop.py
@@ -36,8 +36,7 @@ class TestDataFileInterop(unittest.TestCase):
       datum_reader = io.DatumReader()
       dfr = datafile.DataFileReader(reader, datum_reader)
       i = 0
-      for datum in dfr:
-        i += 1
+      for i, datum in enumerate(dfr):
         assert datum is not None
       assert 0 < i
 

--- a/lang/py/test/test_datafile_interop.py
+++ b/lang/py/test/test_datafile_interop.py
@@ -36,9 +36,9 @@ class TestDataFileInterop(unittest.TestCase):
       datum_reader = io.DatumReader()
       dfr = datafile.DataFileReader(reader, datum_reader)
       i = 0
-      for i, datum in enumerate(dfr):
+      for i, datum in enumerate(dfr, 1):
         assert datum is not None
-      assert 0 < i
+      assert i > 0
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2452
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No additional test, since it's a fix for the existing test. I ran them manually and ensured that they worked as expected.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
