### PR TITLE
AVRO-2686: Bump jetty.version from 9.4.21.v20190926 to 9.4.25.v20191220

### DIFF
--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -43,7 +43,7 @@
     <jackson.version>2.10.0</jackson.version>
     <jackson.databind.version>2.10.0</jackson.databind.version>
     <servlet-api.version>4.0.1</servlet-api.version>
-    <jetty.version>9.4.24.v20191120</jetty.version>
+    <jetty.version>9.4.25.v20191220</jetty.version>
     <jopt-simple.version>5.0.4</jopt-simple.version>
     <junit.version>4.12</junit.version>
     <netty.version>3.10.6.Final</netty.version>


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

This includes a security fix:
Moderate severity vulnerability that affects org.eclipse.jetty:jetty-server In Eclipse Jetty versions 9.4.21.v20190926, 9.4.22.v20191022, and 9.4.23.v20191118, the generation of default unhandled Error response content (in text/html and text/json Content-Type) does not escape Exception messages in stacktraces included in error output.

Affected versions: = 9.4.21.v20190926

### Jira

- [ ] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2686
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
