### PR TITLE
AVRO-2515: Enable granular access to ProtobufData methods

### DIFF
--- a/lang/java/protobuf/src/main/java/org/apache/avro/protobuf/ProtobufData.java
+++ b/lang/java/protobuf/src/main/java/org/apache/avro/protobuf/ProtobufData.java
@@ -226,7 +226,7 @@ public class ProtobufData extends GenericData {
     }
   }
 
-  private String getNamespace(FileDescriptor fd, Descriptor containing) {
+  public String getNamespace(FileDescriptor fd, Descriptor containing) {
     FileOptions o = fd.getOptions();
     String p = o.hasJavaPackage() ? o.getJavaPackage() : fd.getPackage();
     String outer = "";
@@ -268,7 +268,7 @@ public class ProtobufData extends GenericData {
 
   private static final Schema NULL = Schema.create(Schema.Type.NULL);
 
-  private Schema getSchema(FieldDescriptor f) {
+  public Schema getSchema(FieldDescriptor f) {
     Schema s = getNonRepeatedSchema(f);
     if (f.isRepeated())
       s = Schema.createArray(s);


### PR DESCRIPTION
Enable direct access to utility methods in `ProtobufData` that deal with the message description on a more granular level.

`ProtobufData` presents some great functionality that allows dealing with the Protobuf message descriptors. The intention of this PR is to provide access to the methods that deal with these descriptors on a more granular level. This would make it more flexible for the library clients to deal with their Protobuf message.

In terms of extending the functionality, this would make it possible for clients to adjust some specific moments of the conversion from Protobuf descriptors to Avro schemas.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2515
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: _the functionality is already tested. It just allows access on a more granular level of the functionality._

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
