### PR TITLE
AVRO-2494: Introduce JSHint for linting the JavaScript bindings

### DIFF
--- a/lang/js/build.sh
+++ b/lang/js/build.sh
@@ -21,7 +21,7 @@ cd `dirname "$0"`
 
 case "$1" in
   lint)
-    echo 'This is a stub where someone can provide linting.'
+    npm run lint
     ;;
   test)
     npm install

--- a/lang/js/lib/protocols.js
+++ b/lang/js/lib/protocols.js
@@ -444,6 +444,7 @@ StatelessEmitter.prototype._emit = function (message, req, cb) {
           }
 
           var tap = new Tap(buf);
+          var args;
           try {
             var info = self._finalizeHandshake(tap, handshakeReq);
             serverHashString = info.serverHashString;
@@ -452,7 +453,7 @@ StatelessEmitter.prototype._emit = function (message, req, cb) {
               return;
             }
             self._idType._read(tap); // Skip metadata.
-            var args = self._decodeArguments(tap, serverHashString, message);
+            args = self._decodeArguments(tap, serverHashString, message);
           } catch (err) {
             done(err);
             return;
@@ -547,8 +548,9 @@ function StatefulEmitter(ptcl, readable, writable, opts) {
 
   function onHandshakeData(buf) {
     var tap = new Tap(buf);
+    var info;
     try {
-      var info = self._finalizeHandshake(tap, handshakeReq);
+      info = self._finalizeHandshake(tap, handshakeReq);
     } catch (err) {
       self.emit('error', err);
       self.destroy(); // This isn't a recoverable error.
@@ -568,8 +570,9 @@ function StatefulEmitter(ptcl, readable, writable, opts) {
 
   function onMessageData(buf) {
     var tap = new Tap(buf);
+    var id;
     try {
-      var id = self._idType._read(tap);
+      id = self._idType._read(tap);
       if (!id) {
         throw new Error('missing ID');
       }
@@ -584,8 +587,9 @@ function StatefulEmitter(ptcl, readable, writable, opts) {
       return;
     }
 
+    var args;
     try {
-      var args = self._decodeArguments(
+      args = self._decodeArguments(
         tap,
         self._serverHashString,
         info.message
@@ -701,9 +705,11 @@ MessageListener.prototype._validateHandshake = function (reqTap, resTap) {
   // occurs when parsing the request, a response with match NONE will be sent.
   // Also emits 'handshake' event with both the request and the response.
   var validationErr = null;
+  var handshakeReq;
+  var serverHashString;
   try {
-    var handshakeReq = HANDSHAKE_REQUEST_TYPE._read(reqTap);
-    var serverHashString = handshakeReq.serverHash.toString('binary');
+    handshakeReq = HANDSHAKE_REQUEST_TYPE._read(reqTap);
+    serverHashString = handshakeReq.serverHash.toString('binary');
   } catch (err) {
     validationErr = err;
   }
@@ -827,14 +833,16 @@ function StatelessListener(ptcl, readableFactory, opts) {
       return;
     }
 
+    var name;
+    var req;
     try {
       self._idType._read(reqTap); // Skip metadata.
-      var name = STRING_TYPE._read(reqTap);
+      name = STRING_TYPE._read(reqTap);
       self._message = self._ptcl._messages[name];
       if (!self._message) {
         throw new Error(f('unknown message: %s', name));
       }
-      var req = self._decodeRequest(reqTap, self._message);
+      req = self._decodeRequest(reqTap, self._message);
     } catch (err) {
       onResponse(err);
       return;
@@ -908,13 +916,16 @@ function StatefulListener(ptcl, readable, writable, opts) {
     }
 
     self._pending++;
+    var name;
+    var message;
+    var req;
     try {
-      var name = STRING_TYPE._read(reqTap);
-      var message = self._ptcl._messages[name];
+      name = STRING_TYPE._read(reqTap);
+      message = self._ptcl._messages[name];
       if (!message) {
         throw new Error('unknown message: ' + name);
       }
-      var req = self._decodeRequest(reqTap, message);
+      req = self._decodeRequest(reqTap, message);
     } catch (err) {
       onResponse(err);
       return;

--- a/lang/js/lib/schemas.js
+++ b/lang/js/lib/schemas.js
@@ -93,7 +93,8 @@ function createType(attrs, opts) {
       // Reference to a primitive type. These are also defined names by default
       // so we create the appropriate type and it to the registry for future
       // reference.
-      return opts.registry[attrs] = createType({type: attrs}, opts);
+      type = opts.registry[attrs] = createType({type: attrs}, opts);
+      return type;
     }
     throw new Error(f('undefined type name: %s', attrs));
   }
@@ -1789,8 +1790,9 @@ LogicalType.prototype._write = function (tap, any) {
 };
 
 LogicalType.prototype._check = function (any, cb) {
+  var val;
   try {
-    var val = this._toValue(any);
+    val = this._toValue(any);
   } catch (err) {
     if (cb) {
       cb(PATH.slice(), any, this);

--- a/lang/js/lib/utils.js
+++ b/lang/js/lib/utils.js
@@ -140,7 +140,10 @@ function Lcg(seed) {
   var state = Math.floor(seed || Math.random() * (m - 1));
 
   this._max = m;
-  this._nextInt = function () { return state = (a * state + c) % m; };
+  this._nextInt = function () {
+    state = (a * state + c) % m;
+    return state;
+  };
 }
 
 Lcg.prototype.nextBoolean = function () {

--- a/lang/js/package.json
+++ b/lang/js/package.json
@@ -36,7 +36,8 @@
   "scripts": {
     "cover": "istanbul cover _mocha",
     "test": "mocha",
-    "clean": "rm -rf coverage node_modules"
+    "clean": "rm -rf coverage node_modules",
+    "lint": "jshint lib test"
   },
   "dependencies": {
     "underscore": "*"
@@ -44,6 +45,7 @@
   "devDependencies": {
     "coveralls": "^2.11.4",
     "istanbul": "^0.3.19",
+    "jshint": "^2.10.2",
     "mocha": "^2.3.2",
     "tmp": "^0.0.28"
   },


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2494
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

This PR adds linting feature to the JavaScript bindings. It also contains fixes for the existing violations.
I ran `./build.sh lint` in the `lang/js` directory and confirmed all violations were fixed.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
