### PR TITLE
AVRO-2460: Add zstd codec support to the Python3 bindings

### DIFF
--- a/lang/py3/avro/datafile.py
+++ b/lang/py3/avro/datafile.py
@@ -34,6 +34,11 @@ try:
 except ImportError:
   has_snappy = False
 
+try:
+  import zstandard as zstd
+  has_zstandard = True
+except ImportError:
+  has_zstandard = False
 
 logger = logging.getLogger(__name__)
 
@@ -80,6 +85,8 @@ META_SCHEMA = schema.Parse("""
 VALID_CODECS = frozenset(['null', 'deflate'])
 if has_snappy:
   VALID_CODECS = frozenset.union(VALID_CODECS, ['snappy'])
+if has_zstandard:
+  VALID_CODECS = frozenset.union(VALID_CODECS, ['zstandard'])
 
 # Not used yet
 VALID_ENCODINGS = frozenset(['binary'])
@@ -272,6 +279,9 @@ class DataFileWriter(object):
     elif codec == 'snappy':
       compressed_data = snappy.compress(uncompressed_data)
       compressed_data_length = len(compressed_data) + 4 # crc32
+    elif codec == 'zstandard':
+      compressed_data = zstd.ZstdCompressor().compress(uncompressed_data)
+      compressed_data_length = len(compressed_data)
     else:
       fail_msg = '"%s" codec is not supported.' % codec
       raise DataFileException(fail_msg)
@@ -495,6 +505,18 @@ class DataFileReader(object):
       uncompressed = snappy.decompress(data)
       self._datum_decoder = avro_io.BinaryDecoder(io.BytesIO(uncompressed))
       self.raw_decoder.check_crc32(uncompressed);
+    elif self.codec == 'zstandard':
+      length = self.raw_decoder.read_long()
+      data = self.raw_decoder.read(length)
+      uncompressed = bytearray()
+      dctx = zstd.ZstdDecompressor()
+      with dctx.stream_reader(io.BytesIO(data)) as reader:
+        while True:
+          chunk = reader.read(16384)
+          if not chunk:
+            break
+          uncompressed.extend(chunk)
+      self._datum_decoder = avro_io.BinaryDecoder(io.BytesIO(uncompressed))
     else:
       raise DataFileException("Unknown codec: %r" % self.codec)
 

--- a/lang/py3/avro/tests/test_datafile.py
+++ b/lang/py3/avro/tests/test_datafile.py
@@ -83,8 +83,13 @@ try:
   import snappy
   CODECS_TO_VALIDATE += ('snappy',)
 except ImportError:
-  logging.info('Snappy not present, will skip testing it.')
+  logging.warning('Snappy not present, will skip testing it.')
 
+try:
+  import zstandard
+  CODECS_TO_VALIDATE += ('zstandard',)
+except ImportError:
+  logging.warning('Zstandard not present, will skip testing it.')
 
 # ------------------------------------------------------------------------------
 

--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -69,8 +69,10 @@ RUN apt-get -qq update && \
     python \
     python-setuptools \
     python-snappy \
+    python3-pip \
     python3-setuptools \
     python3-snappy \
+    python3-wheel \
     rake \
     ruby \
     ruby-dev \
@@ -90,6 +92,9 @@ RUN curl -L https://cpanmin.us | perl - --mirror https://www.cpan.org/ --self-up
 
 # Install PHPUnit
 RUN wget -O /usr/local/bin/phpunit https://phar.phpunit.de/phpunit-5.6.phar && chmod +x /usr/local/bin/phpunit
+
+# Install Python packages
+RUN pip3 install zstandard
 
 # Install Ruby modules
 RUN gem install echoe yajl-ruby multi_json snappy


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2460
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

This PR adds zstd to the codecs to be validated in test_datafile.py. I ran `./build.sh docker-test` and confirmed that all tests passed.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
