### PR TITLE
AVRO-2527: Upgrade PHP version to 7.x

### DIFF
--- a/lang/php/README.txt
+++ b/lang/php/README.txt
@@ -5,12 +5,24 @@ A library for using [Avro](https://avro.apache.org/) with PHP.
 
 Requirements
 ============
- * PHP 5
+ * PHP 7
+
+   * NOTE: Currently, the Avro code is supposed to work with PHP 5.6
+     as well, but that support may be dropped in a future version.
+
  * On 32-bit platforms, the [GMP PHP extension](https://php.net/gmp)
+
  * For testing, [PHPUnit](https://www.phpunit.de/)
 
+   * NOTE: If you use Avro with PHP 5.6, use PHPUnit 5.7, which is the only
+     version that works with the 5.6 runtime and the 7.x style test code.
+     Otherwise, use PHPUnit 7.x.
+
 Both GMP and PHPUnit are often available via package management
-systems as `php5-gmp` and `phpunit`, respectively.
+systems as `php7-gmp` and `phpunit`, respectively.
+But if you use a specific version of PHPUnit as described above,
+download and install it manually without the package manager.
+
 
 Getting started
 ===============

--- a/lang/php/build.sh
+++ b/lang/php/build.sh
@@ -53,16 +53,23 @@ case "$1" in
        phpunit test/InterOpTest.php
        ;;
 
-    lint)
-      echo 'This is a stub where someone can provide linting.'
-      ;;
+     lint)
+       echo 'This is a stub where someone can provide linting.'
+       ;;
 
      test)
-       phpunit test/AllTests.php
+       phpunit -v test/AllTests.php
+
+       # Check backward compatibility with PHP 5.x if both PHP 5.6 and PHPUnit 5.7 are installed.
+       # TODO: remove this check when we drop PHP 5.x support in the future
+       if command -v php5.6 > /dev/null && phpunit --version | grep -q 'PHPUnit 5.7'; then
+         echo 'Checking backward compatibility with PHP 5.x'
+         php5.6 $(which phpunit) -v test/AllTests.php
+       fi
        ;;
 
      dist)
-        dist
+       dist
        ;;
 
      clean)

--- a/lang/php/lib/avro/datum.php
+++ b/lang/php/lib/avro/datum.php
@@ -946,7 +946,7 @@ class AvroIOBinaryDecoder
   protected function skip_long()
   {
     $b = $this->next_byte();
-    while (0 != ($b & 0x80))
+    while (0 != (ord($b) & 0x80))
       $b = $this->next_byte();
   }
 

--- a/lang/php/test/AllTests.php
+++ b/lang/php/test/AllTests.php
@@ -32,7 +32,7 @@ class AllTests
 {
   public static function suite()
   {
-    $suite = new PHPUnit_Framework_TestSuite('AvroAllTests');
+    $suite = new PHPUnit\Framework\TestSuite('AvroAllTests');
     $suite->addTestSuite('DataFileTest');
     $suite->addTestSuite('SchemaTest');
     $suite->addTestSuite('NameTest');

--- a/lang/php/test/DataFileTest.php
+++ b/lang/php/test/DataFileTest.php
@@ -19,7 +19,7 @@
 
 require_once('test_helper.php');
 
-class DataFileTest extends PHPUnit_Framework_TestCase
+class DataFileTest extends PHPUnit\Framework\TestCase
 {
   private $data_files;
   const REMOVE_DATA_FILES = true;
@@ -45,7 +45,7 @@ class DataFileTest extends PHPUnit_Framework_TestCase
   protected function remove_data_files()
   {
     if (self::REMOVE_DATA_FILES
-        && 0 < count($this->data_files))
+        && !empty($this->data_files))
       foreach ($this->data_files as $data_file)
         $this->remove_data_file($data_file);
   }
@@ -71,9 +71,10 @@ class DataFileTest extends PHPUnit_Framework_TestCase
       $dw->close();
 
       $dr = AvroDataIO::open_file($data_file);
-      $read_data = array_shift($dr->data());
+      $read_data = $dr->data();
+      $datum = array_shift($read_data);
       $dr->close();
-      $this->assertEquals(null, $read_data);
+      $this->assertEquals(null, $datum);
     }
   }
 
@@ -88,9 +89,10 @@ class DataFileTest extends PHPUnit_Framework_TestCase
       $dw->close();
 
       $dr = AvroDataIO::open_file($data_file);
-      $read_data = array_shift($dr->data());
+      $read_data = $dr->data();
+      $datum = array_shift($read_data);
       $dr->close();
-      $this->assertEquals($data, $read_data);
+      $this->assertEquals($data, $datum);
     }
   }
 
@@ -105,9 +107,10 @@ class DataFileTest extends PHPUnit_Framework_TestCase
       $dw->close();
 
       $dr = AvroDataIO::open_file($data_file);
-      $read_data = array_shift($dr->data());
+      $read_data = $dr->data();
+      $datum = array_shift($read_data);
       $dr->close();
-      $this->assertEquals($data, $read_data);
+      $this->assertEquals($data, $datum);
     }
   }
 
@@ -123,9 +126,10 @@ class DataFileTest extends PHPUnit_Framework_TestCase
       $dw->close();
 
       $dr = AvroDataIO::open_file($data_file);
-      $read_data = array_shift($dr->data());
+      $read_data = $dr->data();
+      $datum = array_shift($read_data);
       $dr->close();
-      $this->assertEquals($data, $read_data);
+      $this->assertEquals($data, $datum);
     }
   }
 
@@ -140,7 +144,8 @@ class DataFileTest extends PHPUnit_Framework_TestCase
       $dw->close();
 
       $dr = AvroDataIO::open_file($data_file);
-      $read_datum = array_shift($dr->data());
+      $read_data = $dr->data();
+      $read_datum = array_shift($read_data);
       $dr->close();
       $this->assertEquals($datum, $read_datum);
     }
@@ -157,7 +162,8 @@ class DataFileTest extends PHPUnit_Framework_TestCase
       $dw->close();
 
       $dr = AvroDataIO::open_file($data_file);
-      $read_datum = array_shift($dr->data());
+      $read_data = $dr->data();
+      $read_datum = array_shift($read_data);
       $dr->close();
       $this->assertEquals($datum, $read_datum);
     }

--- a/lang/php/test/DatumIOTest.php
+++ b/lang/php/test/DatumIOTest.php
@@ -19,7 +19,7 @@
 
 require_once('test_helper.php');
 
-class DatumIOTest extends PHPUnit_Framework_TestCase
+class DatumIOTest extends PHPUnit\Framework\TestCase
 {
   /**
    * @dataProvider data_provider

--- a/lang/php/test/FloatIntEncodingTest.php
+++ b/lang/php/test/FloatIntEncodingTest.php
@@ -18,7 +18,7 @@
  */
 require_once('test_helper.php');
 
-class FloatIntEncodingTest extends PHPUnit_Framework_TestCase
+class FloatIntEncodingTest extends PHPUnit\Framework\TestCase
 {
   const FLOAT_TYPE = 'float';
   const DOUBLE_TYPE = 'double';

--- a/lang/php/test/IODatumReaderTest.php
+++ b/lang/php/test/IODatumReaderTest.php
@@ -19,7 +19,7 @@
 
 require_once('test_helper.php');
 
-class IODatumReaderTest extends PHPUnit_Framework_TestCase
+class IODatumReaderTest extends PHPUnit\Framework\TestCase
 {
 
   public function testSchemaMatching()

--- a/lang/php/test/InterOpTest.php
+++ b/lang/php/test/InterOpTest.php
@@ -19,7 +19,7 @@
 
 require_once('test_helper.php');
 
-class InterOpTest extends PHPUnit_Framework_TestCase
+class InterOpTest extends PHPUnit\Framework\TestCase
 {
   var $projection_json;
   var $projection;

--- a/lang/php/test/LongEncodingTest.php
+++ b/lang/php/test/LongEncodingTest.php
@@ -18,7 +18,7 @@
  */
 require_once('test_helper.php');
 
-class LongEncodingTest extends PHPUnit_Framework_TestCase
+class LongEncodingTest extends PHPUnit\Framework\TestCase
 {
 
   function setUp()

--- a/lang/php/test/NameTest.php
+++ b/lang/php/test/NameTest.php
@@ -42,7 +42,7 @@ class NameExample
   }
 }
 
-class NameTest extends PHPUnit_Framework_TestCase
+class NameTest extends PHPUnit\Framework\TestCase
 {
 
   function fullname_provider()
@@ -101,6 +101,6 @@ class NameTest extends PHPUnit_Framework_TestCase
    */
   function test_name($name, $is_well_formed)
   {
-    $this->assertEquals(AvroName::is_well_formed_name($name), $is_well_formed, $name);
+    $this->assertEquals(AvroName::is_well_formed_name($name), $is_well_formed);
   }
 }

--- a/lang/php/test/ProtocolFileTest.php
+++ b/lang/php/test/ProtocolFileTest.php
@@ -20,7 +20,7 @@
 require_once('test_helper.php');
 
 // near-verbatim port of test_protocol.py
-class ProtocolFileTest extends PHPUnit_Framework_TestCase
+class ProtocolFileTest extends PHPUnit\Framework\TestCase
 {
 	protected function setUp() {
 	}

--- a/lang/php/test/SchemaTest.php
+++ b/lang/php/test/SchemaTest.php
@@ -38,7 +38,7 @@ class SchemaExample
   }
 }
 
-class SchemaTest extends PHPUnit_Framework_TestCase
+class SchemaTest extends PHPUnit\Framework\TestCase
 {
   static $examples = array();
   static $valid_examples = array();

--- a/lang/php/test/StringIOTest.php
+++ b/lang/php/test/StringIOTest.php
@@ -19,7 +19,7 @@
 
 require_once('test_helper.php');
 
-class StringIOTest extends PHPUnit_Framework_TestCase
+class StringIOTest extends PHPUnit\Framework\TestCase
 {
 
   public function test_write()

--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -19,6 +19,8 @@
 
 FROM openjdk:8
 
+ENV PHP_VERSION 7.1
+
 WORKDIR /root
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -66,8 +68,8 @@ RUN apt-get -qq update && \
     maven \
     nodejs \
     perl \
-    php7.1 \
-    php7.1-gmp \
+    php${PHP_VERSION} \
+    php${PHP_VERSION}-gmp \
     pycodestyle \
     python \
     python-isort \
@@ -98,7 +100,7 @@ RUN curl -L https://cpanmin.us | perl - --self-upgrade && \
   Test::Exception Test::Pod
 
 # Install PHPUnit
-RUN wget -O /usr/local/bin/phpunit https://phar.phpunit.de/phpunit-7.1.phar && chmod +x /usr/local/bin/phpunit
+RUN wget -O /usr/local/bin/phpunit https://phar.phpunit.de/phpunit-${PHP_VERSION}.phar && chmod +x /usr/local/bin/phpunit
 
 # Install Python2 packages
 RUN pip install zstandard

--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -19,7 +19,9 @@
 
 FROM openjdk:8
 
-ENV PHP_VERSION 7.1
+# TODO: Consolidate them into a single version (7.x) when we drop PHP 5.6 support in the future
+ENV PHP5_VERSION 5.6
+ENV PHP7_VERSION 7.1
 
 WORKDIR /root
 
@@ -41,6 +43,7 @@ RUN curl https://packages.sury.org/php/apt.gpg | apt-key add --no-tty - && \
       echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list
 
 # Install dependencies from packages
+# TODO: remove php5-related packages when we drop PHP 5.6 support in the future
 RUN apt-get -qq update && \
   apt-get -qq install --no-install-recommends -y \
     ant \
@@ -68,8 +71,10 @@ RUN apt-get -qq update && \
     maven \
     nodejs \
     perl \
-    php${PHP_VERSION} \
-    php${PHP_VERSION}-gmp \
+    php${PHP5_VERSION} \
+    php${PHP5_VERSION}-gmp \
+    php${PHP7_VERSION} \
+    php${PHP7_VERSION}-gmp \
     pycodestyle \
     python \
     python-isort \
@@ -99,8 +104,9 @@ RUN curl -L https://cpanmin.us | perl - --self-upgrade && \
   IO::String Object::Tiny Compress::Zlib Test::More \
   Test::Exception Test::Pod
 
-# Install PHPUnit
-RUN wget -O /usr/local/bin/phpunit https://phar.phpunit.de/phpunit-${PHP_VERSION}.phar && chmod +x /usr/local/bin/phpunit
+# Install PHPUnit 5.7, which is the only version that supports both PHP 5.6 and 7.x
+# TODO: use PHPUnit 7.x instead of 5.7 when we drop PHP 5.6 support in the future
+RUN wget -O /usr/local/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar && chmod +x /usr/local/bin/phpunit
 
 # Install Python2 packages
 RUN pip install zstandard

--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -66,8 +66,8 @@ RUN apt-get -qq update && \
     maven \
     nodejs \
     perl \
-    php5.6 \
-    php5.6-gmp \
+    php7.1 \
+    php7.1-gmp \
     pycodestyle \
     python \
     python-isort \
@@ -98,7 +98,7 @@ RUN curl -L https://cpanmin.us | perl - --self-upgrade && \
   Test::Exception Test::Pod
 
 # Install PHPUnit
-RUN wget -O /usr/local/bin/phpunit https://phar.phpunit.de/phpunit-5.6.phar && chmod +x /usr/local/bin/phpunit
+RUN wget -O /usr/local/bin/phpunit https://phar.phpunit.de/phpunit-7.1.phar && chmod +x /usr/local/bin/phpunit
 
 # Install Python2 packages
 RUN pip install zstandard


### PR DESCRIPTION
This PR addresses the following incompatibilities between PHP 5.6 and 7.x:

* https://www.php.net/manual/en/migration70.incompatible.php#migration70.incompatible.error-handling.strict

* https://www.php.net/manual/en/migration71.other-changes.php#migration71.other-changes.apprise-on-arithmetic-with-invalid-strings

* https://www.php.net/manual/en/migration72.incompatible.php#migration72.incompatible.warn-on-non-countable-types

* https://github.com/sebastianbergmann/phpunit/commit/ba2241e6e0a634dc333b6e1d2fd6d0e8c16c2f57

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2527
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

This PR revises all PHP test files so that they can work with PHP 7.1+.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
