### PR TITLE
AVRO-2630: Use apt-get to install perl modules.

### DIFF
--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -107,6 +107,7 @@ RUN apt-get -qqy update \
                                                  libperl-critic-perl \
                                                  libregexp-common-perl \
                                                  libtest-exception-perl \
+                                                 libtest-pod-perl \
                                                  libtry-tiny-perl \
  && apt-get -qqy clean \
  && rm -rf /var/lib/apt/lists
@@ -114,6 +115,7 @@ RUN curl -sSL https://cpanmin.us \
   | perl - --self-upgrade \
  && cpanm --mirror https://www.cpan.org/ install Compress::Zstd \
                                                  Module::Install::Repository \
+                                                 Test::Pod \
  && rm -rf .cpanm
 
 # Install Python packages

--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -96,24 +96,24 @@ RUN curl -sSL https://phar.phpunit.de/phpunit-5.7.phar > /usr/local/bin/phpunit 
  && chmod +x /usr/local/bin/phpunit
 
 # Install Perl modules
+RUN apt-get -qqy update \
+ && apt-get -qqy install --no-install-recommends libcompress-raw-zlib-perl \
+                                                 libencode-perl \
+                                                 libio-string-perl \
+                                                 libjson-xs-perl \
+                                                 libmodule-install-perl \
+                                                 libmodule-install-readmefrompod-perl \
+                                                 libobject-tiny-perl \
+                                                 libperl-critic-perl \
+                                                 libregexp-common-perl \
+                                                 libtest-exception-perl \
+                                                 libtry-tiny-perl \
+ && apt-get -qqy clean \
+ && rm -rf /var/lib/apt/lists
 RUN curl -sSL https://cpanmin.us \
   | perl - --self-upgrade \
- && cpanm --mirror https://www.cpan.org/ install Compress::Zlib \
-                                                 Compress::Zstd \
-                                                 Encode \
-                                                 IO::String \
-                                                 JSON::XS \
-                                                 Math::BigInt \
-                                                 Module::Install \
-                                                 Module::Install::ReadmeFromPod \
+ && cpanm --mirror https://www.cpan.org/ install Compress::Zstd \
                                                  Module::Install::Repository \
-                                                 Object::Tiny \
-                                                 Perl::Critic \
-                                                 Regexp::Common \
-                                                 Test::Exception \
-                                                 Test::More \
-                                                 Test::Pod \
-                                                 Try::Tiny \
  && rm -rf .cpanm
 
 # Install Python packages


### PR DESCRIPTION
**Note**: I separated the perl modules installed via apt-get to be in the "perl" section and close to the CPAN installation.

I checked that all of the modules were available with `perl -e "use Compress::Zlib"` inside the docker.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2630
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: *Non-regression only*

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
