### PR TITLE
AVRO-2483: Fix broken links to wiki pages in the documentation

### DIFF
--- a/doc/src/content/xdocs/site.xml
+++ b/doc/src/content/xdocs/site.xml
@@ -65,8 +65,8 @@ See https://forrest.apache.org/docs/linking.html for more info
       <download href="#Download" />
     </releases>
     <jira      href="https://avro.apache.org/issue_tracking.html"/>
-    <wiki      href="https://wiki.apache.org/hadoop/Avro/" />
-    <faq       href="https://wiki.apache.org/hadoop/Avro/FAQ" />
+    <wiki      href="https://cwiki.apache.org/confluence/display/AVRO/Index" />
+    <faq       href="https://cwiki.apache.org/confluence/display/AVRO/FAQ" />
     <json      href="https://www.json.org/" />
     <vint      href="https://lucene.apache.org/java/3_5_0/fileformats.html#VInt"/>
     <zigzag    href="https://code.google.com/apis/protocolbuffers/docs/encoding.html#types"/>

--- a/doc/src/content/xdocs/tabs.xml
+++ b/doc/src/content/xdocs/tabs.xml
@@ -33,7 +33,7 @@
   -->
 
   <tab label="Project" href="https://avro.apache.org/" />
-  <tab label="Wiki" href="https://wiki.apache.org/hadoop/Avro/" />
+  <tab label="Wiki" href="https://cwiki.apache.org/confluence/display/AVRO/Index" />
   <tab label="Avro &AvroVersion; Documentation" dir="" />
 
 </tabs>


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2483
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No additional test, since it's just a documentation fix. I ran `ant` in the `doc` directory and confirmed that those links were fixed in the generated documents.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
