### PR TITLE
AVRO-2442: Set LANG variable for C# tests - branch 1.9

### DIFF
--- a/lang/csharp/build.sh
+++ b/lang/csharp/build.sh
@@ -28,7 +28,9 @@ case "$1" in
   test)
     dotnet build --configuration Release --framework netcoreapp2.0 ./src/apache/codegen/Avro.codegen.csproj
     dotnet build --configuration Release --framework netstandard2.0 ./src/apache/msbuild/Avro.msbuild.csproj
-    dotnet test --configuration Release --framework netcoreapp2.0 ./src/apache/test/Avro.test.csproj
+
+    # AVRO-2442: Explictly set LANG to work around ICU bug in `dotnet test`
+    LANG=en_US.UTF-8 dotnet test --configuration Release --framework netcoreapp2.0 ./src/apache/test/Avro.test.csproj
     ;;
 
   perf)


### PR DESCRIPTION
This is the branch-1.9 cherry-pick of #560 .

See: https://issues.apache.org/jira/browse/AVRO-2442