### PR TITLE
AVRO-2758: Bump istanbul to 0.4.5

### DIFF
--- a/lang/js/package.json
+++ b/lang/js/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "coveralls": "^3.0.7",
-    "istanbul": "^0.3.19",
+    "istanbul": "^0.4.5",
     "jshint": "^2.10.2",
     "mocha": "^6.2.2",
     "tmp": "^0.0.28"


### PR DESCRIPTION
Backport to 1.9. See #827.
I just updated package.json but not package-lock.json, because the Dockerfile provided by branch-1.9 installs npm 3.x, which does not support package-lock.json ([that support was added in version 5](https://nodejs.dev/the-package-lock-json-file)).

----

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2758
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No additional test, since it's a version upgrade for a code coverage tool. I ran `./build.sh test` and `./build.sh dist` in lang/js and confirmed that they succeeded.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
