### PR TITLE
AVRO-2505: `./build.sh clean` in the c++ directory doesn't remove all temporary files

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -23,7 +23,7 @@ VERSION=`cat share/VERSION.txt`
 DOCKER_XTRA_ARGS=""
 
 function usage {
-  echo "Usage: $0 {lint|test|dist|sign|clean|docker [--args \"docker-args\"]|rat|githooks|docker-test}"
+  echo "Usage: $0 {lint|test|dist|sign|clean|veryclean|docker [--args \"docker-args\"]|rat|githooks|docker-test}"
   exit 1
 }
 
@@ -208,6 +208,7 @@ do
 
       (cd lang/perl; ./build.sh clean)
       ;;
+
     veryclean)
       rm -rf build dist
       (cd doc; ant clean)
@@ -241,8 +242,8 @@ do
       (cd lang/php; ./build.sh clean)
 
       (cd lang/perl; ./build.sh clean)
+
       rm -rf lang/c++/build
-      rm -rf lang/c++/test?.df
       rm -rf lang/js/node_modules
       rm -rf lang/perl/inc/
       rm -rf lang/ruby/.gem/

--- a/lang/c++/build.sh
+++ b/lang/c++/build.sh
@@ -44,10 +44,6 @@ DOC_CPP=$BUILD/$AVRO_DOC/api/cpp
 DIST_DIR=../../dist/cpp
 TARFILE=../dist/cpp/$AVRO_CPP.tar.gz
 
-(mkdir -p build; cd build; cmake -G "Unix Makefiles" ..)
-for target in "$@"
-do
-
 function do_doc() {
   doxygen
   if [ -d doc ]
@@ -58,6 +54,7 @@ function do_doc() {
     exit 1
   fi
 }
+
 function do_dist() {
   rm -rf $BUILD_CPP/
   mkdir -p $BUILD_CPP
@@ -73,6 +70,10 @@ function do_dist() {
     exit 1
   fi
 }
+
+(mkdir -p build; cd build; cmake -G "Unix Makefiles" ..)
+for target in "$@"
+do
 
 case "$target" in
   lint)
@@ -112,7 +113,7 @@ case "$target" in
 
   clean)
     (cd build && make clean)
-    rm -rf doc test.avro test6.df
+    rm -rf doc test.avro test?.df test_skip.df
     ;;
 
   install)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2505
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No additional test, since it's a fix for the build scripts (with some code cleanup). I locally ran `./build.sh clean` in the lang/c++ directory and `./build.sh veryclean` in the toplevel and confirmed they worked as expected.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
