### PR TITLE
AVRO-2603: Provide PYTHONPATH in Environment

### DIFF
--- a/lang/py/test/test_tether_word_count.py
+++ b/lang/py/test/test_tether_word_count.py
@@ -52,8 +52,6 @@ _OUT_SCHEMA = """{
              {"name": "value", "type": "long", "order": "ignore"}]
 }"""
 
-# Create a shell script to act as the program we want to execute
-# We do this so we can set the python path appropriately
 _PYTHON_PATH = os.pathsep.join([os.path.dirname(os.path.dirname(avro.__file__)),
                                 os.path.dirname(__file__)])
 

--- a/lang/py/test/test_tether_word_count.py
+++ b/lang/py/test/test_tether_word_count.py
@@ -122,7 +122,7 @@ class TestTetherWordCount(unittest.TestCase):
             "--program", sys.executable,
             "--exec_args", "-m avro.tether.tether_task_runner word_count_task.WordCountTask")
     print("Command:\n\t{0}".format(" ".join(args)))
-    subprocess.check_call(args, env={"PYTHONPATH": _PYTHON_PATH})
+    subprocess.check_call(args, env={"PYTHONPATH": _PYTHON_PATH, "PATH": os.environ["PATH"]})
 
     # ...and test the results.
     datum_reader = avro.io.DatumReader()


### PR DESCRIPTION
_Blocked by [AVRO-2624](https://issues.apache.org/jira/browse/AVRO-2603)._

Avoid the need to generate a script in a temporary file by providing the python path in the environment.

### Jira

- [x] Addresses part of [AVRO-2603](https://issues.apache.org/jira/browse/AVRO-2603)
- [x] References it in the PR title
- [x] Adds no new dependencies

### Tests

- [x] Improves an existing test

### Commits

- [ ] Commits reference the Jira issue. (Not all commits do right now, but a squash commit will fix that.)
- [x] Commits follow guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)"

### Documentation

- [x] No new documentation needed.
