### PR TITLE
AVRO-2429: Ignore unknown logical types in python2.

### DIFF
--- a/lang/py/src/avro/schema.py
+++ b/lang/py/src/avro/schema.py
@@ -42,7 +42,7 @@ from __future__ import absolute_import, division, print_function
 
 import json
 import sys
-from math import floor, log10
+import math
 
 from avro import constants
 
@@ -506,7 +506,7 @@ class FixedSchema(NamedSchema):
 
 class FixedDecimalSchema(FixedSchema, DecimalLogicalSchema):
   def __init__(self, size, name, precision, scale=0, namespace=None, names=None, other_props=None):
-    max_precision = round(floor(log10(pow(2, (8 * max(1, size) - 1)) - 1)))
+    max_precision = math.floor(math.log10(2) * (8 * size - 1)) - 1
     DecimalLogicalSchema.__init__(self, precision, scale, max_precision)
     FixedSchema.__init__(self, name, namespace, size, names, other_props)
     self.set_prop('precision', precision)

--- a/lang/py/src/avro/schema.py
+++ b/lang/py/src/avro/schema.py
@@ -506,7 +506,7 @@ class FixedSchema(NamedSchema):
 
 class FixedDecimalSchema(FixedSchema, DecimalLogicalSchema):
   def __init__(self, size, name, precision, scale=0, namespace=None, names=None, other_props=None):
-    max_precision = math.floor(math.log10(2) * (8 * size - 1)) - 1
+    max_precision = math.floor(math.log10(2) * (8 * size - 1))
     DecimalLogicalSchema.__init__(self, precision, scale, max_precision)
     FixedSchema.__init__(self, name, namespace, size, names, other_props)
     self.set_prop('precision', precision)

--- a/lang/py/src/avro/schema.py
+++ b/lang/py/src/avro/schema.py
@@ -335,8 +335,7 @@ class LogicalSchema(object):
 #
 
 class DecimalLogicalSchema(LogicalSchema):
-  def __init__(self, precision, scale=0):
-    max_precision = self._max_precision()
+  def __init__(self, precision, scale=0, max_precision=0):
     if not isinstance(precision, int) or precision <= 0:
       raise SchemaParseException("""Precision is required for logical type
                                 DECIMAL and must be a positive integer but
@@ -353,9 +352,6 @@ class DecimalLogicalSchema(LogicalSchema):
                                  %(scale, precision))
 
     super(DecimalLogicalSchema, self).__init__('decimal')
-
-  def _max_precision(self):
-    raise NotImplementedError()
 
 
 class Field(object):
@@ -456,7 +452,7 @@ class PrimitiveSchema(Schema):
 
 class BytesDecimalSchema(PrimitiveSchema, DecimalLogicalSchema):
   def __init__(self, precision, scale=0, other_props=None):
-    DecimalLogicalSchema.__init__(self, precision, scale)
+    DecimalLogicalSchema.__init__(self, precision, scale, max_precision=((1 << 31) - 1))
     PrimitiveSchema.__init__(self, 'bytes', other_props)
     self.set_prop('precision', precision)
     self.set_prop('scale', scale)
@@ -464,10 +460,6 @@ class BytesDecimalSchema(PrimitiveSchema, DecimalLogicalSchema):
   # read-only properties
   precision = property(lambda self: self.get_prop('precision'))
   scale = property(lambda self: self.get_prop('scale'))
-
-  def _max_precision(self):
-    # Considering the max 32 bit integer value
-    return (1 << 31) - 1
 
   def to_json(self, names=None):
     return self.props
@@ -514,17 +506,15 @@ class FixedSchema(NamedSchema):
 
 class FixedDecimalSchema(FixedSchema, DecimalLogicalSchema):
   def __init__(self, size, name, precision, scale=0, namespace=None, names=None, other_props=None):
+    max_precision = round(floor(log10(pow(2, (8 * max(1, size) - 1)) - 1)))
+    DecimalLogicalSchema.__init__(self, precision, scale, max_precision)
     FixedSchema.__init__(self, name, namespace, size, names, other_props)
-    DecimalLogicalSchema.__init__(self, precision, scale)
     self.set_prop('precision', precision)
     self.set_prop('scale', scale)
 
   # read-only properties
   precision = property(lambda self: self.get_prop('precision'))
   scale = property(lambda self: self.get_prop('scale'))
-
-  def _max_precision(self):
-    return round(floor(log10(pow(2, (8 * self.size - 1)) - 1)))
 
   def to_json(self, names=None):
     return self.props
@@ -905,19 +895,19 @@ def make_logical_schema(logical_type, type_, other_props):
     constants.TIME_MICROS: ('long', TimeMicrosSchema),
     constants.TIME_MILLIS: ('int', TimeMillisSchema),
   }
+  literal_type, schema_type = logical_types.get(logical_type, (None, None))
   try:
-    literal_type, schema_type = logical_types[logical_type]
-  except KeyError:
-    raise SchemaParseException("Currently does not support {} logical type".format(logical_type))
-  if literal_type != type_:
-    raise SchemaParseException("Logical type {} requires literal type {}, not {}".format(logical_type, literal_type, type_))
-  return schema_type(other_props)
+    if literal_type == type_:
+      return schema_type(other_props)
+  except SchemaParseException:
+    pass
+  return None
 
 def make_avsc_object(json_data, names=None):
   """
   Build Avro Schema from data parsed out of JSON string.
 
-  @arg names: A Name object (tracks seen names and default space)
+  @arg names: A Names object (tracks seen names and default space)
   """
   if names is None:
     names = Names()
@@ -927,6 +917,10 @@ def make_avsc_object(json_data, names=None):
     type = json_data.get('type')
     other_props = get_other_props(json_data, SCHEMA_RESERVED_PROPS)
     logical_type = json_data.get('logicalType')
+    if logical_type:
+      logical_schema = make_logical_schema(logical_type, type, other_props or {})
+      if logical_schema is not None:
+        return logical_schema
     if type in NAMED_TYPES:
       name = json_data.get('name')
       namespace = json_data.get('namespace', names.default_namespace)
@@ -935,7 +929,10 @@ def make_avsc_object(json_data, names=None):
         if logical_type == 'decimal':
           precision = json_data.get('precision')
           scale = 0 if json_data.get('scale') is None else json_data.get('scale')
-          return FixedDecimalSchema(size, name, precision, scale, namespace, names, other_props)
+          try:
+            return FixedDecimalSchema(size, name, precision, scale, namespace, names, other_props)
+          except (AvroException, SchemaParseException):
+            pass
         return FixedSchema(name, namespace, size, names, other_props)
       elif type == 'enum':
         symbols = json_data.get('symbols')
@@ -947,8 +944,6 @@ def make_avsc_object(json_data, names=None):
         return RecordSchema(name, namespace, fields, names, type, doc, other_props)
       else:
         raise SchemaParseException('Unknown Named Type: %s' % type)
-    if logical_type:
-      return make_logical_schema(logical_type, type, other_props or {})
     if type in PRIMITIVE_TYPES:
       return PrimitiveSchema(type, other_props)
     if type in VALID_TYPES:

--- a/lang/py/src/avro/schema.py
+++ b/lang/py/src/avro/schema.py
@@ -41,8 +41,8 @@ A schema may be one of:
 from __future__ import absolute_import, division, print_function
 
 import json
-import sys
 import math
+import sys
 
 from avro import constants
 

--- a/lang/py/test/test_io.py
+++ b/lang/py/test/test_io.py
@@ -82,6 +82,9 @@ SCHEMAS_TO_VALIDATE = (
     '{"type": "long", "logicalType": "timestamp-micros"}',
     datetime.datetime(2000, 1, 18, 2, 2, 1, 123499, tzinfo=timezones.tst)
   ),
+  ('{"type": "string", "logicalType": "uuid"}', unicode('12345abcd')),
+  ('{"type": "string", "logicalType": "unknown-logical-type"}', unicode('12345abcd')),
+  ('{"type": "string", "logicalType": "timestamp-millis"}', unicode('12345abcd')),
   ("""\
    {"type": "record",
     "name": "Test",

--- a/lang/py/test/test_io.py
+++ b/lang/py/test/test_io.py
@@ -36,7 +36,7 @@ except ImportError:
 SCHEMAS_TO_VALIDATE = (
   ('"null"', None),
   ('"boolean"', True),
-  ('"string"', unicode('adsfasdf09809dsf-=adsf')),
+  ('"string"', u'adsfasdf09809dsf-=adsf'),
   ('"bytes"', '12345abcd'),
   ('"int"', 1234),
   ('"long"', 1234),
@@ -82,9 +82,9 @@ SCHEMAS_TO_VALIDATE = (
     '{"type": "long", "logicalType": "timestamp-micros"}',
     datetime.datetime(2000, 1, 18, 2, 2, 1, 123499, tzinfo=timezones.tst)
   ),
-  ('{"type": "string", "logicalType": "uuid"}', unicode('12345abcd')),
-  ('{"type": "string", "logicalType": "unknown-logical-type"}', unicode('12345abcd')),
-  ('{"type": "string", "logicalType": "timestamp-millis"}', unicode('12345abcd')),
+  ('{"type": "string", "logicalType": "uuid"}', u'12345abcd'),
+  ('{"type": "string", "logicalType": "unknown-logical-type"}', u'12345abcd'),
+  ('{"type": "string", "logicalType": "timestamp-millis"}', u'12345abcd'),
   ("""\
    {"type": "record",
     "name": "Test",

--- a/lang/py/test/test_schema.py
+++ b/lang/py/test/test_schema.py
@@ -193,42 +193,47 @@ OTHER_PROP_EXAMPLES = [
 DECIMAL_LOGICAL_TYPE = [
   ValidTestSchema({"type": "fixed", "logicalType": "decimal", "name": "TestDecimal", "precision": 4, "size": 10, "scale": 2}),
   ValidTestSchema({"type": "bytes", "logicalType": "decimal", "precision": 4, "scale": 2}),
-  InvalidTestSchema({"type": "bytes", "logicalType": "decimal", "precision": 2, "scale": -2}),
-  InvalidTestSchema({"type": "bytes", "logicalType": "decimal", "precision": -2, "scale": 2}),
-  InvalidTestSchema({"type": "bytes", "logicalType": "decimal", "precision": 2, "scale": 3}),
-  InvalidTestSchema({"type": "fixed", "logicalType": "decimal", "name": "TestDecimal", "precision": -10, "scale": 2, "size": 5}),
-  InvalidTestSchema({"type": "fixed", "logicalType": "decimal", "name": "TestDecimal", "precision": 2, "scale": 3, "size": 2}),
-  InvalidTestSchema({"type": "fixed", "logicalType": "decimal", "name": "TestDecimal", "precision": 2, "scale": 2, "size": -2}),
+  InvalidTestSchema({"type": "fixed", "logicalType": "decimal", "name": "TestDecimal2", "precision": 2, "scale": 2, "size": -2}),
 ]
 
 DATE_LOGICAL_TYPE = [
-  ValidTestSchema({"type": "int", "logicalType": "date"}),
-  InvalidTestSchema({"type": "int", "logicalType": "date1"}),
-  InvalidTestSchema({"type": "long", "logicalType": "date"}),
+  ValidTestSchema({"type": "int", "logicalType": "date"})
 ]
 
 TIMEMILLIS_LOGICAL_TYPE = [
-  ValidTestSchema({"type": "int", "logicalType": "time-millis"}),
-  InvalidTestSchema({"type": "int", "logicalType": "time-milis"}),
-  InvalidTestSchema({"type": "long", "logicalType": "time-millis"}),
+  ValidTestSchema({"type": "int", "logicalType": "time-millis"})
 ]
 
 TIMEMICROS_LOGICAL_TYPE = [
-  ValidTestSchema({"type": "long", "logicalType": "time-micros"}),
-  InvalidTestSchema({"type": "long", "logicalType": "time-micro"}),
-  InvalidTestSchema({"type": "int", "logicalType": "time-micros"}),
+  ValidTestSchema({"type": "long", "logicalType": "time-micros"})
 ]
 
 TIMESTAMPMILLIS_LOGICAL_TYPE = [
-  ValidTestSchema({"type": "long", "logicalType": "timestamp-millis"}),
-  InvalidTestSchema({"type": "long", "logicalType": "timestamp-milis"}),
-  InvalidTestSchema({"type": "int", "logicalType": "timestamp-millis"}),
+  ValidTestSchema({"type": "long", "logicalType": "timestamp-millis"})
 ]
 
 TIMESTAMPMICROS_LOGICAL_TYPE = [
-  ValidTestSchema({"type": "long", "logicalType": "timestamp-micros"}),
-  InvalidTestSchema({"type": "long", "logicalType": "timestamp-micro"}),
-  InvalidTestSchema({"type": "int", "logicalType": "timestamp-micros"}),
+  ValidTestSchema({"type": "long", "logicalType": "timestamp-micros"})
+]
+
+IGNORED_LOGICAL_TYPE = [
+  ValidTestSchema({"type": "string", "logicalType": "uuid"}),
+  ValidTestSchema({"type": "string", "logicalType": "unknown-logical-type"}),
+  ValidTestSchema({"type": "bytes", "logicalType": "decimal", "precision": 2, "scale": -2}),
+  ValidTestSchema({"type": "bytes", "logicalType": "decimal", "precision": -2, "scale": 2}),
+  ValidTestSchema({"type": "bytes", "logicalType": "decimal", "precision": 2, "scale": 3}),
+  ValidTestSchema({"type": "fixed", "logicalType": "decimal", "name": "TestIgnored", "precision": -10, "scale": 2, "size": 5}),
+  ValidTestSchema({"type": "fixed", "logicalType": "decimal", "name": "TestIgnored2", "precision": 2, "scale": 3, "size": 2}),
+  ValidTestSchema({"type": "int", "logicalType": "date1"}),
+  ValidTestSchema({"type": "long", "logicalType": "date"}),
+  ValidTestSchema({"type": "int", "logicalType": "time-milis"}),
+  ValidTestSchema({"type": "long", "logicalType": "time-millis"}),
+  ValidTestSchema({"type": "long", "logicalType": "time-micro"}),
+  ValidTestSchema({"type": "int", "logicalType": "time-micros"}),
+  ValidTestSchema({"type": "long", "logicalType": "timestamp-milis"}),
+  ValidTestSchema({"type": "int", "logicalType": "timestamp-millis"}),
+  ValidTestSchema({"type": "long", "logicalType": "timestamp-micro"}),
+  ValidTestSchema({"type": "int", "logicalType": "timestamp-micros"})
 ]
 
 EXAMPLES = PRIMITIVE_EXAMPLES
@@ -245,6 +250,7 @@ EXAMPLES += TIMEMILLIS_LOGICAL_TYPE
 EXAMPLES += TIMEMICROS_LOGICAL_TYPE
 EXAMPLES += TIMESTAMPMILLIS_LOGICAL_TYPE
 EXAMPLES += TIMESTAMPMICROS_LOGICAL_TYPE
+EXAMPLES += IGNORED_LOGICAL_TYPE
 
 VALID_EXAMPLES = [e for e in EXAMPLES if e.valid]
 INVALID_EXAMPLES = [e for e in EXAMPLES if not e.valid]

--- a/lang/py/test/test_schema.py
+++ b/lang/py/test/test_schema.py
@@ -356,6 +356,35 @@ class TestSchema(unittest.TestCase):
     self.assertEqual(4, bytes_decimal.get_prop('precision'))
     self.assertEqual(0, bytes_decimal.get_prop('scale'))
 
+  def test_fixed_decimal_valid_max_precision(self):
+    # An 8 byte number can represent any 18 digit number.
+    fixed_decimal_schema = ValidTestSchema({
+      "type": "fixed",
+      "logicalType": "decimal",
+      "name": "TestDecimal",
+      "precision": 18,
+      "scale": 0,
+      "size": 8})
+
+    fixed_decimal = fixed_decimal_schema.parse()
+    self.assertIsInstance(fixed_decimal, schema.FixedSchema)
+    self.assertIsInstance(fixed_decimal, schema.DecimalLogicalSchema)
+
+  def test_fixed_decimal_invalid_max_precision(self):
+    # An 8 byte number can't represent every 19 digit number, so the logical
+    # type is not applied.
+    fixed_decimal_schema = ValidTestSchema({
+      "type": "fixed",
+      "logicalType": "decimal",
+      "name": "TestDecimal",
+      "precision": 19,
+      "scale": 0,
+      "size": 8})
+
+    fixed_decimal = fixed_decimal_schema.parse()
+    self.assertIsInstance(fixed_decimal, schema.FixedSchema)
+    self.assertNotIsInstance(fixed_decimal, schema.DecimalLogicalSchema)
+
 class SchemaParseTestCase(unittest.TestCase):
   """Enable generating parse test cases over all the valid and invalid example schema."""
 


### PR DESCRIPTION
When an unknown or invalid logical type is encountered, it should be ignored by the implementation.  The python2 implementation throws an exception instead.

It appears that just *not* throwing the exception behaves correctly.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2429
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
