### PR TITLE
AVRO-2611: Use warnings for invalid logical types.

### DIFF
--- a/lang/py/src/avro/schema.py
+++ b/lang/py/src/avro/schema.py
@@ -909,9 +909,8 @@ def make_logical_schema(logical_type, type_, other_props):
     if schema_type is not None:
       return schema_type(other_props)
 
-    expected_types = [literal_type for lt, literal_type in logical_types if lt == logical_type]
+    expected_types = sorted(literal_type for lt, literal_type in logical_types if lt == logical_type)
     if expected_types:
-      expected_types.sort()
       warnings.warn(
           IgnoredLogicalType("Logical type {} requires literal type {}, not {}.".format(
               logical_type, "/".join(expected_types), type_)))

--- a/lang/py/src/avro/schema.py
+++ b/lang/py/src/avro/schema.py
@@ -358,7 +358,7 @@ class DecimalLogicalSchema(LogicalSchema):
       raise IgnoredLogicalType("Invalid decimal precision %d. Max is %d." % (precision, max_precision))
 
     if not isinstance(scale, int) or scale < 0:
-      raise IgnoredLogicalType("Invalid decimal scale %d. Must be a positive integer." % scale)
+      raise IgnoredLogicalType("Invalid decimal scale %s. Must be a positive integer." % scale)
 
     if scale > precision:
       raise IgnoredLogicalType("Invalid decimal scale %d. Cannot be greater than precision %d."

--- a/lang/py/test/test_schema.py
+++ b/lang/py/test/test_schema.py
@@ -228,8 +228,8 @@ IGNORED_LOGICAL_TYPE = [
     {"type": "bytes", "logicalType": "decimal", "scale": 0},
     warnings=[schema.IgnoredLogicalType('Invalid decimal precision None. Must be a positive integer.')]),
   ValidTestSchema(
-    {"type": "bytes", "logicalType": "decimal", "precision": 2.0, "scale": 0},
-    warnings=[schema.IgnoredLogicalType('Invalid decimal precision 2.0. Must be a positive integer.')]),
+    {"type": "bytes", "logicalType": "decimal", "precision": 2.4, "scale": 0},
+    warnings=[schema.IgnoredLogicalType('Invalid decimal precision 2.4. Must be a positive integer.')]),
   ValidTestSchema(
     {"type": "bytes", "logicalType": "decimal", "precision": 2, "scale": -2},
     warnings=[schema.IgnoredLogicalType('Invalid decimal scale -2. Must be a positive integer.')]),

--- a/lang/py/test/test_schema.py
+++ b/lang/py/test/test_schema.py
@@ -455,14 +455,14 @@ class SchemaParseTestCase(unittest.TestCase):
     with warnings.catch_warnings(record=True) as actual_warnings:
       try:
         self.test_schema.parse()
-        actual_messages = [str(wmsg.message) for wmsg in actual_warnings]
-        if self.test_schema.warnings:
-          expected_messages = [str(w) for w in self.test_schema.warnings]
-          self.assertItemsEqual(actual_messages, expected_messages)
-        else:
-          self.assertEqual(actual_messages, [])
       except (schema.AvroException, schema.SchemaParseException):
         self.fail("Valid schema failed to parse: {!s}".format(self.test_schema))
+      actual_messages = [str(wmsg.message) for wmsg in actual_warnings]
+      if self.test_schema.warnings:
+        expected_messages = [str(w) for w in self.test_schema.warnings]
+        self.assertItemsEqual(actual_messages, expected_messages)
+      else:
+        self.assertEqual(actual_messages, [])
 
   def parse_invalid(self):
     """Parsing an invalid schema should error."""


### PR DESCRIPTION
Instead of silently ignoring LogicalTypes that happen to be invalid (for any reason), this PR brings in the warning module to print a warning to the output when the schema is encountered.  At runtime, this can be configured to be fatal, or silently ignored.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2611
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
