### PR TITLE
AVRO-2559: schema.indexOf(/)is not compatible on windows

### DIFF
--- a/lang/js/lib/files.js
+++ b/lang/js/lib/files.js
@@ -27,6 +27,7 @@ var protocols = require('./protocols'),
     fs = require('fs'),
     stream = require('stream'),
     util = require('util'),
+    path = require('path'),
     zlib = require('zlib');
 
 // Type of Avro header.
@@ -639,7 +640,7 @@ function loadSchema(schema) {
     try {
       obj = JSON.parse(schema);
     } catch (err) {
-      if (~schema.indexOf('/')) {
+      if (~schema.indexOf(path.sep)) {
         // This can't be a valid name, so we interpret is as a filepath. This
         // makes is always feasible to read a file, independent of its name
         // (i.e. even if its name is valid JSON), by prefixing it with `./`.


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2559
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
