### PR TITLE
ensure GenericDatumWriter specifies which field triggered an UnresolvedUnionException

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/UnresolvedUnionException.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/UnresolvedUnionException.java
@@ -29,6 +29,12 @@ public class UnresolvedUnionException extends AvroRuntimeException {
     this.unresolvedDatum = unresolvedDatum;
   }
 
+  public UnresolvedUnionException(Schema unionSchema, Schema.Field field, Object unresolvedDatum) {
+    super("Not in union " + unionSchema + ": " + unresolvedDatum + " (field=" + field.name() + ")");
+    this.unionSchema = unionSchema;
+    this.unresolvedDatum = unresolvedDatum;
+  }
+
   public Object getUnresolvedDatum() {
     return unresolvedDatum;
   }

--- a/lang/java/avro/src/main/java/org/apache/avro/generic/GenericDatumWriter.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/generic/GenericDatumWriter.java
@@ -32,6 +32,7 @@ import org.apache.avro.Conversions;
 import org.apache.avro.LogicalType;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field;
+import org.apache.avro.UnresolvedUnionException;
 import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.Encoder;
 
@@ -86,7 +87,7 @@ public class GenericDatumWriter<D> implements DatumWriter<D> {
   /**
    * Convert a high level representation of a logical type (such as a BigDecimal)
    * to the its underlying representation object (such as a ByteBuffer).
-   * 
+   *
    * @throws IllegalArgumentException if a null schema or logicalType is passed in
    *                                  while datum and conversion are not null.
    *                                  Please be noticed that the exception type
@@ -204,6 +205,10 @@ public class GenericDatumWriter<D> implements DatumWriter<D> {
     Object value = data.getField(datum, f.name(), f.pos(), state);
     try {
       write(f.schema(), value, out);
+    } catch (final UnresolvedUnionException uue) { // recreate it with the right field info
+      final UnresolvedUnionException unresolvedUnionException = new UnresolvedUnionException(f.schema(), f, value);
+      unresolvedUnionException.addSuppressed(uue);
+      throw unresolvedUnionException;
     } catch (NullPointerException e) {
       throw npe(e, " in field " + f.name());
     }

--- a/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericDatumWriter.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericDatumWriter.java
@@ -30,6 +30,7 @@ import java.util.concurrent.*;
 
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
+import org.apache.avro.UnresolvedUnionException;
 import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.Encoder;
@@ -38,6 +39,21 @@ import org.apache.avro.util.Utf8;
 import org.junit.Test;
 
 public class TestGenericDatumWriter {
+  @Test
+  public void testUnionUnresolvedExceptionExplicitWhichField() throws IOException {
+    Schema s = schemaWithExplicitNullDefault();
+    GenericRecord r = new GenericData.Record(s);
+    r.put("f", 100);
+    ByteArrayOutputStream bao = new ByteArrayOutputStream();
+    EncoderFactory.get().jsonEncoder(s, bao);
+    try {
+      new GenericDatumWriter<>(s).write(r, EncoderFactory.get().jsonEncoder(s, bao));
+      fail();
+    } catch (final UnresolvedUnionException uue) {
+      assertEquals("Not in union [\"null\",\"string\"]: 100 (field=f)", uue.getMessage());
+    }
+  }
+
   @Test
   public void testWrite() throws IOException {
     String json = "{\"type\": \"record\", \"name\": \"r\", \"fields\": [" + "{ \"name\": \"f1\", \"type\": \"long\" }"


### PR DESCRIPTION
Overall idea is to not log a message which can't be understood (like union string,null: 123 where 123 is an index and not something human readable). It is particularly important when schema are generated or encapsulated.