### PR TITLE
AVRO-2548: Handle logicalTypes with stringType

### DIFF
--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
@@ -646,7 +646,9 @@ public class SpecificCompiler {
     switch (s.getType()) {
     case STRING:
       result = Schema.create(Schema.Type.STRING);
-      GenericData.setStringType(result, stringType);
+      if (s.getLogicalType() == null) {
+        GenericData.setStringType(result, stringType);
+      }
       break;
     case RECORD:
       result = Schema.createRecord(s.getFullName(), s.getDoc(), null, s.isError());
@@ -678,6 +680,9 @@ public class SpecificCompiler {
       break;
     }
     result.addAllProps(s);
+    if (s.getLogicalType() != null) {
+      s.getLogicalType().addToSchema(result);
+    }
     seen.put(s, result);
     return result;
   }

--- a/lang/java/integration-test/codegen-test/pom.xml
+++ b/lang/java/integration-test/codegen-test/pom.xml
@@ -59,6 +59,7 @@
               <enableDecimalLogicalType>true</enableDecimalLogicalType>
               <customConversions>
                 <conversion>org.apache.avro.codegentest.CustomDecimalConversion</conversion>
+                <conversion>org.apache.avro.Conversions$UUIDConversion</conversion>
               </customConversions>
             </configuration>
           </execution>

--- a/lang/java/integration-test/codegen-test/src/test/java/org/apache/avro/codegentest/TestLogicalTypeForStringType.java
+++ b/lang/java/integration-test/codegen-test/src/test/java/org/apache/avro/codegentest/TestLogicalTypeForStringType.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.avro.codegentest;
+
+import org.apache.avro.codegentest.testdata.StringLogicalType;
+import org.apache.avro.generic.GenericData;
+import org.junit.Test;
+
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class TestLogicalTypeForStringType {
+
+  /**
+   * See AVRO-2548: StringType of "String" causes logicalType converters to be
+   * ignored for field
+   */
+  @Test
+  public void shouldUseUUIDAsType() {
+    StringLogicalType stringLogicalType = new StringLogicalType();
+    stringLogicalType.setSomeIdentifier(UUID.randomUUID());
+    assertThat(stringLogicalType.getSomeIdentifier(), instanceOf(UUID.class));
+    assertThat(StringLogicalType.getClassSchema().getField("someJavaString").schema().getProp(GenericData.STRING_PROP),
+        equalTo("String"));
+  }
+
+}

--- a/lang/java/integration-test/codegen-test/src/test/resources/avro/string_logical_type.avsc
+++ b/lang/java/integration-test/codegen-test/src/test/resources/avro/string_logical_type.avsc
@@ -1,0 +1,20 @@
+{
+  "namespace": "org.apache.avro.codegentest.testdata",
+  "type": "record",
+  "name": "StringLogicalType",
+  "doc": "Test logical type applied to field of type string",
+  "fields": [
+    {
+      "name": "someIdentifier",
+      "type": {
+        "type": "string",
+        "logicalType": "uuid"
+      }
+    },
+    {
+      "name": "someJavaString",
+      "type": "string",
+      "doc": "Just to ensure no one removed <stringType>String</stringType> because this is the basis of this test"
+    }
+  ]
+}


### PR DESCRIPTION
When using 'stringType', logical types whose
Avro type was string would not have that conversion
applied.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/):
  - https://issues.apache.org/jira/browse/AVRO-2548

### Tests

- [X] My PR adds the following unit tests:
TestLogicalTypeForStringType#shouldUseUUIDAsType
