### PR TITLE
AVRO-2689:  add reader-schema to DataFileReadTool

### DIFF
--- a/lang/java/tools/src/main/java/org/apache/avro/tool/DataFileReadTool.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/DataFileReadTool.java
@@ -56,10 +56,24 @@ public class DataFileReadTool implements Tool {
     OptionSpec<Void> prettyOption = optionParser.accepts("pretty", "Turns on pretty printing.");
     String headDesc = String.format("Converts the first X records (default is %d).", DEFAULT_HEAD_COUNT);
     OptionSpec<String> headOption = optionParser.accepts("head", headDesc).withOptionalArg();
+    OptionSpec<String> readerSchemaFileOption = optionParser.accepts("reader-schema-file", "Reader schema file")
+        .withOptionalArg().ofType(String.class);
+    OptionSpec<String> readerSchemaOption = optionParser.accepts("reader-schema", "Reader schema").withOptionalArg()
+        .ofType(String.class);
 
     OptionSet optionSet = optionParser.parse(args.toArray(new String[0]));
     Boolean pretty = optionSet.has(prettyOption);
     List<String> nargs = new ArrayList<>((List<String>) optionSet.nonOptionArguments());
+
+    String readerSchemaStr = readerSchemaOption.value(optionSet);
+    String readerSchemaFile = readerSchemaFileOption.value(optionSet);
+
+    Schema readerSchema = null;
+    if (readerSchemaFile != null) {
+      readerSchema = Util.parseSchemaFromFS(readerSchemaFile);
+    } else if (readerSchemaStr != null) {
+      readerSchema = new Schema.Parser().parse(readerSchemaStr);
+    }
 
     long headCount = getHeadCount(optionSet, headOption, nargs);
 
@@ -73,9 +87,12 @@ public class DataFileReadTool implements Tool {
     BufferedInputStream inStream = Util.fileOrStdin(nargs.get(0), stdin);
 
     GenericDatumReader<Object> reader = new GenericDatumReader<>();
+    if (readerSchema != null) {
+      reader.setExpected(readerSchema);
+    }
     try (DataFileStream<Object> streamReader = new DataFileStream<>(inStream, reader)) {
-      Schema schema = streamReader.getSchema();
-      DatumWriter<Object> writer = new GenericDatumWriter<>(schema);
+      Schema schema = readerSchema != null ? readerSchema : streamReader.getSchema();
+      DatumWriter writer = new GenericDatumWriter<>(schema);
       JsonEncoder encoder = EncoderFactory.get().jsonEncoder(schema, out, pretty);
       for (long recordCount = 0; streamReader.hasNext() && recordCount < headCount; recordCount++) {
         Object datum = streamReader.next();

--- a/lang/java/tools/src/test/java/org/apache/avro/tool/TestDataFileTools.java
+++ b/lang/java/tools/src/test/java/org/apache/avro/tool/TestDataFileTools.java
@@ -35,6 +35,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.avro.AvroRuntimeException;
+import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Type;
 import org.apache.avro.file.DataFileReader;
@@ -111,6 +112,27 @@ public class TestDataFileTools {
   @Test
   public void testReadToJsonPretty() throws Exception {
     assertEquals(jsonData, run(new DataFileReadTool(), "--pretty", sampleFile.getPath()));
+  }
+
+  @Test
+  public void testReadWithReaderSchema() throws Exception {
+    assertEquals(jsonData, run(new DataFileReadTool(), "--reader-schema", "\"long\"", sampleFile.getPath()));
+  }
+
+  @Test(expected = AvroTypeException.class)
+  public void testReadWithIncompatibleReaderSchema() throws Exception {
+    // Fails: an int can't be read as a string.
+    run(new DataFileReadTool(), "--reader-schema", "\"string\"", sampleFile.getPath());
+  }
+
+  @Test
+  public void testReadWithReaderSchemaFile() throws Exception {
+    File readerSchemaFile = new File(DIR.getRoot(), "reader-schema-temp.schema");
+    try (FileWriter fw = new FileWriter(readerSchemaFile)) {
+      fw.append("\"long\"");
+    }
+    assertEquals(jsonData,
+        run(new DataFileReadTool(), "--reader-schema-file", readerSchemaFile.getPath(), sampleFile.getPath()));
   }
 
   @Test


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AVRO-2689
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

 - testReadWithReaderSchema
 - testReadWithIncompatibleReaderSchema
 - testReadWithReaderSchemaFile

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
