### PR TITLE
AVRO-2475: rake generate_interop should generate files for all codecs

### DIFF
--- a/lang/ruby/Rakefile
+++ b/lang/ruby/Rakefile
@@ -38,17 +38,13 @@ task :generate_interop do
 
   schema = Avro::Schema.parse(File.read(SCHEMAS + '/interop.avsc'))
   r = RandomData.new(schema, ENV['SEED'])
-  f = File.open(BUILD + '/interop/data/ruby.avro', 'w')
-  writer = Avro::DataFile::Writer.new(f, Avro::IO::DatumWriter.new(schema), schema)
-  begin
-    writer << r.next
-    writer << r.next
-  ensure
-    writer.close
-  end
-
-  Avro::DataFile.open(BUILD + '/interop/data/ruby_deflate.avro', 'w', schema.to_s, :deflate) do |writer|
-    20.times { writer << r.next }
+  Avro::DataFile.codecs.each do |name, codec|
+    next unless codec
+    filename = name == 'null' ? 'ruby.avro' : "ruby_#{name}.avro"
+    path = File.join(BUILD, 'interop/data', filename)
+    Avro::DataFile.open(path, 'w', schema.to_s, name) do |writer|
+      writer << r.next
+    end
   end
 end
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2475
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No additional test, since it's a fix for the test itself. I ran `rake generate_interop` manually and confirmed that output files were generated for all codecs.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
