### PR TITLE
AVRO-2786:Initialize the buffer area for Stringbuilder/List

### DIFF
--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
@@ -473,7 +473,7 @@ public class SpecificCompiler {
 
   /** Generate java classes for enqueued schemas. */
   Collection<OutputFile> compile() {
-    List<OutputFile> out = new ArrayList<>();
+    List<OutputFile> out = new ArrayList<>(queue.size() + 1);
     for (Schema schema : queue) {
       out.add(compile(schema));
     }
@@ -655,7 +655,7 @@ public class SpecificCompiler {
       for (String alias : s.getAliases())
         result.addAlias(alias, null); // copy aliases
       seen.put(s, result);
-      List<Field> newFields = new ArrayList<>();
+      List<Field> newFields = new ArrayList<>(s.getFields().size());
       for (Field f : s.getFields()) {
         Schema fSchema = addStringType(f.schema(), seen);
         Field newF = new Field(f, fSchema);
@@ -673,7 +673,7 @@ public class SpecificCompiler {
       GenericData.setStringType(result, stringType);
       break;
     case UNION:
-      List<Schema> types = new ArrayList<>();
+      List<Schema> types = new ArrayList<>(s.getTypes().size());
       for (Schema branch : s.getTypes())
         types.add(addStringType(branch, seen));
       result = Schema.createUnion(types);
@@ -941,7 +941,7 @@ public class SpecificCompiler {
       return new String[] { value.toString() };
     if (value instanceof List) {
       final List<?> list = (List<?>) value;
-      final List<String> annots = new ArrayList<>();
+      final List<String> annots = new ArrayList<>(list.size());
       for (Object o : list) {
         annots.add(o.toString());
       }
@@ -961,7 +961,8 @@ public class SpecificCompiler {
    * @return A sequence of quoted, comma-separated, escaped strings
    */
   public String javaSplit(String s) throws IOException {
-    StringBuilder b = new StringBuilder("\""); // initial quote
+    StringBuilder b = new StringBuilder(s.length());
+    b.append("\""); // initial quote
     for (int i = 0; i < s.length(); i += maxStringChars) {
       if (i != 0)
         b.append("\",\""); // insert quote-comma-quote

--- a/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/AbstractAvroMojo.java
+++ b/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/AbstractAvroMojo.java
@@ -292,12 +292,13 @@ public abstract class AbstractAvroMojo extends AbstractMojo {
   }
 
   private List<URL> appendElements(List runtimeClasspathElements) throws MalformedURLException {
-    List<URL> runtimeUrls = new ArrayList<>();
-    if (runtimeClasspathElements != null) {
-      for (Object runtimeClasspathElement : runtimeClasspathElements) {
-        String element = (String) runtimeClasspathElement;
-        runtimeUrls.add(new File(element).toURI().toURL());
-      }
+    if (runtimeClasspathElements == null) {
+      return new ArrayList<>();
+    }
+    List<URL> runtimeUrls = new ArrayList<>(runtimeClasspathElements.size());
+    for (Object runtimeClasspathElement : runtimeClasspathElements) {
+      String element = (String) runtimeClasspathElement;
+      runtimeUrls.add(new File(element).toURI().toURL());
     }
     return runtimeUrls;
   }

--- a/lang/java/protobuf/src/main/java/org/apache/avro/protobuf/ProtobufData.java
+++ b/lang/java/protobuf/src/main/java/org/apache/avro/protobuf/ProtobufData.java
@@ -212,7 +212,7 @@ public class ProtobufData extends GenericData {
 
       seen.put(descriptor, result);
 
-      List<Field> fields = new ArrayList<>();
+      List<Field> fields = new ArrayList<>(descriptor.getFields().size());
       for (FieldDescriptor f : descriptor.getFields())
         fields.add(Accessor.createField(f.getName(), getSchema(f), null, getDefault(f)));
       result.setFields(fields);
@@ -253,7 +253,7 @@ public class ProtobufData extends GenericData {
 
   private static String toCamelCase(String s) {
     String[] parts = s.split("_");
-    StringBuilder camelCaseString = new StringBuilder();
+    StringBuilder camelCaseString = new StringBuilder(s.length());
     for (String part : parts) {
       camelCaseString.append(cap(part));
     }
@@ -315,7 +315,7 @@ public class ProtobufData extends GenericData {
   }
 
   public Schema getSchema(EnumDescriptor d) {
-    List<String> symbols = new ArrayList<>();
+    List<String> symbols = new ArrayList<>(d.getValues().size());
     for (EnumValueDescriptor e : d.getValues()) {
       symbols.add(e.getName());
     }

--- a/lang/java/tools/src/main/java/org/apache/avro/tool/Util.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/Util.java
@@ -56,7 +56,7 @@ class Util {
    * Returns stdin if filename is "-", else opens the File in the owning
    * filesystem and returns an InputStream for it. Relative paths will be opened
    * in the default filesystem.
-   * 
+   *
    * @param filename The filename to be opened
    * @throws IOException
    */
@@ -68,7 +68,7 @@ class Util {
    * Returns stdout if filename is "-", else opens the file from the owning
    * filesystem and returns an OutputStream for it. Relative paths will be opened
    * in the default filesystem.
-   * 
+   *
    * @param filename The filename to be opened
    * @throws IOException
    */
@@ -79,7 +79,7 @@ class Util {
   /**
    * Returns an InputStream for the file using the owning filesystem, or the
    * default if none is given.
-   * 
+   *
    * @param filename The filename to be opened
    * @throws IOException
    */
@@ -91,7 +91,7 @@ class Util {
   /**
    * Returns an InputStream for the file using the owning filesystem, or the
    * default if none is given.
-   * 
+   *
    * @param filename The filename to be opened
    * @throws IOException
    */
@@ -102,7 +102,7 @@ class Util {
   /**
    * Returns a seekable FsInput using the owning filesystem, or the default if
    * none is given.
-   * 
+   *
    * @param filename The filename to be opened
    * @throws IOException
    */
@@ -113,7 +113,7 @@ class Util {
   /**
    * Opens the file for writing in the owning filesystem, or the default if none
    * is given.
-   * 
+   *
    * @param filename The filename to be opened.
    * @return An OutputStream to the specified file.
    * @throws IOException
@@ -126,7 +126,7 @@ class Util {
   /**
    * Closes the inputstream created from {@link Util.fileOrStdin} unless it is
    * System.in.
-   * 
+   *
    * @param in The inputstream to be closed.
    */
   static void close(InputStream in) {
@@ -142,7 +142,7 @@ class Util {
   /**
    * Closes the outputstream created from {@link Util.fileOrStdout} unless it is
    * System.out.
-   * 
+   *
    * @param out The outputStream to be closed.
    */
   static void close(OutputStream out) {
@@ -157,7 +157,7 @@ class Util {
 
   /**
    * Parses a schema from the specified file.
-   * 
+   *
    * @param filename The file name to parse
    * @return The parsed schema
    * @throws IOException
@@ -180,7 +180,7 @@ class Util {
    * included.
    *
    * The List is sorted alphabetically.
-   * 
+   *
    * @param fileOrDirName filename, directoryname or a glob pattern
    * @return A Path List
    * @throws IOException
@@ -218,13 +218,13 @@ class Util {
    * subdirectories or files within those.
    *
    * The list is sorted alphabetically.
-   * 
+   *
    * @param fileOrDirNames A list of filenames, directorynames or glob patterns
    * @return A list of Paths, one for each file
    * @throws IOException
    */
   static List<Path> getFiles(List<String> fileOrDirNames) throws IOException {
-    ArrayList<Path> pathList = new ArrayList<>();
+    ArrayList<Path> pathList = new ArrayList<>(fileOrDirNames.size());
     for (String name : fileOrDirNames) {
       pathList.addAll(getFiles(name));
     }


### PR DESCRIPTION
I set the initial cache area to some files.
________________________________
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2786
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
