### PR TITLE
AVRO-2754: Add support for UUID logical types in C#

### DIFF
--- a/lang/csharp/src/apache/main/CodeGen/CodeGen.cs
+++ b/lang/csharp/src/apache/main/CodeGen/CodeGen.cs
@@ -777,7 +777,15 @@ namespace Avro
                     var logicalSchema = schema as LogicalSchema;
                     if (null == logicalSchema)
                         throw new CodeGenException("Unable to cast schema into a logical schema");
-                    return logicalSchema.LogicalType.GetCSharpType(nullible).ToString();
+                    var csharpType = logicalSchema.LogicalType.GetCSharpType(nullible);
+                    if (csharpType.IsGenericType && csharpType.GetGenericTypeDefinition() == typeof(Nullable<>))
+                    {
+                        return $"Nullable<{csharpType.GetGenericArguments()[0]}>";
+                    }
+                    else
+                    {
+                        return csharpType.ToString();
+                    }
 
             }
             throw new CodeGenException("Unable to generate CodeTypeReference for " + schema.Name + " type " + schema.Tag);

--- a/lang/csharp/src/apache/main/CodeGen/CodeGen.cs
+++ b/lang/csharp/src/apache/main/CodeGen/CodeGen.cs
@@ -780,7 +780,7 @@ namespace Avro
                     var csharpType = logicalSchema.LogicalType.GetCSharpType(nullible);
                     if (csharpType.IsGenericType && csharpType.GetGenericTypeDefinition() == typeof(Nullable<>))
                     {
-                        return $"Nullable<{csharpType.GetGenericArguments()[0]}>";
+                        return $"System.Nullable<{csharpType.GetGenericArguments()[0]}>";
                     }
                     else
                     {

--- a/lang/csharp/src/apache/main/Util/LogicalTypeFactory.cs
+++ b/lang/csharp/src/apache/main/Util/LogicalTypeFactory.cs
@@ -42,7 +42,8 @@ namespace Avro.Util
                 { TimeMillisecond.LogicalTypeName, new TimeMillisecond() },
                 { TimeMicrosecond.LogicalTypeName, new TimeMicrosecond() },
                 { TimestampMillisecond.LogicalTypeName, new TimestampMillisecond() },
-                { TimestampMicrosecond.LogicalTypeName, new TimestampMicrosecond() }
+                { TimestampMicrosecond.LogicalTypeName, new TimestampMicrosecond() },
+                { Uuid.LogicalTypeName, new Uuid() }
             };
         }
 

--- a/lang/csharp/src/apache/main/Util/Uuid.cs
+++ b/lang/csharp/src/apache/main/Util/Uuid.cs
@@ -1,0 +1,52 @@
+using System;
+
+namespace Avro.Util
+{
+    /// <summary>
+    /// UUid logical type
+    /// </summary>
+    public class Uuid : LogicalType
+    {
+        /// <summary>
+        /// Logical type name
+        /// </summary>
+        public static readonly string LogicalTypeName = "uuid";
+
+        /// <summary>
+        /// Constructs Uuid object
+        /// </summary>
+        public Uuid() : base(LogicalTypeName) { }
+
+
+        /// <inheritdoc />
+        public override object ConvertToBaseValue(object logicalValue, LogicalSchema schema)
+        {
+            return logicalValue.ToString();
+        }
+
+        /// <inheritdoc />
+        public override object ConvertToLogicalValue(object baseValue, LogicalSchema schema)
+        {
+            return new Guid((string) baseValue);
+        }
+
+        /// <inheritdoc />
+        public override Type GetCSharpType(bool nullible)
+        {
+            return nullible ? typeof(Guid?) : typeof(Guid);
+        }
+
+        /// <inheritdoc />
+        public override bool IsInstanceOfLogicalType(object logicalValue)
+        {
+            return logicalValue is Guid;
+        }
+
+        /// <inheritdoc />
+        public override void ValidateSchema(LogicalSchema schema)
+        {
+            if (Schema.Type.String != schema.BaseSchema.Tag)
+                throw new AvroTypeException("'uuid' can only be used with an underlying string type");
+        }
+    }
+}

--- a/lang/csharp/src/apache/test/CodGen/CodeGenTest.cs
+++ b/lang/csharp/src/apache/test/CodGen/CodeGenTest.cs
@@ -69,6 +69,27 @@ namespace Avro.Test
 	]
 }
 ", new object[] { "schematest.SchemaObject", typeof(IList<object>) }, TestName = "TestCodeGen1")]
+        [TestCase(@"{
+	""type"" : ""record"",
+	""name"" : ""LogicalTypes"",
+	""namespace"" : ""schematest"",
+	""fields"" :
+		[ 	
+			{ ""name"" : ""nullibleguid"", ""type"" : [""null"", {""type"": ""string"", ""logicalType"": ""uuid"" } ]},
+			{ ""name"" : ""guid"", ""type"" : {""type"": ""string"", ""logicalType"": ""uuid"" } },
+			{ ""name"" : ""nullibletimestampmillis"", ""type"" : [""null"", {""type"": ""long"", ""logicalType"": ""timestamp-millis""}]  },
+			{ ""name"" : ""timestampmillis"", ""type"" : {""type"": ""long"", ""logicalType"": ""timestamp-millis""} },
+			{ ""name"" : ""nullibiletimestampmicros"", ""type"" : [""null"", {""type"": ""long"", ""logicalType"": ""timestamp-micros""}]  },
+			{ ""name"" : ""timestampmicros"", ""type"" : {""type"": ""long"", ""logicalType"": ""timestamp-micros""} },
+			{ ""name"" : ""nullibiletimemicros"", ""type"" : [""null"", {""type"": ""long"", ""logicalType"": ""time-micros""}]  },
+			{ ""name"" : ""timemicros"", ""type"" : {""type"": ""long"", ""logicalType"": ""time-micros""} },
+			{ ""name"" : ""nullibiletimemillis"", ""type"" : [""null"", {""type"": ""int"", ""logicalType"": ""time-millis""}]  },
+			{ ""name"" : ""timemillis"", ""type"" : {""type"": ""int"", ""logicalType"": ""time-millis""} },
+			{ ""name"" : ""nullibledecimal"", ""type"" : [""null"", {""type"": ""bytes"", ""logicalType"": ""decimal"", ""precision"": 4, ""scale"": 2}]  },
+            { ""name"" : ""decimal"", ""type"" : {""type"": ""bytes"", ""logicalType"": ""decimal"", ""precision"": 4, ""scale"": 2} }
+		]
+}
+", new object[] { "schematest.LogicalTypes", typeof(Guid?), typeof(Guid), typeof(DateTime?), typeof(DateTime), typeof(DateTime?), typeof(DateTime), typeof(TimeSpan?), typeof(TimeSpan), typeof(TimeSpan?), typeof(TimeSpan), typeof(AvroDecimal?), typeof(AvroDecimal) }, TestName = "TestCodeGen2 - Logical Types")]
         public static void TestCodeGen(string str, object[] result)
         {
             Schema schema = Schema.Parse(str);
@@ -94,6 +115,8 @@ namespace Avro.Test
                     stype = (Type)result[i];
                 if (!stype.IsValueType)
                     Assert.IsNull(field);   // can't test reference type, it will be null
+                else if (stype.IsValueType && field == null)
+                    Assert.IsNull(field); // nullable value type, so we can't get the type using GetType
                 else
                     Assert.AreEqual(stype, field.GetType());
             }

--- a/lang/csharp/src/apache/test/Util/LogicalTypeTests.cs
+++ b/lang/csharp/src/apache/test/Util/LogicalTypeTests.cs
@@ -178,5 +178,20 @@ namespace Avro.Test
 
             }
         }
+
+        [TestCase("633a6cf0-52cb-43aa-b00a-658510720958")]
+        public void TestUuid(string guidString)
+        {
+            var schema = (LogicalSchema)Schema.Parse("{\"type\": \"string\", \"logicalType\": \"uuid\" }");
+
+            var guid = new Guid(guidString);
+
+            var avroUuid = new Uuid();
+
+            Assert.True(avroUuid.IsInstanceOfLogicalType(guid));
+
+            var converted = (Guid) avroUuid.ConvertToLogicalValue(avroUuid.ConvertToBaseValue(guid, schema), schema);
+            Assert.AreEqual(guid, converted);
+        }
     }
 }

--- a/lang/java/avro/src/main/java/org/apache/avro/data/RecordBuilderBase.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/data/RecordBuilderBase.java
@@ -29,7 +29,6 @@ import java.util.Arrays;
 
 /** Abstract base class for RecordBuilder implementations. Not thread-safe. */
 public abstract class RecordBuilderBase<T extends IndexedRecord> implements RecordBuilder<T> {
-  private static final Field[] EMPTY_FIELDS = new Field[0];
   private final Schema schema;
   private final Field[] fields;
   private final boolean[] fieldSetFlags;
@@ -59,7 +58,7 @@ public abstract class RecordBuilderBase<T extends IndexedRecord> implements Reco
   protected RecordBuilderBase(Schema schema, GenericData data) {
     this.schema = schema;
     this.data = data;
-    fields = schema.getFields().toArray(EMPTY_FIELDS);
+    fields = schema.getFields().toArray(new Field[0]);
     fieldSetFlags = new boolean[fields.length];
   }
 
@@ -72,7 +71,7 @@ public abstract class RecordBuilderBase<T extends IndexedRecord> implements Reco
   protected RecordBuilderBase(RecordBuilderBase<T> other, GenericData data) {
     this.schema = other.schema;
     this.data = data;
-    fields = schema.getFields().toArray(EMPTY_FIELDS);
+    fields = schema.getFields().toArray(new Field[0]);
     fieldSetFlags = Arrays.copyOf(other.fieldSetFlags, other.fieldSetFlags.length);
   }
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2754

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
 - Modified codegen test to add logical type tests. Nullable value types were also broken in the test so that fix sneaked in
 - LogicalTypeTests.TestUuid - Verifies translation between serialized string and System.Guid

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
