### PR TITLE
AVRO-2737: Fix pycodestyle regression.

### DIFF
--- a/lang/py3/setup.py
+++ b/lang/py3/setup.py
@@ -38,8 +38,6 @@ import subprocess
 
 import setuptools
 
-import pycodestyle
-
 _HERE = os.path.dirname(os.path.abspath(__file__))
 _AVRO_DIR = os.path.join(_HERE, 'avro')
 _VERSION_FILE_NAME = 'VERSION.txt'


### PR DESCRIPTION
There was a regression / cherry-pick error in the avro-python3 1.9.2 release with this unused import.  There is no issue to fix on master.

The artifact was republished as avro-python3 1.9.2.1 with this change applied manually, and it should definitely be applied to future releases on this branch (if any).

N.B. the avro-python3 1.9.2.1 release is source-identical to the signed 1.9.2 code; just the `setup.py` was fixed to install the module correctly via pip.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2737
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
