### PR TITLE
AVRO-2691: Do Not Cache Empty Array in RecordBuilderBase

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/data/RecordBuilderBase.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/data/RecordBuilderBase.java
@@ -29,7 +29,6 @@ import java.util.Arrays;
 
 /** Abstract base class for RecordBuilder implementations. Not thread-safe. */
 public abstract class RecordBuilderBase<T extends IndexedRecord> implements RecordBuilder<T> {
-  private static final Field[] EMPTY_FIELDS = new Field[0];
   private final Schema schema;
   private final Field[] fields;
   private final boolean[] fieldSetFlags;
@@ -59,7 +58,7 @@ public abstract class RecordBuilderBase<T extends IndexedRecord> implements Reco
   protected RecordBuilderBase(Schema schema, GenericData data) {
     this.schema = schema;
     this.data = data;
-    fields = schema.getFields().toArray(EMPTY_FIELDS);
+    fields = schema.getFields().toArray(new Field[0]);
     fieldSetFlags = new boolean[fields.length];
   }
 
@@ -72,7 +71,7 @@ public abstract class RecordBuilderBase<T extends IndexedRecord> implements Reco
   protected RecordBuilderBase(RecordBuilderBase<T> other, GenericData data) {
     this.schema = other.schema;
     this.data = data;
-    fields = schema.getFields().toArray(EMPTY_FIELDS);
+    fields = schema.getFields().toArray(new Field[0]);
     fieldSetFlags = Arrays.copyOf(other.fieldSetFlags, other.fieldSetFlags.length);
   }
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [AVRO-2691](https://issues.apache.org/jira/browse/AVROAVRO-2691/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2691
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
