### PR TITLE
AVRO-2836 Generated java includes logical type conversions

### DIFF
--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
@@ -328,6 +328,11 @@ public class SpecificCompiler {
       break;
     case ENUM:
     case FIXED:
+      String convertedLogicalType = getConvertedLogicalType(schema);
+      if (convertedLogicalType != null) {
+        result.add(convertedLogicalType);
+      }
+      break;
     case NULL:
       break;
     case STRING:
@@ -337,7 +342,7 @@ public class SpecificCompiler {
     case FLOAT:
     case DOUBLE:
     case BOOLEAN:
-      result.add(javaType(schema));
+      result.add(javaType(schema, true));
       break;
     default:
       throw new RuntimeException("Unknown type: " + schema);

--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
@@ -326,15 +326,10 @@ public class SpecificCompiler {
       for (Schema s : schema.getTypes())
         getClassNamesOfPrimitiveFields(s, result, seenSchemas);
       break;
-    case ENUM:
-    case FIXED:
-      String convertedLogicalType = getConvertedLogicalType(schema);
-      if (convertedLogicalType != null) {
-        result.add(convertedLogicalType);
-      }
-      break;
     case NULL:
       break;
+    case ENUM:
+    case FIXED:
     case STRING:
     case BYTES:
     case INT:

--- a/lang/java/integration-test/codegen-test/src/test/java/org/apache/avro/codegentest/TestNestedLogicalTypes.java
+++ b/lang/java/integration-test/codegen-test/src/test/java/org/apache/avro/codegentest/TestNestedLogicalTypes.java
@@ -17,11 +17,20 @@
  */
 package org.apache.avro.codegentest;
 
-import java.time.LocalDate;
-
-import org.apache.avro.codegentest.testdata.*;
+import org.apache.avro.codegentest.testdata.NestedLogicalTypesArray;
+import org.apache.avro.codegentest.testdata.NestedLogicalTypesMap;
+import org.apache.avro.codegentest.testdata.NestedLogicalTypesRecord;
+import org.apache.avro.codegentest.testdata.NestedLogicalTypesUnion;
+import org.apache.avro.codegentest.testdata.NestedLogicalTypesUnionFixedDecimal;
+import org.apache.avro.codegentest.testdata.NestedRecord;
+import org.apache.avro.codegentest.testdata.NullableLogicalTypesArray;
+import org.apache.avro.codegentest.testdata.RecordInArray;
+import org.apache.avro.codegentest.testdata.RecordInMap;
+import org.apache.avro.codegentest.testdata.RecordInUnion;
 import org.junit.Test;
 
+import java.math.BigInteger;
+import java.time.LocalDate;
 import java.util.Collections;
 
 public class TestNestedLogicalTypes extends AbstractSpecificRecordTest {
@@ -64,4 +73,12 @@ public class TestNestedLogicalTypes extends AbstractSpecificRecordTest {
         .build();
     verifySerDeAndStandardMethods(nestedLogicalTypesMap);
   }
+
+  @Test
+  public void testNullableLogicalTypeInRecordInFixedDecimal() {
+    final NestedLogicalTypesUnionFixedDecimal nestedLogicalTypesUnionFixedDecimal = NestedLogicalTypesUnionFixedDecimal
+        .newBuilder().setUnionOfFixedDecimal(new CustomDecimal(BigInteger.TEN, 15)).build();
+    verifySerDeAndStandardMethods(nestedLogicalTypesUnionFixedDecimal);
+  }
+
 }

--- a/lang/java/integration-test/codegen-test/src/test/resources/avro/nested_logical_types_union_fixed.avsc
+++ b/lang/java/integration-test/codegen-test/src/test/resources/avro/nested_logical_types_union_fixed.avsc
@@ -1,0 +1,21 @@
+{"namespace": "org.apache.avro.codegentest.testdata",
+  "type": "record",
+  "name": "NestedLogicalTypesUnionFixedDecimal",
+  "doc" : "Test nested types with logical types in generated Java classes",
+  "fields": [
+    {
+      "name": "unionOfFixedDecimal",
+      "type": ["null", {
+        "namespace": "org.apache.avro.codegentest.testdata",
+        "name": "FixedInUnion",
+        "type": "fixed",
+        "size": 12,
+        "logicalType": "decimal",
+        "precision": 28,
+        "scale": 15
+      }]
+    }]
+}
+
+
+

--- a/lang/java/integration-test/test-custom-conversions/src/main/java/org/apache/avro/codegentest/CustomDecimal.java
+++ b/lang/java/integration-test/test-custom-conversions/src/main/java/org/apache/avro/codegentest/CustomDecimal.java
@@ -45,6 +45,10 @@ public class CustomDecimal implements Comparable<CustomDecimal> {
 
   }
 
+  int signum() {
+    return internalValue.signum();
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o)


### PR DESCRIPTION
If the logical type is used for a Fixed type (potentially also Enum)
then it should check if there are any conversions used, and
include in the generated java source

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO-2836) issues and references them in the PR title.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Added new test in TestNestedLogicalTypes that fails before this change, but succeeds with it

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
