### PR TITLE
AVRO-2594: Use JAVA env when building local docker.

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -19,7 +19,6 @@ set -e
 
 case "$TRAVIS_OS_NAME" in
 "linux")
-    sed -i.bak "s/openjdk:8/openjdk:${JAVA}/" share/docker/Dockerfile
     # Workaround for Yetus. For now, Yetus assumes the directory in which Dockerfile is placed is the docker context.
     # So the Dockerfile should be here to refer to other subdirectories than share/docker from inside the Dockerfile.
     cp share/docker/Dockerfile .

--- a/build.sh
+++ b/build.sh
@@ -303,10 +303,10 @@ do
       ;;
 
     docker-test)
-      tar -cf- share/docker/Dockerfile \
-               lang/ruby/Gemfile |
-        docker build -t avro-test -f share/docker/Dockerfile -
-      docker run --rm -v ${PWD}:/avro/ avro-test
+      sed -r "s/openjdk:8/openjdk:${JAVA:-8}/g" share/docker/Dockerfile > Dockerfile
+      tar -cf- lang/ruby/Gemfile Dockerfile | docker build -t avro-test -
+      rm Dockerfile
+      docker run --rm -v ${PWD}:/avro/ avro-test /avro/share/docker/run-tests.sh
       ;;
 
     *)

--- a/build.sh
+++ b/build.sh
@@ -264,8 +264,8 @@ do
         GROUP_ID=50
       fi
       {
-        cat share/docker/Dockerfile
-        grep -vF 'FROM avro-build-ci' share/docker/DockerfileLocal
+        sed -r "s/openjdk:8/openjdk:${JAVA:-8}/g" share/docker/Dockerfile
+        [ ${JAVA:-8} -le 8 ] && grep -vF 'FROM avro-build-ci' share/docker/DockerfileLocal
         echo "ENV HOME /home/$USER_NAME"
         echo "RUN getent group $GROUP_ID || groupadd -g $GROUP_ID $USER_NAME"
         echo "RUN getent passwd $USER_ID || useradd -g $GROUP_ID -u $USER_ID -k /root -m $USER_NAME"

--- a/build.sh
+++ b/build.sh
@@ -35,7 +35,7 @@ change_java_version() {
 }
 
 # Stop here if sourcing for functions
-[[ "${0%/*}" == "bash" ]] && return 0
+[[ "$0" == *"bash" ]] && return 0
 
 # ===========================================================================
 
@@ -56,7 +56,7 @@ usage() {
 # This only occurs when the JAVA environment variable is set and a Java environment exists in
 # the "standard" location (defined by the openjdk docker images).  This will typically occur in CI
 # builds.  In all other cases, the Java version is taken from the current installation for the user.
-change_java_version $JAVA
+change_java_version "$JAVA"
 
 while (( "$#" ))
 do

--- a/build.sh
+++ b/build.sh
@@ -30,11 +30,10 @@ usage() {
 
 # The two JDKs installed in the uber tool jar.  Ignore if JAVA is not set or
 # the directory doesn't exist.
-((JAVA)) && [[ -d /usr/local/openjdk-${JAVA} ]] && (
-  export JAVA_HOME=/usr/local/openjdk-${JAVA}
-  export PATH=$JAVA_HOME/bin:$PATH
+((JAVA)) && [[ -d /usr/local/openjdk-${JAVA} ]] &&
+  export JAVA_HOME=/usr/local/openjdk-${JAVA} &&
+  export PATH=$JAVA_HOME/bin:$PATH &&
   java -version
-)
 
 while (( "$#" ))
 do

--- a/build.sh
+++ b/build.sh
@@ -15,6 +15,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# ===========================================================================
+# Bash functions that can be used in this script or exported by using
+# source build.sh
+
+change_java_version() {
+  local jdk=$1
+  if ((jdk)) && [[ -d /usr/local/openjdk-${jdk} ]]; then
+    export JAVA_HOME=/usr/local/openjdk-${jdk}
+    export PATH=$JAVA_HOME/bin:$PATH
+    echo "----------------------"
+    echo "Java version switched:"
+  else
+    echo "Using the current Java version:"
+  fi
+  echo "  JAVA_HOME=$JAVA_HOME"
+  echo "  PATH=$PATH"
+  java -version
+}
+
+# Stop here if sourcing for functions
+[[ "${0%/*}" == "bash" ]] && return 0
+
+# ===========================================================================
+
 set -xe
 cd "${0%/*}"
 
@@ -28,12 +52,11 @@ usage() {
 
 (( $# == 0 )) && usage
 
-# Change the JDK from the default if the JAVA environment was set.
-# Only taken into account if the path to JAVA_HOME is in the expected location.
-((JAVA)) && [[ -d /usr/local/openjdk-${JAVA} ]] &&
-  export JAVA_HOME=/usr/local/openjdk-${JAVA} &&
-  export PATH=$JAVA_HOME/bin:$PATH &&
-  java -version
+# Change the JDK from the default.
+# This only occurs when the JAVA environment variable is set and a Java environment exists in
+# the "standard" location (defined by the openjdk docker images).  This will typically occur in CI
+# builds.  In all other cases, the Java version is taken from the current installation for the user.
+change_java_version $JAVA
 
 while (( "$#" ))
 do

--- a/build.sh
+++ b/build.sh
@@ -28,8 +28,8 @@ usage() {
 
 (( $# == 0 )) && usage
 
-# The two JDKs installed in the uber tool jar.  Ignore if JAVA is not set or
-# the directory doesn't exist.
+# Change the JDK from the default if the JAVA environment was set.
+# Only taken into account if the path to JAVA_HOME is in the expected location.
 ((JAVA)) && [[ -d /usr/local/openjdk-${JAVA} ]] &&
   export JAVA_HOME=/usr/local/openjdk-${JAVA} &&
   export PATH=$JAVA_HOME/bin:$PATH &&

--- a/build.sh
+++ b/build.sh
@@ -31,7 +31,7 @@ change_java_version() {
   fi
   echo "  JAVA_HOME=$JAVA_HOME"
   echo "  PATH=$PATH"
-  java -version
+  java -version || true
 }
 
 # Stop here if sourcing for functions

--- a/build.sh
+++ b/build.sh
@@ -31,7 +31,7 @@ change_java_version() {
   fi
   echo "  JAVA_HOME=$JAVA_HOME"
   echo "  PATH=$PATH"
-  java -version || true
+  java -version
 }
 
 # Stop here if sourcing for functions
@@ -52,16 +52,21 @@ usage() {
 
 (( $# == 0 )) && usage
 
-# Change the JDK from the default.
-# This only occurs when the JAVA environment variable is set and a Java environment exists in
-# the "standard" location (defined by the openjdk docker images).  This will typically occur in CI
-# builds.  In all other cases, the Java version is taken from the current installation for the user.
-change_java_version "$JAVA"
-
 while (( "$#" ))
 do
   target="$1"
   shift
+
+  # Change the JDK from the default for all targets that will eventually require Java (or maven).
+  # This only occurs when the JAVA environment variable is set and a Java environment exists in
+  # the "standard" location (defined by the openjdk docker images).  This will typically occur in CI
+  # builds.  In all other cases, the Java version is taken from the current installation for the user.
+  case "$target" in
+    lint|test|dist|clean|veryclean|rat)
+    change_java_version "$JAVA"
+    ;;
+  esac
+
   case "$target" in
 
     lint)

--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -19,7 +19,7 @@
 
 FROM openjdk:8
 WORKDIR /root
-CMD ["/avro/share/docker/run-tests.sh"]
+
 ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=isolemnlysweariamuptonogood \
     DEBIAN_FRONTEND=noninteractive
 

--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -139,3 +139,5 @@ RUN curl -sSLO https://packages.microsoft.com/config/ubuntu/16.04/packages-micro
 # Install Ruby modules
 COPY lang/ruby/Gemfile /tmp
 RUN bundle install --gemfile=/tmp/Gemfile
+
+CMD ["/bin/bash", "-i"]

--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -17,7 +17,8 @@
 # Dockerfile for installing the necessary dependencies for building Avro.
 # See BUILD.txt.
 
-FROM openjdk:8
+# Despite this base, JDK8 is used by default.  See below.
+FROM openjdk:11
 WORKDIR /root
 
 ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=isolemnlysweariamuptonogood \
@@ -47,6 +48,7 @@ RUN apt-get -qqy update \
                                                  libsnappy1v5 \
                                                  make \
                                                  maven \
+                                                 openjdk-8-jdk \
                                                  perl \
                                                  python \
                                                  python-pip \
@@ -139,5 +141,10 @@ RUN curl -sSLO https://packages.microsoft.com/config/ubuntu/16.04/packages-micro
 # Install Ruby modules
 COPY lang/ruby/Gemfile /tmp
 RUN bundle install --gemfile=/tmp/Gemfile
+
+# Use JDK8 by default.
+RUN ln -s /usr/lib/jvm/java-8-openjdk-amd64 /usr/local/openjdk-8
+ENV JAVA_HOME /usr/local/openjdk-8
+ENV PATH $JAVA_HOME/bin:$PATH
 
 CMD ["/bin/bash", "-i"]

--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -142,7 +142,16 @@ RUN curl -sSLO https://packages.microsoft.com/config/ubuntu/16.04/packages-micro
 COPY lang/ruby/Gemfile /tmp
 RUN bundle install --gemfile=/tmp/Gemfile
 
-# Use JDK8 by default.
+# Note: This "ubertool" container has two JDK versions:
+# - OpenJDK 8 (installed as a package and available at /usr/bin/java)
+# - OpenJDK 11 (installed from the base image, and prioritized in the PATH)
+# - The root build.sh script switches between the versions according to 
+#   the JAVA environment variable.
+
+# Since want the JDK8 as a default, we have to re-prepend it to the PATH.
+# The /usr/local/openjdk-8 link is created to be consistent with the
+# openjdk:8 image.
+
 RUN ln -s /usr/lib/jvm/java-8-openjdk-amd64 /usr/local/openjdk-8
 ENV JAVA_HOME /usr/local/openjdk-8
 ENV PATH $JAVA_HOME/bin:$PATH

--- a/share/docker/DockerfileLocal
+++ b/share/docker/DockerfileLocal
@@ -14,8 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Dockerfile for installing the necessary dependencies for building Avro.
-# See BUILD.txt.
+# Dockerfile for installing the Apache Forrest tools for building the
+# Avro site.
+
 FROM avro-build-ci
 
 # Install Forrest in /usr/local/apache-forrest

--- a/share/precommit/buildtest.sh
+++ b/share/precommit/buildtest.sh
@@ -60,3 +60,7 @@ function buildtest_postcompile {
     add_vote_table +1 buildtest "The build has passed"
   done
 }
+
+function buildtest_docker_support {
+  DOCKER_EXTRAARGS+=("--env" "JAVA=$JAVA")
+}

--- a/share/precommit/buildtest.sh
+++ b/share/precommit/buildtest.sh
@@ -22,7 +22,7 @@ VERBOSE=false
 BUILD_FILES=( build.sh )
 
 
-function buildtest_usage {
+buildtest_usage() {
   yetus_add_option "--verbose=<true|false>" "print output to console (default: false)"
 }
 
@@ -37,7 +37,7 @@ function buildtest_usage {
 #   fi
 # }
 
-function buildtest_postcompile {
+buildtest_postcompile() {
   for file in "${BUILD_FILES[@]}"; do
 
     big_console_header "Running ${file}"
@@ -61,6 +61,6 @@ function buildtest_postcompile {
   done
 }
 
-function buildtest_docker_support {
+buildtest_docker_support() {
   DOCKER_EXTRAARGS+=("--env" "JAVA=$JAVA")
 }


### PR DESCRIPTION
It currently takes some manual intervention to create a "local user" docker image based on Java 11.

This PR adds *both* JDK8 (default) and JDK11 to the docker, so the same container can be used to build the two versions.

* Not setting the `JAVA` environment variable will use the java on the path.
* Setting the `JAVA` environment variable will add the JDK to use to the front of the path **inside the main build.sh** script (but only if the JDK is in the expected place).
* The `lang/java/build.sh` always uses the JDK on the path.

*N.B.* The docker image tag that is generated always has the unchanged form `avro-build-rskraba:latest`.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2594
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
