### PR TITLE
AVRO-2788: Default Proto repeated fields to empty arrays

### DIFF
--- a/lang/java/protobuf/src/main/java/org/apache/avro/protobuf/ProtobufData.java
+++ b/lang/java/protobuf/src/main/java/org/apache/avro/protobuf/ProtobufData.java
@@ -327,8 +327,11 @@ public class ProtobufData extends GenericData {
   private static final JsonNodeFactory NODES = JsonNodeFactory.instance;
 
   private JsonNode getDefault(FieldDescriptor f) {
-    if (f.isRequired() || f.isRepeated()) // no default
+    if (f.isRequired()) // no default
       return null;
+
+    if (f.isRepeated()) // empty array as repeated fields' default value
+      return NODES.arrayNode();
 
     if (f.hasDefaultValue()) { // parse spec'd default value
       Object value = f.getDefaultValue();

--- a/lang/java/protobuf/src/test/java/org/apache/avro/protobuf/TestProtobuf.java
+++ b/lang/java/protobuf/src/test/java/org/apache/avro/protobuf/TestProtobuf.java
@@ -25,7 +25,7 @@ import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.specific.SpecificData;
-
+import org.apache.commons.compress.utils.Lists;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -85,6 +85,28 @@ public class TestProtobuf {
         DecoderFactory.get().binaryDecoder(new ByteArrayInputStream(bao.toByteArray()), null));
 
     assertEquals(foo, o);
+  }
+
+  @Test
+  public void testMessageWithEmptyArray() throws Exception {
+    Foo foo = Foo.newBuilder().setInt32(5).setBool(true).build();
+    ByteArrayOutputStream bao = new ByteArrayOutputStream();
+    ProtobufDatumWriter<Foo> w = new ProtobufDatumWriter<>(Foo.class);
+    Encoder e = EncoderFactory.get().binaryEncoder(bao, null);
+    w.write(foo, e);
+    e.flush();
+    Foo o = new ProtobufDatumReader<>(Foo.class).read(null,
+        DecoderFactory.get().binaryDecoder(new ByteArrayInputStream(bao.toByteArray()), null));
+
+    assertEquals(foo.getInt32(), o.getInt32());
+    assertEquals(foo.getBool(), o.getBool());
+    assertEquals(0, o.getFooArrayCount());
+  }
+
+  @Test
+  public void testEmptyArray() throws Exception {
+    Schema s = ProtobufData.get().getSchema(Foo.class);
+    assertEquals(s.getField("fooArray").defaultVal(), Lists.newArrayList());
   }
 
   @Test


### PR DESCRIPTION
… fields

Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO-2788) issues and references them in the PR title. 
  - https://issues.apache.org/jira/browse/AVRO-2788

### Tests

- [X] My PR adds the following unit tests:
  - TestProtobuf#testMessageWithEmptyArray
  - TestProtobuf#testEmptyArray

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
