### PR TITLE
AVRO-2592: Avoid consuming ByteBuffer for decimal.

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/Conversions.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Conversions.java
@@ -80,7 +80,7 @@ public class Conversions {
       int scale = ((LogicalTypes.Decimal) type).getScale();
       // always copy the bytes out because BigInteger has no offset/length ctor
       byte[] bytes = new byte[value.remaining()];
-      value.get(bytes);
+      value.duplicate().get(bytes);
       return new BigDecimal(new BigInteger(bytes), scale);
     }
 
@@ -122,7 +122,7 @@ public class Conversions {
   /**
    * Convert a underlying representation of a logical type (such as a ByteBuffer)
    * to a higher level object (such as a BigDecimal).
-   * 
+   *
    * @param datum      The object to be converted.
    * @param schema     The schema of datum. Cannot be null if datum is not null.
    * @param type       The {@link org.apache.avro.LogicalType} of datum. Cannot be
@@ -181,7 +181,7 @@ public class Conversions {
   /**
    * Convert a high level representation of a logical type (such as a BigDecimal)
    * to the its underlying representation object (such as a ByteBuffer)
-   * 
+   *
    * @param datum      The object to be converted.
    * @param schema     The schema of datum. Cannot be null if datum is not null.
    * @param type       The {@link org.apache.avro.LogicalType} of datum. Cannot be

--- a/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericLogicalTypes.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericLogicalTypes.java
@@ -40,6 +40,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
 public class TestGenericLogicalTypes {
 
   @Rule
@@ -142,6 +145,44 @@ public class TestGenericLogicalTypes {
     File test = write(GENERIC, decimalSchema, d1, d2);
     Assert.assertEquals("Should read BigDecimals as fixed", expected,
         read(GenericData.get().createDatumReader(fixedSchema), test));
+  }
+
+  @Test
+  public void testDecimalToFromBytes() throws IOException {
+    LogicalType decimal = LogicalTypes.decimal(9, 2);
+    Schema bytesSchema = Schema.create(Schema.Type.BYTES);
+
+    // Check that the round trip to and from bytes
+    BigDecimal d1 = new BigDecimal("-34.34");
+    BigDecimal d2 = new BigDecimal("117230.00");
+
+    Conversion<BigDecimal> conversion = new Conversions.DecimalConversion();
+
+    ByteBuffer d1bytes = conversion.toBytes(d1, bytesSchema, decimal);
+    ByteBuffer d2bytes = conversion.toBytes(d2, bytesSchema, decimal);
+
+    assertThat(conversion.fromBytes(d1bytes, bytesSchema, decimal), is(d1));
+    assertThat(conversion.fromBytes(d2bytes, bytesSchema, decimal), is(d2));
+
+    assertThat("Ensure ByteBuffer not consumed by conversion", conversion.fromBytes(d1bytes, bytesSchema, decimal),
+        is(d1));
+  }
+
+  @Test
+  public void testDecimalToFromFixed() throws IOException {
+    LogicalType decimal = LogicalTypes.decimal(9, 2);
+    Schema fixedSchema = Schema.createFixed("aFixed", null, null, 4);
+
+    // Check that the round trip to and from fixed data.
+    BigDecimal d1 = new BigDecimal("-34.34");
+    BigDecimal d2 = new BigDecimal("117230.00");
+
+    Conversion<BigDecimal> conversion = new Conversions.DecimalConversion();
+
+    GenericFixed d1fixed = conversion.toFixed(d1, fixedSchema, decimal);
+    GenericFixed d2fixed = conversion.toFixed(d2, fixedSchema, decimal);
+    assertThat(conversion.fromFixed(d1fixed, fixedSchema, decimal), is(d1));
+    assertThat(conversion.fromFixed(d2fixed, fixedSchema, decimal), is(d2));
   }
 
   @Test


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2592
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
