### PR TITLE
AVRO-2432: Handle Empty Datafiles

### DIFF
--- a/lang/py/src/avro/datafile.py
+++ b/lang/py/src/avro/datafile.py
@@ -373,21 +373,14 @@ class DataFileReader(object):
     if proposed_sync_marker != self.sync_marker:
       self.reader.seek(-SYNC_SIZE, 1)
       return False
-    else:
-      return True
+    return True
 
-  # TODO(hammer): handle block of length zero
-  # TODO(hammer): clean this up with recursion
   def next(self):
     """Return the next datum in the file."""
-    if self.block_count == 0:
-      if self.is_EOF():
+    while self.block_count == 0:
+      if self.is_EOF() or (self._skip_sync() and self.is_EOF()):
         raise StopIteration
-      elif self._skip_sync():
-        if self.is_EOF(): raise StopIteration
-        self._read_block_header()
-      else:
-        self._read_block_header()
+      self._read_block_header()
 
     datum = self.datum_reader.read(self.datum_decoder)
     self.block_count -= 1

--- a/lang/py/test/test_datafile.py
+++ b/lang/py/test/test_datafile.py
@@ -203,5 +203,19 @@ class TestDataFile(unittest.TestCase):
         datums.append(datum)
     self.assertTrue(reader.closed)
 
+  def test_empty_datafile(self):
+    """A reader should not fail to read a file consisting of a single empty block."""
+    sample_schema = schema.parse(SCHEMAS_TO_VALIDATE[1][0])
+    with datafile.DataFileWriter(open(FILENAME, 'wb'), io.DatumWriter(),
+        sample_schema) as dfw:
+      dfw.flush()
+      # Write an empty block
+      dfw.encoder.write_long(0)
+      dfw.encoder.write_long(0)
+      dfw.writer.write(dfw.sync_marker)
+
+    with datafile.DataFileReader(open(FILENAME, 'rb'), io.DatumReader()) as dfr:
+      self.assertEqual([], list(dfr))
+
 if __name__ == '__main__':
   unittest.main()

--- a/lang/py3/avro/tests/test_datafile.py
+++ b/lang/py3/avro/tests/test_datafile.py
@@ -287,6 +287,21 @@ class TestDataFile(unittest.TestCase):
           datums.append(datum)
       self.assertTrue(reader.closed)
 
+  def test_empty_datafile(self):
+    """A reader should not fail to read a file consisting of a single empty block."""
+    file_path = self.NewTempFile()
+    sample_schema = schema.parse(SCHEMAS_TO_VALIDATE[1][0])
+    with datafile.DataFileWriter(open(file_path, 'wb'), io.DatumWriter(),
+        sample_schema) as dfw:
+      dfw.flush()
+      # Write an empty block
+      dfw.encoder.write_long(0)
+      dfw.encoder.write_long(0)
+      dfw.writer.write(dfw.sync_marker)
+
+    with datafile.DataFileReader(open(file_path, 'rb'), io.DatumReader()) as dfr:
+      self.assertEqual([], list(dfr))
+
 
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
Fix DataFileReader so it can handle datafiles with zero blocks in them. I refactored David Beswick's patch in the ticket to close out two old TODOs in the DataFileReader iterator implementation.

### Jira

- [x] My PR addresses [AVRO-2432](https://issues.apache.org/jira/browse/AVRO-2432)
- [x] My PR references the ticket in the PR title.
- [x] My PR does not add any dependencies.

### Tests

- [x] My PR adds a test case for a datafile with an empty file data block.

### Commits

- [x] My commits all reference the Jira ticket in their subject lines.
- [x] My commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)

### Documentation

- [x] My PR fixes a bug in the python implementations and does not require a change to documentation.