### PR TITLE
AVRO-2721: Version bump cherry-picks for 1.9.2

### DIFF
--- a/lang/java/grpc/src/main/java/org/apache/avro/grpc/AvroRequestMarshaller.java
+++ b/lang/java/grpc/src/main/java/org/apache/avro/grpc/AvroRequestMarshaller.java
@@ -18,6 +18,7 @@
 
 package org.apache.avro.grpc;
 
+import com.google.common.io.ByteStreams;
 import org.apache.avro.Protocol;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
@@ -34,7 +35,6 @@ import java.io.OutputStream;
 
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
-import io.grpc.internal.IoUtils;
 
 /** Marshaller for Avro RPC request. */
 public class AvroRequestMarshaller implements MethodDescriptor.Marshaller<Object[]> {
@@ -84,7 +84,7 @@ public class AvroRequestMarshaller implements MethodDescriptor.Marshaller<Object
     public int drainTo(OutputStream target) throws IOException {
       int written;
       if (getPartial() != null) {
-        written = (int) IoUtils.copy(getPartial(), target);
+        written = (int) ByteStreams.copy(getPartial(), target);
       } else {
         Schema reqSchema = message.getRequest();
         CountingOutputStream outputStream = new CountingOutputStream(target);

--- a/lang/java/grpc/src/main/java/org/apache/avro/grpc/AvroResponseMarshaller.java
+++ b/lang/java/grpc/src/main/java/org/apache/avro/grpc/AvroResponseMarshaller.java
@@ -18,6 +18,7 @@
 
 package org.apache.avro.grpc;
 
+import com.google.common.io.ByteStreams;
 import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.Protocol;
 import org.apache.avro.io.BinaryDecoder;
@@ -35,7 +36,6 @@ import java.io.OutputStream;
 
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
-import io.grpc.internal.IoUtils;
 
 /** Marshaller for Avro RPC response. */
 public class AvroResponseMarshaller implements MethodDescriptor.Marshaller<Object> {
@@ -88,7 +88,7 @@ public class AvroResponseMarshaller implements MethodDescriptor.Marshaller<Objec
     public int drainTo(OutputStream target) throws IOException {
       int written;
       if (getPartial() != null) {
-        written = (int) IoUtils.copy(getPartial(), target);
+        written = (int) ByteStreams.copy(getPartial(), target);
       } else {
         written = writeResponse(target);
       }

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -46,7 +46,7 @@
     <jopt-simple.version>5.0.4</jopt-simple.version>
     <junit.version>4.12</junit.version>
     <netty.version>3.10.6.Final</netty.version>
-    <protobuf.version>3.6.1</protobuf.version>
+    <protobuf.version>3.11.1</protobuf.version>
     <thrift.version>0.12.0</thrift.version>
     <slf4j.version>1.7.25</slf4j.version>
     <snappy.version>1.1.7.3</snappy.version>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -66,10 +66,10 @@
     <!-- version properties for plugins -->
     <archetype-plugin.version>3.0.1</archetype-plugin.version>
     <bundle-plugin-version>4.1.0</bundle-plugin-version>
-    <compiler-plugin.version>3.8.0</compiler-plugin.version>
+    <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <exec-plugin.version>1.6.0</exec-plugin.version>
     <file-management.version>1.2.1</file-management.version>
-    <jar-plugin.version>3.1.1</jar-plugin.version>
+    <jar-plugin.version>3.1.2</jar-plugin.version>
     <javacc-plugin.version>2.6</javacc-plugin.version>
     <maven-site-plugin.version>3.7.1</maven-site-plugin.version>
     <plugin-plugin.version>3.6.0</plugin-plugin.version>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -50,7 +50,7 @@
     <thrift.version>0.12.0</thrift.version>
     <slf4j.version>1.7.25</slf4j.version>
     <snappy.version>1.1.7.3</snappy.version>
-    <velocity.version>2.0</velocity.version>
+    <velocity.version>2.1</velocity.version>
     <maven.version>2.0.11</maven.version>
     <ant.version>1.10.5</ant.version>
     <commons-cli.version>1.4</commons-cli.version>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -60,7 +60,7 @@
     <easymock.version>4.0.2</easymock.version>
     <hamcrest.version>2.1</hamcrest.version>
     <joda.version>2.10.1</joda.version>
-    <grpc.version>1.19.0</grpc.version>
+    <grpc.version>1.23.0</grpc.version>
     <netty-codec-http2.version>4.1.45.Final</netty-codec-http2.version>
     <zstd-jni.version>1.4.3-1</zstd-jni.version>
     <!-- version properties for plugins -->

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -42,7 +42,7 @@
     <jackson.version>2.10.0</jackson.version>
     <jackson.databind.version>2.10.0</jackson.databind.version>
     <servlet-api.version>4.0.1</servlet-api.version>
-    <jetty.version>9.4.24.v20191120</jetty.version>
+    <jetty.version>9.4.25.v20191220</jetty.version>
     <jopt-simple.version>5.0.4</jopt-simple.version>
     <junit.version>4.12</junit.version>
     <netty.version>3.10.6.Final</netty.version>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -62,8 +62,7 @@
     <joda.version>2.10.1</joda.version>
     <grpc.version>1.19.0</grpc.version>
     <netty-codec-http2.version>4.1.33.Final</netty-codec-http2.version>
-    <zstd-jni.version>1.4.0-1</zstd-jni.version>
-
+    <zstd-jni.version>1.4.3-1</zstd-jni.version>
     <!-- version properties for plugins -->
     <archetype-plugin.version>3.0.1</archetype-plugin.version>
     <bundle-plugin-version>4.1.0</bundle-plugin-version>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -55,7 +55,7 @@
     <ant.version>1.10.5</ant.version>
     <commons-cli.version>1.4</commons-cli.version>
     <commons-compress.version>1.19</commons-compress.version>
-    <commons-lang.version>3.8.1</commons-lang.version>
+    <commons-lang.version>3.9</commons-lang.version>
     <tukaani.version>1.8</tukaani.version>
     <easymock.version>4.0.2</easymock.version>
     <hamcrest.version>2.1</hamcrest.version>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -60,7 +60,7 @@
     <easymock.version>4.0.2</easymock.version>
     <hamcrest.version>2.1</hamcrest.version>
     <joda.version>2.10.1</joda.version>
-    <grpc.version>1.23.0</grpc.version>
+    <grpc.version>1.26.0</grpc.version>
     <netty-codec-http2.version>4.1.45.Final</netty-codec-http2.version>
     <zstd-jni.version>1.4.3-1</zstd-jni.version>
     <!-- version properties for plugins -->

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -61,7 +61,7 @@
     <hamcrest.version>2.1</hamcrest.version>
     <joda.version>2.10.1</joda.version>
     <grpc.version>1.19.0</grpc.version>
-    <netty-codec-http2.version>4.1.33.Final</netty-codec-http2.version>
+    <netty-codec-http2.version>4.1.45.Final</netty-codec-http2.version>
     <zstd-jni.version>1.4.3-1</zstd-jni.version>
     <!-- version properties for plugins -->
     <archetype-plugin.version>3.0.1</archetype-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <maven-plugin-plugin.version>3.6.0</maven-plugin-plugin.version>
     <rat.version>0.13</rat.version>
     <source-plugin.version>3.0.1</source-plugin.version>
-    <spotless-maven-plugin.version>1.25.1</spotless-maven-plugin.version>
+    <spotless-maven-plugin.version>1.27.0</spotless-maven-plugin.version>
   </properties>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>21</version>
+    <version>22</version>
   </parent>
 
   <groupId>org.apache.avro</groupId>


### PR DESCRIPTION
Including the JIRAs that have bumped dependencies in 1.10.0-SNAPSHOT.

This builds on #794 and should be merged afterwards.   Commits in this PR start from `AVRO-2537: Bump zstd-jni from 1.4.0-1 to 1.4.3-1 (#630)`

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-2721: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2721
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

Only includes cherry-picked commits.

### Commits

Only includes cherry-picked commits.

### Documentation

Only includes cherry-picked commits.
