### PR TITLE
AVRO-2526: Implement all tests for the PHP bindings

### DIFF
--- a/lang/php/lib/avro/io.php
+++ b/lang/php/lib/avro/io.php
@@ -47,11 +47,11 @@ class AvroIO
   const WRITE_MODE = 'w';
 
   /**
-   * @var int set position equal to $offset bytes
+   * @var int set position to current index + $offset bytes
    */
   const SEEK_CUR = SEEK_CUR;
   /**
-   * @var int set position to current index + $offset bytes
+   * @var int set position equal to $offset bytes
    */
   const SEEK_SET = SEEK_SET;
   /**

--- a/lang/php/test/StringIOTest.php
+++ b/lang/php/test/StringIOTest.php
@@ -34,17 +34,30 @@ class StringIOTest extends PHPUnit_Framework_TestCase
 
   public function test_seek()
   {
-    $this->markTestIncomplete('This test has not been implemented yet.');
+    $strio = new AvroStringIO('abcdefghijklmnopqrstuvwxyz');
+    $strio->seek(4, AvroIO::SEEK_SET);
+    $this->assertEquals('efgh', $strio->read(4));
+    $strio->seek(4, AvroIO::SEEK_CUR);
+    $this->assertEquals('mnop', $strio->read(4));
+    $strio->seek(-4, AvroIO::SEEK_END);
+    $this->assertEquals('wxyz', $strio->read(4));
   }
 
   public function test_tell()
   {
-    $this->markTestIncomplete('This test has not been implemented yet.');
+    $strio = new AvroStringIO('foobar');
+    $this->assertEquals(0, $strio->tell());
+    $strlen = 3;
+    $strio->read($strlen);
+    $this->assertEquals($strlen, $strio->tell());
   }
 
   public function test_read()
   {
-    $this->markTestIncomplete('This test has not been implemented yet.');
+    $str = 'foobar';
+    $strio = new AvroStringIO($str);
+    $strlen = 3;
+    $this->assertEquals(substr($str, 0, $strlen), $strio->read($strlen));
   }
 
   public function test_string_rep()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2526
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

This PR implements test_seek, test_tell, and test_read in lang/php/test/StringIOTest.php.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
