### PR TITLE
AVRO-2644: Non-Deterministic avsc Directory Compilation

### DIFF
--- a/lang/java/tools/src/main/java/org/apache/avro/tool/SpecificCompilerTool.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/SpecificCompilerTool.java
@@ -23,7 +23,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.LinkedHashSet;
@@ -132,8 +135,23 @@ public class SpecificCompilerTool implements Tool {
   }
 
   /**
+   * For an Array of files, sort using {@link String#compareTo(String)} for each
+   * filename.
+   *
+   * @param files Array of File objects to sort
+   * @return the sorted File array
+   */
+  private static File[] sortFiles(File[] files) {
+    Objects.requireNonNull(files, "files cannot be null");
+    Arrays.sort(files, Comparator.comparing(File::getName));
+    return files;
+  }
+
+  /**
    * For a List of files or directories, returns a File[] containing each file
    * passed as well as each file with a matching extension found in the directory.
+   * Each directory is sorted using {@link String#compareTo(String)} for each
+   * filename.
    *
    * @param inputs List of File objects that are files or directories
    * @param filter File extension filter to match on when fetching files from a
@@ -147,7 +165,9 @@ public class SpecificCompilerTool implements Tool {
       // if directory, look at contents to see what files match extension
       if (file.isDirectory()) {
         File[] files = file.listFiles(filter);
-        Collections.addAll(fileSet, files != null ? files : new File[0]);
+        // sort files in directory to compile deterministically
+        // independent of system/ locale
+        Collections.addAll(fileSet, files != null ? sortFiles(files) : new File[0]);
       }
       // otherwise, just add the file.
       else {


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following ticket https://issues.apache.org/jira/browse/AVRO-2644

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Happy to add tests, though would greatly appreciate some guidance as to how. Should I create a new schema directory in `lang/java/tools/src/test/compiler/input`? Should I just test the `sortFiles` function? 

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does

Is there a good place to put this for documentation of the tool itself? In the Usage text? Some other place? 


Thanks! 