### PR TITLE
AVRO-2652: Use Tox to Enable Multi Python Testing

### DIFF
--- a/lang/py/.gitignore
+++ b/lang/py/.gitignore
@@ -9,3 +9,5 @@ avro/VERSION.txt
 avro/interop.avsc
 avro/tether/InputProtocol.avpr
 avro/tether/OutputProtocol.avpr
+.tox
+dist

--- a/lang/py/MANIFEST.in
+++ b/lang/py/MANIFEST.in
@@ -1,2 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 include avro/*.avsc avro/tether/*.avpr 
 include avro/VERSION.txt avro/LICENSE avro/NOTICE

--- a/lang/py/MANIFEST.in
+++ b/lang/py/MANIFEST.in
@@ -1,0 +1,2 @@
+include avro/*.avsc avro/tether/*.avpr 
+include avro/VERSION.txt avro/LICENSE avro/NOTICE

--- a/lang/py/avro/test/test_script.py
+++ b/lang/py/avro/test/test_script.py
@@ -66,9 +66,9 @@ def looney_records():
 SCRIPT = join(dirname(dirname(dirname(__file__))), "scripts", "avro")
 
 _JSON_PRETTY = '''{
-    "type": "duck",
+    "first": "daffy",
     "last": "duck",
-    "first": "daffy"
+    "type": "duck"
 }'''
 
 def gen_avro(filename):

--- a/lang/py/avro/test/test_tether_task_runner.py
+++ b/lang/py/avro/test/test_tether_task_runner.py
@@ -28,11 +28,11 @@ import time
 import unittest
 
 import avro.io
+import avro.test.mock_tether_parent
+import avro.test.word_count_task
 import avro.tether.tether_task
 import avro.tether.tether_task_runner
 import avro.tether.util
-import avro.test.mock_tether_parent
-import avro.test.word_count_task
 
 
 class TestTetherTaskRunner(unittest.TestCase):

--- a/lang/py/build.sh
+++ b/lang/py/build.sh
@@ -51,7 +51,7 @@ lint() {
 }
 
 test_() {
-  ./setup.py test
+  tox
 }
 
 main() {

--- a/lang/py/build.sh
+++ b/lang/py/build.sh
@@ -40,10 +40,12 @@ dist() {
 
 interop-data-generate() {
   ./setup.py generate_interop_data
-  cp avro/test/interop/data/* ../../build/interop/data/
+  cp -r avro/test/interop/data ../../build/interop
 }
 
 interop-data-test() {
+  mkdir -p avro/test/interop ../../build/interop/data
+  cp -r ../../build/interop/data avro/test/interop
   python -m unittest avro.test.test_datafile_interop
 }
 

--- a/lang/py/build.sh
+++ b/lang/py/build.sh
@@ -40,6 +40,7 @@ dist() {
 
 interop-data-generate() {
   ./setup.py generate_interop_data
+  cp avro/test/interop/data/* ../../build/interop/data/
 }
 
 interop-data-test() {

--- a/lang/py/scripts/avro
+++ b/lang/py/scripts/avro
@@ -52,7 +52,7 @@ def print_json_pretty(row):
     """Pretty print JSON"""
     # Need to work around https://bugs.python.org/issue16333
     # where json.dumps leaves trailing spaces.
-    result = json.dumps(row, indent=4).replace(' \n', '\n')
+    result = json.dumps(row, sort_keys=True, indent=4).replace(' \n', '\n')
     print(result)
 
 _write_row = csv.writer(stdout).writerow

--- a/lang/py/setup.cfg
+++ b/lang/py/setup.cfg
@@ -34,9 +34,14 @@ classifiers =
     Programming Language :: Python :: 2.7 :: Only
 
 [options]
-packages = avro
+packages =
+    avro
+    avro.test
+    avro.tether
 package_dir =
     avro = avro
+    avro.test = avro/test
+    avro.tether = avro/tether
 include_package_data = true
 setup_requires =
   isort
@@ -51,9 +56,12 @@ python_requires = <3.0,>=2.7
 avro =
     HandshakeRequest.avsc
     HandshakeResponse.avsc
-    share/VERSION.txt
+    VERSION.txt
     LICENSE
     NOTICE
+avro.tether =
+    InputProtocol.avpr
+    OutputProtocol.avpr
 
 [options.extras_require]
 snappy = python-snappy

--- a/lang/py/setup.py
+++ b/lang/py/setup.py
@@ -109,8 +109,8 @@ class GenerateInteropDataCommand(setuptools.Command):
 
 def _get_version():
   curdir = os.getcwd()
-  if os.path.isfile("share/VERSION.txt"):
-    version_file = "share/VERSION.txt"
+  if os.path.isfile("avro/VERSION.txt"):
+    version_file = "avro/VERSION.txt"
   else:
     index = curdir.index("lang/py")
     path = curdir[:index]

--- a/lang/py/setup.py
+++ b/lang/py/setup.py
@@ -59,7 +59,7 @@ def _generate_package_data():
     # Create a PEP440 compliant version file.
     version_file_path = os.path.join(share_dir, _VERSION_FILE_NAME)
     with open(version_file_path, 'rb') as vin:
-        version = vin.read().replace('-', '+')
+        version = vin.read().replace(b'-', b'+')
     with open(os.path.join(_AVRO_DIR, _VERSION_FILE_NAME), 'wb') as vout:
         vout.write(version)
 

--- a/lang/py/tox.ini
+++ b/lang/py/tox.ini
@@ -1,0 +1,15 @@
+[tox]
+envlist =
+    py27
+
+[testenv]
+deps =
+    python-snappy
+    zstandard
+whitelist_externals =
+    mkdir
+commands_pre =
+    mkdir -p avro/test/interop/data
+    python -m avro.test.gen_interop_data avro/interop.avsc avro/test/interop/data/py.avro
+commands =
+    python -m unittest discover

--- a/lang/py/tox.ini
+++ b/lang/py/tox.ini
@@ -22,9 +22,12 @@ deps =
     python-snappy
     zstandard
 whitelist_externals =
+    cp
     mkdir
 commands_pre =
-    mkdir -p avro/test/interop/data
+    mkdir -p avro/test/interop {toxinidir}/../../build/interop/data
+    cp -r {toxinidir}/../../build/interop/data avro/test/interop
     python -m avro.test.gen_interop_data avro/interop.avsc avro/test/interop/data/py.avro
+    cp -r avro/test/interop/data {toxinidir}/../../build/interop
 commands =
     python -m unittest discover

--- a/lang/py/tox.ini
+++ b/lang/py/tox.ini
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 [tox]
 envlist =
     py27

--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -64,6 +64,7 @@ RUN apt-get -qqy update \
                                                  ruby-dev \
                                                  source-highlight \
                                                  subversion \
+                                                 tox \
                                                  valgrind \
  && apt-get -qqy clean \
  && rm -rf /var/lib/apt/lists


### PR DESCRIPTION
### Jira

- [x] My PR addresses [AVRO-2652](https://issues.apache.org/jira/browse/AVRO-2652)
- [x] ...and references it in the PR title.
- [x] Adds `tox` as a test meta-runner. [Tox has an MIT license](https://github.com/tox-dev/tox/blob/f1a933b59c2682f40054c0cabe8c1f42a3635168/LICENSE). That license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR changes how we run tests, but doesn't really change the tests.

### Commits

- [x] My commits all reference Jira issues in their subject lines.
- [x] In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)".

### Documentation

- [x] My PR contains no documentation changes because it does not change how the avro implementation functions.