### PR TITLE
AVRO-2789: Make non-reserved-word keys part of the RecordSchema & Field objects

### DIFF
--- a/lang/ruby/lib/avro/schema.rb
+++ b/lang/ruby/lib/avro/schema.rb
@@ -80,7 +80,8 @@ module Avro
           when :record, :error
             fields = json_obj['fields']
             doc    = json_obj['doc']
-            return RecordSchema.new(name, namespace, fields, names, type_sym, doc)
+            non_spec_metadata = RecordSchema.extract_non_spec_metadata(json_obj)
+            return RecordSchema.new(name, namespace, fields, names, type_sym, doc, non_spec_metadata)
           else
             raise SchemaParseError.new("Unknown named type: #{type}")
           end
@@ -256,7 +257,7 @@ module Avro
     end
 
     class RecordSchema < NamedSchema
-      attr_reader :fields, :doc
+      attr_reader :fields, :doc, :non_spec_metadata
 
       def self.make_field_objects(field_data, names, namespace=nil)
         field_objects, field_names = [], Set.new
@@ -267,7 +268,8 @@ module Avro
             default = field.key?('default') ? field['default'] : :no_default
             order = field['order']
             doc = field['doc']
-            new_field = Field.new(type, name, default, order, names, namespace, doc)
+            non_spec_metadata = Field.extract_non_spec_metadata(field)
+            new_field = Field.new(type, name, default, order, names, namespace, doc, non_spec_metadata)
             # make sure field name has not been used yet
             if field_names.include?(new_field.name)
               raise SchemaParseError, "Field name #{new_field.name.inspect} is already in use"
@@ -281,7 +283,16 @@ module Avro
         field_objects
       end
 
-      def initialize(name, namespace, fields, names=nil, schema_type=:record, doc=nil)
+      RESERVED_WORDS = %w(aliases doc fields name namespace)
+
+      def self.extract_non_spec_metadata(record_specification)
+        (record_specification.keys - RESERVED_WORDS).reduce({}) do |metadata, key|
+          metadata[key] = record_specification[key]
+          metadata
+        end
+      end
+
+      def initialize(name, namespace, fields, names=nil, schema_type=:record, doc=nil, non_spec_metadata={})
         if schema_type == :request || schema_type == 'request'
           @type_sym = schema_type.to_sym
           @namespace = namespace
@@ -295,6 +306,7 @@ module Avro
                   else
                     {}
                   end
+        @non_spec_metadata = non_spec_metadata
       end
 
       def fields_hash
@@ -308,7 +320,7 @@ module Avro
         if type_sym == :request
           hsh['fields']
         else
-          hsh
+          non_spec_metadata.merge(hsh)
         end
       end
     end
@@ -438,14 +450,24 @@ module Avro
     end
 
     class Field < Schema
-      attr_reader :type, :name, :default, :order, :doc
+      RESERVED_WORDS = %w(aliases default doc items logicalType name namespace order precision scale size symbols type values)
 
-      def initialize(type, name, default=:no_default, order=nil, names=nil, namespace=nil, doc=nil)
+      def self.extract_non_spec_metadata(field_specification)
+        (field_specification.keys - RESERVED_WORDS).reduce({}) do |metadata, key|
+          metadata[key] = field_specification[key]
+          metadata
+        end
+      end
+
+      attr_reader :type, :name, :default, :order, :doc, :non_spec_metadata
+
+      def initialize(type, name, default=:no_default, order=nil, names=nil, namespace=nil, doc=nil, non_spec_metadata={})
         @type = subparse(type, names, namespace)
         @name = name
         @default = default
         @order = order
         @doc = doc
+        @non_spec_metadata = non_spec_metadata
         validate_default! if default? && !Avro.disable_field_default_validation
       end
 
@@ -454,7 +476,7 @@ module Avro
       end
 
       def to_avro(names=Set.new)
-        {'name' => name, 'type' => type.to_avro(names)}.tap do |avro|
+        non_spec_metadata.merge('name' => name, 'type' => type.to_avro(names)).tap do |avro|
           avro['default'] = default if default?
           avro['order'] = order if order
           avro['doc'] = doc if doc

--- a/lang/ruby/test/test_schema.rb
+++ b/lang/ruby/test/test_schema.rb
@@ -249,6 +249,39 @@ class TestSchema < Test::Unit::TestCase
     assert_equal field_schema_hash, field_schema_json.to_avro
   end
 
+  def test_record_field_non_spec_metadata
+    field_schema = Avro::Schema.parse <<-SCHEMA
+      {
+        "type": "record",
+        "name": "Record",
+        "namespace": "my.name.space",
+        "fields": [
+          {
+            "name": "name",
+            "type": "boolean",
+            "some_key": "some_value"
+          }
+        ]
+      }
+    SCHEMA
+
+    field_schema_hash =
+      {
+        'type' => 'record',
+        'name' => 'Record',
+        'namespace' => 'my.name.space',
+        'fields' => [
+          {
+            'name' => 'name',
+            'type' => 'boolean',
+            'some_key' => 'some_value'
+          }
+        ]
+      }
+
+    assert_equal field_schema_hash, field_schema.to_avro
+  end
+
   def test_record_doc_attribute
     record_schema_json = Avro::Schema.parse <<-SCHEMA
       {
@@ -280,6 +313,39 @@ class TestSchema < Test::Unit::TestCase
       }
 
     assert_equal record_schema_hash, record_schema_json.to_avro
+  end
+
+  def test_record_non_spec_metadata
+    record_schema = Avro::Schema.parse <<-SCHEMA
+      {
+        "type": "record",
+        "name": "Record",
+        "namespace": "my.name.space",
+        "some_key": "some_value",
+        "fields": [
+          {
+            "name": "name",
+            "type": "boolean"
+          }
+        ]
+      }
+    SCHEMA
+
+    record_schema_hash =
+      {
+        'type' => 'record',
+        'name' => 'Record',
+        'namespace' => 'my.name.space',
+        'some_key' => 'some_value',
+        'fields' => [
+          {
+            'name' => 'name',
+            'type' => 'boolean'
+          }
+        ]
+      }
+
+    assert_equal record_schema_hash, record_schema.to_avro
   end
 
   def test_enum_doc_attribute


### PR DESCRIPTION
Currently, the Avro specification is fine with fields having keys that aren't reserved by the specification. We have use cases that need programmatic access to key-value pairs that aren't part of the specification.

AVRO-2789

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO-2789) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
