### PR TITLE
AVRO-2546: Add bzip2 and xz support to the Python3 bindings

### DIFF
--- a/lang/java/avro/pom.xml
+++ b/lang/java/avro/pom.xml
@@ -118,6 +118,7 @@
                 </configuration>
                 <goals><goal>java</goal></goals>
               </execution>
+
               <!-- Generate random data for interop tests, using deflate codec -->
               <execution>
                 <id>interop-generate-deflate-codec</id>
@@ -133,6 +134,7 @@
                 </configuration>
                 <goals><goal>java</goal></goals>
               </execution>
+
               <!-- Generate random data for interop tests, using snappy codec -->
               <execution>
                 <id>interop-generate-snappy-codec</id>
@@ -148,6 +150,39 @@
                 </configuration>
                 <goals><goal>java</goal></goals>
               </execution>
+
+              <!-- Generate random data for interop tests, using bzip2 codec -->
+              <execution>
+                <id>interop-generate-bzip2-codec</id>
+                <phase>generate-resources</phase>
+                <configuration>
+                  <mainClass>org.apache.avro.util.RandomData</mainClass>
+                  <arguments>
+                    <argument>../../../share/test/schemas/interop.avsc</argument>
+                    <argument>../../../build/interop/data/java_bzip2.avro</argument>
+                    <argument>100</argument>
+                    <argument>bzip2</argument>
+                  </arguments>
+                </configuration>
+                <goals><goal>java</goal></goals>
+              </execution>
+
+              <!-- Generate random data for interop tests, using xz codec -->
+              <execution>
+                <id>interop-generate-xz-codec</id>
+                <phase>generate-resources</phase>
+                <configuration>
+                  <mainClass>org.apache.avro.util.RandomData</mainClass>
+                  <arguments>
+                    <argument>../../../share/test/schemas/interop.avsc</argument>
+                    <argument>../../../build/interop/data/java_xz.avro</argument>
+                    <argument>100</argument>
+                    <argument>xz</argument>
+                  </arguments>
+                </configuration>
+                <goals><goal>java</goal></goals>
+              </execution>
+
               <!-- Generate random data for interop tests, using zstandard codec -->
               <execution>
                 <id>interop-generate-zstandard-codec</id>
@@ -191,8 +226,6 @@
     <dependency>
       <groupId>org.tukaani</groupId>
       <artifactId>xz</artifactId>
-      <version>${tukaani.version}</version>
-      <scope>provided</scope>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/lang/java/ipc/pom.xml
+++ b/lang/java/ipc/pom.xml
@@ -154,6 +154,10 @@
       <artifactId>snappy-java</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.tukaani</groupId>
+      <artifactId>xz</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.github.luben</groupId>
       <artifactId>zstd-jni</artifactId>
     </dependency>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -595,6 +595,11 @@
         <version>${netty-codec-http2.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.tukaani</groupId>
+        <artifactId>xz</artifactId>
+        <version>${tukaani.version}</version>
+      </dependency>
+      <dependency>
         <groupId>com.github.luben</groupId>
         <artifactId>zstd-jni</artifactId>
         <version>${zstd-jni.version}</version>

--- a/lang/py/test/test_datafile_interop.py
+++ b/lang/py/test/test_datafile_interop.py
@@ -27,17 +27,22 @@ class TestDataFileInterop(unittest.TestCase):
     print '============'
     print ''
     for f in os.listdir('@INTEROP_DATA_DIR@'):
-      print 'READING %s' % f
-      print ''
+      base_ext = os.path.splitext(os.path.basename(f))[0].split('_', 1)
+      if len(base_ext) < 2 or base_ext[1] in datafile.VALID_CODECS:
+        print 'READING %s' % f
+        print ''
 
-      # read data in binary from file
-      reader = open(os.path.join('@INTEROP_DATA_DIR@', f), 'rb')
-      datum_reader = io.DatumReader()
-      dfr = datafile.DataFileReader(reader, datum_reader)
-      i = 0
-      for i, datum in enumerate(dfr, 1):
-        assert datum is not None
-      assert i > 0
+        # read data in binary from file
+        reader = open(os.path.join('@INTEROP_DATA_DIR@', f), 'rb')
+        datum_reader = io.DatumReader()
+        dfr = datafile.DataFileReader(reader, datum_reader)
+        i = 0
+        for i, datum in enumerate(dfr, 1):
+          assert datum is not None
+        assert i > 0
+      else:
+        print 'SKIPPING %s due to an unsupported codec' % f
+        print ''
 
 if __name__ == '__main__':
   unittest.main()

--- a/lang/py3/avro/tests/gen_interop_data.py
+++ b/lang/py3/avro/tests/gen_interop_data.py
@@ -22,6 +22,7 @@ import sys
 from pathlib import Path
 
 from avro import datafile, io, schema
+from avro.datafile import NULL_CODEC
 
 DATUM = {
     'intField': 12,
@@ -49,7 +50,7 @@ def generate(schema_file, output_path):
   datum_writer = io.DatumWriter()
   for codec in datafile.VALID_CODECS:
     filename = 'py3'
-    if codec != 'null':
+    if codec != NULL_CODEC:
       filename += '_' + codec
     with Path(output_path, filename).with_suffix('.avro').open('wb') as writer, \
       datafile.DataFileWriter(writer, datum_writer, interop_schema, codec) as dfw:

--- a/lang/py3/avro/tests/test_datafile.py
+++ b/lang/py3/avro/tests/test_datafile.py
@@ -24,6 +24,7 @@ import tempfile
 import unittest
 
 from avro import datafile, io, schema
+from avro.datafile import NULL_CODEC, DEFLATE_CODEC, BZIP2_CODEC, SNAPPY_CODEC, XZ_CODEC, ZSTANDARD_CODEC
 
 try:
   import snappy
@@ -86,15 +87,15 @@ SCHEMAS_TO_VALIDATE = (
 )
 
 def get_codecs_to_validate():
-  codecs = ('null', 'deflate')
+  codecs = (NULL_CODEC, DEFLATE_CODEC, BZIP2_CODEC, XZ_CODEC)
 
   if HAS_SNAPPY:
-    codecs += ('snappy',)
+    codecs += (SNAPPY_CODEC,)
   else:
     logging.warning('Snappy not present, will skip testing it.')
 
   if HAS_ZSTANDARD:
-    codecs += ('zstandard',)
+    codecs += (ZSTANDARD_CODEC,)
   else:
     logging.warning('Zstandard not present, will skip testing it.')
 

--- a/lang/py3/avro/tests/test_datafile_interop.py
+++ b/lang/py3/avro/tests/test_datafile_interop.py
@@ -32,12 +32,15 @@ class TestDataFileInterop(unittest.TestCase):
     for avro_file in glob.glob('../../build/interop/data/*.avro'):
       base_ext = os.path.splitext(os.path.basename(avro_file))[0].split('_', 1)
       if len(base_ext) < 2 or base_ext[1] in datafile.VALID_CODECS:
+        print('Reading {}'.format(avro_file))
         with open(avro_file, 'rb') as reader, \
           datafile.DataFileReader(reader, datum_reader) as dfr:
           i = 0
           for i, datum in enumerate(dfr, 1):
             self.assertIsNotNone(datum)
           self.assertGreater(i, 0)
+      else:
+        print('Skipping {} due to an unsupported codec'.format(avro_file))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Add bzip2 and xz support to the Python3 bindings

* Add data interoperability test for these codecs
  executed between Java and Python3

* Fix the Python2 data interop test to skip the files
  which are compressed with the unsupported codecs

* Add print statements to the Python test codes so that
  developers can confirm which files are read and skipped
  during the data interop tests

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2546
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

I added new codecs to the data interoperability test. I ran it locally and confirmed Java and Python3 could read the files compressed by these codecs each other, as follows:

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
Reading data files from directory: /home/sekikn/avro/lang/java/ipc/../../../build/interop/data
[INFO] Running org.apache.avro.DataFileInteropTest
Reading with specific:
Reading: java_snappy.avro
Reading: java_zstandard.avro
Reading: ruby.avro
Reading: py3_deflate.avro
Reading: csharp_deflate.avro
Reading: py3_zstandard.avro
Reading: perl_deflate.avro
Reading: java.avro
Reading: perl.avro
Reading: py_zstandard.avro
Reading: java_deflate.avro
Reading: php_deflate.avro
Reading: java_bzip2.avro
Reading: py3_bzip2.avro
Reading: ruby_zstandard.avro
Reading: java_xz.avro
Reading: py3.avro
Reading: c.avro
Reading: ruby_deflate.avro
Reading: py_deflate.avro
Reading: py3_xz.avro
Reading: py.avro
Reading: ruby_snappy.avro
Reading: php.avro
Reading: py_snappy.avro
Reading: perl_zstandard.avro
Reading: py3_snappy.avro
Reading: csharp.avro
Reading with generic:
Reading: java_snappy.avro
Reading: java_zstandard.avro
Reading: ruby.avro
Reading: py3_deflate.avro
Reading: csharp_deflate.avro
Reading: py3_zstandard.avro
Reading: perl_deflate.avro
Reading: java.avro
Reading: perl.avro
Reading: py_zstandard.avro
Reading: java_deflate.avro
Reading: php_deflate.avro
Reading: java_bzip2.avro
Reading: py3_bzip2.avro
Reading: ruby_zstandard.avro
Reading: java_xz.avro
Reading: py3.avro
Reading: c.avro
Reading: ruby_deflate.avro
Reading: py_deflate.avro
Reading: py3_xz.avro
Reading: py.avro
Reading: ruby_snappy.avro
Reading: php.avro
Reading: py_snappy.avro
Reading: perl_zstandard.avro
Reading: py3_snappy.avro
Reading: csharp.avro
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.616 s - in org.apache.avro.DataFileInteropTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
```

```
+ cd lang/py3
+ python3 setup.py test --test-suite avro.tests.test_datafile_interop.TestDataFileInterop
running test
running egg_info
writing top-level names to avro_python3.egg-info/top_level.txt
writing requirements to avro_python3.egg-info/requires.txt
writing dependency_links to avro_python3.egg-info/dependency_links.txt
writing avro_python3.egg-info/PKG-INFO
reading manifest file 'avro_python3.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'avro_python3.egg-info/SOURCES.txt'
running build_ext
testInterop (avro.tests.test_datafile_interop.TestDataFileInterop) ... Reading ../../build/interop/data/java_snappy.avro
Reading ../../build/interop/data/java_zstandard.avro
Reading ../../build/interop/data/ruby.avro
Reading ../../build/interop/data/py3_deflate.avro
Reading ../../build/interop/data/csharp_deflate.avro
Reading ../../build/interop/data/py3_zstandard.avro
Reading ../../build/interop/data/perl_deflate.avro
Reading ../../build/interop/data/java.avro
Reading ../../build/interop/data/perl.avro
Reading ../../build/interop/data/py_zstandard.avro
Reading ../../build/interop/data/java_deflate.avro
Reading ../../build/interop/data/php_deflate.avro
Reading ../../build/interop/data/java_bzip2.avro
Reading ../../build/interop/data/py3_bzip2.avro
Reading ../../build/interop/data/ruby_zstandard.avro
Reading ../../build/interop/data/java_xz.avro
Reading ../../build/interop/data/py3.avro
Reading ../../build/interop/data/c.avro
Reading ../../build/interop/data/ruby_deflate.avro
Reading ../../build/interop/data/py_deflate.avro
Reading ../../build/interop/data/py3_xz.avro
Reading ../../build/interop/data/py.avro
Reading ../../build/interop/data/ruby_snappy.avro
Reading ../../build/interop/data/php.avro
Reading ../../build/interop/data/py_snappy.avro
Reading ../../build/interop/data/perl_zstandard.avro
Reading ../../build/interop/data/py3_snappy.avro
Reading ../../build/interop/data/csharp.avro
ok

----------------------------------------------------------------------
Ran 1 test in 0.169s

OK
```

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
