### PR TITLE
Add support for uuid logical type in C++

### DIFF
--- a/lang/c++/api/LogicalType.hh
+++ b/lang/c++/api/LogicalType.hh
@@ -35,7 +35,8 @@ class AVRO_DECL LogicalType {
         TIME_MICROS,
         TIMESTAMP_MILLIS,
         TIMESTAMP_MICROS,
-        DURATION
+        DURATION,
+        UUID
     };
 
     explicit LogicalType(Type type);

--- a/lang/c++/impl/Compiler.cc
+++ b/lang/c++/impl/Compiler.cc
@@ -368,6 +368,8 @@ static LogicalType makeLogicalType(const Entity& e, const Object& m) {
         t = LogicalType::TIMESTAMP_MICROS;
     else if (typeField == "duration")
         t = LogicalType::DURATION;
+    else if (typeField == "uuid")
+        t = LogicalType::UUID;
     return LogicalType(t);
 }
 

--- a/lang/c++/impl/LogicalType.cc
+++ b/lang/c++/impl/LogicalType.cc
@@ -75,6 +75,9 @@ void LogicalType::printJson(std::ostream& os) const {
     case DURATION:
         os << "\"logicalType\": \"duration\"";
         break;
+    case UUID:
+        os << "\"logicalType\": \"uuid\"";
+        break;
     }
 }
 

--- a/lang/c++/impl/Node.cc
+++ b/lang/c++/impl/Node.cc
@@ -147,6 +147,12 @@ void Node::setLogicalType(LogicalType logicalType) {
                             "FIXED type of size 12");
         }
         break;
+    case LogicalType::UUID:
+        if (type_ != AVRO_STRING) {
+            throw Exception("UUID logical type can only annotate "
+                            "STRING type");
+        }
+        break;
     }
 
     logicalType_ = logicalType;

--- a/lang/c++/test/SchemaTests.cc
+++ b/lang/c++/test/SchemaTests.cc
@@ -212,6 +212,7 @@ const char* roundTripSchemas[] = {
     "{\"type\":\"long\",\"logicalType\":\"timestamp-millis\"}",
     "{\"type\":\"long\",\"logicalType\":\"timestamp-micros\"}",
     "{\"type\":\"fixed\",\"name\":\"test\",\"size\":12,\"logicalType\":\"duration\"}",
+    "{\"type\":\"string\",\"logicalType\":\"uuid\"}",
 
     // namespace with '$' in it.
     "{\"type\":\"record\",\"namespace\":\"a.b$\",\"name\":\"Test\",\"fields\":"
@@ -227,6 +228,7 @@ const char* malformedLogicalTypes[] = {
     "{\"type\":\"string\",\"logicalType\":\"timestamp-millis\"}",
     "{\"type\":\"string\",\"logicalType\":\"timestamp-micros\"}",
     "{\"type\":\"string\",\"logicalType\":\"duration\"}",
+    "{\"type\":\"long\",\"logicalType\":\"uuid\"}",
     // Missing the required field 'precision'.
     "{\"type\":\"bytes\",\"logicalType\":\"decimal\"}",
     // The claimed precision is not supported by the size of the fixed type.
@@ -349,6 +351,10 @@ static void testLogicalTypes()
         \"name\": \"durationType\",\n\
         \"logicalType\": \"duration\"\n\
     }";
+    const char* uuidType = "{\n\
+        \"type\": \"string\",\n\
+        \"logicalType\": \"uuid\"\n\
+    }";
     {
         BOOST_TEST_CHECKPOINT(bytesDecimalType);
         ValidSchema schema1 = compileJsonSchemaFromString(bytesDecimalType);
@@ -426,6 +432,15 @@ static void testLogicalTypes()
         BOOST_CHECK(logicalType.type() == LogicalType::DURATION);
         GenericDatum datum(schema);
         BOOST_CHECK(datum.logicalType().type() == LogicalType::DURATION);
+    }
+    {
+        BOOST_TEST_CHECKPOINT(uuidType);
+        ValidSchema schema = compileJsonSchemaFromString(uuidType);
+        BOOST_CHECK(schema.root()->type() == AVRO_STRING);
+        LogicalType logicalType = schema.root()->logicalType();
+        BOOST_CHECK(logicalType.type() == LogicalType::UUID);
+        GenericDatum datum(schema);
+        BOOST_CHECK(datum.logicalType().type() == LogicalType::UUID);
     }
 }
 


### PR DESCRIPTION
Add support  for UUID logical type in C++ api as defined in Apache Avro 1.9.0 Specification