### PR TITLE
AVRO-2801: Cache Hashcode of UTF8 Strings in all Set Methods

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/util/Utf8.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/util/Utf8.java
@@ -128,6 +128,7 @@ public class Utf8 implements Comparable<Utf8>, CharSequence {
     this.bytes = getBytesFor(string);
     this.length = bytes.length;
     this.string = string;
+    this.hasHash = false;
     return this;
   }
 
@@ -138,6 +139,8 @@ public class Utf8 implements Comparable<Utf8>, CharSequence {
     this.length = other.length;
     System.arraycopy(other.bytes, 0, bytes, 0, length);
     this.string = other.string;
+    this.hash = other.hash;
+    this.hasHash = other.hasHash;
     return this;
   }
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [AVRO-2801](https://issues.apache.org/jira/browse/AVRO/AVRO-2801) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2801
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
