### PR TITLE
AVRO-2639: add option to write Optional only when fields are nullable

### DIFF
--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
@@ -113,6 +113,7 @@ public class SpecificCompiler {
   private FieldVisibility fieldVisibility = FieldVisibility.PRIVATE;
   private boolean createOptionalGetters = false;
   private boolean gettersReturnOptional = false;
+  private boolean gettersReturnOptionalOnlyForNullable = false;
   private boolean createSetters = true;
   private boolean createAllArgsConstructor = true;
   private String outputCharacterEncoding;
@@ -238,7 +239,8 @@ public class SpecificCompiler {
   }
 
   /**
-   * Set to false to not create the getters that return an Optional.
+   * Set to true to create getters of the form
+   * {@code getOptionalFoo<Optional<T>>()}.=
    */
   public void setCreateOptionalGetters(boolean createOptionalGetters) {
     this.createOptionalGetters = createOptionalGetters;
@@ -249,10 +251,25 @@ public class SpecificCompiler {
   }
 
   /**
-   * Set to false to not create the getters that return an Optional.
+   * Set to to true to make the regular getters return Optional. Generated code
+   * will be {@code getFoo<Optional<T>>()}
    */
   public void setGettersReturnOptional(boolean gettersReturnOptional) {
     this.gettersReturnOptional = gettersReturnOptional;
+  }
+
+  public boolean isGettersReturnOptionalOnlyForNullable() {
+    return this.gettersReturnOptionalOnlyForNullable;
+  }
+
+  /**
+   * Set to true to make getters return Optional only if the underlying field in
+   * nullable. Generated code will be either {@code getFoo<T>()} or
+   * {@code getFoo<Optional<T>>()}. This setting only takes effect if
+   * {@link #gettersReturnOptional} is true.
+   */
+  public void setGettersReturnOptionalOnlyForNullable(boolean gettersReturnOptionalOnlyForNullable) {
+    this.gettersReturnOptionalOnlyForNullable = gettersReturnOptionalOnlyForNullable;
   }
 
   /**

--- a/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/record.vm
+++ b/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/record.vm
@@ -209,7 +209,7 @@ static {
   }
 
 #foreach ($field in $schema.getFields())
-#if (${this.gettersReturnOptional})
+#if (${this.gettersReturnOptional} && ((${this.gettersReturnOptionalOnlyForNullable} && ${field.schema().isNullable()}) || !${this.gettersReturnOptionalOnlyForNullable}))
   /**
    * Gets the value of the '${this.mangle($field.name(), $schema.isError())}' field as an Optional<${this.javaType($field.schema())}>.
 #if ($field.doc())      * $field.doc()

--- a/lang/java/compiler/src/test/java/org/apache/avro/compiler/specific/TestSpecificCompiler.java
+++ b/lang/java/compiler/src/test/java/org/apache/avro/compiler/specific/TestSpecificCompiler.java
@@ -699,6 +699,45 @@ public class TestSpecificCompiler {
   }
 
   @Test
+  public void testPojoWithOptionalOnlyWhenNullableCreatedTurnedOn() throws IOException {
+    SpecificCompiler compiler = createCompiler();
+    compiler.setGettersReturnOptional(true);
+    compiler.setGettersReturnOptionalOnlyForNullable(true);
+    compiler.compileToDestination(this.src, OUTPUT_DIR.getRoot());
+    assertTrue(this.outputFile.exists());
+    int optionalFound = 0;
+    try (BufferedReader reader = new BufferedReader(new FileReader(this.outputFile))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        line = line.trim();
+        if (line.contains("Optional")) {
+          optionalFound++;
+        }
+      }
+    }
+    // only the nullable field (four uses of optional) and the import should be
+    // found
+    assertEquals(5, optionalFound);
+  }
+
+  @Test
+  public void testPojoWithOptionalOnlyWhenNullableCreatedTurnedOnAndGettersReturnOptionalTurnedOff()
+      throws IOException {
+    SpecificCompiler compiler = createCompiler();
+    compiler.setGettersReturnOptionalOnlyForNullable(true);
+    compiler.compileToDestination(this.src, OUTPUT_DIR.getRoot());
+    assertTrue(this.outputFile.exists());
+    try (BufferedReader reader = new BufferedReader(new FileReader(this.outputFile))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        line = line.trim();
+        // no optionals since gettersReturnOptionalOnlyForNullable is false
+        assertFalse(line.contains("Optional"));
+      }
+    }
+  }
+
+  @Test
   public void testPojoWithOptionalCreatedWhenOptionalForEverythingTurnedOn() throws IOException {
     SpecificCompiler compiler = createCompiler();
     // compiler.setGettersReturnOptional(true);


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - [AVRO-2639](https://issues.apache.org/jira/browse/AVRO-2639)
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

- `testPojoWithOptionalOnlyWhenNullableCreatedTurnedOn`
- `testPojoWithOptionalOnlyWhenNullableCreatedTurnedOnAndGettersReturnOptionalTurnedOff`

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
