### PR TITLE
AVRO-2664: Pin Ruby rdoc to <=6.2.0

### DIFF
--- a/lang/ruby/Gemfile
+++ b/lang/ruby/Gemfile
@@ -21,3 +21,6 @@ gem 'snappy'
 gem 'zstd-ruby'
 gem 'test-unit'
 gem 'rubocop'
+
+# rdoc 6.2.1 requires Ruby 2.4+
+gem 'rdoc', '<= 6.2.0'


### PR DESCRIPTION
The CI is broken because of a new release of rdoc, which is being pulled in using a transitive dependency.

Ruby rdoc 6.2.1 has been released which requires Ruby 2.4: https://rubygems.org/gems/rdoc/versions/6.2.1

We would like to contrain this to 6.2.0: https://rubygems.org/gems/rdoc/versions/6.2.0

https://jira.apache.org/jira/browse/AVRO-2664

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
