### PR TITLE
AVRO-2641: Fix for SpecificRecord String deserialization

### DIFF
--- a/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/record.vm
+++ b/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/record.vm
@@ -201,7 +201,7 @@ static {
     switch (field$) {
 #set ($i = 0)
 #foreach ($field in $schema.getFields())
-    case $i: ${this.mangle($field.name(), $schema.isError())} = #if(${this.javaType($field.schema())} != "java.lang.Object" && ${this.javaType($field.schema())} != "java.lang.String")(${this.javaType($field.schema())})#{end}value$#if(${this.javaType($field.schema())} == "java.lang.String")!=null?value$.toString():null#{end}; break;
+    case $i: ${this.mangle($field.name(), $schema.isError())} = #if(${this.javaType($field.schema())} != "java.lang.Object" && ${this.javaType($field.schema())} != "java.lang.String")(${this.javaType($field.schema())})#{end}value$#if(${this.javaType($field.schema())} == "java.lang.String") != null ? value$.toString() : null#{end}; break;
 #set ($i = $i + 1)
 #end
     default: throw new org.apache.avro.AvroRuntimeException("Bad index");

--- a/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/record.vm
+++ b/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/record.vm
@@ -201,7 +201,7 @@ static {
     switch (field$) {
 #set ($i = 0)
 #foreach ($field in $schema.getFields())
-    case $i: ${this.mangle($field.name(), $schema.isError())} = #if(${this.javaType($field.schema())} != "java.lang.Object")(${this.javaType($field.schema())})#{end}value$; break;
+    case $i: ${this.mangle($field.name(), $schema.isError())} = #if(${this.javaType($field.schema())} != "java.lang.Object" && ${this.javaType($field.schema())} != "java.lang.String")(${this.javaType($field.schema())})#{end}value$#if(${this.javaType($field.schema())} == "java.lang.String")!=null?value$.toString():null#{end}; break;
 #set ($i = $i + 1)
 #end
     default: throw new org.apache.avro.AvroRuntimeException("Bad index");

--- a/lang/java/tools/src/test/compiler/output-string/avro/examples/baseball/FieldTest.java
+++ b/lang/java/tools/src/test/compiler/output-string/avro/examples/baseball/FieldTest.java
@@ -145,7 +145,7 @@ static {
   public void put(int field$, java.lang.Object value$) {
     switch (field$) {
     case 0: number = (java.lang.Integer)value$; break;
-    case 1: last_name = value$ != null ? value$.toString(): null; break;
+    case 1: last_name = value$ != null ? value$.toString() : null; break;
     case 2: timestamp = (java.time.Instant)value$; break;
     case 3: timestampMicros = (java.time.Instant)value$; break;
     case 4: timeMillis = (java.time.LocalTime)value$; break;
@@ -653,6 +653,7 @@ static {
   }
 
 }
+
 
 
 

--- a/lang/java/tools/src/test/compiler/output-string/avro/examples/baseball/FieldTest.java
+++ b/lang/java/tools/src/test/compiler/output-string/avro/examples/baseball/FieldTest.java
@@ -145,7 +145,7 @@ static {
   public void put(int field$, java.lang.Object value$) {
     switch (field$) {
     case 0: number = (java.lang.Integer)value$; break;
-    case 1: last_name = value$!=null?value$.toString():null; break;
+    case 1: last_name = value$ != null ? value$.toString(): null; break;
     case 2: timestamp = (java.time.Instant)value$; break;
     case 3: timestampMicros = (java.time.Instant)value$; break;
     case 4: timeMillis = (java.time.LocalTime)value$; break;
@@ -653,7 +653,6 @@ static {
   }
 
 }
-
 
 
 

--- a/lang/java/tools/src/test/compiler/output-string/avro/examples/baseball/FieldTest.java
+++ b/lang/java/tools/src/test/compiler/output-string/avro/examples/baseball/FieldTest.java
@@ -145,7 +145,7 @@ static {
   public void put(int field$, java.lang.Object value$) {
     switch (field$) {
     case 0: number = (java.lang.Integer)value$; break;
-    case 1: last_name = (java.lang.String)value$; break;
+    case 1: last_name = value$!=null?value$.toString():null; break;
     case 2: timestamp = (java.time.Instant)value$; break;
     case 3: timestampMicros = (java.time.Instant)value$; break;
     case 4: timeMillis = (java.time.LocalTime)value$; break;

--- a/lang/java/tools/src/test/compiler/output-string/avro/examples/baseball/Player.java
+++ b/lang/java/tools/src/test/compiler/output-string/avro/examples/baseball/Player.java
@@ -117,8 +117,8 @@ public class Player extends org.apache.avro.specific.SpecificRecordBase implemen
   public void put(int field$, java.lang.Object value$) {
     switch (field$) {
     case 0: number = (java.lang.Integer)value$; break;
-    case 1: first_name = (java.lang.String)value$; break;
-    case 2: last_name = (java.lang.String)value$; break;
+    case 1: first_name = value$!=null?value$.toString():null; break;
+    case 2: last_name = value$!=null?value$.toString():null; break;
     case 3: position = (java.util.List<avro.examples.baseball.Position>)value$; break;
     default: throw new org.apache.avro.AvroRuntimeException("Bad index");
     }

--- a/lang/java/tools/src/test/compiler/output-string/avro/examples/baseball/Player.java
+++ b/lang/java/tools/src/test/compiler/output-string/avro/examples/baseball/Player.java
@@ -117,8 +117,8 @@ public class Player extends org.apache.avro.specific.SpecificRecordBase implemen
   public void put(int field$, java.lang.Object value$) {
     switch (field$) {
     case 0: number = (java.lang.Integer)value$; break;
-    case 1: first_name = value$ != null ? value$.toString(): null; break;
-    case 2: last_name = value$!=null?value$.toString():null; break;
+    case 1: first_name = value$ != null ? value$.toString() : null; break;
+    case 2: last_name = value$ != null ? value$.toString() : null; break;
     case 3: position = (java.util.List<avro.examples.baseball.Position>)value$; break;
     default: throw new org.apache.avro.AvroRuntimeException("Bad index");
     }
@@ -583,6 +583,7 @@ public class Player extends org.apache.avro.specific.SpecificRecordBase implemen
     }
   }
 }
+
 
 
 

--- a/lang/java/tools/src/test/compiler/output-string/avro/examples/baseball/Player.java
+++ b/lang/java/tools/src/test/compiler/output-string/avro/examples/baseball/Player.java
@@ -117,7 +117,7 @@ public class Player extends org.apache.avro.specific.SpecificRecordBase implemen
   public void put(int field$, java.lang.Object value$) {
     switch (field$) {
     case 0: number = (java.lang.Integer)value$; break;
-    case 1: first_name = value$!=null?value$.toString():null; break;
+    case 1: first_name = value$ != null ? value$.toString(): null; break;
     case 2: last_name = value$!=null?value$.toString():null; break;
     case 3: position = (java.util.List<avro.examples.baseball.Position>)value$; break;
     default: throw new org.apache.avro.AvroRuntimeException("Bad index");
@@ -583,7 +583,6 @@ public class Player extends org.apache.avro.specific.SpecificRecordBase implemen
     }
   }
 }
-
 
 
 


### PR DESCRIPTION
Changed from casting object to String when schema expects String field. Since Avro can represent Strings in Java as either String, CharSequence or org.apache.avro.util.Utf8, the put can fail with a ClassCastException. By changing from cast to toString() the issue is circumvented.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO-2641) 

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
 Updated existing unit tests to reflect changes.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
