### PR TITLE
AVRO-2601: zstandard in extras_require

### DIFF
--- a/lang/py/setup.py
+++ b/lang/py/setup.py
@@ -84,5 +84,6 @@ setuptools.setup(
   url = 'https://avro.apache.org/',
   extras_require = {
     'snappy': ['python-snappy'],
+    'zstandard': ['zstandard'],
   },
 )

--- a/lang/py3/setup.cfg
+++ b/lang/py3/setup.cfg
@@ -62,6 +62,7 @@ avro =
 
 [options.extras_require]
 snappy = snappy
+zstandard = zstandard
 
 [aliases]
 dist = sdist --dist-dir ../../dist/py3


### PR DESCRIPTION
### Jira

- My PR...
- [x] ...addresses [AVRO-2601](https://issues.apache.org/jira/browse/AVRO-2601).
- [x] ...references that ticket in the PR title.
- [x] ...does not add any new dependencies. (It does provide a more convenient way to handle an existing, optional dependency.)

### Tests

- [x] My PR does not need testing because it does not change the main codebase, and because we don't currently have a testing framework for using python setuptools directly.

### Commits

- [x] My commits all reference Jira issues in their subject lines.
- [x] My commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)"

### Documentation

- [ ] It would be worthwhile to add documentation for this, but I'm not sure where/how to add it yet. In any case it isn't worth waiting for documentation to merge this PR...
