### PR TITLE
AVRO-2561: Bump hadoop dependency to 2.7.7.

### DIFF
--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -39,7 +39,7 @@
 
     <!-- version properties for dependencies -->
 
-    <hadoop.version>2.7.3</hadoop.version>
+    <hadoop.version>2.7.7</hadoop.version>
     <jackson.version>2.10.0</jackson.version>
     <jackson.databind.version>2.10.0</jackson.databind.version>
     <servlet-api.version>4.0.1</servlet-api.version>


### PR DESCRIPTION
There has been several point releases in Hadoop since 2.7.3.  

This bumps the version to 2.7.7 to fix a bug when using avro-tools and some recent JDKs.  See https://issues.apache.org/jira/browse/AVRO-2561 for an error which occurs when the java.version reported by the JDK is less than three characters.

Alternatively, we could switch to the -Phadoop3 profile for the default build.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2561
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Testing over all possible providers of all versions of JDK would be prohibitively expensive!

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
