### PR TITLE
AVRO-2560: Skip unnecessary mvn execution for speeding up tests

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -77,7 +77,7 @@ do
       (cd lang/perl; ./build.sh interop-data-generate)
 
       # run interop data tests
-      (cd lang/java; mvn -B test -P interop-data-test)
+      (cd lang/java/ipc; mvn -B test -P interop-data-test)
       (cd lang/py; ant interop-data-test)
       (cd lang/py3; python3 setup.py test --test-suite avro.tests.test_datafile_interop.TestDataFileInterop)
       (cd lang/c; ./build.sh interop-data-test)
@@ -88,7 +88,7 @@ do
       (cd lang/perl; ./build.sh interop-data-test)
 
       # java needs to package the jars for the interop rpc tests
-      (cd lang/java; mvn -B package -DskipTests)
+      (cd lang/java/tools; mvn -B package -DskipTests)
 
       # run interop rpc test
       ./share/test/interop/bin/test_rpc_interop.sh


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2560
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No additional test, since it's a fix for the test itself. I ran `./build.sh test` on the toplevel directory and confirmed it succeeded and took less time (about several minutes, in my environment).

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
