### PR TITLE
AVRO-2427: Add undocumented codecs to the specification

### DIFF
--- a/doc/src/content/xdocs/spec.xml
+++ b/doc/src/content/xdocs/spec.xml
@@ -773,12 +773,31 @@
       <section>
 	<title>Optional Codecs</title>
         <section>
+          <title>bzip2</title>
+          <p>The "bzip2" codec uses the <a href="https://sourceware.org/bzip2/">bzip2</a>
+            compression library.</p>
+        </section>
+
+        <section>
           <title>snappy</title>
           <p>The "snappy" codec uses
             Google's <a href="https://code.google.com/p/snappy/">Snappy</a>
             compression library.  Each compressed block is followed
             by the 4-byte, big-endian CRC32 checksum of the
             uncompressed data in the block.</p>
+        </section>
+
+        <section>
+          <title>xz</title>
+          <p>The "xz" codec uses the <a href="https://tukaani.org/xz/">XZ</a>
+            compression library.</p>
+        </section>
+
+        <section>
+          <title>zstandard</title>
+          <p>The "zstandard" codec uses
+            Facebook's <a href="https://facebook.github.io/zstd/">Zstandard</a>
+            compression library.</p>
         </section>
       </section>
     </section>


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2427
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No additional test since it's a documentation fix. I ran `ant` in the `doc` directory and made sure the fix updated the document as expected.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
