### PR TITLE
AVRO-2749: Add ruby support for datum hashes with non-string keys

### DIFF
--- a/lang/ruby/lib/avro/io.rb
+++ b/lang/ruby/lib/avro/io.rb
@@ -590,8 +590,13 @@ module Avro
 
       def write_record(writers_schema, datum, encoder)
         raise AvroTypeError.new(writers_schema, datum) unless datum.is_a?(Hash)
+
+        datum_s = {}
+          datum.each do |k,v|
+          datum_s[k.to_s] = v
+        end
         writers_schema.fields.each do |field|
-          write_data(field.type, datum[field.name], encoder)
+          write_data(field.type, datum_s[field.name], encoder)
         end
       end
     end # DatumWriter

--- a/lang/ruby/lib/avro/io.rb
+++ b/lang/ruby/lib/avro/io.rb
@@ -590,13 +590,8 @@ module Avro
 
       def write_record(writers_schema, datum, encoder)
         raise AvroTypeError.new(writers_schema, datum) unless datum.is_a?(Hash)
-
-        datum_s = {}
-          datum.each do |k,v|
-          datum_s[k.to_s] = v
-        end
         writers_schema.fields.each do |field|
-          write_data(field.type, datum_s[field.name], encoder)
+          write_data(field.type, datum.key?(field.name) ? datum[field.name] : datum[field.name.to_sym], encoder)
         end
       end
     end # DatumWriter

--- a/lang/ruby/test/test_io.rb
+++ b/lang/ruby/test/test_io.rb
@@ -161,6 +161,17 @@ EOS
     check_default(fixed_schema, '"a"', "a")
   end
 
+  def test_record_variable_key_types
+    datum = { sym: "foo", "str"=>"bar"}
+    ret_val = { "sym"=> "foo", "str"=>"bar"}
+    schema = Schema.parse('{"type":"record", "name":"rec", "fields":[{"name":"sym", "type":"string"}, {"name":"str", "type":"string"}]}')
+
+    writer, encoder, datum_writer = write_datum(datum, schema)
+
+    ret_datum = read_datum(writer, schema)
+    assert_equal ret_datum, ret_val
+  end
+
   def test_record_with_nil
     schema = Avro::Schema.parse('{"type":"record", "name":"rec", "fields":[{"type":"int", "name":"i"}]}')
     assert_raise(Avro::IO::AvroTypeError) do

--- a/lang/ruby/test/test_io.rb
+++ b/lang/ruby/test/test_io.rb
@@ -166,7 +166,7 @@ EOS
     ret_val = { "sym"=> "foo", "str"=>"bar"}
     schema = Schema.parse('{"type":"record", "name":"rec", "fields":[{"name":"sym", "type":"string"}, {"name":"str", "type":"string"}]}')
 
-    writer, encoder, datum_writer = write_datum(datum, schema)
+    writer, _encoder, _datum_writer = write_datum(datum, schema)
 
     ret_datum = read_datum(writer, schema)
     assert_equal ret_datum, ret_val


### PR DESCRIPTION
Ruby allows hash keys to be any simple type, but when encoding a hash with non-string keys the error raised is not obvious as to the issue (`The datum nil is not an example of schema "long" (Avro::IO::AvroTypeError)`).

Rather than attempt to provide a more meaningful error, enhancing the encoding to handle keys of all types allows user flexibility.

### Jira

- [ ] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO-2749) 
- [ ] My PR does not add any dependencies.

### Tests

- [ ] My PR adds the following unit tests: `test_record_variable_key_types`

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
