### PR TITLE
 AVRO-2677: Ruby parse/serialize bytes decimal logical type

### DIFF
--- a/lang/ruby/lib/avro/schema.rb
+++ b/lang/ruby/lib/avro/schema.rb
@@ -412,7 +412,10 @@ module Avro
 
       def to_avro(names=Set.new)
         avro = super
-        avro.is_a?(Hash) ? avro.merge('precision' => precision, 'scale' => scale) : avro
+        props = {}
+        props.merge!('precision' => @precision) if @precision
+        props.merge!('scale' => @scale) if @scale
+        avro.is_a?(Hash) ? avro.merge(props) : avro
       end
     end
 

--- a/lang/ruby/lib/avro/schema.rb
+++ b/lang/ruby/lib/avro/schema.rb
@@ -405,9 +405,7 @@ module Avro
     class BytesDecimalSchema < Schema
       attr_reader :precision, :scale
       def initialize(type, logical_type, precision, scale)
-        # Ensure valid cto args
         super(type.to_sym, logical_type)
-
         @precision = precision
         @scale = scale
       end

--- a/lang/ruby/lib/avro/schema.rb
+++ b/lang/ruby/lib/avro/schema.rb
@@ -407,7 +407,6 @@ module Avro
       def initialize(type, logical_type, precision, scale)
         # Ensure valid cto args
         super(type.to_sym, logical_type)
-        # super(:bytes, name, space, names, nil, logical_type)
 
         @precision = precision
         @scale = scale

--- a/lang/ruby/test/test_schema.rb
+++ b/lang/ruby/test/test_schema.rb
@@ -492,4 +492,25 @@ class TestSchema < Test::Unit::TestCase
     assert_equal('Error validating default for veggies: at . expected type null, got string with value "apple"',
                  exception.to_s)
   end
+
+  def test_bytes_decimal_to_include_precision_scale
+    schema = Avro::Schema.parse <<-SCHEMA
+      {
+        "type": "bytes",
+        "logicalType": "decimal",
+        "precision": 9,
+        "scale": 2
+      }
+    SCHEMA
+
+    schema_hash =
+      {
+        'type' => 'bytes',
+        'logicalType' => 'decimal',
+        'precision' => 9,
+        'scale' => 2
+      }
+
+    assert_equal schema_hash, schema.to_avro
+  end
 end

--- a/lang/ruby/test/test_schema.rb
+++ b/lang/ruby/test/test_schema.rb
@@ -513,4 +513,21 @@ class TestSchema < Test::Unit::TestCase
 
     assert_equal schema_hash, schema.to_avro
   end
+
+  def test_bytes_decimal_to_without_precision_scale
+    schema = Avro::Schema.parse <<-SCHEMA
+      {
+        "type": "bytes",
+        "logicalType": "decimal"
+      }
+    SCHEMA
+
+    schema_hash =
+      {
+        'type' => 'bytes',
+        'logicalType' => 'decimal'
+      }
+
+    assert_equal schema_hash, schema.to_avro
+  end
 end

--- a/lang/ruby/test/test_schema.rb
+++ b/lang/ruby/test/test_schema.rb
@@ -530,4 +530,15 @@ class TestSchema < Test::Unit::TestCase
 
     assert_equal schema_hash, schema.to_avro
   end
+
+  def test_bytes_schema
+    schema = Avro::Schema.parse <<-SCHEMA
+      {
+        "type": "bytes"
+      }
+    SCHEMA
+
+    schema_str = 'bytes'
+    assert_equal schema_str, schema.to_avro
+  end
 end


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2677

### Tests

- [x] My PR adds the following unit tests:
  - `test_bytes_decimal_to_include_precision_scale`
  - `test_bytes_decimal_to_without_precision_scale`
  - `test_bytes_schema`

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
