### PR TITLE
AVRO-1669: PHP library can't serialise records with optional (union-null) values

### DIFF
--- a/lang/php/lib/Datum/AvroIODatumWriter.php
+++ b/lang/php/lib/Datum/AvroIODatumWriter.php
@@ -163,7 +163,7 @@ class AvroIODatumWriter
     private function writeRecord($writers_schema, $datum, $encoder)
     {
         foreach ($writers_schema->fields() as $field) {
-            $this->writeData($field->type(), $datum[$field->name()], $encoder);
+            $this->writeData($field->type(), $datum[$field->name()] ?? null, $encoder);
         }
     }
 

--- a/lang/php/lib/Schema/AvroSchema.php
+++ b/lang/php/lib/Schema/AvroSchema.php
@@ -481,12 +481,7 @@ class AvroSchema
             case self::REQUEST_SCHEMA:
                 if (is_array($datum)) {
                     foreach ($expected_schema->fields() as $field) {
-                        if (
-                            !array_key_exists($field->name(), $datum) || !self::isValidDatum(
-                                $field->type(),
-                                $datum[$field->name()]
-                            )
-                        ) {
+                        if (!self::isValidDatum($field->type(), $datum[$field->name()] ?? null)) {
                             return false;
                         }
                     }

--- a/lang/php/test/IODatumReaderTest.php
+++ b/lang/php/test/IODatumReaderTest.php
@@ -19,7 +19,10 @@
 
 namespace Apache\Avro\Tests;
 
+use Apache\Avro\Datum\AvroIOBinaryEncoder;
 use Apache\Avro\Datum\AvroIODatumReader;
+use Apache\Avro\Datum\AvroIODatumWriter;
+use Apache\Avro\IO\AvroStringIO;
 use Apache\Avro\Schema\AvroSchema;
 use PHPUnit\Framework\TestCase;
 
@@ -35,5 +38,27 @@ JSON;
         $this->assertTrue(AvroIODatumReader::schemasMatch(
             AvroSchema::parse($writers_schema),
             AvroSchema::parse($readers_schema)));
+    }
+
+    public function testRecordNullField()
+    {
+        $schema_json = <<<_JSON
+{"name":"member",
+ "type":"record",
+ "fields":[{"name":"one", "type":"int"},
+           {"name":"two", "type":["null", "string"]}
+           ]}
+_JSON;
+
+        $schema = AvroSchema::parse($schema_json);
+        $datum = array("one" => 1);
+
+        $io = new AvroStringIO();
+        $writer = new AvroIODatumWriter($schema);
+        $encoder = new AvroIOBinaryEncoder($io);
+        $writer->write($datum, $encoder);
+        $bin = $io->string();
+
+        $this->assertSame('0200', bin2hex($bin));
     }
 }


### PR DESCRIPTION
Fixed `null` handling on fields.

* added testRecordNullField
