### PR TITLE
AVRO-2491: Deprecate Schema#createRecord from list of fields method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ test-output
 /lang/java/compiler/nb-configuration.xml
 /lang/java/compiler/nbproject/
 **/.vscode/**/*
+.factorypath
+

--- a/lang/java/avro/src/main/java/org/apache/avro/Schema.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Schema.java
@@ -191,7 +191,16 @@ public abstract class Schema extends JsonProperties implements Serializable {
     this.logicalType = logicalType;
   }
 
-  /** Create an anonymous record schema. */
+  /**
+   * Create an anonymous record schema.
+   *
+   * @deprecated This method allows to create Schema objects that cannot be parsed
+   *             by {@link Schema.Parser#parse(String)}. It will be removed in a
+   *             future version of Avro. Better use
+   *             i{@link #createRecord(String, String, String, boolean, List)} to
+   *             produce a fully qualified Schema.
+   */
+  @Deprecated
   public static Schema createRecord(List<Field> fields) {
     Schema result = createRecord(null, null, null, false);
     result.setFields(fields);


### PR DESCRIPTION
This method should be removed in the future because it allows to create
invalid schemas (without name) that are not Parseable by Avro.

R: @Fokko 