### PR TITLE
AVRO-2741: Fix Protocol.fullname Crash

### DIFF
--- a/lang/py/src/avro/protocol.py
+++ b/lang/py/src/avro/protocol.py
@@ -108,7 +108,7 @@ class Protocol(object):
   name = property(lambda self: self.get_prop('name'))
   namespace = property(lambda self: self.get_prop('namespace'))
   fullname = property(lambda self:
-                      schema.Name(self.name, self.namespace).fullname)
+                      schema.Name(self.name, self.namespace, None).fullname)
   types = property(lambda self: self.get_prop('types'))
   types_dict = property(lambda self: dict([(type.name, type)
                                            for type in self.types]))

--- a/lang/py/test/test_protocol.py
+++ b/lang/py/test/test_protocol.py
@@ -365,7 +365,7 @@ class TestProtocol(unittest.TestCase):
         if not example.valid:
           num_correct += 1
         else:
-          self.fail("Coudl not parse valid protocol: %s" % (example.name,))
+          self.fail("Could not parse valid protocol: %s" % (example.name,))
 
     fail_msg = "Parse behavior correct on %d out of %d protocols." % \
       (num_correct, len(EXAMPLES))
@@ -378,6 +378,7 @@ class TestProtocol(unittest.TestCase):
     print('')
     proto = protocol.parse(HELLO_WORLD.protocol_string)
     self.assertEqual(proto.namespace, "com.acme")
+    self.assertEqual(proto.fullname, "com.acme.HelloWorld")
     greeting_type = proto.types_dict['Greeting']
     self.assertEqual(greeting_type.namespace, 'com.acme')
 


### PR DESCRIPTION
Backport to 1.9. See #812 