### PR TITLE
AVRO-2461: Add compression level support to fromjson and recodec

### DIFF
--- a/lang/java/tools/src/main/java/org/apache/avro/tool/Util.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/Util.java
@@ -255,8 +255,8 @@ class Util {
   }
 
   static OptionSpec<Integer> compressionLevelOption(OptionParser optParser) {
-    return optParser.accepts("level", "Compression level (only applies to deflate and xz)").withRequiredArg()
-        .ofType(Integer.class).defaultsTo(Deflater.DEFAULT_COMPRESSION);
+    return optParser.accepts("level", "Compression level (only applies to deflate, xz, and zstandard)")
+        .withRequiredArg().ofType(Integer.class).defaultsTo(Deflater.DEFAULT_COMPRESSION);
   }
 
   static CodecFactory codecFactory(OptionSet opts, OptionSpec<String> codec, OptionSpec<Integer> level) {
@@ -270,6 +270,8 @@ class Util {
       return CodecFactory.deflateCodec(level.value(opts));
     } else if (codecName.equals(DataFileConstants.XZ_CODEC)) {
       return CodecFactory.xzCodec(level.value(opts));
+    } else if (codecName.equals(DataFileConstants.ZSTANDARD_CODEC)) {
+      return CodecFactory.zstandardCodec(level.value(opts));
     } else {
       return CodecFactory.fromString(codec.value(opts));
     }

--- a/lang/java/tools/src/test/java/org/apache/avro/tool/TestUtil.java
+++ b/lang/java/tools/src/test/java/org/apache/avro/tool/TestUtil.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.avro.tool;
+
+import joptsimple.OptionParser;
+import joptsimple.OptionSet;
+import joptsimple.OptionSpec;
+import org.apache.avro.file.*;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+import java.lang.reflect.Method;
+
+public class TestUtil {
+
+  @Rule
+  public TestName name = new TestName();
+
+  private void zstandardCompressionLevel(int level) throws Exception {
+    OptionParser optParser = new OptionParser();
+    OptionSpec<String> codecOpt = Util.compressionCodecOption(optParser);
+    OptionSpec<Integer> levelOpt = Util.compressionLevelOption(optParser);
+
+    OptionSet opts = optParser.parse(new String[] { "--codec", "zstandard", "--level", String.valueOf(level) });
+    CodecFactory codecFactory = Util.codecFactory(opts, codecOpt, levelOpt);
+    Method createInstance = CodecFactory.class.getDeclaredMethod("createInstance");
+    createInstance.setAccessible(true);
+    Codec codec = (ZstandardCodec) createInstance.invoke(codecFactory);
+    Assert.assertEquals(String.format("zstandard[%d]", level), codec.toString());
+  }
+
+  @Test
+  public void testCodecFactoryZstandardCompressionLevel() throws Exception {
+    zstandardCompressionLevel(1);
+    zstandardCompressionLevel(CodecFactory.DEFAULT_ZSTANDARD_LEVEL);
+  }
+}


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2461
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

testCodecFactoryZstandardCompressionLevel

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
