### PR TITLE
AVRO-2756: Ruby should test all schema fingerprints defined in share/test/data/schema-tests.txt

### DIFF
--- a/lang/ruby/test/case_finder.rb
+++ b/lang/ruby/test/case_finder.rb
@@ -50,7 +50,12 @@ class CaseFinder
       input = scan_input
       canonical = scan_canonical
       fingerprint = scan_fingerprint
-
+      if not fingerprint and @cases
+        fingerprint = @cases[-1].fingerprint
+      end
+      if fingerprint
+        fingerprint = fingerprint.to_i & 0xFFFF_FFFF_FFFF_FFFF
+      end
       Case.new(id, input, canonical, fingerprint)
     else
       @scanner.skip(/.*\n/)

--- a/lang/ruby/test/test_schema_normalization.rb
+++ b/lang/ruby/test/test_schema_normalization.rb
@@ -166,6 +166,7 @@ class TestSchemaNormalization < Test::Unit::TestCase
     CaseFinder.cases.each do |test_case|
       schema = Avro::Schema.parse(test_case.input)
       assert_equal test_case.canonical, Avro::SchemaNormalization.to_parsing_form(schema)
+      assert_equal test_case.fingerprint, schema.crc_64_avro_fingerprint
     end
   end
 end


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2756
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

This PR fixes lang/ruby/test/test_schema_normalization.rb to test schema fingerprints in addition to schema normalization.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
