### PR TITLE
AVRO-2529: Bump protobuf-java from 3.6.1 to 3.9.1

### DIFF
--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -47,7 +47,7 @@
     <jopt-simple.version>5.0.4</jopt-simple.version>
     <junit.version>4.12</junit.version>
     <netty.version>3.10.6.Final</netty.version>
-    <protobuf.version>3.6.1</protobuf.version>
+    <protobuf.version>3.9.1</protobuf.version>
     <thrift.version>0.12.0</thrift.version>
     <slf4j.version>1.7.25</slf4j.version>
     <snappy.version>1.1.7.3</snappy.version>


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-2529: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2529
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
