### PR TITLE
AVRO-2568:Add c compile dependency instructions to BUILD.md

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -8,7 +8,7 @@ The following packages must be installed before Avro can be built:
  - PHP: php5, phpunit, php5-gmp
  - Python 2: 2.7 or greater, python-setuptools for dist target
  - Python 3: 3.5 or greater
- - C: gcc, cmake, asciidoc, source-highlight
+ - C: gcc, cmake, asciidoc, source-highlight, Jansson, pkg-config
  - C++: cmake 3.7.2 or greater, g++, flex, bison, libboost-dev
  - C#: .NET Core 2.2 SDK
  - JavaScript: Node 6.x+, nodejs, npm


### PR DESCRIPTION
According to BUILD.md compile and build c error.
Found missing dependencies in BUILD.md: jansson and pkg-config

Make sure you have checked _all_ steps below.
 
### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2568
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
