### PR TITLE
AVRO-2506: Fix warnings in creating the Ruby distribution

### DIFF
--- a/lang/ruby/Rakefile
+++ b/lang/ruby/Rakefile
@@ -23,8 +23,8 @@ Echoe.new('avro', VERSION) do |p|
   p.summary = "Apache Avro for Ruby"
   p.description = "Avro is a data serialization and RPC format"
   p.url = "https://avro.apache.org/"
-  p.runtime_dependencies = %w[multi_json]
-  p.licenses = ["Apache License 2.0 (Apache-2.0)"]
+  p.runtime_dependencies = ["multi_json ~>1"]
+  p.licenses = ["Apache-2.0"]
 end
 
 t = Rake::TestTask.new(:interop)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2506
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No additional test, since it's a fix for build-related settings. I locally ran `./build.sh dist` in the lang/ruby directory and confirmed it worked as expected.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
