### PR TITLE
AVRO-2766: Fix compilation error: 'size_t' does not name a type

### DIFF
--- a/lang/c++/api/Zigzag.hh
+++ b/lang/c++/api/Zigzag.hh
@@ -21,6 +21,7 @@
 
 #include <stdint.h>
 #include <array>
+#include <cstddef>
 
 #include "Config.hh"
 /// \file


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/2766) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2766