### PR TITLE
AVRO-2808: provide details while encountering non-static inner classes

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectData.java
@@ -65,6 +65,9 @@ import java.util.concurrent.ConcurrentHashMap;
 
 /** Utilities to use existing Java classes and interfaces via reflection. */
 public class ReflectData extends SpecificData {
+
+  private final String STRING_OUTER_PARENT_REFERENCE = "this$0";
+
   @Override
   public boolean useCustomCoders() {
     return false;
@@ -737,7 +740,7 @@ public class ReflectData extends SpecificData {
 
               AvroName annotatedName = field.getAnnotation(AvroName.class); // Rename fields
               String fieldName = (annotatedName != null) ? annotatedName.value() : field.getName();
-              if ("this$0".equals(fieldName)) {
+              if (STRING_OUTER_PARENT_REFERENCE.equals(fieldName)) {
                 throw new AvroTypeException("Class " + fullName + " must be a static inner class");
               }
               Schema.Field recordField = new Schema.Field(fieldName, fieldSchema, doc, defaultValue);

--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectData.java
@@ -737,6 +737,9 @@ public class ReflectData extends SpecificData {
 
               AvroName annotatedName = field.getAnnotation(AvroName.class); // Rename fields
               String fieldName = (annotatedName != null) ? annotatedName.value() : field.getName();
+              if ("this$0".equals(fieldName)) {
+                throw new AvroTypeException("Class " + fullName + " must be a static inner class");
+              }
               Schema.Field recordField = new Schema.Field(fieldName, fieldSchema, doc, defaultValue);
 
               AvroMeta[] metadata = field.getAnnotationsByType(AvroMeta.class); // add metadata

--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectData.java
@@ -66,7 +66,7 @@ import java.util.concurrent.ConcurrentHashMap;
 /** Utilities to use existing Java classes and interfaces via reflection. */
 public class ReflectData extends SpecificData {
 
-  private final String STRING_OUTER_PARENT_REFERENCE = "this$0";
+  private static final String STRING_OUTER_PARENT_REFERENCE = "this$0";
 
   @Override
   public boolean useCustomCoders() {

--- a/lang/java/avro/src/test/java/org/apache/avro/reflect/TestReflectData.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/reflect/TestReflectData.java
@@ -135,29 +135,13 @@ public class TestReflectData {
     public Map<String, String> tokens;
   }
 
-  @Test
-  public void testInnerClasses() {
-    testStaticInnerClasses();
-    testNonStaticInnerClasses();
-  }
-
+  @Test(expected = AvroTypeException.class)
   public void testNonStaticInnerClasses() {
-    boolean successful = false;
-    try {
-      ReflectData.get().getSchema(Definition.class);
-    } catch (AvroTypeException ex) {
-      if (ex.getMessage().contains("must be a static inner class")) {
-        successful = true;
-      }
-    }
-    assertTrue(successful);
+    ReflectData.get().getSchema(Definition.class);
   }
 
+  @Test
   public void testStaticInnerClasses() {
-    try {
-      ReflectData.get().getSchema(Meta.class);
-    } catch (AvroTypeException ex) {
-      fail("Should have no exception");
-    }
+    ReflectData.get().getSchema(Meta.class);
   }
 }

--- a/lang/java/avro/src/test/java/org/apache/avro/reflect/TestReflectData.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/reflect/TestReflectData.java
@@ -18,6 +18,7 @@
 
 package org.apache.avro.reflect;
 
+import org.apache.avro.AvroTypeException;
 import org.apache.avro.Protocol;
 import org.apache.avro.Schema;
 import org.apache.avro.util.internal.JacksonUtils;
@@ -29,8 +30,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 
 public class TestReflectData {
   @Test
@@ -128,6 +128,36 @@ public class TestReflectData {
 
     for (Schema.Field field : cloneSchema.getFields()) {
       assertEquals("Invalid field " + field.name(), field.defaultVal(), testCases.get(field.name()));
+    }
+  }
+
+  public class Definition {
+    public Map<String, String> tokens;
+  }
+
+  @Test
+  public void testInnerClasses() {
+    testStaticInnerClasses();
+    testNonStaticInnerClasses();
+  }
+
+  public void testNonStaticInnerClasses() {
+    boolean successful = false;
+    try {
+      ReflectData.get().getSchema(Definition.class);
+    } catch (AvroTypeException ex) {
+      if (ex.getMessage().contains("must be a static inner class")) {
+        successful = true;
+      }
+    }
+    assertTrue(successful);
+  }
+
+  public void testStaticInnerClasses() {
+    try {
+      ReflectData.get().getSchema(Meta.class);
+    } catch (AvroTypeException ex) {
+      fail("Should have no exception");
     }
   }
 }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AVRO-2808
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests `TestReflectData.testInnerClasses`

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
