### PR TITLE
Allow avro C to be built on musl based systems.

### DIFF
--- a/lang/c/src/avro_generic_internal.h
+++ b/lang/c/src/avro_generic_internal.h
@@ -24,6 +24,8 @@ extern "C" {
 #define CLOSE_EXTERN
 #endif
 
+#include <sys/types.h>
+
 #include "avro/generic.h"
 #include "avro/schema.h"
 #include "avro/value.h"


### PR DESCRIPTION
Currently, the avro C library can not be built for Linux systems based on the [musl standard C library](https://www.musl-libc.org/), which is often used on embedded systems. See the full commit message for more details.

This PR has been tested against the following C libraries, on x86 and arm architectures:
* uClibc
* musl
* glibc

-----
Make sure you have checked _all_ steps below.

### Jira

- My PR does not have an associated JIRA issue

### Tests

- My PR does not add new tests, as it fixes a compilation issue within a particular build environment that is currently not reproducible in Travis

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
