### PR TITLE
AVRO-2574: Add a default value to the spec

### DIFF
--- a/doc/src/content/xdocs/spec.xml
+++ b/doc/src/content/xdocs/spec.xml
@@ -183,7 +183,8 @@
 	  </ul>
 	  <p>For example, playing card suits might be defined with:</p>
 	  <source>
-{ "type": "enum",
+{
+  "type": "enum",
   "name": "Suit",
   "symbols" : ["SPADES", "HEARTS", "DIAMONDS", "CLUBS"]
 }
@@ -199,7 +200,13 @@
 	  </ul>
 	  <p>For example, an array of strings is declared
 	  with:</p>
-	  <source>{"type": "array", "items": "string"}</source>
+    <source>
+{
+  "type": "array",
+  "items" : "string",
+  "default": []
+}
+    </source>
 	</section>
 
         <section>
@@ -212,7 +219,13 @@
 	  <p>Map keys are assumed to be strings.</p>
 	  <p>For example, a map from string to long is declared
 	  with:</p>
-	  <source>{"type": "map", "values": "long"}</source>
+    <source>
+{
+  "type": "map",
+  "items" : "long",
+  "default": {}
+}
+    </source>
 	</section>
 
         <section>


### PR DESCRIPTION
Make sure you have checked _all_ steps below. I think it is good practice to add a default value, therefore I'd like to have this on the website as well :-)

### Jira

- [ ] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2574
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
