### PR TITLE
AVRO-2747: Remove setup_requires

### DIFF
--- a/lang/py/build.sh
+++ b/lang/py/build.sh
@@ -51,11 +51,11 @@ interop-data-test() {
 }
 
 lint() {
-  ./setup.py isort lint
+  tox -e lint
 }
 
 test_() {
-  tox
+  TOX_SKIP_ENV=lint tox --skip-missing-interpreters
 }
 
 main() {

--- a/lang/py/setup.cfg
+++ b/lang/py/setup.cfg
@@ -47,9 +47,6 @@ package_dir =
     avro.test = avro/test
     avro.tether = avro/tether
 include_package_data = true
-setup_requires =
-  isort
-  pycodestyle
 install_requires =
 zip_safe = true
 scripts =
@@ -73,13 +70,3 @@ zstandard = zstandard
 
 [aliases]
 dist = sdist --dist-dir ../../dist/py
-
-[isort]
-line_length = 150
-known_third_party=zope
-
-[pycodestyle]
-exclude = .eggs,.tox,build
-ignore = E101,E111,E114,E121,E122,E124,E125,E126,E127,E128,E129,E201,E202,E203,E222,E226,E225,E231,E241,E251,E261,E262,E265,E266,E301,E302,E303,E305,E306,E402,E501,E701,E703,E704,E711,W191,W291,W292,W293,W391,W503,W504,W601
-max-line-length = 150
-statistics = True

--- a/lang/py/setup.py
+++ b/lang/py/setup.py
@@ -121,35 +121,12 @@ def _get_version():
     return verfile.read().rstrip().replace("-", "+")
 
 
-class LintCommand(setuptools.Command):
-    """Run pycodestyle on all your modules"""
-    description = __doc__
-    user_options = []  # type: ignore
-
-    def initialize_options(self):
-        pass
-
-    def finalize_options(self):
-        pass
-
-    def run(self):
-        # setuptools does not seem to make pycodestyle available
-        # in the pythonpath, so we do it ourselves.
-        try:
-            env = {'PYTHONPATH': next(glob.iglob('.eggs/pycodestyle-*.egg'))}
-        except StopIteration:
-            env = None  # pycodestyle is already installed
-        p = subprocess.Popen(['python', '-m', 'pycodestyle', '.'], close_fds=True, env=env)
-        if p.wait():
-            raise distutils.errors.DistutilsError("pycodestyle exited with a nonzero exit code.")
-
 def main():
     if not _is_distribution():
         _generate_package_data()
 
     setuptools.setup(cmdclass={
         "generate_interop_data": GenerateInteropDataCommand,
-        "lint": LintCommand,
     })
 
 

--- a/lang/py/tox.ini
+++ b/lang/py/tox.ini
@@ -14,9 +14,17 @@
 # limitations under the License.
 
 [tox]
+# Remember to run tox --skip-missing-interpreters
+# If you don't want to install all these interpreters.
 envlist =
+    lint
     py27
     py35
+    py36
+    py37
+    py38
+    pypy3.5
+    pypy3.6
 
 [coverage:run]
 source =
@@ -43,3 +51,23 @@ commands =
 commands_post =
     coverage combine
     coverage report
+
+[testenv:lint]
+deps =
+    isort
+    pycodestyle
+commands_pre =
+commands =
+    isort --check-only
+    pycodestyle
+commands_post =
+
+[tool:isort]
+line_length = 150
+known_third_party=zope
+
+[pycodestyle]
+exclude = .eggs,.tox,build
+ignore = E101,E111,E114,E121,E122,E124,E125,E126,E127,E128,E129,E201,E202,E203,E222,E226,E225,E231,E241,E251,E261,E262,E265,E266,E301,E302,E303,E305,E306,E402,E501,E701,E703,E704,E711,W191,W291,W292,W293,W391,W503,W504,W601
+max-line-length = 150
+statistics = True


### PR DESCRIPTION
Having `setup_requires` in setup.cfg causes problems for folks trying to install avro behind a proxy, since `pip` doesn't use the `-i` option for stuff in `setup_requires`. However, we don't really need the `setup_requires` now that we have tox.

### Jira

- [x] My PR addresses [AVRO-2747](https://issues.apache.org/jira/browse/AVRO-2747)
- [x] My PR does not add any dependencies.

### Tests

- [x] My PR does not require additional tests.

### Commits

- [x] My commits all reference Jira issues in their subject lines.
- [x] My commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":

### Documentation

- [x] No new functionality.