### PR TITLE
AVRO-2645: Validate names in schemas in Ruby client

### DIFF
--- a/lang/ruby/lib/avro.rb
+++ b/lang/ruby/lib/avro.rb
@@ -35,11 +35,18 @@ module Avro
 
   class << self
     attr_writer :disable_field_default_validation
+    attr_writer :disable_schema_name_validation
 
     def disable_field_default_validation
       @disable_field_default_validation ||=
         ENV.fetch('AVRO_DISABLE_FIELD_DEFAULT_VALIDATION', '') != ''
     end
+
+    def disable_schema_name_validation
+      @disable_schema_name_validation ||=
+        ENV.fetch('AVRO_DISABLE_SCHEMA_NAME_VALIDATION', '') != ''
+    end
+
   end
 end
 

--- a/lang/ruby/lib/avro/schema.rb
+++ b/lang/ruby/lib/avro/schema.rb
@@ -59,7 +59,7 @@ module Avro
 
         elsif NAMED_TYPES_SYM.include? type_sym
           name = json_obj['name']
-          unless name =~ NAME_REGEX
+          if name !~ NAME_REGEX || name =~ /\.\./ # do not allow multiple periods
             raise SchemaParseError, "Name #{name} is invalid for type #{type}!"
           end
           namespace = json_obj.include?('namespace') ? json_obj['namespace'] : default_namespace

--- a/lang/ruby/lib/avro/schema.rb
+++ b/lang/ruby/lib/avro/schema.rb
@@ -59,7 +59,7 @@ module Avro
 
         elsif NAMED_TYPES_SYM.include? type_sym
           name = json_obj['name']
-          if name !~ NAME_REGEX && !Avro.disable_schema_name_validation
+          if !Avro.disable_schema_name_validation && name !~ NAME_REGEX
             raise SchemaParseError, "Name #{name} is invalid for type #{type}!"
           end
           namespace = json_obj.include?('namespace') ? json_obj['namespace'] : default_namespace

--- a/lang/ruby/lib/avro/schema.rb
+++ b/lang/ruby/lib/avro/schema.rb
@@ -29,7 +29,7 @@ module Avro
     NAMED_TYPES_SYM     = Set.new(NAMED_TYPES.map(&:to_sym))
     VALID_TYPES_SYM     = Set.new(VALID_TYPES.map(&:to_sym))
 
-    NAME_REGEX = /^[A-Za-z_][A-Za-z0-9_.]*$/
+    NAME_REGEX = /^([A-Za-z_][A-Za-z0-9_]*)(\.([A-Za-z_][A-Za-z0-9_]*))*$/
 
     INT_MIN_VALUE = -(1 << 31)
     INT_MAX_VALUE = (1 << 31) - 1
@@ -59,7 +59,7 @@ module Avro
 
         elsif NAMED_TYPES_SYM.include? type_sym
           name = json_obj['name']
-          if name !~ NAME_REGEX || name =~ /\.\./ # do not allow multiple periods
+          if name !~ NAME_REGEX
             raise SchemaParseError, "Name #{name} is invalid for type #{type}!"
           end
           namespace = json_obj.include?('namespace') ? json_obj['namespace'] : default_namespace

--- a/lang/ruby/lib/avro/schema.rb
+++ b/lang/ruby/lib/avro/schema.rb
@@ -29,6 +29,8 @@ module Avro
     NAMED_TYPES_SYM     = Set.new(NAMED_TYPES.map(&:to_sym))
     VALID_TYPES_SYM     = Set.new(VALID_TYPES.map(&:to_sym))
 
+    NAME_REGEX = /^[A-Za-z_][A-Za-z0-9_.]*$/
+
     INT_MIN_VALUE = -(1 << 31)
     INT_MAX_VALUE = (1 << 31) - 1
     LONG_MIN_VALUE = -(1 << 63)
@@ -57,6 +59,9 @@ module Avro
 
         elsif NAMED_TYPES_SYM.include? type_sym
           name = json_obj['name']
+          unless name =~ NAME_REGEX
+            raise SchemaParseError, "Name #{name} is invalid for type #{type}!"
+          end
           namespace = json_obj.include?('namespace') ? json_obj['namespace'] : default_namespace
           case type_sym
           when :fixed

--- a/lang/ruby/lib/avro/schema.rb
+++ b/lang/ruby/lib/avro/schema.rb
@@ -59,7 +59,7 @@ module Avro
 
         elsif NAMED_TYPES_SYM.include? type_sym
           name = json_obj['name']
-          if name !~ NAME_REGEX
+          if name !~ NAME_REGEX && !Avro.disable_schema_name_validation
             raise SchemaParseError, "Name #{name} is invalid for type #{type}!"
           end
           namespace = json_obj.include?('namespace') ? json_obj['namespace'] : default_namespace

--- a/lang/ruby/test/test_schema.rb
+++ b/lang/ruby/test/test_schema.rb
@@ -163,6 +163,18 @@ class TestSchema < Test::Unit::TestCase
     assert_equal '"MissingType" is not a schema we know about.', error.message
   end
 
+  def test_invalid_name
+    error = assert_raise Avro::SchemaParseError do
+      Avro::Schema.parse <<-SCHEMA
+        {"type": "record", "name": "my-invalid-name", "fields": [
+          {"name": "id", "type": "int"}
+        ]}
+      SCHEMA
+    end
+
+    assert_equal "Name my-invalid-name is invalid for type record!", error.message
+  end
+
   def test_to_avro_handles_falsey_defaults
     schema = Avro::Schema.parse <<-SCHEMA
       {"type": "record", "name": "Record", "namespace": "my.name.space",

--- a/lang/ruby/test/test_schema.rb
+++ b/lang/ruby/test/test_schema.rb
@@ -175,6 +175,18 @@ class TestSchema < Test::Unit::TestCase
     assert_equal "Name my-invalid-name is invalid for type record!", error.message
   end
 
+  def test_invalid_name_with_two_periods
+    error = assert_raise Avro::SchemaParseError do
+      Avro::Schema.parse <<-SCHEMA
+        {"type": "record", "name": "my..invalid.name", "fields": [
+          {"name": "id", "type": "int"}
+        ]}
+      SCHEMA
+    end
+
+    assert_equal "Name my..invalid.name is invalid for type record!", error.message
+  end
+
   def test_to_avro_handles_falsey_defaults
     schema = Avro::Schema.parse <<-SCHEMA
       {"type": "record", "name": "Record", "namespace": "my.name.space",

--- a/lang/ruby/test/test_schema.rb
+++ b/lang/ruby/test/test_schema.rb
@@ -187,6 +187,18 @@ class TestSchema < Test::Unit::TestCase
     assert_equal "Name my..invalid.name is invalid for type record!", error.message
   end
 
+  def test_invalid_name_with_validation_disabled
+    Avro.disable_schema_name_validation = true
+    assert_nothing_raised do
+      Avro::Schema.parse <<-SCHEMA
+        {"type": "record", "name": "my-invalid-name", "fields": [
+          {"name": "id", "type": "int"}
+        ]}
+      SCHEMA
+    end
+    Avro.disable_schema_name_validation = false
+  end
+
   def test_to_avro_handles_falsey_defaults
     schema = Avro::Schema.parse <<-SCHEMA
       {"type": "record", "name": "Record", "namespace": "my.name.space",

--- a/lang/ruby/test/test_schema_validator.rb
+++ b/lang/ruby/test/test_schema_validator.rb
@@ -277,7 +277,7 @@ class TestSchema < Test::Unit::TestCase
 
   def test_validate_union_of_nil_and_record_inside_array
     schema = hash_to_schema(
-      name: 'this does not matter',
+      name: 'this_does_not_matter',
       type: 'record',
       fields: [
         {


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2645
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
* Test that invalid names fail schema parsing

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does