### PR TITLE
AVRO-2741: Fix Protocol.fullname Crash

### DIFF
--- a/lang/py/avro/protocol.py
+++ b/lang/py/avro/protocol.py
@@ -113,16 +113,37 @@ class Protocol(object):
     self._md5 = hashlib.md5(str(self).encode()).digest()
 
   # read-only properties
-  name = property(lambda self: self.get_prop('name'))
-  namespace = property(lambda self: self.get_prop('namespace'))
-  fullname = property(lambda self:
-                      avro.schema.Name(self.name, self.namespace).fullname)
-  types = property(lambda self: self.get_prop('types'))
-  types_dict = property(lambda self: dict([(type.name, type)
-                                           for type in self.types]))
-  messages = property(lambda self: self.get_prop('messages'))
-  md5 = property(lambda self: self._md5)
-  props = property(lambda self: self._props)
+  @property
+  def name(self):
+    return self.get_prop('name')
+
+  @property
+  def namespace(self):
+    return self.get_prop('namespace')
+
+  @property
+  def fullname(self):
+    return avro.schema.Name(self.name, self.namespace, None).fullname
+
+  @property
+  def types(self):
+    return self.get_prop('types')
+
+  @property
+  def types_dict(self):
+    return {type.name: type for type in self.types}
+
+  @property
+  def messages(self):
+    return self.get_prop('messages')
+
+  @property
+  def md5(self):
+    return self._md5
+
+  @property
+  def props(self):
+    return self._props
 
   # utility functions to manipulate properties dict
   def get_prop(self, key):

--- a/lang/py/avro/test/test_protocol.py
+++ b/lang/py/avro/test/test_protocol.py
@@ -274,6 +274,7 @@ class TestMisc(unittest.TestCase):
     print('')
     proto = HELLO_WORLD.parse()
     self.assertEqual(proto.namespace, "com.acme")
+    self.assertEqual(proto.fullname, "com.acme.HelloWorld")
     greeting_type = proto.types_dict['Greeting']
     self.assertEqual(greeting_type.namespace, 'com.acme')
 


### PR DESCRIPTION
### Jira

- [x] My PR addresses [AVRO-2741](https://issues.apache.org/jira/browse/AVRO-2741)
- [x] My PR title references it.
- [x] My PR adds no dependencies.

### Tests

- [x] My PR adds a check for protocol.fullname to a suitable existing test.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":

### Documentation

- [x] No new functionality.