### PR TITLE
AVRO-2732 / AVRO-2733 Fix master build on CI.

### DIFF
--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -24,6 +24,8 @@ WORKDIR /root
 ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=isolemnlysweariamuptonogood \
     DEBIAN_FRONTEND=noninteractive
 
+RUN echo 'deb http://deb.debian.org/debian sid main' > /etc/apt/sources.list.d/openjdk8.list
+
 # Install dependencies from vanilla system packages
 RUN apt-get -qqy update \
  && apt-get -qqy install --no-install-recommends ant \

--- a/share/test/interop/bin/test_rpc_interop.sh
+++ b/share/test/interop/bin/test_rpc_interop.sh
@@ -34,7 +34,7 @@ py3_tool() {
 }
 
 ruby_tool() {
-  ruby -rubygems -Ilang/ruby/lib lang/ruby/test/tool.rb "$@"
+  ruby -Ilang/ruby/lib lang/ruby/test/tool.rb "$@"
 }
 
 proto=share/test/schemas/simple.avpr


### PR DESCRIPTION
The recent bump in the openjdk images causes some breakage in the travis-ci build.

I've included two independent fixes in this PR (both should be necessary), but I'm specifically not pleased with the first one (importing openjdk-8-jdk from the unstable)...

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2732
  - https://issues.apache.org/jira/browse/AVRO-2733
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

The test will be seeing the build pass!

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
