### PR TITLE
AVRO-2459: Add data interop test for the C# bindings

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -63,6 +63,7 @@ do
       (cd lang/py; ant interop-data-generate)
       (cd lang/c; ./build.sh interop-data-generate)
       #(cd lang/c++; make interop-data-generate)
+      (cd lang/csharp; ./build.sh interop-data-generate)
       (cd lang/ruby; rake generate_interop)
       (cd lang/php; ./build.sh interop-data-generate)
 
@@ -71,6 +72,7 @@ do
       (cd lang/py; ant interop-data-test)
       (cd lang/c; ./build.sh interop-data-test)
       #(cd lang/c++; make interop-data-test)
+      (cd lang/csharp; ./build.sh interop-data-test)
       (cd lang/ruby; rake interop)
       (cd lang/php; ./build.sh test-interop)
 

--- a/lang/csharp/build.sh
+++ b/lang/csharp/build.sh
@@ -29,7 +29,8 @@ case "$1" in
     dotnet build --configuration Release Avro.sln
 
     # AVRO-2442: Explictly set LANG to work around ICU bug in `dotnet test`
-    LANG=en_US.UTF-8 dotnet test  --configuration Release --no-build Avro.sln
+    LANG=en_US.UTF-8 dotnet test  --configuration Release --no-build \
+        --filter "TestCategory!=Interop" Avro.sln
     ;;
 
   perf)
@@ -66,7 +67,7 @@ case "$1" in
     ;;
 
   interop-data-test)
-    LANG=en_US.UTF-8 dotnet test --filter "FullyQualifiedName~Avro.Test.Interop.InteropDataTests"
+    LANG=en_US.UTF-8 dotnet test --filter "TestCategory=Interop"
     ;;
 
   clean)

--- a/lang/csharp/build.sh
+++ b/lang/csharp/build.sh
@@ -61,6 +61,14 @@ case "$1" in
     cp -pr build/doc/* ${ROOT}/build/avro-doc-${VERSION}/api/csharp
     ;;
 
+  interop-data-generate)
+    dotnet run --project src/apache/test/Avro.test.csproj --framework netcoreapp2.2 ../../share/test/schemas/interop.avsc ../../build/interop/data
+    ;;
+
+  interop-data-test)
+    LANG=en_US.UTF-8 dotnet test --filter "FullyQualifiedName~Avro.Test.Interop.InteropDataTests"
+    ;;
+
   clean)
     rm -rf src/apache/{main,test,codegen,ipc,msbuild,perf}/{obj,bin}
     rm -rf build
@@ -68,7 +76,7 @@ case "$1" in
     ;;
 
   *)
-    echo "Usage: $0 {test|clean|dist|perf}"
+    echo "Usage: $0 {test|clean|dist|perf|interop-data-generate|interop-data-test}"
     exit 1
 esac
 

--- a/lang/csharp/src/apache/test/Avro.test.csproj
+++ b/lang/csharp/src/apache/test/Avro.test.csproj
@@ -22,6 +22,7 @@
     <RootNamespace>Avro.test</RootNamespace>
     <AssemblyName>Avro.test</AssemblyName>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/lang/csharp/src/apache/test/Interop/InteropDataConstants.cs
+++ b/lang/csharp/src/apache/test/Interop/InteropDataConstants.cs
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System.Collections.Generic;
+using Avro.File;
+
+namespace Avro.Test.Interop
+{
+    public class InteropDataConstants
+    {
+        public static readonly HashSet<string> SupportedCodecNames = new HashSet<string>
+        {
+            DataFileConstants.NullCodec,
+            DataFileConstants.DeflateCodec
+        };
+    }
+}

--- a/lang/csharp/src/apache/test/Interop/InteropDataGenerator.cs
+++ b/lang/csharp/src/apache/test/Interop/InteropDataGenerator.cs
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Avro.File;
+using Avro.Generic;
+
+namespace Avro.Test.Interop
+{
+    public class InteropDataGenerator
+    {
+        static void GenerateInteropData(string schemaPath, string outputDir)
+        {
+            RecordSchema schema = null;
+            using (var reader = new StreamReader(schemaPath))
+            {
+                schema = Schema.Parse(reader.ReadToEnd()) as RecordSchema;
+            }
+
+            var mapFieldSchema = (schema.Fields.Find(x => x.Name == "mapField").Schema as MapSchema).ValueSchema as RecordSchema;
+            var mapFieldRecord0 = new GenericRecord(mapFieldSchema);
+            var mapFieldRecord1 = new GenericRecord(mapFieldSchema);
+            mapFieldRecord0.Add("label", "a");
+            mapFieldRecord1.Add("label", "cee");
+            var mapFieldValue = new Dictionary<string, GenericRecord>
+            {
+                { "a", mapFieldRecord0 },
+                { "bee", mapFieldRecord1 }
+            };
+
+            var enumFieldValue = new GenericEnum(schema.Fields.Find(x => x.Name == "enumField").Schema as EnumSchema, "C");
+
+            var fixedFieldValue = new GenericFixed(
+                schema.Fields.Find(x => x.Name == "fixedField").Schema as FixedSchema,
+                Encoding.ASCII.GetBytes("1019181716151413"));
+
+            var nodeSchema = schema.Fields.Find(x => x.Name == "recordField").Schema as RecordSchema;
+            var recordFieldValue = new GenericRecord(nodeSchema);
+            var innerRecordFieldValue = new GenericRecord(nodeSchema);
+            innerRecordFieldValue.Add("label", "inner");
+            innerRecordFieldValue.Add("children", new GenericRecord[] { });
+            recordFieldValue.Add("label", "blah");
+            recordFieldValue.Add("children", new GenericRecord[] { innerRecordFieldValue });
+
+            GenericRecord record = new GenericRecord(schema);
+            record.Add("intField", 12);
+            record.Add("longField", 15234324L);
+            record.Add("stringField", "hey");
+            record.Add("boolField", true);
+            record.Add("floatField", 1234.0f);
+            record.Add("doubleField", -1234.0);
+            record.Add("bytesField", Encoding.UTF8.GetBytes("12312adf"));
+            record.Add("nullField", null);
+            record.Add("arrayField", new double[] { 5.0, 0.0, 12.0 });
+            record.Add("mapField", mapFieldValue);
+            record.Add("unionField", 12.0);
+            record.Add("enumField", enumFieldValue);
+            record.Add("fixedField", fixedFieldValue);
+            record.Add("recordField", recordFieldValue);
+
+            var datumWriter = new GenericDatumWriter<GenericRecord>(schema);
+            foreach (var codecName in InteropDataConstants.SupportedCodecNames)
+            {
+                var outputFile = "csharp.avro";
+                if (codecName != DataFileConstants.NullCodec)
+                {
+                    outputFile = string.Format("csharp_{0}.avro", codecName);
+                }
+                var outputPath = Path.Combine(outputDir, outputFile);
+                var codec = Codec.CreateCodecFromString(codecName);
+                using (var dataFileWriter = DataFileWriter<GenericRecord>.OpenWriter(datumWriter, outputPath, codec))
+                {
+                    dataFileWriter.Append(record);
+                }
+            }
+        }
+
+        static void Main(string[] args)
+        {
+            GenerateInteropData(args[0], args[1]);
+        }
+    }
+}

--- a/lang/csharp/src/apache/test/Interop/InteropDataTests.cs
+++ b/lang/csharp/src/apache/test/Interop/InteropDataTests.cs
@@ -23,11 +23,18 @@ using Avro.Generic;
 namespace Avro.Test.Interop
 {
     [TestFixture]
+    [Category("Interop")]
     public class InteropDataTests
     {
         [TestCase("../../../../../../../../build/interop/data")]
-        public void TestInterOp(string inputDir)
+        public void TestInterop(string inputDir)
         {
+            // Resolve inputDir relative to the TestDirectory
+            inputDir = Path.Combine(TestContext.CurrentContext.TestDirectory, inputDir);
+
+            Assert.True(Directory.Exists(inputDir),
+                "Input directory does not exist. Run `build.sh interop-data-generate` first.");
+
             foreach (var avroFile in Directory.EnumerateFiles(inputDir, "*.avro"))
             {
                 var codec = Path.GetFileNameWithoutExtension(avroFile).Split('_');

--- a/lang/csharp/src/apache/test/Interop/InteropDataTests.cs
+++ b/lang/csharp/src/apache/test/Interop/InteropDataTests.cs
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System.IO;
+using NUnit.Framework;
+using Avro.File;
+using Avro.Generic;
+
+namespace Avro.Test.Interop
+{
+    [TestFixture]
+    public class InteropDataTests
+    {
+        [TestCase("../../../../../../../../build/interop/data")]
+        public void TestInterOp(string inputDir)
+        {
+            foreach (var avroFile in Directory.EnumerateFiles(inputDir, "*.avro"))
+            {
+                var codec = Path.GetFileNameWithoutExtension(avroFile).Split('_');
+                if (1 < codec.Length && !InteropDataConstants.SupportedCodecNames.Contains(codec[1]))
+                {
+                    continue;
+                }
+
+                using(var reader = DataFileReader<GenericRecord>.OpenReader(avroFile))
+                {
+                    int i = 0;
+                    foreach (var record in reader.NextEntries)
+                    {
+                        i++;
+                        Assert.IsNotNull(record);
+                    }
+                    Assert.AreNotEqual(0, i);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2459
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

This PR adds data interop test for the C# bindings. I ran it manually and confirmed it worked as follows:

```
$ cd lang/java/avro
$ mvn -B -P interop-data-generate generate-resources

(snip)

$ cd -
$ ls build/interop/data
java.avro  java_deflate.avro
$ cd lang/csharp
$ ./build.sh interop-data-test

(snip)

Starting test execution, please wait...
                                                                                                                                  
Test Run Successful.
Total tests: 1
     Passed: 1
 Total time: 1.9932 Seconds

$ ./build.sh interop-data-generate
$ cd -
$ ls build/interop/data
csharp.avro  csharp_deflate.avro  java.avro  java_deflate.avro
$ cd lang/java/avro
$ mvn -B test -P interop-data-test

(snip)

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  19.050 s
[INFO] Finished at: 2019-07-02T19:08:51+09:00
[INFO] ------------------------------------------------------------------------
```

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
