### PR TITLE
AVRO-2299: Normalize Avro Standard Canonical Schema updated latest rebase.

### DIFF
--- a/doc/src/content/xdocs/spec.xml
+++ b/doc/src/content/xdocs/spec.xml
@@ -1310,6 +1310,92 @@
         </ul>
       </section>
 
+      <section>
+        <title>Standard Canonical Form for Schemas</title>
+
+        <p>One of defined way to normalize the avro schema using
+          <em>Standard Canonical Form Transformation</em>. This involves
+          stripping unwanted properties and maintain same canonical
+          ordering. The canonical ordering involves ordering avro
+          reserved properties followed by custom properties if mentioned while
+          transforming. Normalization schema which helps to reduce the
+          total memory size of schema (removed unwanted properties and whitespace)
+          while transfer avro schema between two system and also reduce the parsing
+          time for compatibility check and schema evolution.
+        </p>
+
+        <p><em>Standard Canonical Form</em> is a transformation of a schema
+          into standard canonical ordered. It contains only avro reserved
+          properties <code>"name", "type", "fields", "symbols", "items", "values",
+            "logicalType", "size", "order", "doc", "aliases", "default"</code>
+          and <em>other (custom properties)</em> schema properties.
+        </p>
+
+        <section>
+          <title>Transforming into Standard Canonical Form</title>
+
+          <p>Assuming an input schema (in JSON form) that's already
+            UTF-8 text for a <em>valid</em> Avro schema (including all
+            quotes as required by JSON), the following transformations
+            will produce its Standard Canonical Form:</p>
+          <ul>
+            <li> [PRIMITIVES] Convert primitive schemas to their simple
+              form (e.g., <code>int</code> instead of
+              <code>{"type":"int"}</code>).</li>
+
+            <li> [FULLNAMES] Replace short names with fullnames, using
+              applicable namespaces to do so.  Then eliminate
+              <code>namespace</code> attributes, which are now redundant.</li>
+
+            <li> [STRIP] Keep only attributes that are relevant to
+              reserved properties, which are:
+              <code>type</code>, <code>name</code>,
+              <code>fields</code>, <code>symbols</code>,
+              <code>items</code>, <code>values</code>,
+              <code>logicalType</code>, <code>size</code>,
+              <code>order</code>, <code>doc</code>
+              <code>aliases</code> and <code>default</code>.
+              Strip all others user defined properties (e.g., <code>format</code>).</li>
+
+            <li> [ORDER] Order the appearance of fields of JSON objects
+              as follows: <code>name</code>, <code>type</code>,
+              <code>fields</code>, <code>symbols</code>,
+              <code>items</code>, <code>values</code>,
+              <code>logicalType</code>, <code>size</code>,
+              <code>order</code>, <code>doc</code>,
+              <code>aliases</code>, <code>default</code>.
+              For example, if an object has <code>type</code>,
+              <code>name</code>, and <code>size</code> fields, then the
+              <code>name</code> field should appear first, followed by the
+              <code>type</code> and then the <code>size</code> fields.</li>
+
+            <li> [STRINGS] For all JSON string literals in the schema
+              text, replace any escaped characters (e.g., \uXXXX escapes)
+              with their UTF-8 equivalents.</li>
+
+            <li> [INTEGERS] Eliminate quotes around and any leading
+              zeros in front of JSON integer literals (which appear in the
+              <code>size</code> attributes of <code>fixed</code> schemas).</li>
+
+            <li> [WHITESPACE] Eliminate all whitespace in JSON outside of string literals.</li>
+          </ul>
+        </section>
+
+        <section>
+          <title>Transforming with Custom Properties</title>
+
+          <p>In addition to the standard canonical form transformation, including
+            <em>custom</em> <code>Schema</code> or <code>Field</code> properties by
+            passing the properties names while transforming.
+            For example, if an object has <code>format</code>, <code>type</code>,
+            <code>name</code>, and <code>size</code> fields, then the
+            <code>name</code> field should appear first, followed by the
+            <code>type</code>, <code>size</code> and then <code>format</code>
+            (custom properties) fields.
+          </p>
+        </section>
+      </section>
+
       <section id="schema_fingerprints">
         <title>Schema Fingerprints</title>
 

--- a/lang/java/avro/src/main/java/org/apache/avro/SchemaNormalization.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/SchemaNormalization.java
@@ -17,17 +17,22 @@
  */
 package org.apache.avro;
 
+import org.apache.avro.util.internal.JacksonUtils;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.TreeSet;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
 /**
- * Collection of static methods for generating the canonical form of schemas
- * (see {@link #toParsingForm}) -- and fingerprints of canonical forms
- * ({@link #fingerprint}).
+ * Collection of static methods for generating the parser canonical form of
+ * schemas (see {@link #toParsingForm}), standard canonical form of schemas (see
+ * {@link #toCanonicalForm}) with user defined properties and fingerprints of
+ * canonical forms ({@link #fingerprint}).
  */
 public class SchemaNormalization {
 
@@ -38,9 +43,31 @@ public class SchemaNormalization {
    * Returns "Parsing Canonical Form" of a schema as defined by Avro spec.
    */
   public static String toParsingForm(Schema s) {
+    return toNormalizedForm(s, true, new LinkedHashSet<>());
+  }
+
+  /**
+   * Returns "Standard Canonical Form" of a schema as defined by Avro spec.
+   */
+  public static String toCanonicalForm(Schema s) {
+    return toCanonicalForm(s, new LinkedHashSet<>());
+  }
+
+  /**
+   * Returns "Standard Canonical Form" of a schema as defined by Avro spec with
+   * additional user standard properties.
+   */
+  public static String toCanonicalForm(Schema s, LinkedHashSet<String> properties) {
+    LinkedHashSet<String> reservedProperties = new LinkedHashSet<>(Arrays.asList("name", "type", "fields", "symbols",
+        "items", "values", "logicalType", "size", "order", "doc", "aliases", "default"));
+    properties.removeAll(reservedProperties);
+    return toNormalizedForm(s, false, properties);
+  }
+
+  private static String toNormalizedForm(Schema s, Boolean ps, LinkedHashSet<String> aps) {
     try {
       Map<String, String> env = new HashMap<>();
-      return build(env, s, new StringBuilder()).toString();
+      return build(env, s, new StringBuilder(), ps, aps).toString();
     } catch (IOException e) {
       // Shouldn't happen, b/c StringBuilder can't throw IOException
       throw new RuntimeException(e);
@@ -103,12 +130,19 @@ public class SchemaNormalization {
     return fingerprint64(toParsingForm(s).getBytes(StandardCharsets.UTF_8));
   }
 
-  private static Appendable build(Map<String, String> env, Schema s, Appendable o) throws IOException {
+  private static Appendable build(Map<String, String> env, Schema s, Appendable o, Boolean ps,
+      LinkedHashSet<String> aps) throws IOException {
     boolean firstTime = true;
     Schema.Type st = s.getType();
+    LogicalType lt = null;
+    if (!ps)
+      lt = s.getLogicalType();
     switch (st) {
     default: // boolean, bytes, double, float, int, long, null, string
-      return o.append('"').append(st.getName()).append('"');
+      if (!ps && lt != null)
+        return writeLogicalType(s, lt, o, aps);
+      else
+        return o.append('"').append(st.getName()).append('"');
 
     case UNION:
       o.append('[');
@@ -117,7 +151,7 @@ public class SchemaNormalization {
           o.append(',');
         else
           firstTime = false;
-        build(env, b, o);
+        build(env, b, o, ps, aps);
       }
       return o.append(']');
 
@@ -125,9 +159,11 @@ public class SchemaNormalization {
     case MAP:
       o.append("{\"type\":\"").append(st.getName()).append("\"");
       if (st == Schema.Type.ARRAY)
-        build(env, s.getElementType(), o.append(",\"items\":"));
+        build(env, s.getElementType(), o.append(",\"items\":"), ps, aps);
       else
-        build(env, s.getValueType(), o.append(",\"values\":"));
+        build(env, s.getValueType(), o.append(",\"values\":"), ps, aps);
+      if (!ps)
+        setSimpleProps(o, s.getObjectProps(), aps); // adding the reserved property if not parser canonical schema
       return o.append("}");
 
     case ENUM:
@@ -160,12 +196,63 @@ public class SchemaNormalization {
           else
             firstTime = false;
           o.append("{\"name\":\"").append(f.name()).append("\"");
-          build(env, f.schema(), o.append(",\"type\":")).append("}");
+          build(env, f.schema(), o.append(",\"type\":"), ps, aps);
+          if (!ps)
+            setFieldProps(o, f, aps); // if standard canonical form then add reserved properties
+          o.append("}");
         }
         o.append("]");
       }
+      if (!ps) {
+        setComplexProps(o, s);
+        setSimpleProps(o, s.getObjectProps(), aps);
+      } // adding the reserved property if not parser canonical schema
       return o.append("}");
     }
+  }
+
+  private static Appendable writeLogicalType(Schema s, LogicalType lt, Appendable o, LinkedHashSet<String> aps)
+      throws IOException {
+    o.append("{\"type\":\"").append(s.getType().getName()).append("\"");
+    o.append("\"").append(LogicalType.LOGICAL_TYPE_PROP).append("\":\"").append(lt.getName()).append("\"");
+    if (lt.getName().equals("decimal")) {
+      LogicalTypes.Decimal dlt = (LogicalTypes.Decimal) lt;
+      o.append(",\"precision\":").append(Integer.toString(dlt.getPrecision()));
+      if (dlt.getScale() != 0)
+        o.append(",\"scale\":").append(Integer.toString(dlt.getScale()));
+    }
+    // adding the reserved property
+    setSimpleProps(o, s.getObjectProps(), aps);
+    return o.append("}");
+  }
+
+  private static void setSimpleProps(Appendable o, Map<String, Object> schemaProps, LinkedHashSet<String> aps)
+      throws IOException {
+    for (String propKey : aps) {
+      if (schemaProps.containsKey(propKey)) {
+        String propValue = JacksonUtils.toJsonNode(schemaProps.get(propKey)).toString();
+        o.append(",\"").append(propKey).append("\":").append(propValue);
+      }
+    }
+  }
+
+  private static void setComplexProps(Appendable o, Schema s) throws IOException {
+    if (s.getDoc() != null && !s.getDoc().isEmpty())
+      o.append(",\"doc\":\"").append(s.getDoc()).append("\"");
+    if (s.getAliases() != null && !s.getAliases().isEmpty())
+      o.append(",\"aliases\":").append(JacksonUtils.toJsonNode(new TreeSet<String>(s.getAliases())).toString());
+  }
+
+  private static void setFieldProps(Appendable o, Schema.Field f, LinkedHashSet<String> aps) throws IOException {
+    if (f.order() != null)
+      o.append(",\"order\":\"").append(f.order().toString()).append("\"");
+    if (f.doc() != null)
+      o.append(",\"doc\":\"").append(f.doc()).append("\"");
+    if (!f.aliases().isEmpty())
+      o.append(",\"aliases\":").append(JacksonUtils.toJsonNode(new TreeSet<String>(f.aliases())).toString());
+    if (f.defaultVal() != null)
+      o.append(",\"default\":").append(JacksonUtils.toJsonNode(f.defaultVal()).toString());
+    setSimpleProps(o, f.getObjectProps(), aps);
   }
 
   final static long EMPTY64 = 0xc15d213aa4d7a795L;

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemaNormalization.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemaNormalization.java
@@ -29,6 +29,8 @@ import java.util.ArrayList;
 import java.util.Formatter;
 import java.util.List;
 import java.util.Locale;
+import java.util.LinkedHashSet;
+import java.util.Arrays;
 
 import org.apache.avro.util.CaseFinder;
 import org.junit.Test;
@@ -40,23 +42,114 @@ import org.junit.runners.Parameterized.Parameters;
 @RunWith(Enclosed.class)
 public class TestSchemaNormalization {
 
+  private static String PARSER_DATA_FILE = (System.getProperty("share.dir", "../../../share")
+      + "/test/data/schema-tests.txt");
+
+  private static String STANDARD_CANONICAL_DATA_FILE = (System.getProperty("share.dir", "../../../share")
+      + "/test/data/standard-schema-tests.txt");
+
+  private static String CUSTOM_CANONICAL_DATA_FILE = (System.getProperty("share.dir", "../../../share")
+      + "/test/data/custom-schema-tests.txt");
+
   @RunWith(Parameterized.class)
-  public static class TestCanonical {
+  public static class TestParserCanonicalSchema {
     String input, expectedOutput;
 
-    public TestCanonical(String i, String o) {
+    public TestParserCanonicalSchema(String i, String o) {
       input = i;
       expectedOutput = o;
     }
 
     @Parameters
     public static List<Object[]> cases() throws IOException {
-      return CaseFinder.find(data(), "canonical", new ArrayList<>());
+      return CaseFinder.find(data(PARSER_DATA_FILE), "canonical", new ArrayList<>());
     }
 
     @Test
     public void testCanonicalization() throws Exception {
       assertEquals(SchemaNormalization.toParsingForm(new Schema.Parser().parse(input)), expectedOutput);
+    }
+  }
+
+  @RunWith(Parameterized.class)
+  public static class TestStandardCanonicalSchema {
+    String input, expectedOutput;
+
+    public TestStandardCanonicalSchema(String i, String o) {
+      input = i;
+      expectedOutput = o;
+    }
+
+    @Parameters
+    public static List<Object[]> cases() throws IOException {
+      return CaseFinder.find(data(STANDARD_CANONICAL_DATA_FILE), "canonical", new ArrayList<>());
+    }
+
+    @Test
+    public void testCanonicalization() throws Exception {
+      assertEquals(SchemaNormalization.toCanonicalForm(new Schema.Parser().parse(input)), expectedOutput);
+    }
+  }
+
+  @RunWith(Parameterized.class)
+  public static class TestCustomCanonicalSchema {
+    String input, expectedOutput;
+    LinkedHashSet<String> properties = new LinkedHashSet<>(Arrays.asList("format"));
+
+    public TestCustomCanonicalSchema(String i, String o) {
+      input = i;
+      expectedOutput = o;
+    }
+
+    @Parameters
+    public static List<Object[]> cases() throws IOException {
+      return CaseFinder.find(data(CUSTOM_CANONICAL_DATA_FILE), "canonical", new ArrayList<>());
+    }
+
+    @Test
+    public void testCanonicalization() throws Exception {
+      assertEquals(SchemaNormalization.toCanonicalForm(new Schema.Parser().parse(input), properties), expectedOutput);
+    }
+  }
+
+  @RunWith(Parameterized.class)
+  public static class TestStandardCanonicalSchema {
+    String input, expectedOutput;
+
+    public TestStandardCanonicalSchema(String i, String o) {
+      input = i;
+      expectedOutput = o;
+    }
+
+    @Parameters
+    public static List<Object[]> cases() throws IOException {
+      return CaseFinder.find(data(STANDARD_CANONICAL_DATA_FILE), "canonical", new ArrayList<>());
+    }
+
+    @Test
+    public void testCanonicalization() throws Exception {
+      assertEquals(SchemaNormalization.toCanonicalForm(new Schema.Parser().parse(input)), expectedOutput);
+    }
+  }
+
+  @RunWith(Parameterized.class)
+  public static class TestCustomCanonicalSchema {
+    String input, expectedOutput;
+    LinkedHashSet<String> properties = new LinkedHashSet<>(Arrays.asList("format"));
+
+    public TestCustomCanonicalSchema(String i, String o) {
+      input = i;
+      expectedOutput = o;
+    }
+
+    @Parameters
+    public static List<Object[]> cases() throws IOException {
+      return CaseFinder.find(data(CUSTOM_CANONICAL_DATA_FILE), "canonical", new ArrayList<>());
+    }
+
+    @Test
+    public void testCanonicalization() throws Exception {
+      assertEquals(SchemaNormalization.toCanonicalForm(new Schema.Parser().parse(input), properties), expectedOutput);
     }
   }
 
@@ -71,7 +164,7 @@ public class TestSchemaNormalization {
 
     @Parameters
     public static List<Object[]> cases() throws IOException {
-      return CaseFinder.find(data(), "fingerprint", new ArrayList<>());
+      return CaseFinder.find(data(PARSER_DATA_FILE), "fingerprint", new ArrayList<>());
     }
 
     @Test
@@ -95,7 +188,7 @@ public class TestSchemaNormalization {
 
     @Parameters
     public static List<Object[]> cases() throws IOException {
-      return CaseFinder.find(data(), "fingerprint", new ArrayList<>());
+      return CaseFinder.find(data(PARSER_DATA_FILE), "fingerprint", new ArrayList<>());
     }
 
     @Test
@@ -110,10 +203,8 @@ public class TestSchemaNormalization {
     }
   }
 
-  private static String DATA_FILE = (System.getProperty("share.dir", "../../../share") + "/test/data/schema-tests.txt");
-
-  private static BufferedReader data() throws IOException {
-    return Files.newBufferedReader(Paths.get(DATA_FILE), UTF_8);
+  private static BufferedReader data(String data_file) throws IOException {
+    return Files.newBufferedReader(Paths.get(data_file), UTF_8);
   }
 
   /**

--- a/share/test/data/custom-schema-tests.txt
+++ b/share/test/data/custom-schema-tests.txt
@@ -1,0 +1,99 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+// NOTE: the Java implementation provides a slow-but-direct implementation
+// of the fingerpriting algorithm which is used to cross-check the
+// "fingerprint" values below.  Thus, the Java unit-tests provide validation
+// for these values, so other languages can just assume they are correct.
+
+
+// 01
+<<INPUT
+{ "fields":[{"type":"boolean", "aliases":[], "name":"f1", "default":true},
+            {"order":"descending","name":"f2","doc":"Hello","type":"int", "format": null}],
+  "type":"record", "name":"foo"
+}
+INPUT
+<<canonical {"name":"foo","type":"record","fields":[{"name":"f1","type":"boolean","order":"ASCENDING","default":true},{"name":"f2","type":"int","order":"DESCENDING","doc":"Hello","format":null}]}
+
+// 02
+<<INPUT {"type":"enum", "name":"foo", "symbols":["A1"], "format": null}
+<<canonical {"name":"foo","type":"enum","symbols":["A1"],"format":null}
+
+// 03
+<<INPUT {"namespace":"x.y.z", "type":"enum", "name":"foo", "doc":"foo bar", "symbols":["A1", "A2"], "format": null}
+<<canonical {"name":"x.y.z.foo","type":"enum","symbols":["A1","A2"],"doc":"foo bar","format":null}
+
+// 04
+// <<INPUT {"type":"fixed", "name":"foo", "size":015} -- Avro parser broken???
+<<INPUT {"name":"foo","type":"fixed","size":15, "format": null}
+<<canonical {"name":"foo","type":"fixed","size":15,"format":null}
+
+// 05
+<<INPUT {"namespace":"x.y.z", "type":"fixed", "name":"foo", "doc":"foo bar", "size":32, "format": null}
+<<canonical {"name":"x.y.z.foo","type":"fixed","size":32,"doc":"foo bar","format":null}
+
+// 06
+<<INPUT { "items":{"type":"null"}, "type":"array", "format": null}
+<<canonical {"type":"array","items":"null","format":null}
+
+// 07
+<<INPUT { "values":"string", "type":"map", "format": null}
+<<canonical {"type":"map","values":"string","format":null}
+
+// 08
+<<INPUT
+  {"name":"PigValue","type":"record",
+   "fields":[{"name":"value", "type":["null", "int", "long", "PigValue"], "format": null}]}
+INPUT
+<<canonical {"name":"PigValue","type":"record","fields":[{"name":"value","type":["null","int","long","PigValue"],"order":"ASCENDING","format":null}]}
+
+// 09
+<<INPUT
+  {"name":"PigValue","type":"record","fields":[{"name":"value", "type":"string", "format": "dd-mm-yyyy"}]}
+INPUT
+<<canonical {"name":"PigValue","type":"record","fields":[{"name":"value","type":"string","order":"ASCENDING","format":"dd-mm-yyyy"}]}
+
+// 010
+<<INPUT
+  {"name":"PigValue","type":"record","fields":[{"name":"value", "type":"string", "format": { "key": "value" }}]}
+INPUT
+<<canonical {"name":"PigValue","type":"record","fields":[{"name":"value","type":"string","order":"ASCENDING","format":{"key":"value"}}]}
+
+// 011
+<<INPUT
+  {"name":"PigValue","type":"record","fields":[{"name":"value", "type":"string", "format": { "key": "value" }, "aliases": ["B", "A"]}]}
+INPUT
+<<canonical {"name":"PigValue","type":"record","fields":[{"name":"value","type":"string","order":"ASCENDING","aliases":["A","B"],"format":{"key":"value"}}]}
+
+// 012
+<<INPUT
+  {"namespace":"com.avro","name":"PigValue","type":"record","aliases":["sample", "com.sample.PVal"],"fields":[{"name":"value", "type":"string", "format": { "key": "value" }}]}
+INPUT
+<<canonical {"name":"com.avro.PigValue","type":"record","fields":[{"name":"value","type":"string","order":"ASCENDING","format":{"key":"value"}}],"aliases":["com.avro.sample","com.sample.PVal"]}
+
+// 013
+<<INPUT
+  {"aliases":["sample", "com.sample.PVal"],"name":"PigValue","type":"record","fields":[{"name":"value", "aliases": ["B", "A"], "type":"string", "format": { "key": "value" }}]}
+INPUT
+<<canonical {"name":"PigValue","type":"record","fields":[{"name":"value","type":"string","order":"ASCENDING","aliases":["A","B"],"format":{"key":"value"}}],"aliases":["com.sample.PVal","sample"]}
+
+// 014
+<<INPUT
+  {"namespace":"com.avro","name":"PigValue","type":"record","aliases":["sample", "com.sample.PVal"],"fields":[{"name":"value", "type":"string", "format": { "key": "value" }},{"name":"nested","type":{"type":"record","name":"Nested","fields":[ ],"aliases":["L","A"]}}]}
+INPUT
+<<canonical {"name":"com.avro.PigValue","type":"record","fields":[{"name":"value","type":"string","order":"ASCENDING","format":{"key":"value"}},{"name":"nested","type":{"name":"com.avro.Nested","type":"record","fields":[],"aliases":["com.avro.A","com.avro.L"]},"order":"ASCENDING"}],"aliases":["com.avro.sample","com.sample.PVal"]}
+

--- a/share/test/data/standard-schema-tests.txt
+++ b/share/test/data/standard-schema-tests.txt
@@ -1,0 +1,166 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+// NOTE: the Java implementation provides a slow-but-direct implementation
+// of the fingerpriting algorithm which is used to cross-check the
+// "fingerprint" values below.  Thus, the Java unit-tests provide validation
+// for these values, so other languages can just assume they are correct.
+
+
+// 000
+<<INPUT "null"
+<<canonical "null"
+
+// 001
+<<INPUT {"type":"null"}
+<<canonical "null"
+
+// 002
+<<INPUT "boolean"
+<<canonical "boolean"
+
+// 003
+<<INPUT {"type":"boolean"}
+<<canonical "boolean"
+
+// 004
+<<INPUT "int"
+<<canonical "int"
+
+// 005
+<<INPUT {"type":"int"}
+<<canonical "int"
+
+// 006
+<<INPUT "long"
+<<canonical "long"
+
+// 007
+<<INPUT {"type":"long"}
+<<canonical "long"
+
+// 008
+<<INPUT "float"
+<<canonical "float"
+
+// 009
+<<INPUT {"type":"float"}
+<<canonical "float"
+
+// 010
+<<INPUT "double"
+<<canonical "double"
+
+// 011
+<<INPUT {"type":"double"}
+<<canonical "double"
+
+// 012
+<<INPUT "bytes"
+<<canonical "bytes"
+
+// 013
+<<INPUT {"type":"bytes"}
+<<canonical "bytes"
+
+// 014
+<<INPUT "string"
+<<canonical "string"
+
+// 015
+<<INPUT {"type":"string"}
+<<canonical "string"
+
+// 016
+<<INPUT [  ]
+<<canonical []
+
+// 017
+<<INPUT [ "int"  ]
+<<canonical ["int"]
+
+// 018
+<<INPUT [ "int" , {"type":"boolean"} ]
+<<canonical ["int","boolean"]
+
+// 019
+<<INPUT {"fields":[], "type":"record", "name":"foo"}
+<<canonical {"name":"foo","type":"record","fields":[]}
+
+// 020
+<<INPUT {"fields":[], "type":"record", "name":"foo", "namespace":"x.y"}
+<<canonical {"name":"x.y.foo","type":"record","fields":[]}
+
+// 021
+<<INPUT {"fields":[], "type":"record", "name":"a.b.foo", "namespace":"x.y"}
+<<canonical {"name":"a.b.foo","type":"record","fields":[]}
+
+// 022
+<<INPUT {"fields":[], "type":"record", "name":"foo", "doc":"Useful info"}
+<<canonical {"name":"foo","type":"record","fields":[],"doc":"Useful info"}
+
+// 023
+<<INPUT {"fields":[], "type":"record", "name":"foo", "aliases":["foo","bar"]}
+<<canonical {"name":"foo","type":"record","fields":[],"aliases":["bar","foo"]}
+
+// 024
+<<INPUT {"fields":[], "type":"record", "name":"foo", "doc":"foo", "aliases":["foo","bar"]}
+<<canonical {"name":"foo","type":"record","fields":[],"doc":"foo","aliases":["bar","foo"]}
+
+// 025
+<<INPUT {"fields":[{"type":{"type":"boolean"}, "name":"f1"}], "type":"record", "name":"foo"}
+<<canonical {"name":"foo","type":"record","fields":[{"name":"f1","type":"boolean","order":"ASCENDING"}]}
+
+// 026
+<<INPUT
+{ "fields":[{"type":"boolean", "aliases":[], "name":"f1", "default":true},
+            {"order":"descending","name":"f2","doc":"Hello","type":"int"}],
+  "type":"record", "name":"foo"
+}
+INPUT
+<<canonical {"name":"foo","type":"record","fields":[{"name":"f1","type":"boolean","order":"ASCENDING","default":true},{"name":"f2","type":"int","order":"DESCENDING","doc":"Hello"}]}
+
+// 027
+<<INPUT {"type":"enum", "name":"foo", "symbols":["A1"]}
+<<canonical {"name":"foo","type":"enum","symbols":["A1"]}
+
+// 028
+<<INPUT {"namespace":"x.y.z", "type":"enum", "name":"foo", "doc":"foo bar", "symbols":["A1", "A2"]}
+<<canonical {"name":"x.y.z.foo","type":"enum","symbols":["A1","A2"],"doc":"foo bar"}
+
+// 029
+// <<INPUT {"type":"fixed", "name":"foo", "size":015} -- Avro parser broken???
+<<INPUT {"name":"foo","type":"fixed","size":15}
+<<canonical {"name":"foo","type":"fixed","size":15}
+
+// 030
+<<INPUT {"namespace":"x.y.z", "type":"fixed", "name":"foo", "doc":"foo bar", "size":32}
+<<canonical {"name":"x.y.z.foo","type":"fixed","size":32,"doc":"foo bar"}
+
+// 031
+<<INPUT { "items":{"type":"null"}, "type":"array"}
+<<canonical {"type":"array","items":"null"}
+
+// 032
+<<INPUT { "values":"string", "type":"map"}
+<<canonical {"type":"map","values":"string"}
+
+// 033
+<<INPUT
+  {"name":"PigValue","type":"record",
+   "fields":[{"name":"value", "type":["null", "int", "long", "PigValue"]}]}
+INPUT
+<<canonical {"name":"PigValue","type":"record","fields":[{"name":"value","type":["null","int","long","PigValue"],"order":"ASCENDING"}]}


### PR DESCRIPTION

### Jira

This is new feature in JAVA component to normalise the Avro schema using canonical order and get the avro schema with reserved properties. The canonical form of schema should follow the below rules,

- Canonical normaliser should filter and order the reserved as well as user given properties.
User able to normalise schema with additional user defined logical types.
reserved avro property ordering as below, followed by user given properties.
 - JIRA issue : https://issues.apache.org/jira/browse/AVRO-2299
 - No additional dependency changes.
 - Normalisation new feature for Java only.

### Tests

- New unit test included  in the file lang/java/avro/src/test/java/org/apache/avro/TestSchemaNormalization.java

### Documentation

- Updated spec.xml
- Updated java documentation.


### Reference discussion:
- https://github.com/apache/avro/pull/452
- https://issues.apache.org/jira/browse/AVRO-2299

Sending to Review : @cutting  , @tjwp , @Fokko 