### PR TITLE
AVRO-2603: Clean Up Imports

### DIFF
--- a/lang/py/test/test_tether_word_count.py
+++ b/lang/py/test/test_tether_word_count.py
@@ -19,13 +19,18 @@
 
 from __future__ import absolute_import, division, print_function
 
-import inspect
 import os
+import shutil
 import subprocess
 import sys
-import time
+import tempfile
 import unittest
 
+import avro
+import avro.datafile
+import avro.io
+import avro.schema
+import avro.tether.tether_task_runner
 import set_avro_test_path
 
 
@@ -41,10 +46,6 @@ class TestTetherWordCount(unittest.TestCase):
     lines - list of strings to write
     fname - the name of the file to write to.
     """
-    import avro.io as avio
-    from avro.datafile import DataFileReader,DataFileWriter
-    from avro import schema
-
     #recursively make all directories
     dparts=fname.split(os.sep)[:-1]
     for i in range(len(dparts)):
@@ -55,10 +56,7 @@ class TestTetherWordCount(unittest.TestCase):
 
     with file(fname,'w') as hf:
       inschema="""{"type":"string"}"""
-      writer=DataFileWriter(hf,avio.DatumWriter(inschema),writers_schema=schema.parse(inschema))
-
-      #encoder = avio.BinaryEncoder(writer)
-      #datum_writer = avio.DatumWriter()
+      writer = avro.datafile.DataFileWriter(hf, avro.io.DatumWriter(inschema), writers_schema=avro.schema.parse(inschema))
       for datum in lines:
         writer.append(datum)
 
@@ -89,17 +87,6 @@ class TestTetherWordCount(unittest.TestCase):
 
     Assumptions: 1) bash is available in /bin/bash
     """
-    from word_count_task import WordCountTask
-    from avro.tether import tether_task_runner
-    from avro.datafile import DataFileReader
-    from avro.io import DatumReader
-    import avro
-
-    import subprocess
-    import shutil
-    import tempfile
-    import inspect
-
     proc=None
     exfile = None
 
@@ -163,7 +150,7 @@ class TestTetherWordCount(unittest.TestCase):
       # form the arguments for the subprocess
       subargs=[]
 
-      srcfile=inspect.getsourcefile(tether_task_runner)
+      srcfile = avro.tether.tether_task_runner.__file__
 
       # Create a shell script to act as the program we want to execute
       # We do this so we can set the python path appropriately
@@ -173,7 +160,7 @@ python -m avro.tether.tether_task_runner word_count_task.WordCountTask
 """
       # We need to make sure avro is on the path
       # getsourcefile(avro) returns .../avro/__init__.py
-      asrc=inspect.getsourcefile(avro)
+      asrc = avro.__file__
       apath=asrc.rsplit(os.sep,2)[0]
 
       # path to where the tests lie
@@ -197,7 +184,7 @@ python -m avro.tether.tether_task_runner word_count_task.WordCountTask
 
       # read the output
       with file(os.path.join(outpath,"part-00000.avro")) as hf:
-        reader=DataFileReader(hf, DatumReader())
+        reader = avro.datafile.DataFileReader(hf, avro.io.DatumReader())
         for record in reader:
           self.assertEqual(record["value"],true_counts[record["key"]])
 


### PR DESCRIPTION
This change moves the imports embedded in test functions to the top of the test module. It also standardizes the imports and removes some unnecessary ones.

### Jira

- [x] My PR addresses [AVRO-2603](https://issues.apache.org/jira/browse/AVRO-2603).
- [x] My PR title references the ticket.
- [x] My PR doesn’t add any dependencies.

### Tests

- [x] My PR improves an existing test.

### Commits

- [x] My commits all reference Jira issues in their subject lines.
- [x] My commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)"

### Documentation

- [x] My PR doesn’t add functionality and doesn’t require documentation.