### PR TITLE
AVRO-2547: Add bzip2 support to the Perl bindings

### DIFF
--- a/lang/perl/lib/Avro.pm
+++ b/lang/perl/lib/Avro.pm
@@ -18,7 +18,7 @@
 package Avro;
 
 use strict;
-use 5.008_001;
+use 5.010_001;
 our $VERSION = '++MODULE_VERSION++';
 
 1;

--- a/lang/perl/lib/Avro/DataFile.pm
+++ b/lang/perl/lib/Avro/DataFile.pm
@@ -36,6 +36,7 @@ EOH
 our %ValidCodec = (
     null      => 1,
     deflate   => 1,
+    bzip2     => 1,
     zstandard => 1,
 );
 

--- a/lang/perl/lib/Avro/DataFileReader.pm
+++ b/lang/perl/lib/Avro/DataFileReader.pm
@@ -36,6 +36,7 @@ use Avro::BinaryDecoder;
 use Avro::Schema;
 use Carp;
 use Compress::Zstd;
+use IO::Uncompress::Bunzip2 qw(bunzip2);
 use IO::Uncompress::RawInflate ;
 use Fcntl();
 
@@ -213,9 +214,19 @@ sub read_block_header {
     $datafile->{block_marker} = $marker;
 
     ## this is our new reader
-    $datafile->{reader} = $codec eq 'deflate' ?
-        IO::Uncompress::RawInflate->new(\$block) :
-        do { open $fh, '<', \(decompress(\$block)); $fh };
+    $datafile->{reader} = do {
+        if ($codec eq 'deflate') {
+            IO::Uncompress::RawInflate->new(\$block);
+        }
+        elsif ($codec eq 'bzip2') {
+            my $uncompressed;
+            bunzip2 \$block => \$uncompressed;
+            do { open $fh, '<', \$uncompressed; $fh };
+        }
+        elsif ($codec eq 'zstandard') {
+            do { open $fh, '<', \(decompress(\$block)); $fh };
+        }
+    };
 
     return;
 }

--- a/lang/perl/lib/Avro/DataFileWriter.pm
+++ b/lang/perl/lib/Avro/DataFileWriter.pm
@@ -37,6 +37,7 @@ use Avro::Schema;
 use Carp;
 use Compress::Zstd;
 use Error::Simple;
+use IO::Compress::Bzip2 qw(bzip2 $Bzip2Error);
 use IO::Compress::RawDeflate qw(rawdeflate $RawDeflateError);
 
 sub new {
@@ -104,6 +105,14 @@ sub buffer_or_print {
             or croak "rawdeflate failed: $RawDeflateError";
         $datafile->{_current_size} =
             bytes::length($datafile->{_compressed_block});
+    }
+    elsif ($codec eq 'bzip2') {
+        my $uncompressed = join('', map { $$_ } @$ser_objects);
+        my $compressed;
+        bzip2 \$uncompressed => \$compressed
+            or croak "bzip2 failed: $Bzip2Error";
+        $datafile->{_compressed_block} = $compressed;
+        $datafile->{_current_size} = bytes::length($datafile->{_compressed_block});
     }
     elsif ($codec eq 'zstandard') {
         my $uncompressed = join('', map { $$_ } @$ser_objects);

--- a/lang/perl/t/04_datafile.t
+++ b/lang/perl/t/04_datafile.t
@@ -118,6 +118,35 @@ is_deeply $all[0], $data, "Our data is intact!";
     is scalar @all, 1, "one object back";
     is_deeply $all[0], $data, "Our data is intact!";
 
+
+    ## bzip2!
+    $zfh = File::Temp->new(UNLINK => 0);
+    $write_file = Avro::DataFileWriter->new(
+        fh            => $zfh,
+        writer_schema => $schema,
+        codec         => 'bzip2',
+        metadata      => {
+            some => 'metadata',
+        },
+    );
+    $write_file->print($data);
+    $write_file->flush;
+
+    ## rewind
+    seek $zfh, 0, 0;
+
+    $read_file = Avro::DataFileReader->new(
+        fh            => $zfh,
+        reader_schema => $schema,
+    );
+    is $read_file->metadata->{'avro.codec'}, 'bzip2', 'avro.codec';
+    is $read_file->metadata->{'some'}, 'metadata', 'custom meta';
+
+    @all = $read_file->all;
+    is scalar @all, 1, "one object back";
+    is_deeply $all[0], $data, "Our data is intact!";
+
+
     ## zstandard!
     $zfh = File::Temp->new(UNLINK => 0);
     $write_file = Avro::DataFileWriter->new(


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2547
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

I updated lang/perl/t/04_datafile.t to add a test for the bzip2 codec.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
