### PR TITLE
AVRO-2518: Ruby Avro doesn't validate enum fields with default values

### DIFF
--- a/lang/ruby/lib/avro/io.rb
+++ b/lang/ruby/lib/avro/io.rb
@@ -591,7 +591,7 @@ module Avro
       def write_record(writers_schema, datum, encoder)
         raise AvroTypeError.new(writers_schema, datum) unless datum.is_a?(Hash)
         writers_schema.fields.each do |field|
-          write_data(field.type, (if datum[field.name].nil? then field.default else datum[field.name] end), encoder)
+          write_data(field.type, datum[field.name], encoder)
         end
       end
     end # DatumWriter

--- a/lang/ruby/lib/avro/io.rb
+++ b/lang/ruby/lib/avro/io.rb
@@ -591,7 +591,7 @@ module Avro
       def write_record(writers_schema, datum, encoder)
         raise AvroTypeError.new(writers_schema, datum) unless datum.is_a?(Hash)
         writers_schema.fields.each do |field|
-          write_data(field.type, datum[field.name], encoder)
+          write_data(field.type, (if datum[field.name].nil? then field.default else datum[field.name] end), encoder)
         end
       end
     end # DatumWriter

--- a/lang/ruby/lib/avro/schema_validator.rb
+++ b/lang/ruby/lib/avro/schema_validator.rb
@@ -95,7 +95,11 @@ module Avro
           fail TypeMismatchError unless datum.is_a?(Hash)
           expected_schema.fields.each do |field|
             deeper_path = deeper_path_for_hash(field.name, path)
-            validate_recursive(field.type, (if datum[field.name].nil? then field.default else datum[field.name] end), deeper_path, result, options)
+            if field.type.type_sym == :enum then
+              validate_recursive(field.type, (if datum.key?(field.name) || field.default.nil? then datum[field.name] else field.default end), deeper_path, result, options)
+            else
+              validate_recursive(field.type, datum[field.name], deeper_path, result, options)
+            end
           end
           if options[:fail_on_extra_fields]
             datum_fields = datum.keys.map(&:to_s)

--- a/lang/ruby/lib/avro/schema_validator.rb
+++ b/lang/ruby/lib/avro/schema_validator.rb
@@ -95,7 +95,7 @@ module Avro
           fail TypeMismatchError unless datum.is_a?(Hash)
           expected_schema.fields.each do |field|
             deeper_path = deeper_path_for_hash(field.name, path)
-            validate_recursive(field.type, datum[field.name], deeper_path, result, options)
+            validate_recursive(field.type, (if datum[field.name].nil? then field.default else datum[field.name] end), deeper_path, result, options)
           end
           if options[:fail_on_extra_fields]
             datum_fields = datum.keys.map(&:to_s)

--- a/lang/ruby/test/test_io.rb
+++ b/lang/ruby/test/test_io.rb
@@ -112,6 +112,13 @@ EOS
     check_default(enum_schema, '"B"', "B")
   end
 
+  def test_enum_field_default
+    record_schema = '{"type":"record","name":"enum_field_default","fields":[{"name":"msg","type":"string"},{"name":"logClass","type":{"type":"enum","name":"logClass","symbols":["UNCATEGORIZED","E1","E2","E3","E4","E5","E6","E7","E8","E9","E10"]},"default":"UNCATEGORIZED"}]}'
+    check(record_schema)
+    check_default(record_schema, '{"msg": "boom"}', {"msg" => "boom", "logClass" => "UNCATEGORIZED"})
+    check_default(record_schema, '{"msg": "boom","logClass": "E1"}', {"msg" => "boom", "logClass" => "E1"})
+  end
+
   def test_recursive
     recursive_schema = <<EOS
       {"type": "record",


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
