### PR TITLE
AVRO-2554: Fix Ruby interop test to read all supported codecs

### DIFF
--- a/lang/ruby/interop/test_interop.rb
+++ b/lang/ruby/interop/test_interop.rb
@@ -19,7 +19,7 @@ require 'rubygems'
 require 'test/unit'
 require 'avro'
 
-CODECS_TO_VALIDATE = ['deflate', 'zstandard']  # The 'null' codec is implicitly included
+CODECS_TO_VALIDATE = ['deflate', 'snappy', 'zstandard']  # The 'null' codec is implicitly included
 
 class TestInterop < Test::Unit::TestCase
   HERE = File.expand_path(File.dirname(__FILE__))

--- a/lang/ruby/interop/test_interop.rb
+++ b/lang/ruby/interop/test_interop.rb
@@ -19,7 +19,7 @@ require 'rubygems'
 require 'test/unit'
 require 'avro'
 
-CODECS_TO_VALIDATE = ['deflate']  # The 'null' codec is implicitly included
+CODECS_TO_VALIDATE = ['deflate', 'zstandard']  # The 'null' codec is implicitly included
 
 class TestInterop < Test::Unit::TestCase
   HERE = File.expand_path(File.dirname(__FILE__))
@@ -27,12 +27,14 @@ class TestInterop < Test::Unit::TestCase
   SCHEMAS = SHARE + '/test/schemas'
 
   files = Dir[HERE + '/../../../build/interop/data/*.avro'].select do |fn|
-    sep, codec = File.basename(fn, 'avro').rpartition('_')[1, 2]
+    sep, codec = File.basename(fn, '.avro').rpartition('_')[1, 2]
     sep.empty? || CODECS_TO_VALIDATE.include?(codec)
   end
+  puts "The following files will be tested:"
+  puts files
 
   files.each do |fn|
-    define_method("test_read_#{File.basename(fn, 'avro')}") do
+    define_method("test_read_#{File.basename(fn, '.avro')}") do
       projection = Avro::Schema.parse(File.read(SCHEMAS+'/interop.avsc'))
 
       File.open(fn) do |f|


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2554
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No additional test since it's a fix for the existing test itself.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
