### PR TITLE
AVRO-2675: Maintain .gitignore and rat exclusions

### DIFF
--- a/lang/c++/.gitignore
+++ b/lang/c++/.gitignore
@@ -5,3 +5,4 @@ test.avro
 test6.df
 test8.df
 test9.df
+test_skip.df

--- a/lang/py/.gitignore
+++ b/lang/py/.gitignore
@@ -9,5 +9,6 @@ avro/VERSION.txt
 avro/interop.avsc
 avro/tether/InputProtocol.avpr
 avro/tether/OutputProtocol.avpr
+avro/test/interop/
 .tox
 dist

--- a/lang/py/build.sh
+++ b/lang/py/build.sh
@@ -29,6 +29,7 @@ clean() {
                  '*.py[co]' \
                  'VERSION.txt' \
                  '__pycache__' \
+                 '.tox' \
                  'avro/test/interop' \
                  'dist' \
                  'userlogs'

--- a/pom.xml
+++ b/pom.xml
@@ -354,6 +354,7 @@
                 <exclude>.travis.yml</exclude>
                 <exclude>BUILD.md</exclude>
                 <exclude>lang/c/src/avro-c.pc.in</exclude>
+                <exclude>lang/csharp/**/bin/Debug/**/Avro.xml</exclude>
                 <exclude>lang/csharp/**/bin/Release/**/Avro.xml</exclude>
                 <exclude>lang/csharp/TestResult.xml</exclude>
                 <exclude>lang/csharp/src/apache/*/obj/**</exclude>
@@ -369,6 +370,7 @@
                 <exclude>lang/perl/inc/Module/Install.pm</exclude>
                 <exclude>lang/perl/inc/Module/Install/*.pm</exclude>
                 <exclude>lang/py/.eggs/**</exclude>
+                <exclude>lang/py/.tox/**</exclude>
                 <exclude>lang/py/build/**</exclude>
                 <exclude>lang/py/dist/**</exclude>
                 <exclude>lang/py/userlogs/**</exclude>


### PR DESCRIPTION
Some of the recent changes in various languages have added / removed temporary files.  It's simpler for local development if the lists of files excluded by git and rat is kept up to date.

To check, after a complete local build, it should be possible to do a `./build.sh rat` without failure, and a `git status` without new files appearing.

This should have no effect on the CI build.

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2675
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
