### PR TITLE
AVRO-2640: add useFieldNameForGetter option to SpecficCompiler

### DIFF
--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
@@ -115,6 +115,7 @@ public class SpecificCompiler {
   private boolean gettersReturnOptional = false;
   private boolean createSetters = true;
   private boolean createAllArgsConstructor = true;
+  private boolean useFieldNameForGetter = false;
   private String outputCharacterEncoding;
   private boolean enableDecimalLogicalType = false;
   private String suffix = ".java";
@@ -235,6 +236,18 @@ public class SpecificCompiler {
 
   public boolean isCreateOptionalGetters() {
     return this.createOptionalGetters;
+  }
+
+  /**
+   * set to true to create "getters" without the "get" prefix. The resulting
+   * getter methods will have the same name as fields.
+   */
+  public void setUseFieldNameForGetter(boolean useFieldNameForGetter) {
+    this.useFieldNameForGetter = useFieldNameForGetter;
+  }
+
+  public boolean isUseFieldNameForGetter() {
+    return useFieldNameForGetter;
   }
 
   /**

--- a/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/record.vm
+++ b/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/record.vm
@@ -216,7 +216,11 @@ static {
 #end
    * @return The value wrapped in an Optional&lt;${this.javaType($field.schema())}&gt;.
    */
+#if ($this.isUseFieldNameForGetter())
+  public Optional<${this.javaType($field.schema())}> ${this.mangle($field.name(), $schema.isError())}() {
+#else
   public Optional<${this.javaType($field.schema())}> ${this.generateGetMethod($schema, $field)}() {
+#end
     return Optional.<${this.javaType($field.schema())}>ofNullable(${this.mangle($field.name(), $schema.isError())});
   }
 #else
@@ -226,7 +230,11 @@ static {
 #else   * @return The value of the '${this.mangle($field.name(), $schema.isError())}' field.
 #end
    */
+#if ($this.isUseFieldNameForGetter())
+  public ${this.javaUnbox($field.schema())} ${this.mangle($field.name(), $schema.isError())}() {
+#else
   public ${this.javaUnbox($field.schema())} ${this.generateGetMethod($schema, $field)}() {
+#end
     return ${this.mangle($field.name(), $schema.isError())};
   }
 #end

--- a/lang/java/compiler/src/test/java/org/apache/avro/compiler/specific/TestSpecificCompiler.java
+++ b/lang/java/compiler/src/test/java/org/apache/avro/compiler/specific/TestSpecificCompiler.java
@@ -739,4 +739,64 @@ public class TestSpecificCompiler {
     }
     assertEquals(1, itWorksFound);
   }
+
+  @Test
+  public void testFieldNameForGetter() throws IOException {
+    SpecificCompiler compiler = createCompiler();
+    compiler.setUseFieldNameForGetter(true);
+    compiler.compileToDestination(this.src, this.OUTPUT_DIR.getRoot());
+    assertTrue(this.outputFile.exists());
+    int foundGetter = 0;
+    try (BufferedReader reader = new BufferedReader(new FileReader(this.outputFile))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        // We should find the getter in the main class
+        line = line.trim();
+        if (line.startsWith("public int value()")) {
+          foundGetter++;
+        }
+      }
+    }
+    assertEquals("Found the wrong number of getter", 1, foundGetter);
+  }
+
+  @Test
+  public void testFieldNameForGetterReturnsOptional() throws IOException {
+    SpecificCompiler compiler = createCompiler();
+    compiler.setUseFieldNameForGetter(true);
+    compiler.setGettersReturnOptional(true);
+    compiler.compileToDestination(this.src, this.OUTPUT_DIR.getRoot());
+    assertTrue(this.outputFile.exists());
+    int foundGetter = 0;
+    try (BufferedReader reader = new BufferedReader(new FileReader(this.outputFile))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        // We should find the getter in the main class
+        line = line.trim();
+        if (line.startsWith("public Optional<java.lang.Integer> value()")) {
+          foundGetter++;
+        }
+      }
+    }
+    assertEquals("Found the wrong number of getter", 1, foundGetter);
+  }
+
+  @Test
+  public void testFieldNameForGetterCompiles() throws IOException {
+    SpecificCompiler compiler = createCompiler();
+    compiler.setUseFieldNameForGetter(true);
+    compiler.compileToDestination(this.src, this.OUTPUT_DIR.getRoot());
+    assertTrue(this.outputFile.exists());
+    assertCompilesWithJavaCompiler(new File(OUTPUT_DIR.getRoot(), name.getMethodName()), compiler.compile());
+  }
+
+  @Test
+  public void testFieldNameForGetterReturnsOptionalCompiles() throws IOException {
+    SpecificCompiler compiler = createCompiler();
+    compiler.setUseFieldNameForGetter(true);
+    compiler.setGettersReturnOptional(true);
+    compiler.compileToDestination(this.src, this.OUTPUT_DIR.getRoot());
+    assertTrue(this.outputFile.exists());
+    assertCompilesWithJavaCompiler(new File(OUTPUT_DIR.getRoot(), name.getMethodName()), compiler.compile());
+  }
 }


### PR DESCRIPTION
Adds the useFieldNameForGetter option to SpecificCompiler. When enabled,
SpecificCompile will now use the field names without the 'get' prefix as
the name of the getter for that field.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2640
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

`testFieldNameForGetter`
`testFieldNameForGetterReturnsOptional`
`testFieldNameForGetterCompiles`
`testFieldNameForGetterReturnsOptionalCompiles`

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
