### PR TITLE
AVRO-2523: Perf's usage doesn't show the option for specific record test

### DIFF
--- a/lang/java/ipc/src/test/java/org/apache/avro/io/Perf.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/io/Perf.java
@@ -126,6 +126,7 @@ public class Perf {
     new TestDescriptor(GenericOneTimeDecoderUse.class, "-Gotd").add(GENERIC_ONETIME);
     new TestDescriptor(GenericOneTimeReaderUse.class, "-Gotr").add(GENERIC_ONETIME);
     new TestDescriptor(GenericOneTimeUse.class, "-Got").add(GENERIC_ONETIME);
+    BATCHES.put("-specific", SPECIFIC);
     new TestDescriptor(FooBarSpecificRecordTest.class, "-Sf").add(SPECIFIC);
     BATCHES.put("-reflect", REFLECT);
     new TestDescriptor(ReflectRecordTest.class, "-REFr").add(REFLECT);


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2523
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No additional test, since it's a minor fix for the existing test tool. Instead, I ran the following commands locally and confirmed they behaved as expected:

```
~/avro/lang/java/ipc$ mvn exec:java -Dexec.classpathScope=test -Dexec.mainClass=org.apache.avro.io.Perf -Dexec.args="-h"

(snip)

 -specific   (executes all specific tests):
      -Sf  (FooBarSpecificRecordTest)

(snip)

~/avro/lang/java/ipc$ mvn exec:java -Dexec.classpathScope=test -Dexec.mainClass=org.apache.avro.io.Perf -Dexec.args="-specific"

(snip)

Executing tests: 
[FooBarSpecificRecordTest]
 readTests:true
 writeTests:true
 cycles=800
 count=250K
                                                   test name     time    M entries/sec   M bytes/sec  bytes/cycle
              FooBarSpecificRecordTestRead:   4400 ms       0.947       157.641        867109
             FooBarSpecificRecordTestWrite:   3728 ms       1.117       186.048        867109

(snip)

~/avro/lang/java/ipc$ mvn exec:java -Dexec.classpathScope=test -Dexec.mainClass=org.apache.avro.io.Perf -Dexec.args="-Sf"

(snip)

Executing tests: 
[FooBarSpecificRecordTest]
 readTests:true
 writeTests:true
 cycles=800
 count=250K
                                                   test name     time    M entries/sec   M bytes/sec  bytes/cycle
              FooBarSpecificRecordTestRead:   4598 ms       0.906       150.846        867109
             FooBarSpecificRecordTestWrite:   3512 ms       1.186       197.486        867109
```

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
