### PR TITLE
AVRO-2632: Fix Jackson upgrade errors

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/SchemaBuilder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/SchemaBuilder.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import com.fasterxml.jackson.core.util.BufferRecyclers;
+import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import org.apache.avro.Schema.Field;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -2711,11 +2711,11 @@ public class SchemaBuilder {
         bytes.get(data);
         bytes.reset(); // put the buffer back the way we got it
         s = new String(data, StandardCharsets.ISO_8859_1);
-        char[] quoted = BufferRecyclers.getJsonStringEncoder().quoteAsString(s);
+        char[] quoted = JsonStringEncoder.getInstance().quoteAsString(s);
         s = "\"" + new String(quoted) + "\"";
       } else if (o instanceof byte[]) {
         s = new String((byte[]) o, StandardCharsets.ISO_8859_1);
-        char[] quoted = BufferRecyclers.getJsonStringEncoder().quoteAsString(s);
+        char[] quoted = JsonStringEncoder.getInstance().quoteAsString(s);
         s = '\"' + new String(quoted) + '\"';
       } else {
         s = GenericData.get().toString(o);


### PR DESCRIPTION
In this PR, I simply cherry-picked 2b75804d73fa3a8d4d25be2f79aa772f5965bbcd from master.

In [AVRO-2632], I'm trying to determine whether this is the correct approach. The other option I've identified so far is to drop the Jackson version back down to 2.9.9.

[AVRO-2632]: https://issues.apache.org/jira/browse/AVRO-2632