### PR TITLE
AVRO-2387: Type Check Python

### DIFF
--- a/lang/py/avro/test/av_bench.py
+++ b/lang/py/avro/test/av_bench.py
@@ -19,10 +19,10 @@
 
 from __future__ import absolute_import, division, print_function
 
+import string
 import sys
 import time
 from random import choice, randint, sample
-from string import lowercase
 
 import avro.datafile
 import avro.io
@@ -31,7 +31,7 @@ import avro.schema
 types = ["A", "CNAME"]
 
 def rand_name():
-    return ''.join(sample(lowercase, 15))
+    return ''.join(sample(string.ascii_lowercase, 15))
 
 def rand_ip():
     return "%s.%s.%s.%s" %(randint(0,255), randint(0,255), randint(0,255), randint(0,255))

--- a/lang/py/avro/test/test_protocol.py
+++ b/lang/py/avro/test/test_protocol.py
@@ -264,7 +264,8 @@ EXAMPLES = [HELLO_WORLD, ValidTestProtocol({
   }),
 ]
 
-VALID_EXAMPLES = [e for e in EXAMPLES if e.valid]
+VALID_EXAMPLES = [e for e in EXAMPLES if getattr(e, "valid", False)]
+
 
 class TestMisc(unittest.TestCase):
   def test_inner_namespace_set(self):

--- a/lang/py/avro/test/test_schema.py
+++ b/lang/py/avro/test/test_schema.py
@@ -37,6 +37,11 @@ try:
 except NameError:
   basestring = (bytes, unicode)
 
+try:
+  from typing import List
+except ImportError:
+  pass
+
 
 class TestSchema(object):
   """A proxy for a schema string that provides useful test metadata."""
@@ -61,18 +66,17 @@ class ValidTestSchema(TestSchema):
   valid = True
 
 
-class InvalidTestSchema(ValidTestSchema):
+class InvalidTestSchema(TestSchema):
   """A proxy for an invalid schema string that provides useful test metadata."""
   valid = False
 
 
-PRIMITIVE_EXAMPLES = ([
-  InvalidTestSchema('"True"'),
-  InvalidTestSchema('True'),
-  InvalidTestSchema('{"no_type": "test"}'),
-  InvalidTestSchema('{"type": "panther"}'),
-] + [ValidTestSchema('"{}"'.format(t)) for t in schema.PRIMITIVE_TYPES]
-  + [ValidTestSchema({"type": t}) for t in schema.PRIMITIVE_TYPES])
+PRIMITIVE_EXAMPLES = [InvalidTestSchema('"True"')]  # type: List[TestSchema]
+PRIMITIVE_EXAMPLES.append(InvalidTestSchema('True'))
+PRIMITIVE_EXAMPLES.append(InvalidTestSchema('{"no_type": "test"}'))
+PRIMITIVE_EXAMPLES.append(InvalidTestSchema('{"type": "panther"}'))
+PRIMITIVE_EXAMPLES.extend([ValidTestSchema('"{}"'.format(t)) for t in schema.PRIMITIVE_TYPES])
+PRIMITIVE_EXAMPLES.extend([ValidTestSchema({"type": t}) for t in schema.PRIMITIVE_TYPES])
 
 FIXED_EXAMPLES = [
   ValidTestSchema({"type": "fixed", "name": "Test", "size": 1}),
@@ -314,8 +318,9 @@ EXAMPLES += TIMESTAMPMILLIS_LOGICAL_TYPE
 EXAMPLES += TIMESTAMPMICROS_LOGICAL_TYPE
 EXAMPLES += IGNORED_LOGICAL_TYPE
 
-VALID_EXAMPLES = [e for e in EXAMPLES if e.valid]
-INVALID_EXAMPLES = [e for e in EXAMPLES if not e.valid]
+VALID_EXAMPLES = [e for e in EXAMPLES if getattr(e, "valid", False)]
+INVALID_EXAMPLES = [e for e in EXAMPLES if not getattr(e, "valid", True)]
+
 
 class TestMisc(unittest.TestCase):
   """Miscellaneous tests for schema"""

--- a/lang/py/avro/tether/tether_task.py
+++ b/lang/py/avro/tether/tether_task.py
@@ -229,7 +229,7 @@ class TetherTask(object):
     self.midCollector=None
     self.outCollector=None
 
-    self._partitions=None
+    self._partitions = None
 
     # cache a list of the fields used by the reducer as the keys
     # we need the fields to decide when we have finished processing all values for
@@ -339,17 +339,14 @@ class TetherTask(object):
       estr= traceback.format_exc()
       self.fail(estr)
 
-  def set_partitions(self,npartitions):
-
-    try:
-      self._partitions=npartitions
-    except Exception as e:
-      estr= traceback.format_exc()
-      self.fail(estr)
-
-  def get_partitions():
-    """ Return the number of map output partitions of this job."""
+  @property
+  def partitions(self):
+    """Return the number of map output partitions of this job."""
     return self._partitions
+
+  @partitions.setter
+  def partitions(self, npartitions):
+    self._partitions = npartitions
 
   def input(self,data,count):
     """ Recieve input from the server

--- a/lang/py/avro/tether/tether_task.py
+++ b/lang/py/avro/tether/tether_task.py
@@ -48,11 +48,13 @@ if (inputProtocol is None):
   with open(pfile,'r') as hf:
     prototxt=hf.read()
 
-  inputProtocol=protocol.parse(prototxt)
+  inputProtocol = protocol.parse(prototxt)
 
   # use a named tuple to represent the tasktype enumeration
-  taskschema=inputProtocol.types_dict["TaskType"]
-  _ttype=collections.namedtuple("_tasktype",taskschema.symbols)
+  taskschema = inputProtocol.types_dict["TaskType"]
+  # Mypy cannot statically type check a dynamically constructed named tuple.
+  # Since InputProtocol.avpr is hard-coded here, we can hard-code the symbols.
+  _ttype = collections.namedtuple("_tasktype", ("MAP", "REDUCE"))
   TaskType=_ttype(*taskschema.symbols)
 
 if (outputProtocol is None):

--- a/lang/py/avro/tether/tether_task_runner.py
+++ b/lang/py/avro/tether/tether_task_runner.py
@@ -68,7 +68,7 @@ class TaskRunnerResponder(ipc.Responder):
       elif message.name=='partitions':
         self.log.info("TetherTaskRunner: Recieved partitions")
         try:
-          self.task.set_partitions(request["partitions"])
+          self.task.partitions = request["partitions"]
         except Exception as e:
           self.log.error("Exception occured while processing the partitions message: Message:\n"+traceback.format_exc())
           raise

--- a/lang/py/avro/tool.py
+++ b/lang/py/avro/tool.py
@@ -77,7 +77,7 @@ class GenericHandler(http_server.BaseHTTPRequestHandler):
       quitter.start()
 
 def run_server(uri, proto, msg, datum):
-  url_obj = urlparse.urlparse(uri)
+  url_obj = urlparse(uri)
   server_addr = (url_obj.hostname, url_obj.port)
   global responder
   global server_should_shutdown
@@ -91,7 +91,7 @@ def run_server(uri, proto, msg, datum):
   server.serve_forever()
 
 def send_message(uri, proto, msg, datum):
-  url_obj = urlparse.urlparse(uri)
+  url_obj = urlparse(uri)
   client = ipc.HTTPTransceiver(url_obj.hostname, url_obj.port)
   proto_json = open(proto, 'rb').read()
   requestor = ipc.Requestor(protocol.parse(proto_json), client)

--- a/lang/py/mypy.ini
+++ b/lang/py/mypy.ini
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[mypy]
+files =
+    avro
+warn_return_any = True
+warn_unused_configs = True
+warn_unreachable = True
+
+[mypy-snappy]
+ignore_missing_imports = True
+
+[mypy-zstandard]
+ignore_missing_imports = True
+
+[mypy-zope.interface]
+ignore_missing_imports = True
+
+[mypy-twisted.*]
+ignore_missing_imports = True

--- a/lang/py/setup.py
+++ b/lang/py/setup.py
@@ -25,7 +25,7 @@ import glob
 import os
 import subprocess
 
-import setuptools
+import setuptools  # type: ignore
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
 _AVRO_DIR = os.path.join(_HERE, 'avro')

--- a/lang/py/tox.ini
+++ b/lang/py/tox.ini
@@ -17,7 +17,9 @@
 # Remember to run tox --skip-missing-interpreters
 # If you don't want to install all these interpreters.
 envlist =
+    # Fastest checks first
     lint
+    typechecks
     py27
     py35
     py36
@@ -25,6 +27,7 @@ envlist =
     py38
     pypy3.5
     pypy3.6
+
 
 [coverage:run]
 source =
@@ -61,6 +64,15 @@ commands =
     isort --check-only
     pycodestyle
 commands_post =
+
+[testenv:typechecks]
+deps =
+    coverage
+    mypy
+extras =
+    mypy
+commands =
+    mypy
 
 [tool:isort]
 line_length = 150

--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -50,6 +50,7 @@ RUN apt-get -qqy update \
                                                  libsnappy1v5 \
                                                  make \
                                                  maven \
+                                                 mypy \
                                                  openjdk-8-jdk \
                                                  perl \
                                                  python \


### PR DESCRIPTION
This PR adds type checking to the tox tests that run locally and in Travis. Mypy is lightly configured, and already uncovered some minor problems that the tests didn't catch. However, at this stage we only have about 58% coverage via typing. (You can see the coverage by running `pip install lxml && mypy --html-report mypyhtml && open mypyhtml/index.html`.)

### Jira

- [x] My PR addresses [AVRO-2387](https://issues.apache.org/jira/browse/AVRO-2387)
- [x] My PR title references the ticket.
- [x] My PR adds mypy as a test-time dependency. Mypy is licensed under the [MIT License](https://github.com/python/mypy/blob/master/LICENSE), which is compatible with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds type checking to lang/py.

### Commits

- [x] My commits all reference Jira issues in their subject lines.
- [x] My commits mostly follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)".

### Documentation

- [x] My PR does not add any API changes that warrant documentation.