### PR TITLE
AVRO-1880: Futurize Py2 via BytesIO

### DIFF
--- a/lang/py/src/avro/tether/tether_task.py
+++ b/lang/py/src/avro/tether/tether_task.py
@@ -27,7 +27,7 @@ import sys
 import threading
 import traceback
 
-from avro import io as avio
+import avro.io
 from avro import ipc, protocol, schema
 
 __all__ = ["TetherTask", "TaskType", "inputProtocol", "outputProtocol", "HTTPRequestor"]
@@ -88,7 +88,7 @@ class Collector(object):
 
     self.scheme=scheme
 
-    self.datum_writer = avio.DatumWriter(writers_schema=self.scheme)
+    self.datum_writer = avro.io.DatumWriter(writers_schema=self.scheme)
     self.outputClient=outputClient
 
   def collect(self,record,partition=None):
@@ -102,7 +102,7 @@ class Collector(object):
     """
     # Replace the encoder and buffer every time we collect.
     with io.BytesIO() as buff:
-      self.encoder = avio.BinaryEncoder(buff)
+      self.encoder = avro.io.BinaryEncoder(buff)
       self.datum_writer.write(record, self.encoder)
       value = buff.getvalue()
 
@@ -323,11 +323,11 @@ class TetherTask(object):
       outSchema = schema.parse(outSchemaText)
 
       if (taskType==TaskType.MAP):
-        self.inReader=avio.DatumReader(writers_schema=inSchema,readers_schema=self.inschema)
+        self.inReader=avro.io.DatumReader(writers_schema=inSchema,readers_schema=self.inschema)
         self.midCollector=Collector(outSchemaText,self.outputClient)
 
       elif(taskType==TaskType.REDUCE):
-        self.midReader=avio.DatumReader(writers_schema=inSchema,readers_schema=self.midschema)
+        self.midReader=avro.io.DatumReader(writers_schema=inSchema,readers_schema=self.midschema)
         # this.outCollector = new Collector<OUT>(outSchema);
         self.outCollector=Collector(outSchemaText,self.outputClient)
 
@@ -361,9 +361,9 @@ class TetherTask(object):
     count - how many input records are provided in the binary stream
     """
     try:
-      # to avio.BinaryDecoder
+      # to avro.io.BinaryDecoder
       bdata=io.BytesIO(data)
-      decoder = avio.BinaryDecoder(bdata)
+      decoder = avro.io.BinaryDecoder(bdata)
 
       for i in range(count):
         if (self.taskType==TaskType.MAP):

--- a/lang/py/src/avro/tether/tether_task.py
+++ b/lang/py/src/avro/tether/tether_task.py
@@ -20,14 +20,13 @@
 from __future__ import absolute_import, division, print_function
 
 import collections
-import io as pyio
+import io
 import logging
 import os
 import sys
 import threading
 import traceback
-from StringIO import StringIO
-
+import StringIO
 from avro import io as avio
 from avro import ipc, protocol, schema
 
@@ -88,7 +87,9 @@ class Collector(object):
       raise ValueError("output client can't be none.")
 
     self.scheme=scheme
-    self.buff=StringIO()
+    # Some magic bytes-to-unicode switching makes this
+    # hard to replace with io.BytesIO. Help wanted.
+    self.buff=StringIO.StringIO()
     self.encoder=avio.BinaryEncoder(self.buff)
 
     self.datum_writer = avio.DatumWriter(writers_schema=self.scheme)
@@ -374,7 +375,7 @@ class TetherTask(object):
     """
     try:
       # to avio.BinaryDecoder
-      bdata=StringIO(data)
+      bdata=io.BytesIO(data)
       decoder = avio.BinaryDecoder(bdata)
 
       for i in range(count):

--- a/lang/py/src/avro/txipc.py
+++ b/lang/py/src/avro/txipc.py
@@ -19,9 +19,12 @@
 
 from __future__ import absolute_import, division, print_function
 
+import io
+
 from zope.interface import implements
 
-from avro import io, ipc
+import avro.io
+from avro import ipc
 from twisted.internet.defer import Deferred, maybeDeferred
 from twisted.internet.protocol import Protocol
 from twisted.web import resource, server
@@ -29,18 +32,13 @@ from twisted.web.client import Agent
 from twisted.web.http_headers import Headers
 from twisted.web.iweb import IBodyProducer
 
-try:
-  from cStringIO import StringIO
-except ImportError:
-  from StringIO import StringIO
-
 
 class TwistedRequestor(ipc.BaseRequestor):
   """A Twisted-compatible requestor. Returns a Deferred that will fire with the
      returning value, instead of blocking until the request completes."""
   def _process_handshake(self, call_response, message_name, request_datum):
     # process the handshake and call response
-    buffer_decoder = io.BinaryDecoder(StringIO(call_response))
+    buffer_decoder = avro.io.BinaryDecoder(io.BytesIO(call_response))
     call_response_exists = self.read_handshake_response(buffer_decoder)
     if call_response_exists:
       return self.read_call_response(message_name, buffer_decoder)

--- a/lang/py/test/test_script.py
+++ b/lang/py/test/test_script.py
@@ -20,9 +20,9 @@
 from __future__ import absolute_import, division, print_function
 
 import csv
+import io
 import json
 import unittest
-from cStringIO import StringIO
 from operator import itemgetter
 from os import remove
 from os.path import dirname, isfile, join
@@ -110,12 +110,12 @@ class TestCat(unittest.TestCase):
         return len(self._run("--skip", str(skip))) == NUM_RECORDS - skip
 
     def test_csv(self):
-        reader = csv.reader(StringIO(self._run("-f", "csv", raw=True)))
+        reader = csv.reader(io.BytesIO(self._run("-f", "csv", raw=True)))
         assert len(list(reader)) == NUM_RECORDS
 
     def test_csv_header(self):
-        io = StringIO(self._run("-f", "csv", "--header", raw=True))
-        reader = csv.DictReader(io)
+        io_ = io.BytesIO(self._run("-f", "csv", "--header", raw=True))
+        reader = csv.DictReader(io_)
         r = {"type": "duck", "last": "duck", "first": "daffy"}
         assert next(reader) == r
 

--- a/lang/py/test/test_tether_task.py
+++ b/lang/py/test/test_tether_task.py
@@ -19,8 +19,8 @@
 
 from __future__ import absolute_import, division, print_function
 
+import io
 import os
-import StringIO
 import subprocess
 import sys
 import time
@@ -77,7 +77,7 @@ class TestTetherTask(unittest.TestCase):
 
       # Serialize some data so we can send it to the input function
       datum="This is a line of text"
-      writer = StringIO.StringIO()
+      writer = io.BytesIO()
       encoder = avio.BinaryEncoder(writer)
       datum_writer = avio.DatumWriter(task.inschema)
       datum_writer.write(datum, encoder)
@@ -97,7 +97,7 @@ class TestTetherTask(unittest.TestCase):
 
       # Serialize some data so we can send it to the input function
       datum={"key":"word","value":2}
-      writer = StringIO.StringIO()
+      writer = io.BytesIO()
       encoder = avio.BinaryEncoder(writer)
       datum_writer = avio.DatumWriter(task.midschema)
       datum_writer.write(datum, encoder)

--- a/lang/py/test/test_tether_task.py
+++ b/lang/py/test/test_tether_task.py
@@ -26,11 +26,11 @@ import sys
 import time
 import unittest
 
+import avro.io
 import avro.tether.tether_task
 import avro.tether.util
 import mock_tether_parent
 import set_avro_test_path
-from avro import io as avio
 from avro import schema, tether
 from word_count_task import WordCountTask
 
@@ -78,8 +78,8 @@ class TestTetherTask(unittest.TestCase):
       # Serialize some data so we can send it to the input function
       datum="This is a line of text"
       writer = io.BytesIO()
-      encoder = avio.BinaryEncoder(writer)
-      datum_writer = avio.DatumWriter(task.inschema)
+      encoder = avro.io.BinaryEncoder(writer)
+      datum_writer = avro.io.DatumWriter(task.inschema)
       datum_writer.write(datum, encoder)
 
       writer.seek(0)
@@ -98,8 +98,8 @@ class TestTetherTask(unittest.TestCase):
       # Serialize some data so we can send it to the input function
       datum={"key":"word","value":2}
       writer = io.BytesIO()
-      encoder = avio.BinaryEncoder(writer)
-      datum_writer = avio.DatumWriter(task.midschema)
+      encoder = avro.io.BinaryEncoder(writer)
+      datum_writer = avro.io.DatumWriter(task.midschema)
       datum_writer.write(datum, encoder)
 
       writer.seek(0)

--- a/lang/py/test/test_tether_task_runner.py
+++ b/lang/py/test/test_tether_task_runner.py
@@ -27,12 +27,12 @@ import sys
 import time
 import unittest
 
+import avro.io
 import avro.tether.tether_task
 import avro.tether.tether_task_runner
 import avro.tether.util
 import mock_tether_parent
 import set_avro_test_path
-from avro import io as avio
 from word_count_task import WordCountTask
 
 
@@ -80,8 +80,8 @@ class TestTetherTaskRunner(unittest.TestCase):
       # Serialize some data so we can send it to the input function
       datum="This is a line of text"
       writer = io.BytesIO()
-      encoder = avio.BinaryEncoder(writer)
-      datum_writer = avio.DatumWriter(runner.task.inschema)
+      encoder = avro.io.BinaryEncoder(writer)
+      datum_writer = avro.io.DatumWriter(runner.task.inschema)
       datum_writer.write(datum, encoder)
 
       writer.seek(0)
@@ -101,8 +101,8 @@ class TestTetherTaskRunner(unittest.TestCase):
       #Serialize some data so we can send it to the input function
       datum={"key":"word","value":2}
       writer = io.BytesIO()
-      encoder = avio.BinaryEncoder(writer)
-      datum_writer = avio.DatumWriter(runner.task.midschema)
+      encoder = avro.io.BinaryEncoder(writer)
+      datum_writer = avro.io.DatumWriter(runner.task.midschema)
       datum_writer.write(datum, encoder)
 
       writer.seek(0)

--- a/lang/py/test/test_tether_task_runner.py
+++ b/lang/py/test/test_tether_task_runner.py
@@ -19,9 +19,9 @@
 
 from __future__ import absolute_import, division, print_function
 
+import io
 import logging
 import os
-import StringIO
 import subprocess
 import sys
 import time
@@ -79,7 +79,7 @@ class TestTetherTaskRunner(unittest.TestCase):
 
       # Serialize some data so we can send it to the input function
       datum="This is a line of text"
-      writer = StringIO.StringIO()
+      writer = io.BytesIO()
       encoder = avio.BinaryEncoder(writer)
       datum_writer = avio.DatumWriter(runner.task.inschema)
       datum_writer.write(datum, encoder)
@@ -100,7 +100,7 @@ class TestTetherTaskRunner(unittest.TestCase):
 
       #Serialize some data so we can send it to the input function
       datum={"key":"word","value":2}
-      writer = StringIO.StringIO()
+      writer = io.BytesIO()
       encoder = avio.BinaryEncoder(writer)
       datum_writer = avio.DatumWriter(runner.task.midschema)
       datum_writer.write(datum, encoder)


### PR DESCRIPTION
#### Update

The name collision between `io` and `avro.io` is resolved in this codebase. It could still be an issue if a user invokes a python module directly on the command line as in `python lang/py/build/src/avro/tool.py …`. This approach causes python to prepend that path to the pythonpath, which enables the collision. Using `python -m avro.tool …` is a safe alternative. In another pr we may want to consider installing `tool.py` via setuptools' `console_script` entrypoint. However, if we do that, we should probably pick a better name than just "tool".

#### Update

The problem in `avro.tether.tether_task` was resolved by replacing the buffer object each time. This is fine; however, the next problem is the name collision between `io` and `avro.io`.

#### Update

I think I found the root cause of the discrepancy. I still don't understand _why_ it behaves this way, and I have asked about it [on StackOverflow](https://stackoverflow.com/questions/58908593).

#### Context

One of the biggest hurdles to making the lang/py implementation work seamlessly in Python 3 is the differences between how Python 2 and Python 3 handle strings and bytes in streams. In python 2 there were effectively [two implementations](https://docs.python.org/2/library/stringio.html) of these types of streams: `StringIO.StringIO` and `cStringIO.StringIO`. They both handle byte streams, since Python 2 strings are just that.

There is no such thing as a `UnicodeIO` in Python 2, but `StringIO.StringIO` also handles unicode streams. It's confusing and dangerous how it handles both, and I don't understand it.

In Python 3, we use `io.BytesIO` for byte streams, and `io.StringIO` for unicode.

In almost every place avro uses it, it wants a byte stream. So we can replace `StringIO` with `io.BytesIO` and it just works.

Except in `avro.tether.tether_task`. If I replace the `StringIO` in there with `io.BytesIO`, then `test_tether_word_count` will produce a very truncated result instead of the mapping it is supposed to. But if I use `io.StringIO` then the test will fail because the `DatumWriter` actually does want to write bytes to this stream.

I would appreciate any help someone can lend to how to remove this lingering `StringIO.StringIO`, which will not work in Python 3.

### Jira

- [x] Addresses [AVRO-1880](https://issues.apache.org/jira/browse/AVRO-1880)
- [x] References it in the PR title
- [x] Adds no dependencies

### Tests

- [x] Updates existing tests.

### Commits

- [x] Reference Jira issues in their subject lines.
- [x] Follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)"

### Documentation

- [x] Does not require additional documentation yet. (This is incremental compatibility work.)