### PR TITLE
AVRO-2822: Add toString that doesn't inline referenced schemas

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/Schema.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Schema.java
@@ -388,12 +388,33 @@ public abstract class Schema extends JsonProperties implements Serializable {
    * @param pretty if true, pretty-print JSON.
    */
   public String toString(boolean pretty) {
+    return toString(new Names(), pretty);
+  }
+
+  /**
+   * Render this as <a href="https://json.org/">JSON</a>,
+   * but without inlining the referenced schemas.
+   *
+   * @param referencedSchemas referenced schemas
+   * @param pretty if true, pretty-print JSON.
+   */
+  public String toString(Collection<Schema> referencedSchemas, boolean pretty) {
+    Schema.Names names = new Schema.Names();
+    if (referencedSchemas != null) {
+      for (Schema s : referencedSchemas) {
+        names.add(s);
+      }
+    }
+    return toString(names, pretty);
+  }
+
+  String toString(Names names, boolean pretty) {
     try {
       StringWriter writer = new StringWriter();
       JsonGenerator gen = FACTORY.createGenerator(writer);
       if (pretty)
         gen.useDefaultPrettyPrinter();
-      toJson(new Names(), gen);
+      toJson(names, gen);
       gen.flush();
       return writer.toString();
     } catch (IOException e) {

--- a/lang/java/avro/src/main/java/org/apache/avro/Schema.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Schema.java
@@ -392,11 +392,11 @@ public abstract class Schema extends JsonProperties implements Serializable {
   }
 
   /**
-   * Render this as <a href="https://json.org/">JSON</a>,
-   * but without inlining the referenced schemas.
+   * Render this as <a href="https://json.org/">JSON</a>, but without inlining the
+   * referenced schemas.
    *
    * @param referencedSchemas referenced schemas
-   * @param pretty if true, pretty-print JSON.
+   * @param pretty            if true, pretty-print JSON.
    */
   public String toString(Collection<Schema> referencedSchemas, boolean pretty) {
     Schema.Names names = new Schema.Names();

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchema.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchema.java
@@ -200,4 +200,26 @@ public class TestSchema {
     }
   }
 
+  @Test
+  public void testReconstructSchemaStringWithoutInlinedChildReference() {
+    String child = "{\"type\":\"record\","
+      + "\"name\":\"Child\","
+      + "\"namespace\":\"org.apache.avro.nested\","
+      + "\"fields\":"
+      + "[{\"name\":\"childField\",\"type\":\"string\"}]}";
+    String parent = "{\"type\":\"record\","
+      + "\"name\":\"Parent\","
+      + "\"namespace\":\"org.apache.avro.nested\","
+      + "\"fields\":"
+      + "[{\"name\":\"child\",\"type\":\"Child\"}]}";
+    Schema.Parser parser = new Schema.Parser();
+    Schema childSchema = parser.parse(child);
+    Schema parentSchema = parser.parse(parent);
+    String parentWithoutInlinedChildReference =
+      parentSchema.toString(Collections.singleton(childSchema), false);
+    // The generated string should be the same as the original parent
+    // schema string that did not have the child schema inlined.
+    assertEquals(parent, parentWithoutInlinedChildReference);
+  }
+
 }

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchema.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchema.java
@@ -202,21 +202,14 @@ public class TestSchema {
 
   @Test
   public void testReconstructSchemaStringWithoutInlinedChildReference() {
-    String child = "{\"type\":\"record\","
-      + "\"name\":\"Child\","
-      + "\"namespace\":\"org.apache.avro.nested\","
-      + "\"fields\":"
-      + "[{\"name\":\"childField\",\"type\":\"string\"}]}";
-    String parent = "{\"type\":\"record\","
-      + "\"name\":\"Parent\","
-      + "\"namespace\":\"org.apache.avro.nested\","
-      + "\"fields\":"
-      + "[{\"name\":\"child\",\"type\":\"Child\"}]}";
+    String child = "{\"type\":\"record\"," + "\"name\":\"Child\"," + "\"namespace\":\"org.apache.avro.nested\","
+        + "\"fields\":" + "[{\"name\":\"childField\",\"type\":\"string\"}]}";
+    String parent = "{\"type\":\"record\"," + "\"name\":\"Parent\"," + "\"namespace\":\"org.apache.avro.nested\","
+        + "\"fields\":" + "[{\"name\":\"child\",\"type\":\"Child\"}]}";
     Schema.Parser parser = new Schema.Parser();
     Schema childSchema = parser.parse(child);
     Schema parentSchema = parser.parse(parent);
-    String parentWithoutInlinedChildReference =
-      parentSchema.toString(Collections.singleton(childSchema), false);
+    String parentWithoutInlinedChildReference = parentSchema.toString(Collections.singleton(childSchema), false);
     // The generated string should be the same as the original parent
     // schema string that did not have the child schema inlined.
     assertEquals(parent, parentWithoutInlinedChildReference);


### PR DESCRIPTION
I need a method to reconstruct the original schema string before referenced schemas were resolved and inlined by the Parser.   This is a small enhancement that addresses https://issues.apache.org/jira/browse/AVRO-2822 by exposing a toString() method to pass the referenced schemas.

This also addresses https://github.com/confluentinc/schema-registry/issues/1432