### PR TITLE
AVRO-2657: Fix Python Interop Data Generator

### DIFF
--- a/lang/py/build.sh
+++ b/lang/py/build.sh
@@ -40,6 +40,7 @@ dist() {
 
 interop-data-generate() {
   ./setup.py generate_interop_data
+  cp avro/test/interop/data/* ../../build/interop/data/
 }
 
 interop-data-test() {


### PR DESCRIPTION
### Jira

- [x] My PR addresses [AVRO-2657](https://issues.apache.org/jira/browse/AVRO-2657)
- [x] ...and references it in the PR title.
- [x] ...adds no dependencies.

### Tests

- [x] Fixes where build.sh puts the interop test data generated by Python.

### Commits

- [x] My commits all reference Jira issues in their subject lines.
- [x] My commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)"

### Documentation

- [x] N/A