### PR TITLE
AVRO-2814: Add __version__ to __init__.py (PEP396)

### DIFF
--- a/lang/py/avro/test/test_init.py
+++ b/lang/py/avro/test/test_init.py
@@ -17,10 +17,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division, print_function
+import unittest
 
-import pkgutil
+import avro
 
-__all__ = ['schema', 'io', 'datafile', 'protocol', 'ipc', 'constants', 'timezones', 'codecs']
 
-__version__ = (pkgutil.get_data(__name__, 'VERSION.txt') or b'0.0.1+unknown').decode().strip()
+class TestVersion(unittest.TestCase):
+
+  def test_import_version(self):
+
+    # make sure we have __version__ attribute in avro module
+    avro.__version__
+
+if __name__ == '__main__':
+  unittest.main()

--- a/lang/py3/avro/__init__.py
+++ b/lang/py3/avro/__init__.py
@@ -21,14 +21,7 @@
 __all__ = ('schema', 'io', 'datafile', 'protocol', 'ipc')
 
 
-import os
+import pkgutil
 
-
-def LoadResource(name):
-  dir_path = os.path.dirname(__file__)
-  rsrc_path = os.path.join(dir_path, name)
-  with open(rsrc_path, 'r') as f:
-    return f.read()
-
-
-VERSION = LoadResource('VERSION.txt').strip()
+__version__ = (pkgutil.get_data(__name__, 'VERSION.txt') or b'0.0.1+unknown').decode().strip()
+VERSION = __version__

--- a/lang/py3/avro/tests/run_tests.py
+++ b/lang/py3/avro/tests/run_tests.py
@@ -55,6 +55,7 @@ from avro.tests.test_ipc import *
 from avro.tests.test_protocol import *
 from avro.tests.test_schema import *
 from avro.tests.test_script import *
+from avro.tests.test_init import *
 
 
 def SetupLogging():

--- a/lang/py3/avro/tests/test_init.py
+++ b/lang/py3/avro/tests/test_init.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one
@@ -17,10 +17,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division, print_function
+import unittest
 
-import pkgutil
+import avro
 
-__all__ = ['schema', 'io', 'datafile', 'protocol', 'ipc', 'constants', 'timezones', 'codecs']
 
-__version__ = (pkgutil.get_data(__name__, 'VERSION.txt') or b'0.0.1+unknown').decode().strip()
+class TestVersion(unittest.TestCase):
+
+  def testImportVersion(self):
+
+    # make sure we have __version__ attribute in avro module
+    avro.__version__
+
+if __name__ == '__main__':
+  raise Exception('Use run_tests.py')


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2814

### Tests

- [x] My PR adds the following unit tests
  - lang/py/test/test_init.py
  - lang/py3/test/test_init.py

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
