### PR TITLE
AVRO-2486 C: fwrite failure ignored, corrupting files.

### DIFF
--- a/lang/c/ChangeLog
+++ b/lang/c/ChangeLog
@@ -1,4 +1,10 @@
+Revision history for Avro C Library
 
+Unreleased 
+  - [bugfix] fwrite failure ignored, corrupting files.
 
+14 May 2019: Avro 1.9.0
+
+20 May 2017: Avro 1.8.2
 
 

--- a/lang/c/src/io.c
+++ b/lang/c/src/io.c
@@ -345,7 +345,7 @@ avro_write_file(struct _avro_writer_file_t *writer, void *buf, int64_t len)
 	if (len > 0) {
 		rval = fwrite(buf, len, 1, writer->fp);
 		if (rval == 0) {
-			return feof(writer->fp) ? EOF : 0;
+			return feof(writer->fp) ? EOF : (errno ? errno : EIO);
 		}
 	}
 	return 0;


### PR DESCRIPTION
Addresses: https://issues.apache.org/jira/browse/AVRO-2486 
C: fwrite failures can be ignored, resulting in corrupted files.

Tests:  Existing tests pass, difficult to create a test case without additional test fixtures to force an IO fail, or to use an interceptor library.

