### PR TITLE
AVRO-2573:Javadoc Warning in java compilation

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/message/BinaryMessageEncoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/message/BinaryMessageEncoder.java
@@ -45,8 +45,8 @@ public class BinaryMessageEncoder<D> implements MessageEncoder<D> {
    * {@link GenericData data model} to deconstruct datum instances described by
    * the {@link Schema schema}.
    * <p>
-   * Buffers returned by {@link #encode(D)} are copied and will not be modified by
-   * future calls to {@code encode}.
+   * Buffers returned by {@link BinaryMessageEncoder#encode} are copied and will
+   * not be modified by future calls to {@code encode}.
    *
    * @param model  the {@link GenericData data model} for datum instances
    * @param schema the {@link Schema} for datum instances
@@ -60,8 +60,9 @@ public class BinaryMessageEncoder<D> implements MessageEncoder<D> {
    * {@link GenericData data model} to deconstruct datum instances described by
    * the {@link Schema schema}.
    * <p>
-   * If {@code shouldCopy} is true, then buffers returned by {@link #encode(D)}
-   * are copied and will not be modified by future calls to {@code encode}.
+   * If {@code shouldCopy} is true, then buffers returned by
+   * {@link BinaryMessageEncoder#encode} are copied and will not be modified by
+   * future calls to {@code encode}.
    * <p>
    * If {@code shouldCopy} is false, then buffers returned by {@code encode} wrap
    * a thread-local buffer that can be reused by future calls to {@code encode},

--- a/lang/java/avro/src/main/java/org/apache/avro/message/RawMessageEncoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/message/RawMessageEncoder.java
@@ -49,8 +49,8 @@ public class RawMessageEncoder<D> implements MessageEncoder<D> {
    * {@link GenericData data model} to deconstruct datum instances described by
    * the {@link Schema schema}.
    * <p>
-   * Buffers returned by {@link #encode(D)} are copied and will not be modified by
-   * future calls to {@code encode}.
+   * Buffers returned by {@link RawMessageEncoder#encode} are copied and will not
+   * be modified by future calls to {@code encode}.
    *
    * @param model  the {@link GenericData data model} for datum instances
    * @param schema the {@link Schema} for datum instances
@@ -64,8 +64,9 @@ public class RawMessageEncoder<D> implements MessageEncoder<D> {
    * {@link GenericData data model} to deconstruct datum instances described by
    * the {@link Schema schema}.
    * <p>
-   * If {@code shouldCopy} is true, then buffers returned by {@link #encode(D)}
-   * are copied and will not be modified by future calls to {@code encode}.
+   * If {@code shouldCopy} is true, then buffers returned by
+   * {@link RawMessageEncoder#encode} are copied and will not be modified by
+   * future calls to {@code encode}.
    * <p>
    * If {@code shouldCopy} is false, then buffers returned by {@code encode} wrap
    * a thread-local buffer that can be reused by future calls to {@code encode},

--- a/lang/java/avro/src/main/java/org/apache/avro/package.html
+++ b/lang/java/avro/src/main/java/org/apache/avro/package.html
@@ -26,8 +26,8 @@
   org.apache.avro.io.DatumReader} and {@link
   org.apache.avro.io.DatumWriter} implementations.  Generic
   implementations are provided in the {@link org.apache.avro.generic}
-  package.  A {@link <a href="javascript:">org.apache.avro.compiler.specific.SpecificCompiler
-    compiler</a>} can generate specific java classes and interfaces for
+  package.  A {@link <a href="../../../org/apache/avro/compiler/specific/SpecificCompiler.html" title="class in org.apache.avro.compiler.specific">
+    <code>compiler</code></a>} can generate specific java classes and interfaces for
   schemas and protocols.  Schemas may be automatically generated for
   existing Java classes by reflection using the {@link
   org.apache.avro.reflect} package.

--- a/lang/java/avro/src/main/java/org/apache/avro/package.html
+++ b/lang/java/avro/src/main/java/org/apache/avro/package.html
@@ -26,8 +26,8 @@
   org.apache.avro.io.DatumReader} and {@link
   org.apache.avro.io.DatumWriter} implementations.  Generic
   implementations are provided in the {@link org.apache.avro.generic}
-  package.  A {@link org.apache.avro.compiler.specific.SpecificCompiler
-  compiler} can generate specific java classes and interfaces for
+  package.  A {@link <a href="javascript:">org.apache.avro.compiler.specific.SpecificCompiler
+    compiler</a>} can generate specific java classes and interfaces for
   schemas and protocols.  Schemas may be automatically generated for
   existing Java classes by reflection using the {@link
   org.apache.avro.reflect} package.

--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/MapEntry.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/MapEntry.java
@@ -21,10 +21,10 @@ import java.util.Map;
 
 /**
  * Class to make Avro immune from the naming variations of key/value fields
- * among several {@link Map.Entry} implementations. If objects of this class are
- * used instead of the regular ones obtained by {@link Map#entrySet()}, then we
- * need not worry about the actual field-names or any changes to them in the
- * future.<BR>
+ * among several {@link java.util.Map.Entry} implementations. If objects of this
+ * class are used instead of the regular ones obtained by
+ * {@link Map#entrySet()}, then we need not worry about the actual field-names
+ * or any changes to them in the future.<BR>
  * Example: {@code ConcurrentHashMap.MapEntry} does not name the fields as key/
  * value in Java 1.8 while it used to do so in Java 1.7
  *

--- a/lang/java/avro/src/main/java/org/apache/avro/specific/package.html
+++ b/lang/java/avro/src/main/java/org/apache/avro/specific/package.html
@@ -35,7 +35,7 @@ Generate specific Java classes for schemas and protocols.
   the value will be mapped to the object returned by that Conversion. The
   logical type conversions for {@code date}, {@code time-millis}, {@code
   timestamp-millis} and {@code decimal} are pre-defined in the class {@link
-  <a href="javascript:">org.apache.avro.compiler.specific.SpecificCompiler SpecificCompiler</a>}.</li>
+  <a href="../../../../org/apache/avro/compiler/specific/SpecificCompiler.html" title="class in org.apache.avro.compiler.specific"><code>SpecificCompiler</code></a>}.</li>
 
 <li>All other types are mapped as in the {@link org.apache.avro.generic
   generic} API.</li>

--- a/lang/java/avro/src/main/java/org/apache/avro/specific/package.html
+++ b/lang/java/avro/src/main/java/org/apache/avro/specific/package.html
@@ -35,7 +35,7 @@ Generate specific Java classes for schemas and protocols.
   the value will be mapped to the object returned by that Conversion. The
   logical type conversions for {@code date}, {@code time-millis}, {@code
   timestamp-millis} and {@code decimal} are pre-defined in the class {@link
-  org.apache.avro.compiler.specific.SpecificCompiler SpecificCompiler}.</li>
+  <a href="javascript:">org.apache.avro.compiler.specific.SpecificCompiler SpecificCompiler</a>}.</li>
 
 <li>All other types are mapped as in the {@link org.apache.avro.generic
   generic} API.</li>

--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/schema/SchemaVisitor.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/schema/SchemaVisitor.java
@@ -25,31 +25,31 @@ public interface SchemaVisitor<T> {
    * Invoked for schemas that do not have "child" schemas (like string, int ...)
    * or for a previously encountered schema with children, which will be treated
    * as a terminal. (to avoid circular recursion)
-   * 
+   *
    * @param terminal
-   * @return
+   * @return SchemaVisitorAction
    */
   SchemaVisitorAction visitTerminal(Schema terminal);
 
   /**
    * Invoked for schema with children before proceeding to visit the children.
-   * 
+   *
    * @param nonTerminal
-   * @return
+   * @return SchemaVisitorAction
    */
   SchemaVisitorAction visitNonTerminal(Schema nonTerminal);
 
   /**
    * Invoked for schemas with children after its children have been visited.
-   * 
+   *
    * @param nonTerminal
-   * @return
+   * @return SchemaVisitorAction
    */
   SchemaVisitorAction afterVisitNonTerminal(Schema nonTerminal);
 
   /**
    * Invoked when visiting is complete.
-   * 
+   *
    * @return a value which will be returned by the visit method.
    */
   T get();

--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/schema/SchemaVisitor.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/schema/SchemaVisitor.java
@@ -27,7 +27,6 @@ public interface SchemaVisitor<T> {
    * as a terminal. (to avoid circular recursion)
    *
    * @param terminal
-   * @return SchemaVisitorAction
    */
   SchemaVisitorAction visitTerminal(Schema terminal);
 
@@ -35,7 +34,6 @@ public interface SchemaVisitor<T> {
    * Invoked for schema with children before proceeding to visit the children.
    *
    * @param nonTerminal
-   * @return SchemaVisitorAction
    */
   SchemaVisitorAction visitNonTerminal(Schema nonTerminal);
 
@@ -43,7 +41,6 @@ public interface SchemaVisitor<T> {
    * Invoked for schemas with children after its children have been visited.
    *
    * @param nonTerminal
-   * @return SchemaVisitorAction
    */
   SchemaVisitorAction afterVisitNonTerminal(Schema nonTerminal);
 

--- a/lang/java/mapred/src/main/java/org/apache/avro/hadoop/io/AvroSequenceFile.java
+++ b/lang/java/mapred/src/main/java/org/apache/avro/hadoop/io/AvroSequenceFile.java
@@ -57,10 +57,10 @@ import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IO_FILE_BUFFER_
  * <p>
  * Since Avro data are Plain Old Java Objects (e.g., <code>Integer</code> for
  * data with schema <i>"int"</i>), they do not implement <i>Writable</i>.
- * Furthermore, a {@link org.apache.hadoop.io.Serialization} implementation
- * cannot determine whether an object instance of type <code>CharSequence</code>
- * that also implements <code>Writable</code> should be serialized using Avro or
- * WritableSerialization.
+ * Furthermore, a {@link org.apache.hadoop.io.serializer.Serialization}
+ * implementation cannot determine whether an object instance of type
+ * <code>CharSequence</code> that also implements <code>Writable</code> should
+ * be serialized using Avro or WritableSerialization.
  * </p>
  *
  * <p>

--- a/lang/java/mapred/src/main/java/org/apache/avro/mapred/tether/TetherJob.java
+++ b/lang/java/mapred/src/main/java/org/apache/avro/mapred/tether/TetherJob.java
@@ -62,7 +62,7 @@ public class TetherJob extends Configured {
   /**
    * Set the URI for the application's executable (i.e the program to run in a
    * subprocess and provides the mapper/reducer).
-   * 
+   *
    * @param job        - Job
    * @param executable - The URI of the executable
    * @param args       - List of additional arguments; Null if no arguments
@@ -87,9 +87,9 @@ public class TetherJob extends Configured {
   /**
    * Extract from the job configuration file an instance of the TRANSPROTO
    * enumeration to represent the protocol to use for the communication
-   * 
+   *
    * @param job
-   * @return
+   * @return TetheredProcess.Protocol
    */
   public static TetheredProcess.Protocol getProtocol(JobConf job) {
 

--- a/lang/java/mapred/src/main/java/org/apache/avro/mapred/tether/TetherJob.java
+++ b/lang/java/mapred/src/main/java/org/apache/avro/mapred/tether/TetherJob.java
@@ -89,7 +89,7 @@ public class TetherJob extends Configured {
    * enumeration to represent the protocol to use for the communication
    *
    * @param job
-   * @return TetheredProcess.Protocol
+   * @return - Get the currently used protocol
    */
   public static TetheredProcess.Protocol getProtocol(JobConf job) {
 


### PR DESCRIPTION
In ./build.sh dist, there are many tags @link: reference not found
@return null and more...
So, I just have a little time to do something for the community.
Thanks.
Best regards.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2573
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
