### PR TITLE
AVRO-2454: Resolve more code analysis violations

### DIFF
--- a/lang/csharp/Avro.ruleset
+++ b/lang/csharp/Avro.ruleset
@@ -133,7 +133,6 @@
     <Rule Id="SA1516" Action="Info" />
     <Rule Id="SA1519" Action="Info" />
     <Rule Id="SA1520" Action="Info" />
-    <Rule Id="SA1610" Action="Info" />
     <Rule Id="SA1611" Action="Info" />
     <Rule Id="SA1614" Action="Info" />
     <Rule Id="SA1615" Action="Info" />

--- a/lang/csharp/Avro.ruleset
+++ b/lang/csharp/Avro.ruleset
@@ -133,7 +133,6 @@
     <Rule Id="SA1516" Action="Info" />
     <Rule Id="SA1519" Action="Info" />
     <Rule Id="SA1520" Action="Info" />
-    <Rule Id="SA1611" Action="Info" />
     <Rule Id="SA1614" Action="Info" />
     <Rule Id="SA1615" Action="Info" />
     <Rule Id="SA1616" Action="Info" />

--- a/lang/csharp/Avro.ruleset
+++ b/lang/csharp/Avro.ruleset
@@ -133,7 +133,6 @@
     <Rule Id="SA1516" Action="Info" />
     <Rule Id="SA1519" Action="Info" />
     <Rule Id="SA1520" Action="Info" />
-    <Rule Id="SA1604" Action="Info" />
     <Rule Id="SA1606" Action="Info" />
     <Rule Id="SA1610" Action="Info" />
     <Rule Id="SA1611" Action="Info" />

--- a/lang/csharp/Avro.ruleset
+++ b/lang/csharp/Avro.ruleset
@@ -21,7 +21,6 @@
     AVRO-2454: We need to evaluate each of these rules to determine whether we should enforce them.
     We disabled these rules initially to get the code analyzers installed in the project.
     -->
-    <Rule Id="CA1034" Action="Info" />
     <Rule Id="CA1052" Action="Info" />
     <Rule Id="CA1062" Action="Info" />
     <Rule Id="CA1063" Action="Info" />

--- a/lang/csharp/Avro.ruleset
+++ b/lang/csharp/Avro.ruleset
@@ -95,7 +95,6 @@
     <Rule Id="SA1106" Action="Info" />
     <Rule Id="SA1107" Action="Info" />
     <Rule Id="SA1108" Action="Info" />
-    <Rule Id="SA1119" Action="Info" />
     <Rule Id="SA1121" Action="Info" />
     <Rule Id="SA1122" Action="Info" />
     <Rule Id="SA1128" Action="Info" />

--- a/lang/csharp/Avro.ruleset
+++ b/lang/csharp/Avro.ruleset
@@ -27,7 +27,6 @@
     <Rule Id="CA1062" Action="Info" />
     <Rule Id="CA1707" Action="Info" />
     <Rule Id="CA1710" Action="Info" />
-    <Rule Id="CA1715" Action="Info" />
     <Rule Id="CA1716" Action="Info" />
     <Rule Id="CA1720" Action="Info" />
     <Rule Id="CA1721" Action="Info" />

--- a/lang/csharp/Avro.ruleset
+++ b/lang/csharp/Avro.ruleset
@@ -25,7 +25,6 @@
     We disabled these rules initially to get the code analyzers installed in the project.
     -->
     <Rule Id="CA1062" Action="Info" />
-    <Rule Id="CA1307" Action="Info" />
     <Rule Id="CA1507" Action="Info" />
     <Rule Id="CA1707" Action="Info" />
     <Rule Id="CA1710" Action="Info" />

--- a/lang/csharp/Avro.ruleset
+++ b/lang/csharp/Avro.ruleset
@@ -30,7 +30,6 @@
     <Rule Id="CA1716" Action="Info" />
     <Rule Id="CA1720" Action="Info" />
     <Rule Id="CA1721" Action="Info" />
-    <Rule Id="CA1724" Action="Info" />
     <Rule Id="CA1801" Action="Info" />
     <Rule Id="CA1819" Action="Info" />
     <Rule Id="CA1820" Action="Info" />

--- a/lang/csharp/Avro.ruleset
+++ b/lang/csharp/Avro.ruleset
@@ -25,7 +25,6 @@
     We disabled these rules initially to get the code analyzers installed in the project.
     -->
     <Rule Id="CA1062" Action="Info" />
-    <Rule Id="CA1507" Action="Info" />
     <Rule Id="CA1707" Action="Info" />
     <Rule Id="CA1710" Action="Info" />
     <Rule Id="CA1715" Action="Info" />

--- a/lang/csharp/Avro.ruleset
+++ b/lang/csharp/Avro.ruleset
@@ -134,7 +134,6 @@
     <Rule Id="SA1516" Action="Info" />
     <Rule Id="SA1519" Action="Info" />
     <Rule Id="SA1520" Action="Info" />
-    <Rule Id="SA1600" Action="Info" />
     <Rule Id="SA1604" Action="Info" />
     <Rule Id="SA1606" Action="Info" />
     <Rule Id="SA1610" Action="Info" />

--- a/lang/csharp/Avro.ruleset
+++ b/lang/csharp/Avro.ruleset
@@ -25,7 +25,6 @@
     We disabled these rules initially to get the code analyzers installed in the project.
     -->
     <Rule Id="CA1062" Action="Info" />
-    <Rule Id="CA1305" Action="Info" />
     <Rule Id="CA1307" Action="Info" />
     <Rule Id="CA1507" Action="Info" />
     <Rule Id="CA1707" Action="Info" />

--- a/lang/csharp/Avro.ruleset
+++ b/lang/csharp/Avro.ruleset
@@ -21,7 +21,6 @@
     AVRO-2454: We need to evaluate each of these rules to determine whether we should enforce them.
     We disabled these rules initially to get the code analyzers installed in the project.
     -->
-    <Rule Id="CA1052" Action="Info" />
     <Rule Id="CA1062" Action="Info" />
     <Rule Id="CA1063" Action="Info" />
     <Rule Id="CA1303" Action="Info" />

--- a/lang/csharp/Avro.ruleset
+++ b/lang/csharp/Avro.ruleset
@@ -22,7 +22,6 @@
     We disabled these rules initially to get the code analyzers installed in the project.
     -->
     <Rule Id="CA1062" Action="Info" />
-    <Rule Id="CA1063" Action="Info" />
     <Rule Id="CA1303" Action="Info" />
     <Rule Id="CA1305" Action="Info" />
     <Rule Id="CA1307" Action="Info" />
@@ -35,7 +34,6 @@
     <Rule Id="CA1721" Action="Info" />
     <Rule Id="CA1724" Action="Info" />
     <Rule Id="CA1801" Action="Info" />
-    <Rule Id="CA1816" Action="Info" />
     <Rule Id="CA1819" Action="Info" />
     <Rule Id="CA1820" Action="Info" />
     <Rule Id="CA1822" Action="Info" />

--- a/lang/csharp/Avro.ruleset
+++ b/lang/csharp/Avro.ruleset
@@ -133,7 +133,6 @@
     <Rule Id="SA1516" Action="Info" />
     <Rule Id="SA1519" Action="Info" />
     <Rule Id="SA1520" Action="Info" />
-    <Rule Id="SA1606" Action="Info" />
     <Rule Id="SA1610" Action="Info" />
     <Rule Id="SA1611" Action="Info" />
     <Rule Id="SA1614" Action="Info" />

--- a/lang/csharp/Avro.ruleset
+++ b/lang/csharp/Avro.ruleset
@@ -29,7 +29,6 @@
     <Rule Id="CA1710" Action="Info" />
     <Rule Id="CA1716" Action="Info" />
     <Rule Id="CA1720" Action="Info" />
-    <Rule Id="CA1721" Action="Info" />
     <Rule Id="CA1801" Action="Info" />
     <Rule Id="CA1819" Action="Info" />
     <Rule Id="CA1820" Action="Info" />

--- a/lang/csharp/Avro.ruleset
+++ b/lang/csharp/Avro.ruleset
@@ -17,12 +17,14 @@
 -->
 <RuleSet Name="New Rule Set" Description=" " ToolsVersion="16.0">
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
+    <!-- CA1303: Do not pass literals as localized parameters -->
+    <Rule Id="CA1303" Action="None" />
+
     <!--
     AVRO-2454: We need to evaluate each of these rules to determine whether we should enforce them.
     We disabled these rules initially to get the code analyzers installed in the project.
     -->
     <Rule Id="CA1062" Action="Info" />
-    <Rule Id="CA1303" Action="Info" />
     <Rule Id="CA1305" Action="Info" />
     <Rule Id="CA1307" Action="Info" />
     <Rule Id="CA1507" Action="Info" />

--- a/lang/csharp/Avro.ruleset
+++ b/lang/csharp/Avro.ruleset
@@ -51,6 +51,12 @@
     <!-- PrefixLocalCallsWithThis -->
     <Rule Id="SA1101" Action="None" />
 
+    <!-- SplitParametersMustStartOnLineAfterDeclaration -->
+    <Rule Id="SA1116" Action="None" />
+
+    <!-- ParametersMustBeOnSameLineOrSeparateLines -->
+    <Rule Id="SA1117" Action="None" />
+
     <!--
     Element Ordering Rules
     https://google.github.io/styleguide/javaguide.html#s3.4.2-ordering-class-contents
@@ -89,8 +95,6 @@
     <Rule Id="SA1106" Action="Info" />
     <Rule Id="SA1107" Action="Info" />
     <Rule Id="SA1108" Action="Info" />
-    <Rule Id="SA1116" Action="Info" />
-    <Rule Id="SA1117" Action="Info" />
     <Rule Id="SA1119" Action="Info" />
     <Rule Id="SA1121" Action="Info" />
     <Rule Id="SA1122" Action="Info" />

--- a/lang/csharp/src/apache/main/CodeGen/CodeGen.cs
+++ b/lang/csharp/src/apache/main/CodeGen/CodeGen.cs
@@ -16,14 +16,14 @@
  * limitations under the License.
  */
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Text;
 using System.CodeDom;
 using System.CodeDom.Compiler;
-using Microsoft.CSharp;
+using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
+using System.Reflection;
+using System.Text;
+using Microsoft.CSharp;
 
 namespace Avro
 {
@@ -836,7 +836,8 @@ namespace Avro
         /// <returns>CodeCommentStatement object</returns>
         protected virtual CodeCommentStatement createDocComment(string comment)
         {
-            string text = string.Format("<summary>\r\n {0}\r\n </summary>", comment);
+            string text = string.Format(CultureInfo.InvariantCulture,
+                "<summary>\r\n {0}\r\n </summary>", comment);
             return new CodeCommentStatement(text, true);
         }
 

--- a/lang/csharp/src/apache/main/CodeGen/CodeGen.cs
+++ b/lang/csharp/src/apache/main/CodeGen/CodeGen.cs
@@ -105,7 +105,7 @@ namespace Avro
         protected virtual CodeNamespace addNamespace(string name)
         {
             if (string.IsNullOrEmpty(name))
-                throw new ArgumentNullException("name", "name cannot be null.");
+                throw new ArgumentNullException(nameof(name), "name cannot be null.");
 
             CodeNamespace ns = null;
 

--- a/lang/csharp/src/apache/main/File/DataFileConstants.cs
+++ b/lang/csharp/src/apache/main/File/DataFileConstants.cs
@@ -21,6 +21,9 @@ namespace Avro.File
     /// <summary>
     /// Constants used in data files.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design",
+        "CA1052:Static holder types should be Static or NotInheritable",
+        Justification = "Maintain public API")]
     public class DataFileConstants
     {
         /// <summary>

--- a/lang/csharp/src/apache/main/File/DataFileReader.cs
+++ b/lang/csharp/src/apache/main/File/DataFileReader.cs
@@ -300,6 +300,18 @@ namespace Avro.File
         /// <inheritdoc/>
         public void Dispose()
         {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Releases resources associated with this <see cref="DataFileReader{T}"/>.
+        /// </summary>
+        /// <param name="disposing">
+        /// True if called from <see cref="Dispose()"/>; false otherwise.
+        /// </param>
+        protected virtual void Dispose(bool disposing)
+        {
             _stream.Close();
         }
 

--- a/lang/csharp/src/apache/main/File/DataFileReader.cs
+++ b/lang/csharp/src/apache/main/File/DataFileReader.cs
@@ -239,7 +239,7 @@ namespace Avro.File
         /// <inheritdoc/>
         public bool PastSync(long position)
         {
-            return ((_blockStart >= position + DataFileConstants.SyncSize) || (_blockStart >= _stream.Length));
+            return (_blockStart >= position + DataFileConstants.SyncSize) || (_blockStart >= _stream.Length);
         }
 
         /// <inheritdoc/>

--- a/lang/csharp/src/apache/main/File/DataFileReader.cs
+++ b/lang/csharp/src/apache/main/File/DataFileReader.cs
@@ -17,8 +17,9 @@
  */
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Globalization;
 using System.IO;
+using System.Linq;
 using Avro.Generic;
 using Avro.IO;
 using Avro.Specific;
@@ -165,7 +166,7 @@ namespace Avro.File
         /// <inheritdoc/>
         public long GetMetaLong(string key)
         {
-            return long.Parse(GetMetaString(key));
+            return long.Parse(GetMetaString(key), CultureInfo.InvariantCulture);
         }
 
         /// <inheritdoc/>
@@ -182,7 +183,8 @@ namespace Avro.File
             }
             catch (Exception e)
             {
-                throw new AvroRuntimeException(string.Format("Error fetching meta data for key: {0}", key), e);
+                throw new AvroRuntimeException(string.Format(CultureInfo.InvariantCulture,
+                    "Error fetching meta data for key: {0}", key), e);
             }
         }
 
@@ -285,7 +287,8 @@ namespace Avro.File
             }
             catch (Exception e)
             {
-                throw new AvroRuntimeException(string.Format("Error fetching next object from block: {0}", e));
+                throw new AvroRuntimeException(string.Format(CultureInfo.InvariantCulture,
+                    "Error fetching next object from block: {0}", e));
             }
         }
 
@@ -402,7 +405,8 @@ namespace Avro.File
             }
             catch (Exception e)
             {
-                throw new AvroRuntimeException(string.Format("Error fetching next object from block: {0}", e));
+                throw new AvroRuntimeException(string.Format(CultureInfo.InvariantCulture,
+                    "Error fetching next object from block: {0}", e));
             }
         }
 
@@ -471,7 +475,8 @@ namespace Avro.File
             }
             catch (Exception e)
             {
-                throw new AvroRuntimeException(string.Format("Error ascertaining if data has next block: {0}", e), e);
+                throw new AvroRuntimeException(string.Format(CultureInfo.InvariantCulture,
+                    "Error ascertaining if data has next block: {0}", e), e);
             }
         }
 

--- a/lang/csharp/src/apache/main/File/DataFileWriter.cs
+++ b/lang/csharp/src/apache/main/File/DataFileWriter.cs
@@ -327,6 +327,18 @@ namespace Avro.File
         /// <inheritdoc/>
         public void Dispose()
         {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Releases resources associated with this <see cref="DataFileWriter{T}"/>.
+        /// </summary>
+        /// <param name="disposing">
+        /// True if called from <see cref="Dispose()"/>; false otherwise.
+        /// </param>
+        protected virtual void Dispose(bool disposing)
+        {
             Close();
         }
     }

--- a/lang/csharp/src/apache/main/File/DataFileWriter.cs
+++ b/lang/csharp/src/apache/main/File/DataFileWriter.cs
@@ -107,7 +107,7 @@ namespace Avro.File
         /// <inheritdoc/>
         public bool IsReservedMeta(string key)
         {
-            return key.StartsWith(DataFileConstants.MetaDataReserved);
+            return key.StartsWith(DataFileConstants.MetaDataReserved, StringComparison.Ordinal);
         }
 
         /// <inheritdoc/>

--- a/lang/csharp/src/apache/main/File/DeflateCodec.cs
+++ b/lang/csharp/src/apache/main/File/DeflateCodec.cs
@@ -76,7 +76,7 @@ namespace Avro.File
         {
             if (this == other)
                 return true;
-            return (this.GetType().Name == other.GetType().Name);
+            return this.GetType().Name == other.GetType().Name;
         }
 
         /// <inheritdoc/>

--- a/lang/csharp/src/apache/main/File/NullCodec.cs
+++ b/lang/csharp/src/apache/main/File/NullCodec.cs
@@ -52,7 +52,7 @@ namespace Avro.File
         {
             if (this == other)
                 return true;
-            return (this.GetType().Name == other.GetType().Name);
+            return this.GetType().Name == other.GetType().Name;
         }
 
         /// <inheritdoc/>

--- a/lang/csharp/src/apache/main/Generic/DatumReader.cs
+++ b/lang/csharp/src/apache/main/Generic/DatumReader.cs
@@ -23,6 +23,8 @@ namespace Avro.Generic
     /// Defines the interface for an object that reads data of a schema.
     /// </summary>
     /// <typeparam name="T">Type of the in-memory data representation.</typeparam>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming",
+        "CA1715:Identifiers should have correct prefix", Justification = "Maintain public API")]
     public interface DatumReader<T>
     {
         /// <summary>

--- a/lang/csharp/src/apache/main/Generic/DatumWriter.cs
+++ b/lang/csharp/src/apache/main/Generic/DatumWriter.cs
@@ -23,6 +23,8 @@ namespace Avro.Generic
     /// Defines the interface for an object that writes data of a schema.
     /// </summary>
     /// <typeparam name="T">Type of the in-memory data representation.</typeparam>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming",
+        "CA1715:Identifiers should have correct prefix", Justification = "Maintain public API")]
     public interface DatumWriter<T>
     {
         /// <summary>

--- a/lang/csharp/src/apache/main/Generic/GenericDatumReader.cs
+++ b/lang/csharp/src/apache/main/Generic/GenericDatumReader.cs
@@ -210,7 +210,7 @@ namespace Avro.Generic
 
             public void AddElements(object mapObj, int elements, ReadItem itemReader, Decoder decoder, bool reuse)
             {
-                var map = ((IDictionary<string, object>)mapObj);
+                var map = (IDictionary<string, object>)mapObj;
                 for (int i = 0; i < elements; i++)
                 {
                     var key = decoder.ReadString();

--- a/lang/csharp/src/apache/main/Generic/GenericDatumReader.cs
+++ b/lang/csharp/src/apache/main/Generic/GenericDatumReader.cs
@@ -21,8 +21,13 @@ using Avro.IO;
 
 namespace Avro.Generic
 {
-    /// PreresolvingDatumReader for reading data to GenericRecord classes or primitives.
-    /// <see cref="PreresolvingDatumReader{T}">For more information about performance considerations for choosing this implementation</see>
+    /// <summary>
+    /// <see cref="PreresolvingDatumReader{T}"/> for reading data to <see cref="GenericRecord"/>
+    /// classes or primitives.
+    /// <see cref="PreresolvingDatumReader{T}">For more information about performance considerations
+    /// for choosing this implementation</see>.
+    /// </summary>
+    /// <typeparam name="T">Type to deserialize data into.</typeparam>
     public class GenericDatumReader<T> : PreresolvingDatumReader<T>
     {
         /// <summary>

--- a/lang/csharp/src/apache/main/Generic/GenericDatumWriter.cs
+++ b/lang/csharp/src/apache/main/Generic/GenericDatumWriter.cs
@@ -49,7 +49,7 @@ namespace Avro.Generic
         /// <inheritdoc/>
         protected override void EnsureRecordObject( RecordSchema recordSchema, object value )
         {
-            if( value == null || !( value is GenericRecord ) || !( ( value as GenericRecord ).Schema.Equals( recordSchema ) ) )
+            if( value == null || !( value is GenericRecord ) || ! ( value as GenericRecord ).Schema.Equals( recordSchema )  )
             {
                 throw TypeMismatch( value, "record", "GenericRecord" );
             }
@@ -66,7 +66,7 @@ namespace Avro.Generic
         {
             return (v,e) =>
                        {
-                            if( v == null || !(v is GenericEnum) || !((v as GenericEnum).Schema.Equals(es)))
+                            if( v == null || !(v is GenericEnum) || !(v as GenericEnum).Schema.Equals(es))
                                 throw TypeMismatch(v, "enum", "GenericEnum");
                             e.WriteEnum(es.Ordinal((v as GenericEnum ).Value));
                        };

--- a/lang/csharp/src/apache/main/Generic/GenericEnum.cs
+++ b/lang/csharp/src/apache/main/Generic/GenericEnum.cs
@@ -57,7 +57,9 @@ namespace Avro.Generic
         public override bool Equals(object obj)
         {
             if (obj == this) return true;
-            return (obj != null && obj is GenericEnum) ? Value.Equals((obj as GenericEnum).Value) : false;
+            return (obj != null && obj is GenericEnum)
+                ? Value.Equals((obj as GenericEnum).Value, System.StringComparison.Ordinal)
+                : false;
         }
 
         /// <inheritdoc/>

--- a/lang/csharp/src/apache/main/Generic/GenericReader.cs
+++ b/lang/csharp/src/apache/main/Generic/GenericReader.cs
@@ -246,12 +246,12 @@ namespace Avro.Generic
         /// <summary>
         /// A generic function to read primitive types
         /// </summary>
-        /// <typeparam name="S">The .NET type to read</typeparam>
+        /// <typeparam name="T">The .NET type to read</typeparam>
         /// <param name="tag">The Avro type tag for the object on the stream</param>
         /// <param name="readerSchema">A schema compatible to the Avro type</param>
         /// <param name="reader">A function that can read the avro type from the stream</param>
         /// <returns>The primitive type just read</returns>
-        protected S Read<S>(Schema.Type tag, Schema readerSchema, Reader<S> reader)
+        protected T Read<T>(Schema.Type tag, Schema readerSchema, Reader<T> reader)
         {
             return reader();
         }

--- a/lang/csharp/src/apache/main/Generic/GenericWriter.cs
+++ b/lang/csharp/src/apache/main/Generic/GenericWriter.cs
@@ -179,14 +179,14 @@ namespace Avro.Generic
         /// <summary>
         /// A generic method to serialize primitive Avro types.
         /// </summary>
-        /// <typeparam name="S">Type of the C# type to be serialized</typeparam>
+        /// <typeparam name="T">Type of the C# type to be serialized</typeparam>
         /// <param name="value">The value to be serialized</param>
         /// <param name="tag">The schema type tag</param>
         /// <param name="writer">The writer which should be used to write the given type.</param>
-        protected virtual void Write<S>(object value, Schema.Type tag, Writer<S> writer)
+        protected virtual void Write<T>(object value, Schema.Type tag, Writer<T> writer)
         {
-            if (!(value is S)) throw TypeMismatch(value, tag.ToString(), typeof(S).ToString());
-            writer((S)value);
+            if (!(value is T)) throw TypeMismatch(value, tag.ToString(), typeof(T).ToString());
+            writer((T)value);
         }
 
         /// <summary>

--- a/lang/csharp/src/apache/main/Generic/GenericWriter.cs
+++ b/lang/csharp/src/apache/main/Generic/GenericWriter.cs
@@ -222,7 +222,7 @@ namespace Avro.Generic
         /// <param name="value">Ensure this object is a record</param>
         protected virtual void EnsureRecordObject(RecordSchema s, object value)
         {
-            if (value == null || !(value is GenericRecord) || !((value as GenericRecord).Schema.Equals(s)))
+            if (value == null || !(value is GenericRecord) || !(value as GenericRecord).Schema.Equals(s))
             {
                 throw TypeMismatch(value, "record", "GenericRecord");
             }
@@ -251,7 +251,7 @@ namespace Avro.Generic
         /// <param name="encoder">Encoder for serialization</param>
         protected virtual void WriteEnum(EnumSchema es, object value, Encoder encoder)
         {
-            if (value == null || !(value is GenericEnum) || !((value as GenericEnum).Schema.Equals(es)))
+            if (value == null || !(value is GenericEnum) || !(value as GenericEnum).Schema.Equals(es))
                 throw TypeMismatch(value, "enum", "GenericEnum");
             encoder.WriteEnum(es.Ordinal((value as GenericEnum).Value));
         }

--- a/lang/csharp/src/apache/main/Generic/PreresolvingDatumReader.cs
+++ b/lang/csharp/src/apache/main/Generic/PreresolvingDatumReader.cs
@@ -507,6 +507,7 @@ namespace Avro.Generic
         /// the Specific and Generic implementations. Used to avoid retrieving the existing
         /// value if it's not reusable.
         /// </summary>
+        /// <param name="tag">Schema type to test for reusability.</param>
         protected virtual bool IsReusable(Schema.Type tag)
         {
             return true;

--- a/lang/csharp/src/apache/main/Generic/PreresolvingDatumWriter.cs
+++ b/lang/csharp/src/apache/main/Generic/PreresolvingDatumWriter.cs
@@ -445,7 +445,7 @@ namespace Avro.Generic
             /// <inheritdoc/>
             public void WriteMapValues(object map, WriteItem valueWriter, Encoder encoder)
             {
-                foreach (DictionaryEntry entry in ((IDictionary)map))
+                foreach (DictionaryEntry entry in (IDictionary)map)
                 {
                     encoder.StartItem();
                     encoder.WriteString(entry.Key.ToString());

--- a/lang/csharp/src/apache/main/Generic/PreresolvingDatumWriter.cs
+++ b/lang/csharp/src/apache/main/Generic/PreresolvingDatumWriter.cs
@@ -117,14 +117,14 @@ namespace Avro.Generic
         /// <summary>
         /// A generic method to serialize primitive Avro types.
         /// </summary>
-        /// <typeparam name="S">Type of the C# type to be serialized</typeparam>
+        /// <typeparam name="TValue">Type of the C# type to be serialized</typeparam>
         /// <param name="value">The value to be serialized</param>
         /// <param name="tag">The schema type tag</param>
         /// <param name="writer">The writer which should be used to write the given type.</param>
-        protected void Write<S>(object value, Schema.Type tag, Writer<S> writer)
+        protected void Write<TValue>(object value, Schema.Type tag, Writer<TValue> writer)
         {
-            if (!(value is S)) throw TypeMismatch(value, tag.ToString(), typeof(S).ToString());
-            writer((S)value);
+            if (!(value is TValue)) throw TypeMismatch(value, tag.ToString(), typeof(TValue).ToString());
+            writer((TValue)value);
         }
 
 

--- a/lang/csharp/src/apache/main/GlobalSuppressions.cs
+++ b/lang/csharp/src/apache/main/GlobalSuppressions.cs
@@ -40,4 +40,6 @@
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1065:Do not raise exceptions in unexpected locations", Justification = "Maintain public API", Scope = "member", Target = "~P:Avro.Protocol.MD5")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase", Justification = "Maintain public API", Scope = "member", Target = "~M:Avro.Schema.GetTypeString(Avro.Schema.Type)~System.String")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase", Justification = "Maintain public API", Scope = "member", Target = "~P:Avro.UnnamedSchema.Name")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1721:Property names should not match get methods", Justification = "Maintain public API", Scope = "member", Target = "~M:Avro.NamedSchema.GetName(Newtonsoft.Json.Linq.JToken,System.String)~Avro.SchemaName")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1721:Property names should not match get methods", Justification = "Maintain public API", Scope = "member", Target = "~P:Avro.NamedSchema.Name")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1724:Type names should not match namespaces", Justification = "Reviewed", Scope = "type", Target = "~T:Avro.Schema")]

--- a/lang/csharp/src/apache/main/GlobalSuppressions.cs
+++ b/lang/csharp/src/apache/main/GlobalSuppressions.cs
@@ -40,3 +40,4 @@
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1065:Do not raise exceptions in unexpected locations", Justification = "Maintain public API", Scope = "member", Target = "~P:Avro.Protocol.MD5")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase", Justification = "Maintain public API", Scope = "member", Target = "~M:Avro.Schema.GetTypeString(Avro.Schema.Type)~System.String")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase", Justification = "Maintain public API", Scope = "member", Target = "~P:Avro.UnnamedSchema.Name")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1724:Type names should not match namespaces", Justification = "Reviewed", Scope = "type", Target = "~T:Avro.Schema")]

--- a/lang/csharp/src/apache/main/IO/BinaryEncoder.cs
+++ b/lang/csharp/src/apache/main/IO/BinaryEncoder.cs
@@ -106,7 +106,7 @@ namespace Avro.IO
         {
             long bits = BitConverter.DoubleToInt64Bits(value);
 
-            writeByte((byte)((bits) & 0xFF));
+            writeByte((byte)(bits & 0xFF));
             writeByte((byte)((bits >> 8) & 0xFF));
             writeByte((byte)((bits >> 16) & 0xFF));
             writeByte((byte)((bits >> 24) & 0xFF));

--- a/lang/csharp/src/apache/main/IO/ByteBufferInputStream.cs
+++ b/lang/csharp/src/apache/main/IO/ByteBufferInputStream.cs
@@ -17,6 +17,7 @@
  */
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 
 namespace Avro.IO
@@ -50,7 +51,8 @@ namespace Avro.IO
                 int remainingCheck = buffer.Read(b, off, (int) remaining);
 
                 if(remainingCheck != remaining)
-                    throw new InvalidDataException(string.Format("remainingCheck [{0}] and remaining[{1}] are different.",
+                    throw new InvalidDataException(string.Format(CultureInfo.InvariantCulture,
+                        "remainingCheck [{0}] and remaining[{1}] are different.",
                         remainingCheck, remaining));
                 return (int)remaining;
             }
@@ -58,8 +60,8 @@ namespace Avro.IO
             int lenCheck = buffer.Read(b, off, len);
 
             if (lenCheck != len)
-                throw new InvalidDataException(string.Format("lenCheck [{0}] and len[{1}] are different.",
-                                                             lenCheck, len));
+                throw new InvalidDataException(string.Format(CultureInfo.InvariantCulture,
+                    "lenCheck [{0}] and len[{1}] are different.", lenCheck, len));
 
             return len;
         }

--- a/lang/csharp/src/apache/main/IO/Decoder.cs
+++ b/lang/csharp/src/apache/main/IO/Decoder.cs
@@ -22,6 +22,8 @@ namespace Avro.IO
     /// Decoder is used to decode Avro data on a stream. There are methods to read the Avro types on the stream. There are also
     /// methods to skip items, which are usually more efficient than reading, on the stream.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming",
+        "CA1715:Identifiers should have correct prefix", Justification = "Maintain public API")]
     public interface Decoder
     {
         /// <summary>

--- a/lang/csharp/src/apache/main/IO/Encoder.cs
+++ b/lang/csharp/src/apache/main/IO/Encoder.cs
@@ -22,6 +22,8 @@ namespace Avro.IO
     /// Defines the interface for a class that provies low-level support for serializing Avro
     /// values.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming",
+        "CA1715:Identifiers should have correct prefix", Justification = "Maintain public API")]
     public interface Encoder
     {
         /// <summary>

--- a/lang/csharp/src/apache/main/Protocol/Message.cs
+++ b/lang/csharp/src/apache/main/Protocol/Message.cs
@@ -186,7 +186,7 @@ namespace Avro
           if (!(obj is Message)) return false;
 
           Message that = obj as Message;
-          return this.Name.Equals(that.Name) &&
+          return this.Name.Equals(that.Name, StringComparison.Ordinal) &&
                  this.Request.Equals(that.Request) &&
                  areEqual(this.Response, that.Response) &&
                  areEqual(this.Error, that.Error);

--- a/lang/csharp/src/apache/main/Protocol/Message.cs
+++ b/lang/csharp/src/apache/main/Protocol/Message.cs
@@ -75,7 +75,7 @@ namespace Avro
         /// </param>
         public Message(string name, string doc, RecordSchema request, Schema response, UnionSchema error, bool? oneway)
         {
-            if (string.IsNullOrEmpty(name)) throw new ArgumentNullException("name", "name cannot be null.");
+            if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "name cannot be null.");
             this.Request = request;
             this.Response = response;
             this.Error = error;

--- a/lang/csharp/src/apache/main/Protocol/Protocol.cs
+++ b/lang/csharp/src/apache/main/Protocol/Protocol.cs
@@ -86,9 +86,9 @@ namespace Avro
                         string doc, IEnumerable<Schema> types,
                         IDictionary<string,Message> messages)
         {
-            if (string.IsNullOrEmpty(name)) throw new ArgumentNullException("name", "name cannot be null.");
-            if (null == types) throw new ArgumentNullException("types", "types cannot be null.");
-            if (null == messages) throw new ArgumentNullException("messages", "messages cannot be null.");
+            if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "name cannot be null.");
+            if (null == types) throw new ArgumentNullException(nameof(types), "types cannot be null.");
+            if (null == messages) throw new ArgumentNullException(nameof(messages), "messages cannot be null.");
 
             this.Name = name;
             this.Namespace = space;

--- a/lang/csharp/src/apache/main/Protocol/Protocol.cs
+++ b/lang/csharp/src/apache/main/Protocol/Protocol.cs
@@ -165,9 +165,9 @@ namespace Avro
             {
                 using (Newtonsoft.Json.JsonTextWriter writer = new Newtonsoft.Json.JsonTextWriter(sw))
                 {
-                    #if(DEBUG)
+#if DEBUG
                     writer.Formatting = Newtonsoft.Json.Formatting.Indented;
-                    #endif
+#endif
 
                     WriteJson(writer, new SchemaNames());
                     writer.Flush();
@@ -291,7 +291,7 @@ namespace Avro
         {
             int hash = Messages.Count;
             foreach (KeyValuePair<string, Message> pair in Messages)
-                hash += (pair.Key.GetHashCode() + pair.Value.GetHashCode());
+                hash += pair.Key.GetHashCode() + pair.Value.GetHashCode();
             return hash;
         }
     }

--- a/lang/csharp/src/apache/main/Protocol/Protocol.cs
+++ b/lang/csharp/src/apache/main/Protocol/Protocol.cs
@@ -222,8 +222,10 @@ namespace Avro
 
             Protocol that = obj as Protocol;
 
-            return this.Name.Equals(that.Name) && this.Namespace.Equals(that.Namespace) &&
-                    TypesEquals(that.Types) && MessagesEquals(that.Messages);
+            return this.Name.Equals(that.Name, StringComparison.Ordinal)
+                && this.Namespace.Equals(that.Namespace, StringComparison.Ordinal)
+                && TypesEquals(that.Types)
+                && MessagesEquals(that.Messages);
         }
 
         /// <summary>

--- a/lang/csharp/src/apache/main/Reflect/ArrayHelper.cs
+++ b/lang/csharp/src/apache/main/Reflect/ArrayHelper.cs
@@ -34,7 +34,6 @@ namespace Avro.Reflect
         /// <summary>
         /// Collection type to apply by default to all array objects. If not set this defaults to a generic List.
         /// </summary>
-        /// <value></value>
         public static Type DefaultType
         {
             get => _defaultType;
@@ -44,7 +43,6 @@ namespace Avro.Reflect
         /// <summary>
         /// The array
         /// </summary>
-        /// <value></value>
         public IEnumerable Enumerable { get; set; }
 
         /// <summary>
@@ -80,7 +78,6 @@ namespace Avro.Reflect
         /// <summary>
         /// Type of the array to create when deserializing
         /// </summary>
-        /// <value></value>
         public virtual Type ArrayType
         {
             get => _defaultType;

--- a/lang/csharp/src/apache/main/Reflect/ArrayHelper.cs
+++ b/lang/csharp/src/apache/main/Reflect/ArrayHelper.cs
@@ -58,7 +58,7 @@ namespace Avro.Reflect
         /// <summary>
         /// Add an element to the array.
         /// </summary>
-        /// <value></value>
+        /// <param name="o">Element to add to the array.</param>
         public virtual void Add(object o)
         {
             IList e = (IList)Enumerable;
@@ -86,6 +86,7 @@ namespace Avro.Reflect
         /// <summary>
         /// Constructor
         /// </summary>
+        /// <param name="enumerable">Enumerable to initialize this helper with.</param>
         public ArrayHelper(IEnumerable enumerable)
         {
             Enumerable = enumerable;

--- a/lang/csharp/src/apache/main/Reflect/AvroFieldAttribute.cs
+++ b/lang/csharp/src/apache/main/Reflect/AvroFieldAttribute.cs
@@ -30,13 +30,11 @@ namespace Avro.Reflect
         /// <summary>
         /// Name of the field in the Avro Schema
         /// </summary>
-        /// <value></value>
         public string FieldName { get; set; }
 
         /// <summary>
         /// Convert the property into a standard Avro type - e.g. DateTimeOffset to long
         /// </summary>
-        /// <value></value>
         public IAvroFieldConverter Converter { get; set; }
 
         /// <summary>

--- a/lang/csharp/src/apache/main/Reflect/ClassCache.cs
+++ b/lang/csharp/src/apache/main/Reflect/ClassCache.cs
@@ -19,8 +19,6 @@
 using System;
 using System.Collections;
 using System.Collections.Concurrent;
-using System.Reflection;
-using Avro;
 
 namespace Avro.Reflect
 {
@@ -65,11 +63,11 @@ namespace Avro.Reflect
         /// </summary>
         /// <param name="from"></param>
         /// <param name="to"></param>
-        /// <typeparam name="A"></typeparam>
-        /// <typeparam name="P"></typeparam>
-        public static void AddDefaultConverter<A, P>(Func<A, Schema, P> from, Func<P, Schema, A> to)
+        /// <typeparam name="TAvro"></typeparam>
+        /// <typeparam name="TProperty"></typeparam>
+        public static void AddDefaultConverter<TAvro, TProperty>(Func<TAvro, Schema, TProperty> from, Func<TProperty, Schema, TAvro> to)
         {
-            _defaultConverters.Add(new FuncFieldConverter<A, P>(from, to));
+            _defaultConverters.Add(new FuncFieldConverter<TAvro, TProperty>(from, to));
         }
 
         /// <summary>

--- a/lang/csharp/src/apache/main/Reflect/FuncFieldConverter.cs
+++ b/lang/csharp/src/apache/main/Reflect/FuncFieldConverter.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -17,7 +17,6 @@
  */
 
 using System;
-using Avro.Generic;
 
 namespace Avro.Reflect
 {
@@ -29,7 +28,7 @@ namespace Avro.Reflect
     public class FuncFieldConverter<A, P> : TypedFieldConverter<A, P>
     {
         /// <summary>
-        ///
+        /// Initializes a new instance of the <see cref="FuncFieldConverter{A, P}"/> class.
         /// </summary>
         /// <param name="from">Delegate to convert from C# type to Avro type</param>
         /// <param name="to">Delegate to convert from Avro type to C# type</param>

--- a/lang/csharp/src/apache/main/Reflect/FuncFieldConverter.cs
+++ b/lang/csharp/src/apache/main/Reflect/FuncFieldConverter.cs
@@ -23,24 +23,24 @@ namespace Avro.Reflect
     /// <summary>
     /// Field converter using a Func
     /// </summary>
-    /// <typeparam name="A">Avro type</typeparam>
-    /// <typeparam name="P">Property type</typeparam>
-    public class FuncFieldConverter<A, P> : TypedFieldConverter<A, P>
+    /// <typeparam name="TAvro">Avro type</typeparam>
+    /// <typeparam name="TProperty">Property type</typeparam>
+    public class FuncFieldConverter<TAvro, TProperty> : TypedFieldConverter<TAvro, TProperty>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FuncFieldConverter{A, P}"/> class.
         /// </summary>
         /// <param name="from">Delegate to convert from C# type to Avro type</param>
         /// <param name="to">Delegate to convert from Avro type to C# type</param>
-        public FuncFieldConverter(Func<A, Schema, P> from, Func<P, Schema, A> to)
+        public FuncFieldConverter(Func<TAvro, Schema, TProperty> from, Func<TProperty, Schema, TAvro> to)
         {
             _from = from;
             _to = to;
         }
 
-        private Func<A, Schema, P> _from;
+        private Func<TAvro, Schema, TProperty> _from;
 
-        private Func<P, Schema, A> _to;
+        private Func<TProperty, Schema, TAvro> _to;
 
         /// <summary>
         /// Inherited conversion method - call the Func.
@@ -48,7 +48,7 @@ namespace Avro.Reflect
         /// <param name="o"></param>
         /// <param name="s"></param>
         /// <returns></returns>
-        public override P From(A o, Schema s)
+        public override TProperty From(TAvro o, Schema s)
         {
             return _from(o, s);
         }
@@ -59,7 +59,7 @@ namespace Avro.Reflect
         /// <param name="o"></param>
         /// <param name="s"></param>
         /// <returns></returns>
-        public override A To(P o, Schema s)
+        public override TAvro To(TProperty o, Schema s)
         {
             return _to(o, s);
         }

--- a/lang/csharp/src/apache/main/Reflect/ReflectDefaultReader.cs
+++ b/lang/csharp/src/apache/main/Reflect/ReflectDefaultReader.cs
@@ -35,7 +35,6 @@ namespace Avro.Reflect
         /// C# type to create when deserializing a map. Must implement IDictionary&lt;,&gt; and the first
         /// type parameter must be a string. Default is System.Collections.Generic.Dictionary
         /// </summary>
-        /// <value></value>
         public Type MapType { get => _mapType; set => _mapType = value; }
 
         private ClassCache _classCache = new ClassCache();
@@ -43,7 +42,6 @@ namespace Avro.Reflect
         /// <summary>
         /// Class cache
         /// </summary>
-        /// <value></value>
         public ClassCache ClassCache { get => _classCache; }
 
         private Type _mapType = typeof(Dictionary<,>);

--- a/lang/csharp/src/apache/main/Reflect/ReflectDefaultReader.cs
+++ b/lang/csharp/src/apache/main/Reflect/ReflectDefaultReader.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using Avro.IO;
 using Avro.Specific;
 using Newtonsoft.Json.Linq;
@@ -120,7 +121,8 @@ namespace Avro.Reflect
                     enumType = EnumCache.GetEnumeration(namedSchema);
                     if (enumType == null)
                     {
-                        throw new Exception(string.Format("Couldn't find type matching enum name {0}", namedSchema.Fullname));
+                        throw new Exception(string.Format(CultureInfo.InvariantCulture,
+                            "Couldn't find type matching enum name {0}", namedSchema.Fullname));
                     }
 
                     if (nullable)
@@ -144,7 +146,8 @@ namespace Avro.Reflect
                     recordtype = _classCache.GetClass(recordSchema).GetClassType();
                     if (recordtype == null)
                     {
-                        throw new Exception(string.Format("Couldn't find type matching schema name {0}", recordSchema.Fullname));
+                        throw new Exception(string.Format(CultureInfo.InvariantCulture,
+                            "Couldn't find type matching schema name {0}", recordSchema.Fullname));
                     }
 
                     return recordtype;

--- a/lang/csharp/src/apache/main/Reflect/ReflectDefaultWriter.cs
+++ b/lang/csharp/src/apache/main/Reflect/ReflectDefaultWriter.cs
@@ -33,7 +33,6 @@ namespace Avro.Reflect
         /// <summary>
         /// Class cache
         /// </summary>
-        /// <value></value>
         public ClassCache ClassCache { get => _classCache; }
 
         /// <summary>

--- a/lang/csharp/src/apache/main/Reflect/ReflectReader.cs
+++ b/lang/csharp/src/apache/main/Reflect/ReflectReader.cs
@@ -35,7 +35,6 @@ namespace Avro.Reflect
         /// <summary>
         /// Default reader
         /// </summary>
-        /// <value></value>
         public ReflectDefaultReader Reader { get => _reader; }
 
         /// <summary>

--- a/lang/csharp/src/apache/main/Reflect/ReflectWriter.cs
+++ b/lang/csharp/src/apache/main/Reflect/ReflectWriter.cs
@@ -30,7 +30,6 @@ namespace Avro.Reflect
         /// <summary>
         /// Default writer
         /// </summary>
-        /// <value></value>
         public ReflectDefaultWriter Writer { get => _writer; }
 
         private readonly ReflectDefaultWriter _writer;
@@ -48,7 +47,6 @@ namespace Avro.Reflect
         /// <summary>
         /// The schema
         /// </summary>
-        /// <value></value>
         public Schema Schema { get => _writer.Schema; }
 
         /// <summary>

--- a/lang/csharp/src/apache/main/Reflect/TypedFieldConverter.cs
+++ b/lang/csharp/src/apache/main/Reflect/TypedFieldConverter.cs
@@ -17,16 +17,15 @@
  */
 
 using System;
-using System.Reflection;
 
 namespace Avro.Reflect
 {
     /// <summary>
     /// Constructor
     /// </summary>
-    /// <typeparam name="A">Avro type</typeparam>
-    /// <typeparam name="P">Property type</typeparam>
-    public abstract class TypedFieldConverter<A, P> : IAvroFieldConverter
+    /// <typeparam name="TAvro">Avro type</typeparam>
+    /// <typeparam name="TProperty">Property type</typeparam>
+    public abstract class TypedFieldConverter<TAvro, TProperty> : IAvroFieldConverter
     {
         /// <summary>
         /// Convert from Avro type to property type
@@ -34,7 +33,7 @@ namespace Avro.Reflect
         /// <param name="o">Avro value</param>
         /// <param name="s">Schema</param>
         /// <returns>Property value</returns>
-        public abstract P From(A o, Schema s);
+        public abstract TProperty From(TAvro o, Schema s);
 
         /// <summary>
         /// Convert from property type to Avro type
@@ -42,7 +41,7 @@ namespace Avro.Reflect
         /// <param name="o"></param>
         /// <param name="s"></param>
         /// <returns></returns>
-        public abstract A To(P o, Schema s);
+        public abstract TAvro To(TProperty o, Schema s);
 
         /// <summary>
         /// Implement untyped interface
@@ -52,12 +51,12 @@ namespace Avro.Reflect
         /// <returns></returns>
         public object FromAvroType(object o, Schema s)
         {
-            if (!typeof(A).IsAssignableFrom(o.GetType()))
+            if (!typeof(TAvro).IsAssignableFrom(o.GetType()))
             {
-                throw new AvroException($"Converter from {typeof(A).Name} to {typeof(P).Name} cannot convert object of type {o.GetType().Name} to {typeof(A).Name}, object {o.ToString()}");
+                throw new AvroException($"Converter from {typeof(TAvro).Name} to {typeof(TProperty).Name} cannot convert object of type {o.GetType().Name} to {typeof(TAvro).Name}, object {o.ToString()}");
             }
 
-            return From((A)o, s);
+            return From((TAvro)o, s);
         }
 
         /// <summary>
@@ -66,7 +65,7 @@ namespace Avro.Reflect
         /// <returns></returns>
         public Type GetAvroType()
         {
-            return typeof(A);
+            return typeof(TAvro);
         }
 
         /// <summary>
@@ -75,7 +74,7 @@ namespace Avro.Reflect
         /// <returns></returns>
         public Type GetPropertyType()
         {
-            return typeof(P);
+            return typeof(TProperty);
         }
 
         /// <summary>
@@ -86,12 +85,12 @@ namespace Avro.Reflect
         /// <returns></returns>
         public object ToAvroType(object o, Schema s)
         {
-            if (!typeof(P).IsAssignableFrom(o.GetType()))
+            if (!typeof(TProperty).IsAssignableFrom(o.GetType()))
             {
-                throw new AvroException($"Converter from {typeof(A).Name} to {typeof(P).Name} cannot convert object of type {o.GetType().Name} to {typeof(P).Name}, object {o.ToString()}");
+                throw new AvroException($"Converter from {typeof(TAvro).Name} to {typeof(TProperty).Name} cannot convert object of type {o.GetType().Name} to {typeof(TProperty).Name}, object {o.ToString()}");
             }
 
-            return To((P)o, s);
+            return To((TProperty)o, s);
         }
     }
 }

--- a/lang/csharp/src/apache/main/Schema/ArraySchema.cs
+++ b/lang/csharp/src/apache/main/Schema/ArraySchema.cs
@@ -54,7 +54,7 @@ namespace Avro
         /// <param name="props">dictionary that provides access to custom properties</param>
         private ArraySchema(Schema items, PropertyMap props) : base(Type.Array, props)
         {
-            if (null == items) throw new ArgumentNullException("items");
+            if (null == items) throw new ArgumentNullException(nameof(items));
             this.ItemSchema = items;
         }
 

--- a/lang/csharp/src/apache/main/Schema/EnumSchema.cs
+++ b/lang/csharp/src/apache/main/Schema/EnumSchema.cs
@@ -178,7 +178,14 @@ namespace Avro
                 EnumSchema that = obj as EnumSchema;
                 if (SchemaName.Equals(that.SchemaName) && Count == that.Count)
                 {
-                    for (int i = 0; i < Count; i++) if (!Symbols[i].Equals(that.Symbols[i])) return false;
+                    for (int i = 0; i < Count; i++)
+                    {
+                        if (!Symbols[i].Equals(that.Symbols[i], StringComparison.Ordinal))
+                        {
+                            return false;
+                        }
+                    }
+
                     return areEqual(that.Props, this.Props);
                 }
             }

--- a/lang/csharp/src/apache/main/Schema/Field.cs
+++ b/lang/csharp/src/apache/main/Schema/Field.cs
@@ -124,7 +124,7 @@ namespace Avro
         internal Field(Schema schema, string name, IList<string> aliases, int pos, string doc,
                         JToken defaultValue, SortOrder sortorder, PropertyMap props)
         {
-            if (string.IsNullOrEmpty(name)) throw new ArgumentNullException("name", "name cannot be null.");
+            if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "name cannot be null.");
             if (null == schema) throw new ArgumentNullException("type", "type cannot be null.");
             this.Schema = schema;
             this.Name = name;

--- a/lang/csharp/src/apache/main/Schema/Field.cs
+++ b/lang/csharp/src/apache/main/Schema/Field.cs
@@ -213,7 +213,7 @@ namespace Avro
         {
             if (null == this.Props) return null;
             string v;
-            return (this.Props.TryGetValue(key, out v)) ? v : null;
+            return this.Props.TryGetValue(key, out v) ? v : null;
         }
 
         /// <summary>

--- a/lang/csharp/src/apache/main/Schema/FixedSchema.cs
+++ b/lang/csharp/src/apache/main/Schema/FixedSchema.cs
@@ -69,7 +69,7 @@ namespace Avro
                             : base(Type.Fixed, name, aliases, props, names, doc)
         {
             if (null == name.Name) throw new SchemaParseException("name cannot be null for fixed schema.");
-            if (size <= 0) throw new ArgumentOutOfRangeException("size", "size must be greater than zero.");
+            if (size <= 0) throw new ArgumentOutOfRangeException(nameof(size), "size must be greater than zero.");
             this.Size = size;
         }
 

--- a/lang/csharp/src/apache/main/Schema/JsonHelper.cs
+++ b/lang/csharp/src/apache/main/Schema/JsonHelper.cs
@@ -34,8 +34,8 @@ namespace Avro
         /// <returns>property value if property exists, null if property doesn't exist in the JSON object</returns>
         public static string GetOptionalString(JToken jtok, string field)
         {
-            if (null == jtok) throw new ArgumentNullException("jtok", "jtok cannot be null.");
-            if (string.IsNullOrEmpty(field)) throw new ArgumentNullException("field", $"field cannot be null at '{jtok.Path}'");
+            if (null == jtok) throw new ArgumentNullException(nameof(jtok), "jtok cannot be null.");
+            if (string.IsNullOrEmpty(field)) throw new ArgumentNullException(nameof(field), $"field cannot be null at '{jtok.Path}'");
 
             JToken child = jtok[field];
             if (null == child) return null;
@@ -85,8 +85,8 @@ namespace Avro
         /// <returns>null if property doesn't exist, otherise returns property boolean value</returns>
         public static bool? GetOptionalBoolean(JToken jtok, string field)
         {
-            if (null == jtok) throw new ArgumentNullException("jtok", "jtok cannot be null.");
-            if (string.IsNullOrEmpty(field)) throw new ArgumentNullException("field", $"field cannot be null at '{jtok.Path}'");
+            if (null == jtok) throw new ArgumentNullException(nameof(jtok), "jtok cannot be null.");
+            if (string.IsNullOrEmpty(field)) throw new ArgumentNullException(nameof(field), $"field cannot be null at '{jtok.Path}'");
 
             JToken child = jtok[field];
             if (null == child) return null;

--- a/lang/csharp/src/apache/main/Schema/MapSchema.cs
+++ b/lang/csharp/src/apache/main/Schema/MapSchema.cs
@@ -71,7 +71,7 @@ namespace Avro
         /// <param name="props">dictionary that provides access to custom properties</param>
         private MapSchema(Schema valueSchema, PropertyMap props) : base(Type.Map, props)
         {
-            if (null == valueSchema) throw new ArgumentNullException("valueSchema", "valueSchema cannot be null.");
+            if (null == valueSchema) throw new ArgumentNullException(nameof(valueSchema), "valueSchema cannot be null.");
             this.ValueSchema = valueSchema;
         }
 

--- a/lang/csharp/src/apache/main/Schema/PrimitiveSchema.cs
+++ b/lang/csharp/src/apache/main/Schema/PrimitiveSchema.cs
@@ -45,7 +45,12 @@ namespace Avro
         public static PrimitiveSchema NewInstance(string type, PropertyMap props = null)
         {
             const string q = "\"";
-            if (type.StartsWith(q) && type.EndsWith(q)) type = type.Substring(1, type.Length - 2);
+            if (type.StartsWith(q, StringComparison.Ordinal)
+                && type.EndsWith(q, StringComparison.Ordinal))
+            {
+                type = type.Substring(1, type.Length - 2);
+            }
+
             switch (type)
             {
                 case "null":

--- a/lang/csharp/src/apache/main/Schema/Property.cs
+++ b/lang/csharp/src/apache/main/Schema/Property.cs
@@ -15,9 +15,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+using System;
 using System.Collections.Generic;
-using Newtonsoft.Json.Linq;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Avro
 {
@@ -61,7 +62,10 @@ namespace Avro
             string oldValue;
             if (TryGetValue(key, out oldValue))
             {
-                if (!oldValue.Equals(value)) throw new AvroException("Property cannot be overwritten: " + key);
+                if (!oldValue.Equals(value, StringComparison.Ordinal))
+                {
+                    throw new AvroException("Property cannot be overwritten: " + key);
+                }
             }
             else
                 Add(key, value);
@@ -100,7 +104,7 @@ namespace Avro
                 {
                     if (!that.ContainsKey(pair.Key))
                         return false;
-                    if (!pair.Value.Equals(that[pair.Key]))
+                    if (!pair.Value.Equals(that[pair.Key], StringComparison.Ordinal))
                         return false;
                 }
                 return true;

--- a/lang/csharp/src/apache/main/Schema/RecordSchema.cs
+++ b/lang/csharp/src/apache/main/Schema/RecordSchema.cs
@@ -180,7 +180,7 @@ namespace Avro
             {
                 if (string.IsNullOrEmpty(name)) throw new ArgumentNullException("name");
                 Field field;
-                return (fieldLookup.TryGetValue(name, out field)) ? field : null;
+                return fieldLookup.TryGetValue(name, out field) ? field : null;
             }
         }
 

--- a/lang/csharp/src/apache/main/Schema/RecordSchema.cs
+++ b/lang/csharp/src/apache/main/Schema/RecordSchema.cs
@@ -178,7 +178,7 @@ namespace Avro
         {
             get
             {
-                if (string.IsNullOrEmpty(name)) throw new ArgumentNullException("name");
+                if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name));
                 Field field;
                 return fieldLookup.TryGetValue(name, out field) ? field : null;
             }

--- a/lang/csharp/src/apache/main/Schema/Schema.cs
+++ b/lang/csharp/src/apache/main/Schema/Schema.cs
@@ -183,9 +183,9 @@ namespace Avro
                 {
                     string type = (string)jtype;
 
-                    if (type.Equals("array"))
+                    if (type.Equals("array", StringComparison.Ordinal))
                         return ArraySchema.NewInstance(jtok, props, names, encspace);
-                    if (type.Equals("map"))
+                    if (type.Equals("map", StringComparison.Ordinal))
                         return MapSchema.NewInstance(jtok, props, names, encspace);
 
                     Schema schema = PrimitiveSchema.NewInstance((string)type, props);
@@ -224,7 +224,8 @@ namespace Avro
 
             try
             {
-                bool IsArray = json.StartsWith("[") && json.EndsWith("]");
+                bool IsArray = json.StartsWith("[", StringComparison.Ordinal)
+                    && json.EndsWith("]", StringComparison.Ordinal);
                 JContainer j = IsArray ? (JContainer)JArray.Parse(json) : (JContainer)JObject.Parse(json);
 
                 return ParseJson(j, names, encspace);

--- a/lang/csharp/src/apache/main/Schema/Schema.cs
+++ b/lang/csharp/src/apache/main/Schema/Schema.cs
@@ -206,7 +206,7 @@ namespace Avro
         /// <returns>new Schema object</returns>
         public static Schema Parse(string json)
         {
-            if (string.IsNullOrEmpty(json)) throw new ArgumentNullException("json", "json cannot be null.");
+            if (string.IsNullOrEmpty(json)) throw new ArgumentNullException(nameof(json), "json cannot be null.");
             return Parse(json.Trim(), new SchemaNames(), null); // standalone schema, so no enclosing namespace
         }
 

--- a/lang/csharp/src/apache/main/Schema/Schema.cs
+++ b/lang/csharp/src/apache/main/Schema/Schema.cs
@@ -327,7 +327,7 @@ namespace Avro
         {
             if (null == this.Props) return null;
             string v;
-            return (this.Props.TryGetValue(key, out v)) ? v : null;
+            return this.Props.TryGetValue(key, out v) ? v : null;
         }
 
         /// <summary>

--- a/lang/csharp/src/apache/main/Schema/SchemaNormalization.cs
+++ b/lang/csharp/src/apache/main/Schema/SchemaNormalization.cs
@@ -16,9 +16,10 @@
  * limitations under the License.
  */
 
-using System.Collections.Generic;
-using System.Text;
 using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
 
 namespace Avro
 {
@@ -99,7 +100,8 @@ namespace Avro
                     var sha256 = System.Security.Cryptography.SHA256.Create();
                     return sha256.ComputeHash(data);
                 default:
-                    throw new ArgumentException(string.Format("Unsupported fingerprint computation algorithm ({0})", fpName));
+                    throw new ArgumentException(string.Format(CultureInfo.InvariantCulture,
+                        "Unsupported fingerprint computation algorithm ({0})", fpName));
             }
         }
 
@@ -214,7 +216,8 @@ namespace Avro
                     else if (st == Schema.Type.Fixed)
                     {
                         FixedSchema fixedSchema = s as FixedSchema;
-                        o.Append(",\"size\":").Append(fixedSchema.Size.ToString());
+                        o.Append(",\"size\":")
+                            .Append(fixedSchema.Size.ToString(CultureInfo.InvariantCulture));
                     }
                     else  // st == Schema.Type.Record
                     {

--- a/lang/csharp/src/apache/main/Schema/UnionSchema.cs
+++ b/lang/csharp/src/apache/main/Schema/UnionSchema.cs
@@ -75,7 +75,7 @@ namespace Avro
         private UnionSchema(List<Schema> schemas, PropertyMap props) : base(Type.Union, props)
         {
             if (schemas == null)
-                throw new ArgumentNullException("schemas");
+                throw new ArgumentNullException(nameof(schemas));
             this.Schemas = schemas;
         }
 

--- a/lang/csharp/src/apache/main/Specific/ObjectCreator.cs
+++ b/lang/csharp/src/apache/main/Specific/ObjectCreator.cs
@@ -75,6 +75,7 @@ namespace Avro.Specific
 
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 #pragma warning disable CA1034 // Nested types should not be visible
+#pragma warning disable SA1600 // Elements should be documented
         /// <summary>
         /// Obsolete: This will be removed from the public API in a future version.
         /// </summary>
@@ -117,6 +118,7 @@ namespace Avro.Specific
                 return !left.Equals(right);
             }
         }
+#pragma warning restore SA1600 // Elements should be documented
 #pragma warning restore CA1034 // Nested types should not be visible
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 

--- a/lang/csharp/src/apache/main/Specific/ObjectCreator.cs
+++ b/lang/csharp/src/apache/main/Specific/ObjectCreator.cs
@@ -74,6 +74,7 @@ namespace Avro.Specific
         }
 
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+#pragma warning disable CA1034 // Nested types should not be visible
         /// <summary>
         /// Obsolete: This will be removed from the public API in a future version.
         /// </summary>
@@ -116,6 +117,7 @@ namespace Avro.Specific
                 return !left.Equals(right);
             }
         }
+#pragma warning restore CA1034 // Nested types should not be visible
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
         /// <summary>

--- a/lang/csharp/src/apache/main/Specific/SpecificDatumReader.cs
+++ b/lang/csharp/src/apache/main/Specific/SpecificDatumReader.cs
@@ -227,7 +227,7 @@ namespace Avro.Specific
 
             public void AddElements(object mapObj, int elements, ReadItem itemReader, Decoder decoder, bool reuse)
             {
-                var map = ((IDictionary)mapObj);
+                var map = (IDictionary)mapObj;
                 for (int i = 0; i < elements; i++)
                 {
                     var key = decoder.ReadString();

--- a/lang/csharp/src/apache/main/Specific/SpecificDatumWriter.cs
+++ b/lang/csharp/src/apache/main/Specific/SpecificDatumWriter.cs
@@ -137,7 +137,7 @@ namespace Avro.Specific
                 case Schema.Type.Error:
                 case Schema.Type.Record:
                     return obj is ISpecificRecord &&
-                           (((obj as ISpecificRecord).Schema) as RecordSchema).SchemaName.Equals((sc as RecordSchema).SchemaName);
+                           ((obj as ISpecificRecord).Schema as RecordSchema).SchemaName.Equals((sc as RecordSchema).SchemaName);
                 case Schema.Type.Enumeration:
                     return obj.GetType().IsEnum && (sc as EnumSchema).Symbols.Contains(obj.ToString());
                 case Schema.Type.Array:
@@ -148,7 +148,7 @@ namespace Avro.Specific
                     return false;   // Union directly within another union not allowed!
                 case Schema.Type.Fixed:
                     return obj is SpecificFixed &&
-                           (((obj as SpecificFixed).Schema) as FixedSchema).SchemaName.Equals((sc as FixedSchema).SchemaName);
+                           ((obj as SpecificFixed).Schema as FixedSchema).SchemaName.Equals((sc as FixedSchema).SchemaName);
                 default:
                     throw new AvroException("Unknown schema type: " + sc.Tag);
             }

--- a/lang/csharp/src/apache/main/Specific/SpecificWriter.cs
+++ b/lang/csharp/src/apache/main/Specific/SpecificWriter.cs
@@ -207,7 +207,7 @@ namespace Avro.Specific
                 case Schema.Type.Error:
                 case Schema.Type.Record:
                     return obj is ISpecificRecord &&
-                           (((obj as ISpecificRecord).Schema) as RecordSchema).SchemaName.Equals((sc as RecordSchema).SchemaName);
+                           ((obj as ISpecificRecord).Schema as RecordSchema).SchemaName.Equals((sc as RecordSchema).SchemaName);
                 case Schema.Type.Enumeration:
                     return obj.GetType().IsEnum && (sc as EnumSchema).Symbols.Contains(obj.ToString());
                 case Schema.Type.Array:
@@ -218,7 +218,7 @@ namespace Avro.Specific
                     return false;   // Union directly within another union not allowed!
                 case Schema.Type.Fixed:
                     return obj is SpecificFixed &&
-                           (((obj as SpecificFixed).Schema) as FixedSchema).SchemaName.Equals((sc as FixedSchema).SchemaName);
+                           ((obj as SpecificFixed).Schema as FixedSchema).SchemaName.Equals((sc as FixedSchema).SchemaName);
                 default:
                     throw new AvroException("Unknown schema type: " + sc.Tag);
             }

--- a/lang/csharp/stylecop.json
+++ b/lang/csharp/stylecop.json
@@ -3,7 +3,12 @@
   "settings": {
     "documentationRules": {
       "companyName": "Apache Software Foundation (ASF)",
-      "fileNamingConvention": "stylecop"
+      "fileNamingConvention": "stylecop",
+      "documentInterfaces": false,
+      "documentExposedElements": true,
+      "documentInternalElements": false,
+      "documentPrivateElements": false,
+      "documentPrivateFields": false
     },
     "indentation": {
       "indentationSize": 4,


### PR DESCRIPTION
This is a continuation of #609. In this PR, I addressed the code analysis rules listed below.

Each commit in this PR is stand-alone. As such, we should use the Rebase+Merge strategy when merging this PR.

* [CA1034] - Nested types should not be visible
* [SA1600] - Elements should be documented
* [CA1052] - Static holder types should be Static or NotIn…  …
* [CA1063] - Implement IDisposable correctly
* [CA1303] - Do not pass literals as localized parameters
* [CA1305] - Specify IFormatProvider
* [SA1116] and [SA1117] - Parameters on separate lines
* [SA1119] - StatementMustNotUseUnnecessaryParenthesis
* [CA1307] - Specify StringComparison
* [CA1507] - Use nameof in place of string
* [SA1604] - ElementDocumentationMustHaveSummary
* [SA1606] - ElementDocumentationMustHaveSummaryText
* [SA1610] - PropertyDocumentationMustHaveValueText
* [SA1611] - ElementParametersMustBeDocumented
* [CA1715] - Identifiers should have correct prefix
* [CA1724] - Type names should not match namespaces
* [CA1721] - Property names should not match get methods

[CA1034]: https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1034-nested-types-should-not-be-visible?view=vs-2019
[SA1600]: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1600.md
[CA1052]: https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1052-static-holder-types-should-be-sealed?view=vs-2019
[CA1063]: https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1063-implement-idisposable-correctly?view=vs-2019
[CA1303]: https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1303-do-not-pass-literals-as-localized-parameters?view=vs-2019
[CA1305]: https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1305-specify-iformatprovider?view=vs-2019
[SA1116]: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1116.md
[SA1117]: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1117.md
[SA1119]: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1119.md
[CA1307]: https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1307-specify-stringcomparison?view=vs-2019
[CA1507]: https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1507?view=vs-2019
[SA1604]: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1604.md
[SA1606]: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1606.md
[SA1610]: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1610.md
[SA1611]: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1611.md
[CA1715]: https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1715-identifiers-should-have-correct-prefix?view=vs-2019
[CA1724]: https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1724-type-names-should-not-match-namespaces?view=vs-2019
[CA1721]: https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1721-property-names-should-not-match-get-methods?view=vs-2019

---

## Checklist

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2454
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
