### PR TITLE
AVRO-2553: Remove unnecessary note from the Python docs

### DIFF
--- a/doc/src/content/xdocs/gettingstartedpython.xml
+++ b/doc/src/content/xdocs/gettingstartedpython.xml
@@ -187,8 +187,7 @@ writer = DataFileWriter(open("users.avro", "wb"), DatumWriter(), schema)
           <li>A <code>DatumWriter</code>, which is responsible for actually
           serializing the items to Avro's binary format
           (<code>DatumWriter</code>s can be used separately from
-          <code>DataFileWriter</code>s, e.g., to perform IPC with Avro
-          <strong>TODO: is this true??</strong>).</li>
+          <code>DataFileWriter</code>s, e.g., to perform IPC with Avro).</li>
           <li>The schema we're using.  The <code>DataFileWriter</code> needs the
           schema both to write the schema to the data file, and to verify that
           the items we write are valid items and write the appropriate


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2553
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No additional test since it's just a documentation fix. I ran `ant` in the `doc` directory and confirmed the fixed document was generated as expected.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
