### PR TITLE
AVRO-2679: Fix Shellcheck Warnings in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -329,7 +329,8 @@ do
     githooks)
       echo "Installing AVRO git hooks."
       cp share/githooks/* .git/hooks
-      find .git/hooks/ -type f ! -name '*sample*' -exec chmod +x {} +
+      chmod +x .git/hooks/*
+      chmod -x .git/hooks/*sample*
       ;;
 
     docker-test)

--- a/build.sh
+++ b/build.sh
@@ -132,24 +132,22 @@ do
       SRC_DIR=avro-src-$VERSION
       DOC_DIR=avro-doc-$VERSION
 
-      rm -rf build/${SRC_DIR}
-      if [ -d .svn ];
-      then
-        svn export --force . build/${SRC_DIR}
-      elif [ -d .git ];
-      then
-        mkdir -p build/${SRC_DIR}
-        git archive HEAD | tar -x -C build/${SRC_DIR}
+      rm -rf "build/${SRC_DIR}"
+      if [ -d .svn ]; then
+        svn export --force . "build/${SRC_DIR}"
+      elif [ -d .git ]; then
+        mkdir -p "build/${SRC_DIR}"
+        git archive HEAD | tar -x -C "build/${SRC_DIR}"
       else
         echo "Not SVN and not GIT .. cannot continue"
-        exit -1;
+        exit 255
       fi
 
       # runs RAT on artifacts
       mvn -N -P rat antrun:run verify
 
       mkdir -p dist
-      (cd build; tar czf ../dist/${SRC_DIR}.tar.gz ${SRC_DIR})
+      (cd build; tar czf "../dist/${SRC_DIR}.tar.gz" "${SRC_DIR}")
 
       # build lang-specific artifacts
 
@@ -168,15 +166,15 @@ do
 
       mkdir -p dist/perl
       (cd lang/perl; ./build.sh dist)
-      cp lang/perl/Avro-$VERSION.tar.gz dist/perl/
+      cp "lang/perl/Avro-$VERSION.tar.gz" dist/perl/
 
       # build docs
       (cd doc; ant)
       # add LICENSE and NOTICE for docs
-      mkdir -p build/$DOC_DIR
-      cp doc/LICENSE build/$DOC_DIR
-      cp doc/NOTICE build/$DOC_DIR
-      (cd build; tar czf ../dist/avro-doc-$VERSION.tar.gz $DOC_DIR)
+      mkdir -p "build/$DOC_DIR"
+      cp doc/LICENSE "build/$DOC_DIR"
+      cp doc/NOTICE "build/$DOC_DIR"
+      (cd build; tar czf "../dist/avro-doc-$VERSION.tar.gz" "$DOC_DIR")
 
       cp DIST_README.txt dist/README.txt
       ;;
@@ -186,7 +184,7 @@ do
 
       echo -n "Enter password: "
       stty -echo
-      read password
+      read -r password
       stty echo
 
       for f in $(find dist -type f \
@@ -194,8 +192,8 @@ do
         \! -name '*.sha512' \! -name '*.sha256' \
         \! -name '*.asc' \! -name '*.txt' );
       do
-        (cd `dirname $f`; shasum -a 512 `basename $f`) > $f.sha512
-        gpg --passphrase $password --armor --output $f.asc --detach-sig $f
+        (cd "${f%/*}" && shasum -a 512 "${f##*/}") > "$f.sha512"
+        gpg --passphrase "$password" --armor --output "$f.asc" --detach-sig "$f"
       done
 
       set -x
@@ -287,8 +285,8 @@ do
       fi
       if [[ "$(uname -s)" = Linux ]]; then
         USER_NAME=${SUDO_USER:=$USER}
-        USER_ID=$(id -u $USER_NAME)
-        GROUP_ID=$(id -g $USER_NAME)
+        USER_ID=$(id -u "$USER_NAME")
+        GROUP_ID=$(id -g "$USER_NAME")
       else # boot2docker uid and gid
         USER_NAME=$USER
         USER_ID=1000
@@ -314,14 +312,14 @@ do
       # down to under 10.  However, editing files from OSX may take a few
       # extra second before the changes are available within the docker container.
       docker run --rm -t -i \
-        --env JAVA=${JAVA:-8} \
-        -v ${PWD}:/home/${USER_NAME}/avro${DOCKER_MOUNT_FLAG} \
-        -w /home/${USER_NAME}/avro \
-        -v ${HOME}/.m2:/home/${USER_NAME}/.m2${DOCKER_MOUNT_FLAG} \
-        -v ${HOME}/.gnupg:/home/${USER_NAME}/.gnupg \
-        -u ${USER_NAME} \
+        --env "JAVA=${JAVA:-8}" \
+        --user "${USER_NAME}" \
+        --volume "${HOME}/.gnupg:/home/${USER_NAME}/.gnupg" \
+        --volume "${HOME}/.m2:/home/${USER_NAME}/.m2${DOCKER_MOUNT_FLAG}" \
+        --volume "${PWD}:/home/${USER_NAME}/avro${DOCKER_MOUNT_FLAG}" \
+        --workdir "/home/${USER_NAME}/avro" \
         ${DOCKER_XTRA_ARGS} \
-        avro-build-${USER_NAME} bash
+        "avro-build-${USER_NAME}" bash
       ;;
 
     rat)
@@ -331,14 +329,13 @@ do
     githooks)
       echo "Installing AVRO git hooks."
       cp share/githooks/* .git/hooks
-      find .git/hooks/ -type f | fgrep -v sample | xargs chmod 755
+      find .git/hooks/ -type f ! -name '*sample*' -exec chmod +x {} +
       ;;
 
     docker-test)
-      tar -cf- share/docker/Dockerfile \
-               lang/ruby/Gemfile |
+      tar -cf- share/docker/Dockerfile lang/ruby/Gemfile |
         docker build -t avro-test -f share/docker/Dockerfile -
-      docker run --rm -v ${PWD}:/avro/ --env JAVA=${JAVA:-8} avro-test /avro/share/docker/run-tests.sh
+      docker run --rm -v "${PWD}:/avro/" --env "JAVA=${JAVA:-8}" avro-test /avro/share/docker/run-tests.sh
       ;;
 
     *)


### PR DESCRIPTION
This change fixes the vast majority of problems identified by shellcheck in the build script. The others will take significantly more effort to fix.

### Jira

- [x] My PR addresses [AVRO-2679](https://issues.apache.org/jira/browse/AVRO-2679).
- [x] My PR title references it.
- [x] My PR adds no dependencies.

### Tests

- [x] My PR does not require additional tests because it uses a static analyzer to advise specific manual changes to fix issues in our build.sh

### Commits

- [x] My commits all reference Jira issues in their subject lines.
- [x] My commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)"

### Documentation

- [x] My PR does not add new functionality.