### PR TITLE
AVRO-2462: Restore java.util.Date as a Stringable class [DO NOT MERGE]

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificData.java
@@ -104,6 +104,7 @@ public class SpecificData extends GenericData {
     stringableClasses.add(java.net.URI.class);
     stringableClasses.add(java.net.URL.class);
     stringableClasses.add(java.io.File.class);
+    stringableClasses.add(java.util.Date.class);
   }
 
   /** For subclasses. Applications normally use {@link SpecificData#get()}. */

--- a/lang/java/integration-test/codegen-test/src/test/java/org/apache/avro/codegentest/TestNullableSpecificJavaClass.java
+++ b/lang/java/integration-test/codegen-test/src/test/java/org/apache/avro/codegentest/TestNullableSpecificJavaClass.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.avro.codegentest;
+
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertThat;
+
+import java.util.Date;
+import org.apache.avro.codegentest.testdata.NullableSpecificJavaClass;
+import org.junit.Test;
+
+public class TestNullableSpecificJavaClass extends AbstractSpecificRecordTest {
+
+  @Test
+  public void testSpecificRecordHashCode() {
+    // hashCode shouldn't generate an exception wither the second field is null or
+    // set to a Date.
+    NullableSpecificJavaClass instanceOfGeneratedClass = NullableSpecificJavaClass.newBuilder()
+        .setDate(new Date(-12801286800000L)).setNullableDate(null).build();
+    assertThat(instanceOfGeneratedClass.hashCode(), not(0L));
+    instanceOfGeneratedClass.setNullableDate(new Date(-11161414800000L));
+    assertThat(instanceOfGeneratedClass.hashCode(), not(0L));
+    instanceOfGeneratedClass.setDate(null);
+    assertThat(instanceOfGeneratedClass.hashCode(), not(0L));
+  }
+}

--- a/lang/java/integration-test/codegen-test/src/test/resources/avro/nullable_specific_java_class.avsc
+++ b/lang/java/integration-test/codegen-test/src/test/resources/avro/nullable_specific_java_class.avsc
@@ -1,0 +1,19 @@
+{"namespace": "org.apache.avro.codegentest.testdata",
+  "type": "record",
+  "name": "NullableSpecificJavaClass",
+  "doc" : "Test unions with java-class in generated Java classes",
+  "fields": [
+    {
+      "name": "date",
+      "type": {"type": "string", "java-class": "java.util.Date"}
+    },
+    {
+      "name": "nullableDate",
+      "type": ["null", {"type": "string", "java-class": "java.util.Date"}],
+      "default": null
+    }
+  ]
+}
+
+
+


### PR DESCRIPTION
https://issues.apache.org/jira/browse/AVRO-2462

I'm not entirely satisfied with this -- it looks like java.util.Date was removed for a good reason from the set of stringable classes.  It also appears that this solves *one* specific case (using a string representation of Date).  Other specific records with a `java-class` annotation that are expected to be "stringable" but not in the pre-existing set will have the same problem.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
