### PR TITLE
[AVRO-2827] Fixes property visibility.

### DIFF
--- a/lang/php/lib/avro/datum.php
+++ b/lang/php/lib/avro/datum.php
@@ -76,7 +76,7 @@ class AvroIODatumWriter
    * Schema used by this instance to write Avro data.
    * @var AvroSchema
    */
-  private $writers_schema;
+  public $writers_schema;
 
   /**
    * @param AvroSchema $writers_schema


### PR DESCRIPTION
This property is used in `AvroDataIOWriter::__construct()` and therefore it has to be public.

https://jira.apache.org/jira/browse/AVRO-2827