### PR TITLE
AVRO-2701: Add JMH BlackHole to RecordTest

### DIFF
--- a/lang/java/perf/src/main/java/org/apache/avro/perf/test/record/RecordTest.java
+++ b/lang/java/perf/src/main/java/org/apache/avro/perf/test/record/RecordTest.java
@@ -33,6 +33,7 @@ import org.openjdk.jmh.annotations.OperationsPerInvocation;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
 
 public class RecordTest {
 
@@ -43,16 +44,23 @@ public class RecordTest {
 
   @Benchmark
   @OperationsPerInvocation(BasicState.BATCH_SIZE)
-  public void decode(final TestStateDecode state) throws Exception {
+  public void decode(final TestStateDecode state, final Blackhole blackHole) throws Exception {
     final Decoder d = state.decoder;
+    double sd = 0.0;
+    int si = 0;
+
     for (int i = 0; i < state.getBatchSize(); i++) {
-      d.readDouble();
-      d.readDouble();
-      d.readDouble();
-      d.readInt();
-      d.readInt();
-      d.readInt();
+      sd += d.readDouble();
+      sd += d.readDouble();
+      sd += d.readDouble();
+
+      si += d.readInt();
+      si += d.readInt();
+      si += d.readInt();
     }
+
+    blackHole.consume(sd);
+    blackHole.consume(si);
   }
 
   @State(Scope.Thread)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [AVRO-2701](https://issues.apache.org/jira/browse/AVRO/AVRO-2701) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2701
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
