### PR TITLE
AVRO-2647: spec: fix semantics for union types in defaults

### DIFF
--- a/doc/src/content/xdocs/spec.xml
+++ b/doc/src/content/xdocs/spec.xml
@@ -107,8 +107,8 @@
 		  field, used when reading instances that lack this
 		  field (optional).  Permitted values depend on the
 		  field's schema type, according to the table below.
-		  Default values for union fields correspond to the
-		  first schema in the union. Default values for bytes
+		  Values for union types must be compatible
+		  with the first schema in the union. Default values for bytes
 		  and fixed fields are JSON strings, where Unicode
 		  code points 0-255 are mapped to unsigned 8-bit byte
 		  values 0-255.


### PR DESCRIPTION
This PR suggests a change to the spec to clarify things to fix [this JIRA issue](https://issues.apache.org/jira/browse/AVRO-2647).

