### PR TITLE
AVRO-2617: Use consistent line endings in C# CodeGen

### DIFF
--- a/lang/csharp/src/apache/main/CodeGen/CodeGen.cs
+++ b/lang/csharp/src/apache/main/CodeGen/CodeGen.cs
@@ -406,19 +406,20 @@ namespace Avro
 
             if (protocol.Messages.Count > 0)
             {
-                builder.Append("switch(messageName)\n\t\t\t{");
+                builder.AppendLine("switch(messageName)");
+                builder.Append("\t\t\t{");
 
                 foreach (var a in protocol.Messages)
                 {
-                    builder.Append("\n\t\t\t\tcase \"").Append(a.Key).Append("\":\n");
+                    builder.AppendLine().Append("\t\t\t\tcase \"").Append(a.Key).AppendLine("\":");
 
                     bool unused = false;
                     string type = getType(a.Value.Response, false, ref unused);
 
                     builder.Append("\t\t\t\trequestor.Request<")
                            .Append(type)
-                           .Append(">(messageName, args, callback);\n");
-                    builder.Append("\t\t\t\tbreak;\n");
+                           .AppendLine(">(messageName, args, callback);");
+                    builder.AppendLine("\t\t\t\tbreak;");
                 }
 
                 builder.Append("\t\t\t}");
@@ -575,7 +576,8 @@ namespace Avro
             cmmGet.Attributes = MemberAttributes.Public;
             cmmGet.ReturnType = new CodeTypeReference("System.Object");
             cmmGet.Parameters.Add(new CodeParameterDeclarationExpression(typeof(int), "fieldPos"));
-            StringBuilder getFieldStmt = new StringBuilder("switch (fieldPos)\n\t\t\t{\n");
+            StringBuilder getFieldStmt = new StringBuilder("switch (fieldPos)")
+                .AppendLine().AppendLine("\t\t\t{");
 
             // declare Put() to be used by the Reader classes
             var cmmPut = new CodeMemberMethod();
@@ -584,7 +586,8 @@ namespace Avro
             cmmPut.ReturnType = new CodeTypeReference(typeof(void));
             cmmPut.Parameters.Add(new CodeParameterDeclarationExpression(typeof(int), "fieldPos"));
             cmmPut.Parameters.Add(new CodeParameterDeclarationExpression("System.Object", "fieldValue"));
-            var putFieldStmt = new StringBuilder("switch (fieldPos)\n\t\t\t{\n");
+            var putFieldStmt = new StringBuilder("switch (fieldPos)")
+                .AppendLine().AppendLine("\t\t\t{");
 
             if (isError)
             {
@@ -638,7 +641,7 @@ namespace Avro
                 getFieldStmt.Append(field.Pos);
                 getFieldStmt.Append(": return this.");
                 getFieldStmt.Append(mangledName);
-                getFieldStmt.Append(";\n");
+                getFieldStmt.AppendLine(";");
 
                 // add to Put()
                 putFieldStmt.Append("\t\t\tcase ");
@@ -656,24 +659,26 @@ namespace Avro
                     type = type.Remove(type.Length - 1);   // remove >
 
                     putFieldStmt.Append(type);
-                    putFieldStmt.Append(")fieldValue; break;\n");
+                    putFieldStmt.AppendLine(")fieldValue; break;");
                 }
                 else
                 {
                     putFieldStmt.Append(" = (");
                     putFieldStmt.Append(baseType);
-                    putFieldStmt.Append(")fieldValue; break;\n");
+                    putFieldStmt.AppendLine(")fieldValue; break;");
                 }
             }
 
             // end switch block for Get()
-            getFieldStmt.Append("\t\t\tdefault: throw new AvroRuntimeException(\"Bad index \" + fieldPos + \" in Get()\");\n\t\t\t}");
+            getFieldStmt.AppendLine("\t\t\tdefault: throw new AvroRuntimeException(\"Bad index \" + fieldPos + \" in Get()\");")
+                .Append("\t\t\t}");
             var cseGet = new CodeSnippetExpression(getFieldStmt.ToString());
             cmmGet.Statements.Add(cseGet);
             ctd.Members.Add(cmmGet);
 
             // end switch block for Put()
-            putFieldStmt.Append("\t\t\tdefault: throw new AvroRuntimeException(\"Bad index \" + fieldPos + \" in Put()\");\n\t\t\t}");
+            putFieldStmt.AppendLine("\t\t\tdefault: throw new AvroRuntimeException(\"Bad index \" + fieldPos + \" in Put()\");")
+                .Append("\t\t\t}");
             var csePut = new CodeSnippetExpression(putFieldStmt.ToString());
             cmmPut.Statements.Add(csePut);
             ctd.Members.Add(cmmPut);
@@ -837,7 +842,7 @@ namespace Avro
         protected virtual CodeCommentStatement createDocComment(string comment)
         {
             string text = string.Format(CultureInfo.InvariantCulture,
-                "<summary>\r\n {0}\r\n </summary>", comment);
+                "<summary>{1} {0}{1} </summary>", comment, Environment.NewLine);
             return new CodeCommentStatement(text, true);
         }
 


### PR DESCRIPTION

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2617
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  - CodeGen tests still passing 👍 

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
