### PR TITLE
AVRO-2615: Fail the Linter when Pycodestyle Fails

### DIFF
--- a/lang/py3/avro/tests/test_datafile.py
+++ b/lang/py3/avro/tests/test_datafile.py
@@ -291,8 +291,7 @@ class TestDataFile(unittest.TestCase):
     """A reader should not fail to read a file consisting of a single empty block."""
     file_path = self.NewTempFile()
     sample_schema = schema.parse(SCHEMAS_TO_VALIDATE[1][0])
-    with datafile.DataFileWriter(open(file_path, 'wb'), io.DatumWriter(),
-        sample_schema) as dfw:
+    with datafile.DataFileWriter(open(file_path, 'wb'), io.DatumWriter(), sample_schema) as dfw:
       dfw.flush()
       # Write an empty block
       dfw.encoder.write_long(0)

--- a/lang/py3/setup.py
+++ b/lang/py3/setup.py
@@ -152,7 +152,7 @@ class LintCommand(setuptools.Command):
         except StopIteration:
             env = None  # pycodestyle is already installed
         try:
-            subprocess.run(['python3', '-m', 'pycodestyle', '.'], env=env)
+            subprocess.run(['python3', '-m', 'pycodestyle', '.'], env=env, check=True)
         except subprocess.CalledProcessError:
             raise distutils.errors.DistutilsError("pycodestyle exited with a nonzero exit code.")
 


### PR DESCRIPTION
### Jira

- [x] This PR addresses [AVRO-2615](https://issues.apache.org/jira/browse/AVRO-2615)
- [x] It is referenced in the PR title.
- [x] It adds no new dependencies.

### Tests

- [x] This PR improves existing static analysis.
- [x] [This TravisCI Failure](https://travis-ci.org/apache/avro/builds/612968452?utm_medium=notification&utm_source=github_status) is expected and demonstrates the correct behavior.

### Commits

- [x] All reference Jira issues in their subject lines.
- [x] Follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)"

### Documentation

- [x] No documentation is needed for this changeset.