### PR TITLE
AVRO-2139: Add Test for Decimal @java-class Annotated Generated Classes

### DIFF
--- a/lang/java/ipc/src/test/java/org/apache/avro/generic/TestBuilderCopy.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/generic/TestBuilderCopy.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.avro.generic;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.HashMap;
+
+import org.junit.Test;
+
+import test.StringablesRecord;
+
+import static org.junit.Assert.assertEquals;
+
+/** Unit test for performing a builder copy of an object with a schema */
+public class TestBuilderCopy {
+  @Test
+  public void testBuilderCopy() {
+    StringablesRecord.Builder builder = StringablesRecord.newBuilder();
+    builder.setValue(new BigDecimal("1314.11"));
+
+    HashMap<String, BigDecimal> mapWithBigDecimalElements = new HashMap<>();
+    mapWithBigDecimalElements.put("testElement", new BigDecimal("220.11"));
+    builder.setMapWithBigDecimalElements(mapWithBigDecimalElements);
+
+    HashMap<BigInteger, String> mapWithBigIntKeys = new HashMap<>();
+    mapWithBigIntKeys.put(BigInteger.ONE, "testKey");
+    builder.setMapWithBigIntKeys(mapWithBigIntKeys);
+
+    StringablesRecord original = builder.build();
+
+    StringablesRecord duplicate = StringablesRecord.newBuilder(original).build();
+
+    assertEquals(duplicate, original);
+  }
+}


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [AVRO-2139](https://issues.apache.org/jira/browse/AVRO-2139) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2139
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"
