### PR TITLE
AVRO-2510:avro-grpc failed when ./build.sh lint

### DIFF
--- a/lang/java/grpc/pom.xml
+++ b/lang/java/grpc/pom.xml
@@ -51,27 +51,6 @@
       </resource>
     </resources>
     <plugins>
-      <plugin>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>avro-maven-plugin</artifactId>
-        <version>${project.version}</version>
-        <executions>
-          <execution>
-            <id>schemas</id>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>schema</goal>
-              <goal>protocol</goal>
-              <goal>idl-protocol</goal>
-            </goals>
-            <configuration>
-              <stringType>String</stringType>
-              <testSourceDirectory>${project.basedir}/src/test/avro</testSourceDirectory>
-              <testOutputDirectory>${project.build.directory}/generated-test-sources/java</testOutputDirectory>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
       <!-- Allow guava because hadoop brings it as a transitive dependency. -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -90,6 +69,27 @@
                   </includes>
                 </bannedDependencies>
               </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>avro-maven-plugin</artifactId>
+        <version>${project.version}</version>
+        <executions>
+          <execution>
+            <id>schemas</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>schema</goal>
+              <goal>protocol</goal>
+              <goal>idl-protocol</goal>
+            </goals>
+            <configuration>
+              <stringType>String</stringType>
+              <testSourceDirectory>${project.basedir}/src/test/avro</testSourceDirectory>
+              <testOutputDirectory>${project.build.directory}/generated-test-sources/java</testOutputDirectory>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
Build log without this fix:
```bash
root@71953052ce65:~/avro/lang/java# ./build.sh lint 

[INFO] Reactor Summary:
[INFO] 
[INFO] Apache Avro Java ................................... SUCCESS [  0.360 s]
[INFO] Apache Avro ........................................ SUCCESS [  3.598 s]
[INFO] Apache Avro Compiler ............................... SUCCESS [  0.920 s]
[INFO] Apache Avro Maven Plugin ........................... SUCCESS [  0.923 s]
[INFO] Apache Avro IPC .................................... SUCCESS [  1.170 s]
[INFO] Apache Avro IPC Jetty .............................. SUCCESS [  0.796 s]
[INFO] Apache Avro IPC Netty .............................. SUCCESS [  0.942 s]
[INFO] Trevni Java ........................................ SUCCESS [  0.007 s]
[INFO] Trevni Java Core ................................... SUCCESS [  0.842 s]
[INFO] Apache Avro Mapred API ............................. SUCCESS [  1.518 s]
[INFO] Trevni Java Avro ................................... SUCCESS [  0.843 s]
[INFO] Trevni Specification ............................... SUCCESS [  0.004 s]
[INFO] Apache Avro Tools .................................. SUCCESS [  0.962 s]
[INFO] Apache Avro Protobuf Compatibility ................. SUCCESS [  1.384 s]
[INFO] Apache Avro Thrift Compatibility ................... SUCCESS [  0.983 s]
[INFO] Apache Avro Maven Archetypes ....................... SUCCESS [  0.069 s]
[INFO] Apache Avro Maven Service Archetype ................ SUCCESS [  0.003 s]
[INFO] Apache Avro gRPC ................................... FAILURE [  0.009 s]
[INFO] Avro Integration Tests ............................. SKIPPED
[INFO] Apache Avro Codegen Test dependencies .............. SKIPPED
[INFO] Apache Avro Codegen Test ........................... SKIPPED
[INFO] Apache Avro Performance Test Suite ................. SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 16.287 s
[INFO] Finished at: 2019-08-19T03:16:17+00:00
[INFO] Final Memory: 96M/878M
[INFO] ------------------------------------------------------------------------
[ERROR] Could not find goal 'apply' in plugin org.apache.avro:avro-maven-plugin:1.10.0-SNAPSHOT among available goals help, idl-protocol, induce, protocol, schema -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoNotFoundException

```

Build log with this fix:
```bash
root@71953052ce65:~/avro/lang/java# ./build.sh lint 

[INFO] Reactor Summary:
[INFO] 
[INFO] Apache Avro Java ................................... SUCCESS [  0.339 s]
[INFO] Apache Avro ........................................ SUCCESS [  3.496 s]
[INFO] Apache Avro Compiler ............................... SUCCESS [  0.949 s]
[INFO] Apache Avro Maven Plugin ........................... SUCCESS [  0.881 s]
[INFO] Apache Avro IPC .................................... SUCCESS [  1.142 s]
[INFO] Apache Avro IPC Jetty .............................. SUCCESS [  0.777 s]
[INFO] Apache Avro IPC Netty .............................. SUCCESS [  0.886 s]
[INFO] Trevni Java ........................................ SUCCESS [  0.007 s]
[INFO] Trevni Java Core ................................... SUCCESS [  0.815 s]
[INFO] Apache Avro Mapred API ............................. SUCCESS [  1.462 s]
[INFO] Trevni Java Avro ................................... SUCCESS [  0.832 s]
[INFO] Trevni Specification ............................... SUCCESS [  0.003 s]
[INFO] Apache Avro Tools .................................. SUCCESS [  0.983 s]
[INFO] Apache Avro Protobuf Compatibility ................. SUCCESS [  1.377 s]
[INFO] Apache Avro Thrift Compatibility ................... SUCCESS [  1.192 s]
[INFO] Apache Avro Maven Archetypes ....................... SUCCESS [  0.068 s]
[INFO] Apache Avro Maven Service Archetype ................ SUCCESS [  0.003 s]
[INFO] Apache Avro gRPC ................................... SUCCESS [  0.706 s]
[INFO] Avro Integration Tests ............................. SUCCESS [  0.005 s]
[INFO] Apache Avro Codegen Test dependencies .............. SUCCESS [  0.609 s]
[INFO] Apache Avro Codegen Test ........................... SUCCESS [  0.650 s]
[INFO] Apache Avro Performance Test Suite ................. SUCCESS [  0.904 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 19.042 s
[INFO] Finished at: 2019-08-19T03:15:28+00:00
[INFO] Final Memory: 146M/815M
[INFO] ------------------------------------------------------------------------

```


### Jira

- [ ] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2510
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
