### PR TITLE
AVRO-2562: Expose the JavaScript BlockEncoder's piped stream

### DIFF
--- a/lang/js/lib/files.js
+++ b/lang/js/lib/files.js
@@ -390,6 +390,7 @@ function BlockEncoder(schema, opts) {
   this._pending = 0;
   this._finished = false;
   this._needPush = false;
+  this._downstream = null;
 
   this.on('finish', function () {
     this._finished = true;
@@ -406,6 +407,10 @@ BlockEncoder.getDefaultCodecs = function () {
     'deflate': zlib.deflateRaw
   };
 };
+
+BlockEncoder.prototype.getDownstream = function () {
+  return this._downstream;
+}
 
 BlockEncoder.prototype._write = function (val, encoding, cb) {
   var codec = this._codec;
@@ -561,7 +566,7 @@ function createFileDecoder(path, opts) {
  */
 function createFileEncoder(path, schema, opts) {
   var encoder = new BlockEncoder(schema, opts);
-  encoder.pipe(fs.createWriteStream(path, {defaultEncoding: 'binary'}));
+  encoder._downstream = encoder.pipe(fs.createWriteStream(path, {defaultEncoding: 'binary'}));
   return encoder;
 }
 

--- a/lang/js/test/test_files.js
+++ b/lang/js/test/test_files.js
@@ -564,7 +564,7 @@ suite('files', function () {
     encoder.write({name: 'Ann', age: 32});
     encoder.end({name: 'Bob', age: 33});
     var n = 0;
-    encoder.on('finish', function () {
+    encoder.getDownstream().on('finish', function () {
       files.createFileDecoder(path)
         .on('data', function (obj) {
           n++;


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2562
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Fixed a flaky test called createFileEncoder in lang/js/test/test_files.js. I also iterated `npm t` 100 times with both node v6.17.1 and v8.10.0 locally and confirmed no failure occurred.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
