### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,5 +1,15 @@
 # Apache Avro Build Instructions
 
+You can download and install Avro using the [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    vcpkg install avro-c
+
+The Avro port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Requirements
 
 The following packages must be installed before Avro can be built:


### PR DESCRIPTION
Avro is available as a port in vcpkg. Adding installation instructions will help users get started by providing a single set of commands they can use to build Avro and include it into their projects
