### PR TITLE
AVRO-2820: Update SLF4J to 1.7.30

### DIFF
--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -49,7 +49,7 @@
     <netty.version>3.10.6.Final</netty.version>
     <protobuf.version>3.11.1</protobuf.version>
     <thrift.version>0.12.0</thrift.version>
-    <slf4j.version>1.7.25</slf4j.version>
+    <slf4j.version>1.7.30</slf4j.version>
     <snappy.version>1.1.7.3</snappy.version>
     <velocity.version>2.2</velocity.version>
     <maven.version>3.3.9</maven.version>


### PR DESCRIPTION
This task is to update SLF4J to 1.7.30, in particular to pick up a fix for a CVE fixed in 1.7.26 - https://www.cvedetails.com/cve/CVE-2018-8088/