### PR TITLE
AVRO-2791: Fix lang/py3/build.sh to process each argument separately

### DIFF
--- a/lang/py3/build.sh
+++ b/lang/py3/build.sh
@@ -33,8 +33,8 @@ main() {
       clean|dist|isort|test) :;;
       *) usage; return 1;;
     esac
+    python3 setup.py "$target"
   done
-  python3 setup.py "$@"
 }
 
 main "$@"


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2791
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No additional test, since it's a minor fix for a building script. I manually ran it and confirmed that it worked as expected.

```
$ git diff
diff --git a/lang/py3/build.sh b/lang/py3/build.sh
index fc4564f9..4ed60566 100755
--- a/lang/py3/build.sh
+++ b/lang/py3/build.sh
@@ -33,8 +33,8 @@ main() {
       clean|dist|isort|test) :;;
       *) usage; return 1;;
     esac
+    python3 setup.py "$target"
   done
-  python3 setup.py "$@"
 }
 
 main "$@"
$ ./build.sh docker

(snip)

sekikn@c872b71de646:~/avro$ cd lang/py3
sekikn@c872b71de646:~/avro/lang/py3$ ./build.sh clean test
running clean
removing 'avro_python3.egg-info' (and everything under it)
Removing /home/sekikn/avro/lang/py3/avro/VERSION.txt
removing '/home/sekikn/avro/lang/py3/avro/__pycache__' (and everything under it)
Removing /home/sekikn/avro/lang/py3/avro/HandshakeResponse.avsc
Removing /home/sekikn/avro/lang/py3/avro/HandshakeRequest.avsc
Removing /home/sekikn/avro/lang/py3/avro/tests/interop.avsc
running test

(snip)

Ran 56 tests in 2.983s

OK
```

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
