### PR TITLE
AVRO-2481: Introduce Perl::Critic for linting the Perl bindings

### DIFF
--- a/lang/perl/Makefile.PL
+++ b/lang/perl/Makefile.PL
@@ -27,6 +27,7 @@ readme_from 'lib/Avro.pm';
 all_from 'lib/Avro.pm';
 build_requires 'Test::More', 0.88;
 test_requires 'Math::BigInt';
+test_requires 'Perl::Critic';
 test_requires 'Test::Exception';
 requires 'JSON::XS';
 requires 'Try::Tiny';

--- a/lang/perl/build.sh
+++ b/lang/perl/build.sh
@@ -43,10 +43,23 @@ function do_clean(){
   rm -rf lang/perl/inc/
 }
 
+function do_lint(){
+  local failures=0
+  for i in $(find lib t xt -name '*.p[lm]' -or -name '*.t'); do
+    if ! perlcritic --verbose 1 ${i}; then
+      ((failures=failures+1))
+    fi
+  done
+  if [ ${failures} -gt 0 ]; then
+    return 1
+  fi
+}
+
 case "$target" in
   lint)
-    echo 'This is a stub where someone can provide linting.'
+    do_lint
     ;;
+
   test)
     perl ./Makefile.PL && make test
     ;;

--- a/lang/perl/lib/Avro/Protocol.pm
+++ b/lang/perl/lib/Avro/Protocol.pm
@@ -61,8 +61,8 @@ sub from_struct {
 
     my $types = $class->parse_types($struct->{types});
 
-    my $messages = $class->parse_messages($struct->{messages}, $types)
-        if $struct->{messages};
+    my $messages = $struct->{messages} ?
+        $class->parse_messages($struct->{messages}, $types) : undef;
 
     my $protocol = $class->SUPER::new(
         name      => $name,

--- a/lang/perl/lib/Avro/Protocol/Message.pm
+++ b/lang/perl/lib/Avro/Protocol/Message.pm
@@ -49,8 +49,7 @@ sub new {
     my $err_struct = $struct->{errors};
 
     my $response = Avro::Schema->parse_struct($resp_struct, $types);
-    my $errors   = Avro::Schema->parse_struct($err_struct, $types)
-        if $err_struct;
+    my $errors = $err_struct ? Avro::Schema->parse_struct($err_struct, $types) : undef;
 
     return $class->SUPER::new(
         doc      => $struct->{doc},

--- a/lang/perl/xt/pod.t
+++ b/lang/perl/xt/pod.t
@@ -15,7 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+use strict;
 use Test::More;
-eval "use Test::Pod 1.00";
+eval "use Test::Pod 1.00"; ## no critic qw(BuiltinFunctions::ProhibitStringyEval)
 plan skip_all => "Test::Pod 1.00 required for testing POD" if $@;
 all_pod_files_ok();

--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -94,7 +94,7 @@ RUN curl -L https://cpanmin.us | perl - --mirror https://www.cpan.org/ --self-up
   Module::Install::Repository \
   Math::BigInt JSON::XS Try::Tiny Regexp::Common Encode \
   IO::String Object::Tiny Compress::Zlib Test::More \
-  Test::Exception Test::Pod
+  Test::Exception Test::Pod Perl::Critic
 
 # Install PHPUnit
 RUN wget -O /usr/local/bin/phpunit https://phar.phpunit.de/phpunit-5.6.phar && chmod +x /usr/local/bin/phpunit


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2481
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

This PR adds linting feature to the Perl bindings. It also contains fixes for the existing violations.
I ran `./build.sh lint` in the `lang/perl` directory and confirmed all violations were fixed.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
