### PR TITLE
AVRO-2813: Add cppcheck as a C++ linter

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -88,7 +88,7 @@ do
       (cd lang/py && ./build.sh lint test)
       (cd lang/py3 && ./build.sh lint test)
       (cd lang/c; ./build.sh test)
-      (cd lang/c++; ./build.sh test)
+      (cd lang/c++; ./build.sh lint test)
       (cd lang/csharp; ./build.sh test)
       (cd lang/js; ./build.sh lint test)
       (cd lang/ruby; ./build.sh lint test)

--- a/lang/c++/build.sh
+++ b/lang/c++/build.sh
@@ -77,7 +77,9 @@ do
 
 case "$target" in
   lint)
-    echo 'This is a stub where someone can provide linting.'
+    # some versions of cppcheck seem to require an explicit
+    # "--error-exitcode" option to return non-zero code
+    cppcheck --error-exitcode=1 --inline-suppr -f -q -x c++ .
     ;;
 
   test)

--- a/lang/c++/impl/Zigzag.cc
+++ b/lang/c++/impl/Zigzag.cc
@@ -24,6 +24,7 @@ namespace avro {
 uint64_t
 encodeZigzag64(int64_t input)
 {
+    // cppcheck-suppress shiftTooManyBitsSigned
     return ((input << 1) ^ (input >> 63));
 }
 
@@ -36,6 +37,7 @@ decodeZigzag64(uint64_t input)
 uint32_t
 encodeZigzag32(int32_t input)
 {
+    // cppcheck-suppress shiftTooManyBitsSigned
     return ((input << 1) ^ (input >> 31));
 }
 

--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get -qqy update \
                                                  bzip2 \
                                                  bundler \
                                                  cmake \
+                                                 cppcheck \
                                                  curl \
                                                  doxygen \
                                                  flex \


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2813
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No additional test, since this PR is just adding a static code analysis process for Avro C++.
I ran `./build.sh lint` locally and confirmed it worked as expected.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
