### PR TITLE
AVRO-2465: Fix wrong defalut values in the avro-tools' usage

### DIFF
--- a/lang/java/tools/src/main/java/org/apache/avro/tool/DataFileWriteTool.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/DataFileWriteTool.java
@@ -53,7 +53,7 @@ public class DataFileWriteTool implements Tool {
   public int run(InputStream stdin, PrintStream out, PrintStream err, List<String> args) throws Exception {
 
     OptionParser p = new OptionParser();
-    OptionSpec<String> codec = Util.compressionCodecOption(p);
+    OptionSpec<String> codec = Util.compressionCodecOptionWithDefault(p, DataFileConstants.NULL_CODEC);
     OptionSpec<Integer> level = Util.compressionLevelOption(p);
     OptionSpec<String> file = p.accepts("schema-file", "Schema File").withOptionalArg().ofType(String.class);
     OptionSpec<String> inschema = p.accepts("schema", "Schema").withOptionalArg().ofType(String.class);

--- a/lang/java/tools/src/main/java/org/apache/avro/tool/RecodecTool.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/RecodecTool.java
@@ -41,7 +41,7 @@ public class RecodecTool implements Tool {
   public int run(InputStream in, PrintStream out, PrintStream err, List<String> args) throws Exception {
 
     OptionParser optParser = new OptionParser();
-    OptionSpec<String> codecOpt = Util.compressionCodecOption(optParser);
+    OptionSpec<String> codecOpt = Util.compressionCodecOptionWithDefault(optParser, DataFileConstants.NULL_CODEC);
     OptionSpec<Integer> levelOpt = Util.compressionLevelOption(optParser);
     OptionSet opts = optParser.parse(args.toArray(new String[0]));
 

--- a/lang/java/tools/src/main/java/org/apache/avro/tool/Util.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/Util.java
@@ -251,7 +251,12 @@ class Util {
   }
 
   static OptionSpec<String> compressionCodecOption(OptionParser optParser) {
-    return optParser.accepts("codec", "Compression codec").withRequiredArg().ofType(String.class).defaultsTo("null");
+    return optParser.accepts("codec", "Compression codec").withRequiredArg().ofType(String.class)
+        .defaultsTo(DEFLATE_CODEC);
+  }
+
+  static OptionSpec<String> compressionCodecOptionWithDefault(OptionParser optParser, String s) {
+    return optParser.accepts("codec", "Compression codec").withRequiredArg().ofType(String.class).defaultsTo(s);
   }
 
   static OptionSpec<Integer> compressionLevelOption(OptionParser optParser) {

--- a/lang/java/tools/src/test/java/org/apache/avro/tool/TestCreateRandomFileTool.java
+++ b/lang/java/tools/src/test/java/org/apache/avro/tool/TestCreateRandomFileTool.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Iterator;
 
@@ -133,5 +134,12 @@ public class TestCreateRandomFileTool {
       assertEquals(expected, found.next());
 
     reader.close();
+  }
+
+  @Test
+  public void testDefaultCodec() throws Exception {
+    // The default codec for random is deflate
+    run(Collections.emptyList());
+    assertTrue(err.toString().contains("Compression codec (default: deflate)"));
   }
 }

--- a/lang/java/tools/src/test/java/org/apache/avro/tool/TestDataFileTools.java
+++ b/lang/java/tools/src/test/java/org/apache/avro/tool/TestDataFileTools.java
@@ -257,4 +257,13 @@ public class TestDataFileTools {
     }
     return outFile;
   }
+
+  @Test
+  public void testDefaultCodec() throws Exception {
+    // The default codec for fromjson is null
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    PrintStream err = new PrintStream(baos);
+    new DataFileWriteTool().run(new ByteArrayInputStream(jsonData.getBytes()), null, err, Collections.emptyList());
+    assertTrue(baos.toString().contains("Compression codec (default: null)"));
+  }
 }

--- a/lang/java/tools/src/test/java/org/apache/avro/tool/TestTextFileTools.java
+++ b/lang/java/tools/src/test/java/org/apache/avro/tool/TestTextFileTools.java
@@ -19,18 +19,21 @@ package org.apache.avro.tool;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.File;
-import java.io.OutputStream;
-import java.io.InputStream;
-import java.io.FileOutputStream;
-import java.io.FileInputStream;
-import java.io.BufferedOutputStream;
 import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Random;
 
 import org.apache.avro.Schema;
@@ -130,5 +133,14 @@ public class TestTextFileTools {
         assertEquals(-1, after.read());
       }
     }
+  }
+
+  @Test
+  public void testDefaultCodec() throws Exception {
+    // The default codec for fromtext is deflate
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    PrintStream err = new PrintStream(baos);
+    new FromTextTool().run(null, null, err, Collections.emptyList());
+    Assert.assertTrue(baos.toString().contains("Compression codec (default: deflate)"));
   }
 }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2465
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Added `testDefaultCodec`s to TestCreateRandomFileTool, TestDataFileTools, and TestTextFileTools.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
