### PR TITLE
AVRO-2618: DataFileReader supports non-seekable Streams

### DIFF
--- a/lang/csharp/src/apache/main/File/DataFileWriter.cs
+++ b/lang/csharp/src/apache/main/File/DataFileWriter.cs
@@ -190,15 +190,20 @@ namespace Avro.File
         public void Flush()
         {
             EnsureHeader();
-            Sync();
+            SyncInternal();
         }
 
         /// <inheritdoc/>
         public long Sync()
         {
+            SyncInternal();
+            return _stream.Position;
+        }
+
+        private void SyncInternal()
+        {
             AssertOpen();
             WriteBlock();
-            return _stream.Position;
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
This commit allows to support non-seekable Stream as reading input in
avro DataFileReader. This allow not to force the user to fully download
a file from a network storage prior to read it.
When creating an DataFileReader with a non-seekable Stream, features as
Seek(), Sync(), PastSync(), PreviousSync() and Tell() can't be used.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO-2618) issues and references them in the PR title.

### Tests

- [X ] My PR adds the following unit tests : TestNonSeekableStream that ensure a standard non-seekable Stream (DeflateStream used to implement the test) can be used as DateFileReader Stream.

### Commits

- [ X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X ] In case of new functionality, my PR adds documentation that describes how to use it.
 No new functionnality, just removed an arbitrary limitation.
