### PR TITLE
AVRO-1646: Print/parse consistency for nested null namespace

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/Schema.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Schema.java
@@ -1611,9 +1611,7 @@ public abstract class Schema extends JsonProperties implements Serializable {
         if (space == null)
           space = names.space();
         name = new Name(getRequiredText(schema, "name", "No name in schema"), space);
-        if (name.space != null) { // set default namespace
-          names.space(name.space);
-        }
+        names.space(name.space); // set default namespace
       }
       if (PRIMITIVES.containsKey(type)) { // primitive
         result = create(PRIMITIVES.get(type));

--- a/lang/java/ipc/src/test/java/org/apache/avro/TestSchema.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/TestSchema.java
@@ -448,6 +448,16 @@ public class TestSchema {
   }
 
   @Test
+  public void testDeeplyNestedNullNamespace() {
+    Schema inner = new Schema.Parser().parse("{\"type\":\"record\",\"name\":\"Inner\",\"fields\":["
+        + "{\"name\":\"x\",\"type\":{\"type\":\"record\",\"name\":\"Deeper\",\"fields\":["
+        + "{\"name\":\"y\",\"type\":\"int\"}]}}]}");
+    Schema outer = Schema.createRecord("Outer", null, "space", false);
+    outer.setFields(Collections.singletonList(new Field("f", inner, null, null)));
+    assertEquals(outer, new Schema.Parser().parse(outer.toString()));
+  }
+
+  @Test
   public void testNestedNullNamespaceReferencing() {
     Schema inner = new Schema.Parser().parse("{\"type\":\"record\",\"name\":\"Inner\",\"fields\":[]}");
     Schema outer = Schema.createRecord("Outer", null, "space", false);


### PR DESCRIPTION
Fixes print-parse consistency for named types with null namespace,
enclosed in named fields with null namespace, which are themselves
enclosed in named fields with non-null namespace.

Currently, if a type specifies the null namespace, this overrides the
enclosing non-null namespace for the purpose of naming that type, but
not for the purposes of determining the closest enclosing namespace for
more deeply nested types. This fixes that by removing special-casing of
null when setting the default namespace for recursively parsed schemas.

For example:
```json
{
    "type": "record",
    "name": "Outer",
    "space": "space",
    "fields": [
        {
            "name": "f",
            "type": {
                "type": "record",
                "name": "Inner",
                "namespace": "",
                "fields": [
                    {
                        "name": "x",
                        "type": {
                            "type": "record",
                            "name": "Deeper",
                            "fields": [
                                {
                                    "name": "y",
                                    "type": "int"
                                }
                            ]
                        }
                    }
                ]
            }
        }
    ]
}
```
when parsed and re-printed becomes
```
{
  "type": "record",
  "name": "Outer",
  "namespace": "space",
  "fields": [
    {
      "name": "f",
      "type": {
        "type": "record",
        "name": "Inner",
        "namespace": "",
        "fields": [
          {
            "name": "x",
            "type": {
              "type": "record",
              "name": "Deeper",
              "namespace": "space",
              "fields": [
                {
                  "name": "y",
                  "type": "int"
                }
              ]
            }
          }
        ]
      }
    }
  ]
}
```

Adapted from the patch that was submitted with the AVRO-1646 ticket.



### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AVRO-1646

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  - `TestSchema.testDeeplyNestedNullNamespace`

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
