### PR TITLE
AVRO-2070 tolerate any numbers in GenericDatumWriter while writing primitives in java

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/generic/GenericDatumWriter.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/generic/GenericDatumWriter.java
@@ -86,7 +86,7 @@ public class GenericDatumWriter<D> implements DatumWriter<D> {
   /**
    * Convert a high level representation of a logical type (such as a BigDecimal)
    * to the its underlying representation object (such as a ByteBuffer).
-   * 
+   *
    * @throws IllegalArgumentException if a null schema or logicalType is passed in
    *                                  while datum and conversion are not null.
    *                                  Please be noticed that the exception type
@@ -156,13 +156,13 @@ public class GenericDatumWriter<D> implements DatumWriter<D> {
         out.writeInt(((Number) datum).intValue());
         break;
       case LONG:
-        out.writeLong((Long) datum);
+        out.writeLong(((Number) datum).longValue());
         break;
       case FLOAT:
-        out.writeFloat((Float) datum);
+        out.writeFloat(((Number) datum).floatValue());
         break;
       case DOUBLE:
-        out.writeDouble((Double) datum);
+        out.writeDouble(((Number) datum).doubleValue());
         break;
       case BOOLEAN:
         out.writeBoolean((Boolean) datum);

--- a/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericDatumWriter.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericDatumWriter.java
@@ -17,17 +17,6 @@
  */
 package org.apache.avro.generic;
 
-import static org.junit.Assert.*;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.ConcurrentModificationException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.*;
-
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.io.BinaryEncoder;
@@ -36,6 +25,15 @@ import org.apache.avro.io.Encoder;
 import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.util.Utf8;
 import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.*;
+import java.util.concurrent.*;
+
+import static org.junit.Assert.*;
 
 public class TestGenericDatumWriter {
   @Test
@@ -120,6 +118,25 @@ public class TestGenericDatumWriter {
     } catch (ExecutionException ex) {
       assertTrue(ex.getCause() instanceof ConcurrentModificationException);
     }
+  }
+
+  @Test
+  public void testAllowWritingPrimitives() throws IOException {
+    Schema doubleType = Schema.create(Schema.Type.DOUBLE);
+    Schema.Field field = new Schema.Field("double", doubleType);
+    List<Schema.Field> fields = Collections.singletonList(field);
+    Schema schema = Schema.createRecord("test", "doc", "", false, fields);
+
+    GenericRecord record = new GenericData.Record(schema);
+    record.put("double", 456.4);
+    record.put("double", 100000L);
+    record.put("double", 444);
+
+    ByteArrayOutputStream bao = new ByteArrayOutputStream();
+    GenericDatumWriter<GenericRecord> writer = new GenericDatumWriter<>(schema);
+    Encoder encoder = EncoderFactory.get().jsonEncoder(schema, bao);
+
+    writer.write(record, encoder);
   }
 
   static class TestEncoder extends Encoder {

--- a/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericDatumWriter.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericDatumWriter.java
@@ -17,6 +17,19 @@
  */
 package org.apache.avro.generic;
 
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.ConcurrentModificationException;
+import java.util.List;
+import java.util.Collections;
+import java.util.concurrent.*;
+
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.io.BinaryEncoder;
@@ -25,15 +38,6 @@ import org.apache.avro.io.Encoder;
 import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.util.Utf8;
 import org.junit.Test;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.*;
-import java.util.concurrent.*;
-
-import static org.junit.Assert.*;
 
 public class TestGenericDatumWriter {
   @Test


### PR DESCRIPTION

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://jira.apache.org/jira/browse/AVRO-2070) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://jira.apache.org/jira/browse/AVRO-2070
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
