### PR TITLE
AVRO-2830: Union with aliases for java

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/Schema.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Schema.java
@@ -239,7 +239,7 @@ public abstract class Schema extends JsonProperties implements Serializable {
 
   /** Create a union schema. */
   public static Schema createUnion(List<Schema> types) {
-    return new UnionSchema(new LockableArrayList<>(types));
+    return new UnionSchema(new LockableArrayList<>(types), false);
   }
 
   /** Create a union schema. */
@@ -1169,7 +1169,7 @@ public abstract class Schema extends JsonProperties implements Serializable {
     private final List<Schema> types;
     private final Map<String, Integer> indexByName = new HashMap<>();
 
-    public UnionSchema(LockableArrayList<Schema> types) {
+    public UnionSchema(LockableArrayList<Schema> types, boolean fromAliases) {
       super(Type.UNION);
       this.types = types.lock();
       int index = 0;
@@ -1179,7 +1179,7 @@ public abstract class Schema extends JsonProperties implements Serializable {
         String name = type.getFullName();
         if (name == null)
           throw new AvroRuntimeException("Nameless in union:" + this);
-        if (indexByName.put(name, index++) != null)
+        if (indexByName.put(name, index++) != null && !fromAliases)
           throw new AvroRuntimeException("Duplicate in union:" + name);
       }
     }
@@ -1737,7 +1737,7 @@ public abstract class Schema extends JsonProperties implements Serializable {
       LockableArrayList<Schema> types = new LockableArrayList<>(schema.size());
       for (JsonNode typeNode : schema)
         types.add(parse(typeNode, names));
-      return new UnionSchema(types);
+      return new UnionSchema(types, false);
     } else {
       throw new SchemaParseException("Schema not yet supported: " + schema);
     }
@@ -1860,7 +1860,7 @@ public abstract class Schema extends JsonProperties implements Serializable {
       List<Schema> types = new ArrayList<>();
       for (Schema branch : s.getTypes())
         types.add(applyAliases(branch, seen, aliases, fieldAliases));
-      result = Schema.createUnion(types);
+      result = new UnionSchema(new LockableArrayList<>(types), true);
       break;
     case FIXED:
       if (aliases.containsKey(name))

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemaCompatibility.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemaCompatibility.java
@@ -30,6 +30,7 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericData.EnumSymbol;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.avro.io.*;
 import org.apache.avro.util.Utf8;
 import org.junit.Test;
@@ -361,6 +362,12 @@ public class TestSchemaCompatibility {
 
   // -----------------------------------------------------------------------------------------------
 
+  private static final Schema UNION_A_AND_B = SchemaBuilder.unionOf().record("A").fields().requiredBoolean("a")
+      .endRecord().and().record("B").fields().requiredBoolean("b").endRecord().endUnion();
+  private static final Schema UNION_B_ALIAS_A = SchemaBuilder.unionOf().record("B").aliases("A").fields().name("a")
+      .type().booleanType().booleanDefault(false).name("b").type().booleanType().booleanDefault(false).endRecord()
+      .endUnion();
+
   public static final List<DecodingTestCase> DECODING_COMPATIBILITY_TEST_CASES = list(
       new DecodingTestCase(INT_SCHEMA, 1, INT_SCHEMA, 1), new DecodingTestCase(INT_SCHEMA, 1, LONG_SCHEMA, 1L),
       new DecodingTestCase(INT_SCHEMA, 1, FLOAT_SCHEMA, 1.0f), new DecodingTestCase(INT_SCHEMA, 1, DOUBLE_SCHEMA, 1.0d),
@@ -386,7 +393,12 @@ public class TestSchemaCompatibility {
 
       new DecodingTestCase(INT_STRING_UNION_SCHEMA, "the string", STRING_SCHEMA, new Utf8("the string")),
 
-      new DecodingTestCase(INT_STRING_UNION_SCHEMA, "the string", STRING_UNION_SCHEMA, new Utf8("the string")));
+      new DecodingTestCase(INT_STRING_UNION_SCHEMA, "the string", STRING_UNION_SCHEMA, new Utf8("the string")),
+
+      // AVRO-2830
+      new DecodingTestCase(UNION_A_AND_B,
+          new GenericRecordBuilder(UNION_A_AND_B.getTypes().get(0)).set("a", true).build(), UNION_B_ALIAS_A,
+          new GenericRecordBuilder(UNION_B_ALIAS_A.getTypes().get(0)).set("a", true).build()));
 
   /**
    * Tests the reader/writer compatibility at decoding time.


### PR DESCRIPTION
When evolving a union over time allow to merge multiple records into one
using aliases.

So a writer with the following schema:

```
[ {
  "type" : "record",
  "name" : "A",
  "fields" : [ { "name" : "a", "type" : "boolean" } ]
}, {
  "type" : "record",
  "name" : "B",
  "fields" : [ { "name" : "b", "type" : "boolean" } ]
} ]
```

can be read by a reader with schema:

```
[ {
  "type" : "record",
  "name" : "B",
  "aliases" : [ "A" ],
  "fields" : [
     { "name" : "a", "type" : "boolean", "default" : true},
     { "name" : "b", "type" : "boolean", "default" : true}
  ]
} ]
```

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [AVRO-2830](https://issues.apache.org/jira/browse/AVRO/AVRO-2830) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"

### Tests

- [X] My PR extends unite test org.apache.avro.TestSchemaCompatibility#testReaderWriterDecodingCompatibility 

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
