### PR TITLE
AVRO-2581:Generate @Deprecated public attribute in Java

### DIFF
--- a/lang/java/ipc/src/test/java/org/apache/avro/TestProtocolSpecific.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/TestProtocolSpecific.java
@@ -298,7 +298,7 @@ public class TestProtocolSpecific {
       }
 
       // check that a given client protocol is only sent once
-      String clientProtocol = context.getHandshakeRequest().clientProtocol;
+      String clientProtocol = context.getHandshakeRequest().getClientProtocol();
       if (clientProtocol != null) {
         assertFalse(seenProtocols.contains(clientProtocol));
         seenProtocols.add(clientProtocol);

--- a/lang/java/ipc/src/test/java/org/apache/avro/compiler/specific/TestSpecificCompiler.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/compiler/specific/TestSpecificCompiler.java
@@ -581,7 +581,7 @@ public class TestSpecificCompiler {
     assertNotNull(Kind.class.getAnnotation(TestAnnotation.class));
 
     // a field
-    assertNotNull(TestRecord.class.getField("name").getAnnotation(TestAnnotation.class));
+    assertNotNull(TestRecord.class.getDeclaredField("name").getAnnotation(TestAnnotation.class));
     // a method
     assertNotNull(Simple.class.getMethod("ack").getAnnotation(TestAnnotation.class));
   }

--- a/lang/java/ipc/src/test/java/org/apache/avro/specific/TestSpecificRecordBuilder.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/specific/TestSpecificRecordBuilder.java
@@ -214,12 +214,12 @@ public class TestSpecificRecordBuilder {
     long startTimeNanos = System.nanoTime();
     for (int ii = 0; ii < count; ii++) {
       Person person = new Person();
-      person.name = "James Gosling";
-      person.year_of_birth = 1955;
-      person.state = "CA";
-      person.country = "US";
-      person.friends = friends;
-      person.languages = languages;
+      person.setName("James Gosling");
+      person.setYearOfBirth(1955);
+      person.setState("CA");
+      person.setCountry("US");
+      person.setFriends(friends);
+      person.setLanguages(languages);
     }
     long durationNanos = System.nanoTime() - startTimeNanos;
     double durationMillis = durationNanos / 1e6d;

--- a/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/AbstractAvroMojo.java
+++ b/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/AbstractAvroMojo.java
@@ -72,7 +72,7 @@ public abstract class AbstractAvroMojo extends AbstractMojo {
    * string values of SpecificCompiler.FieldVisibility. The text is case
    * insensitive.
    *
-   * @parameter default-value="PUBLIC_DEPRECATED"
+   * @parameter default-value="PRIVATE"
    */
   private String fieldVisibility;
 


### PR DESCRIPTION
In AbstractAvroMojo developed by maven plugin, @parameter should be set to PRIVATE by default instead of PUBLIC_DEPRECATED.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2581
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
