### PR TITLE
AVRO-2654: Use JDK Arrays.copyOf

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/data/RecordBuilderBase.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/data/RecordBuilderBase.java
@@ -73,8 +73,7 @@ public abstract class RecordBuilderBase<T extends IndexedRecord> implements Reco
     this.schema = other.schema;
     this.data = data;
     fields = schema.getFields().toArray(EMPTY_FIELDS);
-    fieldSetFlags = new boolean[other.fieldSetFlags.length];
-    System.arraycopy(other.fieldSetFlags, 0, fieldSetFlags, 0, fieldSetFlags.length);
+    fieldSetFlags = Arrays.copyOf(other.fieldSetFlags, other.fieldSetFlags.length);
   }
 
   /**

--- a/lang/java/avro/src/main/java/org/apache/avro/util/Utf8.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/util/Utf8.java
@@ -18,6 +18,7 @@
 package org.apache.avro.util;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 
 import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.io.BinaryData;
@@ -61,8 +62,7 @@ public class Utf8 implements Comparable<Utf8>, CharSequence {
 
   public Utf8(Utf8 other) {
     this.length = other.length;
-    this.bytes = new byte[other.length];
-    System.arraycopy(other.bytes, 0, this.bytes, 0, this.length);
+    this.bytes = Arrays.copyOf(other.bytes, other.length);
     this.string = other.string;
   }
 
@@ -113,9 +113,7 @@ public class Utf8 implements Comparable<Utf8>, CharSequence {
       throw new AvroRuntimeException("String length " + newLength + " exceeds maximum allowed");
     }
     if (this.bytes.length < newLength) {
-      byte[] newBytes = new byte[newLength];
-      System.arraycopy(bytes, 0, newBytes, 0, this.length);
-      this.bytes = newBytes;
+      this.bytes = Arrays.copyOf(this.bytes, newLength);
     }
     this.length = newLength;
     this.string = null;


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [AVRO-2654](https://issues.apache.org/jira/browse/AVRO/AVRO-2654) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: Does not change functionality

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
