### PR TITLE
AVRO-2593: Ensure exfile is Always Defined

### DIFF
--- a/lang/py/test/test_tether_word_count.py
+++ b/lang/py/test/test_tether_word_count.py
@@ -98,6 +98,7 @@ class TestTetherWordCount(unittest.TestCase):
     import inspect
 
     proc=None
+    exfile = None
 
     try:
 
@@ -207,7 +208,7 @@ python -m avro.tether.tether_task_runner word_count_task.WordCountTask
         proc.kill()
       if os.path.exists(base_dir):
         shutil.rmtree(base_dir)
-      if os.path.exists(exfile):
+      if exfile is not None and os.path.exists(exfile):
         os.remove(exfile)
 
 if __name__== "__main__":


### PR DESCRIPTION
Fixes a bug where when a test fails the cleanup code tries to access a variable that might not have been defined when the error occurred. While I ultimately prefer the changes in #679, that PR has some problem with the Java 11 tether test. This PR is a much smaller changeset and solves the immediate problem, so it may be possible to merge it sooner.

### Jira

- [x] My PR addresses [AVRO-2593](https://issues.apache.org/jira/browse/AVRO-2593).
- [x] My PR references AVRO-2593 in the title.
- [x] My PR does not add any dependencies.

### Tests

- [x] My PR fixes a problem with an existing test.

### Commits

- [x] My commits all reference JIRA-2593 in their subject lines.
- [x] My commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)"

### Documentation

- [x] My PR does not require new documentation.