### PR TITLE
AVRO-748: Protocol Error Schema Implicit String

### DIFF
--- a/lang/py/src/avro/protocol.py
+++ b/lang/py/src/avro/protocol.py
@@ -169,8 +169,7 @@ class Message(object):
     self._props = {}
     self.set_prop('request', self._parse_request(request, names))
     self.set_prop('response', self._parse_response(response, names))
-    if errors is not None:
-      self.set_prop('errors', self._parse_errors(errors, names))
+    self.set_prop('errors', self._parse_errors(errors or [], names))
 
   # read-only properties
   name = property(lambda self: self._name)

--- a/lang/py/test/test_protocol.py
+++ b/lang/py/test/test_protocol.py
@@ -365,11 +365,21 @@ class TestProtocol(unittest.TestCase):
         if not example.valid:
           num_correct += 1
         else:
-          self.fail("Coudl not parse valid protocol: %s" % (example.name,))
+          self.fail("Could not parse valid protocol: %s" % (example.name,))
 
     fail_msg = "Parse behavior correct on %d out of %d protocols." % \
       (num_correct, len(EXAMPLES))
     self.assertEqual(num_correct, len(EXAMPLES), fail_msg)
+
+  def test_error_schema(self):
+    """Protocol messages should always have at least a string error schema."""
+    for example in EXAMPLES:
+      if not example.valid:
+        continue
+      p = protocol.parse(example.protocol_string)
+      for k, m in p.messages.items():
+        self.assertIsNotNone(m.errors, "Message {} did not have the expected implicit "
+                                       "string error schema.".format(k))
 
   def test_inner_namespace_set(self):
     print('')

--- a/lang/py/test/test_schema.py
+++ b/lang/py/test/test_schema.py
@@ -305,7 +305,7 @@ EXAMPLES += IGNORED_LOGICAL_TYPE
 VALID_EXAMPLES = [e for e in EXAMPLES if e.valid]
 INVALID_EXAMPLES = [e for e in EXAMPLES if not e.valid]
 
-class TestSchema(unittest.TestCase):
+class TestMisc(unittest.TestCase):
   """Miscellaneous tests for schema"""
 
   def test_correct_recursive_extraction(self):
@@ -554,7 +554,7 @@ class OtherAttributesTestCase(unittest.TestCase):
 def load_tests(loader, default_tests, pattern):
   """Generate test cases across many test schema."""
   suite = unittest.TestSuite()
-  suite.addTests(loader.loadTestsFromTestCase(TestSchema))
+  suite.addTests(loader.loadTestsFromTestCase(TestMisc))
   suite.addTests(SchemaParseTestCase(ex) for ex in EXAMPLES)
   suite.addTests(RoundTripParseTestCase(ex) for ex in VALID_EXAMPLES)
   suite.addTests(DocAttributesTestCase(ex) for ex in DOC_EXAMPLES)


### PR DESCRIPTION
### Jira

- [x] Addresses [AVRO-748](https://issues.apache.org/jira/browse/AVRO-748)
- [x] References it in the PR title.
- [x] Adds no dependency

### Tests

- [x] Adds a test to ensure that the effective error schema is never _truly_ `None`
- [x] Refactors the protocol tests so that they aren't invalidated by their own internal error handling, similar to the recent refactor of schema tests.

### Commits

- [x] Reference Jira issues in their subject lines.
- [x] Follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)"

### Documentation

- [x] This is a bugfix for already-documented behavior.
