### PR TITLE
AVRO-2750: Add support for enum defaults in c#

### DIFF
--- a/lang/csharp/src/apache/main/CodeGen/CodeGen.cs
+++ b/lang/csharp/src/apache/main/CodeGen/CodeGen.cs
@@ -607,6 +607,10 @@ namespace Avro
                 string privFieldName = string.Concat("_", field.Name);
                 var codeField = new CodeMemberField(ctrfield, privFieldName);
                 codeField.Attributes = MemberAttributes.Private;
+                if (field.Schema is EnumSchema es && es.Default != null)
+                {
+                    codeField.InitExpression = new CodeTypeReferenceExpression($"{es.Name}.{es.Default}");
+                }
 
                 // Process field documentation if it exist and add to the field
                 CodeCommentStatement propertyComment = null;

--- a/lang/csharp/src/apache/main/Generic/GenericEnum.cs
+++ b/lang/csharp/src/apache/main/Generic/GenericEnum.cs
@@ -37,8 +37,15 @@ namespace Avro.Generic
             get { return value; }
             set
             {
-                if (! Schema.Contains(value)) throw new AvroException("Unknown value for enum: " + value + "(" + Schema + ")");
-                this.value = value;
+                if (!string.IsNullOrEmpty(Schema.Default))
+                {
+                    this.value = Schema.Contains(value) ? value : Schema.Default;
+                }
+                else
+                {
+                    if (! Schema.Contains(value)) throw new AvroException("Unknown value for enum: " + value + "(" + Schema + ")");
+                    this.value = value;
+                }
             }
         }
 

--- a/lang/csharp/src/apache/main/Generic/GenericEnum.cs
+++ b/lang/csharp/src/apache/main/Generic/GenericEnum.cs
@@ -37,14 +37,19 @@ namespace Avro.Generic
             get { return value; }
             set
             {
-                if (!string.IsNullOrEmpty(Schema.Default))
+                if (!Schema.Contains(value))
                 {
-                    this.value = Schema.Contains(value) ? value : Schema.Default;
+                    if (!string.IsNullOrEmpty(Schema.Default))
+                    {
+                        this.value = Schema.Default;
+                    }
+                    else
+                    {
+                        throw new AvroException("Unknown value for enum: " + value + "(" + Schema + ")");
+                    }
                 }
                 else
                 {
-                    if (!Schema.Contains(value))
-                        throw new AvroException("Unknown value for enum: " + value + "(" + Schema + ")");
                     this.value = value;
                 }
             }

--- a/lang/csharp/src/apache/main/Generic/GenericEnum.cs
+++ b/lang/csharp/src/apache/main/Generic/GenericEnum.cs
@@ -43,7 +43,8 @@ namespace Avro.Generic
                 }
                 else
                 {
-                    if (! Schema.Contains(value)) throw new AvroException("Unknown value for enum: " + value + "(" + Schema + ")");
+                    if (!Schema.Contains(value))
+                        throw new AvroException("Unknown value for enum: " + value + "(" + Schema + ")");
                     this.value = value;
                 }
             }

--- a/lang/csharp/src/apache/main/Generic/PreresolvingDatumReader.cs
+++ b/lang/csharp/src/apache/main/Generic/PreresolvingDatumReader.cs
@@ -195,8 +195,10 @@ namespace Avro.Generic
 
             var translator = new int[writerSchema.Symbols.Count];
 
+            var readerDefaultOrdinal = null != readerSchema.Default ? readerSchema.Ordinal(readerSchema.Default) : -1;
+
             foreach (var symbol in writerSchema.Symbols)
-            {
+            { 
                 var writerOrdinal = writerSchema.Ordinal(symbol);
                 if (readerSchema.Contains(symbol))
                 {
@@ -212,6 +214,11 @@ namespace Avro.Generic
                         {
                             var writerOrdinal = d.ReadEnum();
                             var readerOrdinal = translator[writerOrdinal];
+                            if (readerOrdinal == -1 && readerDefaultOrdinal != -1) //the symbol doesn't exist, but the default does
+                            {
+                                return enumAccess.CreateEnum(r, readerDefaultOrdinal);
+                            }
+
                             if (readerOrdinal == -1)
                             {
                                 throw new AvroException("No such symbol: " + writerSchema[writerOrdinal]);

--- a/lang/csharp/src/apache/main/Schema/EnumSchema.cs
+++ b/lang/csharp/src/apache/main/Schema/EnumSchema.cs
@@ -35,7 +35,7 @@ namespace Avro
         /// <summary>
         /// The default token to use when deserializing an enum when the provided token is not found
         /// </summary>
-        public string Default {get; private set; }
+        public string Default { get; private set; }
 
         /// <summary>
         /// Map of enum symbols and it's corresponding ordinal number
@@ -97,18 +97,19 @@ namespace Avro
         /// <param name="props">custom properties on this schema</param>
         /// <param name="names">list of named schema already read</param>
         /// <param name="doc">documentation for this named schema</param>
-        /// <param name="defaultToken">default token</param>
+        /// <param name="defaultSymbol">default token</param>
         private EnumSchema(SchemaName name, IList<SchemaName> aliases, List<string> symbols,
                             IDictionary<String, int> symbolMap, PropertyMap props, SchemaNames names,
-                            string doc, string defaultToken)
+                            string doc, string defaultSymbol)
                             : base(Type.Enumeration, name, aliases, props, names, doc)
         {
             if (null == name.Name) throw new SchemaParseException("name cannot be null for enum schema.");
             this.Symbols = symbols;
             this.symbolMap = symbolMap;
 
-            if (defaultToken != null && !symbolMap.ContainsKey(defaultToken)) throw new SchemaParseException($"Default symbol: {defaultToken} not found in symbols");
-            Default = defaultToken;
+            if (null != defaultSymbol && !symbolMap.ContainsKey(defaultSymbol))
+                throw new SchemaParseException($"Default symbol: {defaultSymbol} not found in symbols");
+            Default = defaultSymbol;
         }
 
         /// <summary>
@@ -126,7 +127,7 @@ namespace Avro
             foreach (string s in this.Symbols)
                 writer.WriteValue(s);
             writer.WriteEndArray();
-            if(Default != null) 
+            if (Default != null) 
             {
                 writer.WritePropertyName("default");
                 writer.WriteValue(Default);

--- a/lang/csharp/src/apache/main/Schema/EnumSchema.cs
+++ b/lang/csharp/src/apache/main/Schema/EnumSchema.cs
@@ -97,7 +97,7 @@ namespace Avro
         /// <param name="props">custom properties on this schema</param>
         /// <param name="names">list of named schema already read</param>
         /// <param name="doc">documentation for this named schema</param>
-        /// <param name="defaultSymbol">default token</param>
+        /// <param name="defaultSymbol">default symbol</param>
         private EnumSchema(SchemaName name, IList<SchemaName> aliases, List<string> symbols,
                             IDictionary<String, int> symbolMap, PropertyMap props, SchemaNames names,
                             string doc, string defaultSymbol)

--- a/lang/csharp/src/apache/main/Schema/EnumSchema.cs
+++ b/lang/csharp/src/apache/main/Schema/EnumSchema.cs
@@ -127,7 +127,7 @@ namespace Avro
             foreach (string s in this.Symbols)
                 writer.WriteValue(s);
             writer.WriteEndArray();
-            if (Default != null) 
+            if (null != Default) 
             {
                 writer.WritePropertyName("default");
                 writer.WriteValue(Default);
@@ -143,7 +143,11 @@ namespace Avro
         public int Ordinal(string symbol)
         {
             int result;
-            if (symbolMap.TryGetValue(symbol, out result)) return result;
+            if (symbolMap.TryGetValue(symbol, out result))
+                return result;
+            if (null != Default)
+                return symbolMap[Default];
+
             throw new AvroException("No such symbol: " + symbol);
         }
 

--- a/lang/csharp/src/apache/test/CodGen/CodeGenTest.cs
+++ b/lang/csharp/src/apache/test/CodGen/CodeGenTest.cs
@@ -18,7 +18,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.CodeDom.Compiler;
 using Microsoft.CSharp;
 using NUnit.Framework;
@@ -45,7 +44,7 @@ namespace Avro.Test
 			{ ""name"" : ""internal"", ""type"" : ""bytes"" },
 			{ ""name"" : ""while"", ""type"" : ""string"" },
 			{ ""name"" : ""return"", ""type"" : ""null"" },
-			{ ""name"" : ""enum"", ""type"" : { ""type"" : ""enum"", ""name"" : ""class"", ""symbols"" : [ ""A"", ""B"" ] } },
+			{ ""name"" : ""enum"", ""type"" : { ""type"" : ""enum"", ""name"" : ""class"", ""symbols"" : [ ""Unknown"", ""A"", ""B"" ], ""default"" : ""Unknown"" } },
 			{ ""name"" : ""string"", ""type"" : { ""type"": ""fixed"", ""size"": 16, ""name"": ""static"" } }
 		]
 }

--- a/lang/csharp/src/apache/test/Generic/GenericTests.cs
+++ b/lang/csharp/src/apache/test/Generic/GenericTests.cs
@@ -108,6 +108,15 @@ namespace Avro.Test.Generic
             test(schema, mkMap(values));
         }
 
+        [TestCase("{\"type\": \"enum\", \"name\": \"Test\", \"symbols\": [\"Unknown\", \"A\", \"B\"], \"default\": \"Unknown\" }", "C", "Unknown")]
+        [TestCase("{\"type\": \"enum\", \"name\": \"Test\", \"symbols\": [\"Unknown\", \"A\", \"B\"], \"default\": \"Unknown\" }", "A", "A")]
+        public void TestEnumDefault(string schema, string attemptedValue, string expectedValue)
+        {
+            var newEnum = mkEnum(schema, attemptedValue) as GenericEnum;
+            Assert.NotNull(newEnum);
+            Assert.AreEqual(newEnum.Value, expectedValue);
+        }
+
         [TestCase()]
         public void TestLogical_Date()
         {

--- a/lang/csharp/src/apache/test/Schema/SchemaTests.cs
+++ b/lang/csharp/src/apache/test/Schema/SchemaTests.cs
@@ -249,6 +249,20 @@ namespace Avro.Test
             Assert.AreEqual(expectedDoc, es.Documentation);
         }
 
+        [TestCase("{\"type\": \"enum\", \"name\": \"Test\", \"symbols\": [\"Unknown\", \"A\", \"B\"], \"default\": \"Unknown\" }", "Unknown")]
+        public void TestEnumDefault(string s, string expectedToken) 
+        {
+            var es = Schema.Parse(s) as EnumSchema;
+            Assert.IsNotNull(es);
+            Assert.AreEqual(es.Default, expectedToken);
+        }
+
+        [TestCase("{\"type\": \"enum\", \"name\": \"Test\", \"symbols\": [\"Unknown\", \"A\", \"B\"], \"default\": \"Something\" }")]
+        public void TestEnumDefaultSymbolDoesntExist(string s)
+        {
+            Assert.Throws<SchemaParseException>(() => Schema.Parse(s));
+        }
+
         [TestCase("{\"type\": \"array\", \"items\": \"long\"}", "long")]
         public void TestArray(string s, string item)
         {

--- a/lang/csharp/src/apache/test/Specific/SpecificTests.cs
+++ b/lang/csharp/src/apache/test/Specific/SpecificTests.cs
@@ -563,6 +563,7 @@ namespace Avro.Test
                 return Schema.Parse(@"{
    ""type"":""record"",
    ""name"":""EnumRecord"",
+   ""namespace"":""Avro.Test"",
    ""fields"":[
       {
          ""name"":""enumType"",

--- a/lang/csharp/src/apache/test/Specific/SpecificTests.cs
+++ b/lang/csharp/src/apache/test/Specific/SpecificTests.cs
@@ -18,7 +18,6 @@
 using System;
 using System.Collections;
 using System.IO;
-using System.Linq;
 using NUnit.Framework;
 using Avro.IO;
 using System.CodeDom;
@@ -246,6 +245,24 @@ namespace Avro.Test
             // deserialize
             var rec2 = deserialize<EnumRecord>(stream, writerSchema, readerSchema);
             Assert.AreEqual( EnumType.SECOND, rec2.enumType );
+        }
+
+        [Test]
+        public void TestEnumDefault()
+        {
+            //writerSchema has "SECOND"
+            Schema writerSchema = Schema.Parse("{ \"type\": \"record\", \"name\": \"EnumRecord\", \"fields\": [ { \"name\": \"enumType\", \"type\": { \"type\": \"enum\", \"name\": \"EnumType\", \"symbols\": [ \"DEFAULT\", \"FIRST\", \"SECOND\", \"THIRD\" ], \"default\": \"DEFAULT\" } } ] }");
+            Schema readerSchema = Schema.Parse("{ \"type\": \"record\", \"name\": \"EnumRecord\", \"fields\": [ { \"name\": \"enumType\", \"type\": { \"type\": \"enum\", \"name\": \"EnumType\", \"symbols\": [ \"DEFAULT\", \"FIRST\", \"THIRD\" ], \"default\": \"DEFAULT\" } } ] }");
+
+            //readerSchema is missing "SECOND" so should therefore be "DEFAULT"
+            var testRecord = new EnumRecord {enumType = EnumType.SECOND};
+
+            // serialize
+            var stream = serialize(writerSchema, testRecord);
+
+            // deserialize
+            var rec2 = deserialize<EnumRecord>(stream, writerSchema, readerSchema);
+            Assert.AreEqual(EnumType.DEFAULT, rec2.enumType);
         }
 
         [Test]
@@ -528,11 +545,12 @@ namespace Avro.Test
         }
     }
 
-    enum EnumType
+    public enum EnumType
     {
-        THIRD,
+        DEFAULT, //putting the default first here so there isn't an ordinal collision for testing defaults
         FIRST,
-        SECOND
+        SECOND,
+        THIRD,
     }
 
     class EnumRecord : ISpecificRecord
@@ -541,10 +559,27 @@ namespace Avro.Test
         public Schema Schema
         {
             get
-            {
-                return Schema.Parse("{\"type\":\"record\",\"name\":\"EnumRecord\",\"namespace\":\"Avro.Test\"," +
-                                        "\"fields\":[{\"name\":\"enumType\",\"type\": { \"type\": \"enum\", \"name\":" +
-                                        " \"EnumType\", \"symbols\": [\"THIRD\", \"FIRST\", \"SECOND\"]} }]}");
+            { 
+                return Schema.Parse(@"{
+   ""type"":""record"",
+   ""name"":""EnumRecord"",
+   ""fields"":[
+      {
+         ""name"":""enumType"",
+         ""type"":{
+            ""type"":""enum"",
+            ""name"":""EnumType"",
+            ""symbols"":[
+               ""DEFAULT"",
+               ""FIRST"",
+               ""SECOND"",
+               ""THIRD""
+            ]
+         },
+         ""default"": ""DEFAULT""
+      }
+   ]
+}");
             }
         }
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2750

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
 - Modifies CodeGenTest to just exercise the codegen. Looked at the outputted code to verify that it sets the field to the default if its present
 - GenericTests.TestEnumDefault
 - SchemaTests.TestEnumDefault
 - SchemaTests.TestEnumDefaultSymbolDoesntExist

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
