### PR TITLE
Add ruby decimal logical type

### DIFF
--- a/lang/ruby/Gemfile
+++ b/lang/ruby/Gemfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-source 'https://rubygems.org' 
+source 'https://rubygems.org'
 gem 'rake'
 gem 'echoe'
 gem 'multi_json'

--- a/lang/ruby/lib/avro/logical_types.rb
+++ b/lang/ruby/lib/avro/logical_types.rb
@@ -16,9 +16,20 @@
 # limitations under the License.
 
 require 'date'
+require 'bigdecimal'
 
 module Avro
   module LogicalTypes
+    module Decimal
+      def self.encode(value)
+        value.to_s
+      end
+
+      def self.decode(value)
+        BigDecimal(value)
+      end
+    end
+
     module IntDate
       EPOCH_START = Date.new(1970, 1, 1)
 
@@ -79,6 +90,9 @@ module Avro
         "timestamp-millis" => TimestampMillis,
         "timestamp-micros" => TimestampMicros
       },
+      "bytes" => {
+        "decimal" => Decimal
+      }
     }.freeze
 
     def self.type_adapter(type, logical_type)

--- a/lang/ruby/test/test_logical_types.rb
+++ b/lang/ruby/test/test_logical_types.rb
@@ -18,6 +18,37 @@
 require 'test_help'
 
 class TestLogicalTypes < Test::Unit::TestCase
+  def test_decimal
+    schema = Avro::Schema.parse <<-SCHEMA
+      {
+        "type": "bytes",
+        "logicalType": "decimal",
+        "precision": 4,
+        "scale": 2
+      }
+    SCHEMA
+
+    assert_equal 'decimal', schema.logical_type
+
+    value = BigDecimal('5230.23')
+    assert_encode_and_decode value, schema
+  end
+
+  def test_decimal_converstion
+    Avro::Schema.parse <<-SCHEMA
+      {
+        "type": "bytes",
+        "logicalType": "decimal",
+        "precision": 4,
+        "scale": 2
+      }
+    SCHEMA
+
+    value = BigDecimal('5230.23')
+
+    assert_equal(value, Avro::LogicalTypes::Decimal.decode(value.to_s))
+  end
+
   def test_int_date
     schema = Avro::Schema.parse <<-SCHEMA
       { "type": "int", "logicalType": "date" }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
