### PR TITLE
AVRO-2507: Add Python3 to the RPC interop test

### DIFF
--- a/lang/py/src/avro/ipc.py
+++ b/lang/py/src/avro/ipc.py
@@ -443,16 +443,7 @@ class HTTPTransceiver(object):
     self.req_resource = req_resource
     self.conn = httplib.HTTPConnection(host, port)
     self.conn.connect()
-
-  # read-only properties
-  sock = property(lambda self: self.conn.sock)
-  remote_name = property(lambda self: self.sock.getsockname())
-
-  # read/write properties
-  def set_conn(self, new_conn):
-    self._conn = new_conn
-  conn = property(lambda self: self._conn, set_conn)
-  req_resource = '/'
+    self.remote_name = self.conn.sock.getsockname()
 
   def transceive(self, request):
     self.write_framed_message(request)

--- a/lang/py3/avro/tool.py
+++ b/lang/py3/avro/tool.py
@@ -25,21 +25,21 @@ NOTE: The API for the command-line tool is experimental.
 
 import sys
 import urllib
-from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, HTTPServer
 
 from avro import datafile, io, ipc, protocol
 
 
 class GenericResponder(ipc.Responder):
   def __init__(self, proto, msg, datum):
-    proto_json = file(proto, 'r').read()
+    proto_json = open(proto, 'r').read()
     ipc.Responder.__init__(self, protocol.Parse(proto_json))
     self.msg = msg
     self.datum = datum
 
-  def invoke(self, message, request):
+  def Invoke(self, message, request):
     if message.name == self.msg:
-      print >> sys.stderr, "Message: %s Datum: %s" % (message.name, self.datum)
+      print("Message: %s Datum: %s" % (message.name, self.datum), sys.stderr)
       # server will shut down after processing a single Avro request
       global server_should_shutdown
       server_should_shutdown = True
@@ -49,15 +49,15 @@ class GenericHandler(BaseHTTPRequestHandler):
   def do_POST(self):
     self.responder = responder
     call_request_reader = ipc.FramedReader(self.rfile)
-    call_request = call_request_reader.read_framed_message()
-    resp_body = self.responder.respond(call_request)
+    call_request = call_request_reader.Read()
+    resp_body = self.responder.Respond(call_request)
     self.send_response(200)
     self.send_header('Content-Type', 'avro/binary')
     self.end_headers()
     resp_writer = ipc.FramedWriter(self.wfile)
-    resp_writer.write_framed_message(resp_body)
+    resp_writer.Write(resp_body)
     if server_should_shutdown:
-      print >> sys.stderr, "Shutting down server."
+      print("Shutting down server.", sys.stderr)
       self.server.force_stop()
 
 class StoppableHTTPServer(HTTPServer):
@@ -88,15 +88,15 @@ def run_server(uri, proto, msg, datum):
   print("Port: %s" % server.server_port)
   sys.stdout.flush()
   server.allow_reuse_address = True
-  print >> sys.stderr, "Starting server."
+  print("Starting server.", sys.stderr)
   server.serve_forever()
 
 def send_message(uri, proto, msg, datum):
   url_obj = urllib.parse.urlparse(uri)
   client = ipc.HTTPTransceiver(url_obj.hostname, url_obj.port)
-  proto_json = file(proto, 'r').read()
+  proto_json = open(proto, 'r').read()
   requestor = ipc.Requestor(protocol.Parse(proto_json), client)
-  print(requestor.request(msg, datum))
+  print(requestor.Request(msg, datum))
 
 def file_or_stdin(f):
   if f == "-":
@@ -125,10 +125,9 @@ def main(args=sys.argv):
     datum = None
     if len(args) > 5:
       if args[5] == "-file":
-        reader = open(args[6], 'rb')
-        datum_reader = io.DatumReader()
-        dfr = datafile.DataFileReader(reader, datum_reader)
-        datum = dfr.next()
+        with open(args[6], 'rb') as reader:
+          with datafile.DataFileReader(reader, io.DatumReader()) as dfr:
+            datum = next(dfr)
       elif args[5] == "-data":
         print("JSON Decoder not yet implemented.")
         return 1
@@ -146,10 +145,9 @@ def main(args=sys.argv):
     datum = None
     if len(args) > 5:
       if args[5] == "-file":
-        reader = open(args[6], 'rb')
-        datum_reader = io.DatumReader()
-        dfr = datafile.DataFileReader(reader, datum_reader)
-        datum = dfr.next()
+        with open(args[6], 'rb') as reader:
+          with datafile.DataFileReader(reader, io.DatumReader()) as dfr:
+            datum = next(dfr)
       elif args[5] == "-data":
         print("JSON Decoder not yet implemented.")
         return 1

--- a/share/test/interop/bin/test_rpc_interop.sh
+++ b/share/test/interop/bin/test_rpc_interop.sh
@@ -24,16 +24,17 @@ VERSION=`cat share/VERSION.txt`
 java_client="java -jar lang/java/tools/target/avro-tools-$VERSION.jar rpcsend"
 java_server="java -jar lang/java/tools/target/avro-tools-$VERSION.jar rpcreceive"
 
-py_client="python lang/py/build/src/avro/tool.py rpcsend"
-py_server="python lang/py/build/src/avro/tool.py rpcreceive"
+py_client="env PYTHONPATH=lang/py/build/src python lang/py/build/src/avro/tool.py rpcsend"
+py_server="env PYTHONPATH=lang/py/build/src python lang/py/build/src/avro/tool.py rpcreceive"
+
+py3_client="env PYTHONPATH=lang/py3 python3 lang/py3/avro/tool.py rpcsend"
+py3_server="env PYTHONPATH=lang/py3 python3 lang/py3/avro/tool.py rpcreceive"
 
 ruby_client="ruby -rubygems -Ilang/ruby/lib lang/ruby/test/tool.rb rpcsend"
 ruby_server="ruby -rubygems -Ilang/ruby/lib lang/ruby/test/tool.rb rpcreceive"
 
-export PYTHONPATH=lang/py/build/src      # path to avro Python module
-
-clients=("$java_client" "$py_client" "$ruby_client")
-servers=("$java_server" "$py_server" "$ruby_server")
+clients=("$java_client" "$py_client" "$py3_client" "$ruby_client")
+servers=("$java_server" "$py_server" "$py3_server" "$ruby_server")
 
 proto=share/test/schemas/simple.avpr
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2507
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Fixed share/test/interop/bin/test_rpc_interop.sh to test the RPC interoperability of the Python3 bindings.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
