### PR TITLE
AVRO-2858: Fix NaN regard as TextNode

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/SchemaBuilder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/SchemaBuilder.java
@@ -17,10 +17,7 @@
  */
 package org.apache.avro;
 
-import java.io.IOException;
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -31,14 +28,11 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import org.apache.avro.Schema.Field;
-import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.util.internal.JacksonUtils;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 

--- a/lang/java/avro/src/main/java/org/apache/avro/SchemaBuilder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/SchemaBuilder.java
@@ -2228,7 +2228,7 @@ public class SchemaBuilder {
     }
 
     private FieldAssembler<R> completeField(Schema schema, Object defaultVal) {
-      JsonNode defaultNode = defaultVal == null ? NullNode.getInstance() : toJsonNode(defaultVal);
+      JsonNode defaultNode = defaultVal == null ? NullNode.getInstance() : JacksonUtils.toJsonNode(defaultVal);
       return completeField(schema, defaultNode);
     }
 
@@ -2694,31 +2694,4 @@ public class SchemaBuilder {
     }
   }
 
-  // create default value JsonNodes from objects
-  private static JsonNode toJsonNode(Object o) {
-    try {
-      String s;
-      if (o instanceof ByteBuffer) {
-        // special case since GenericData.toString() is incorrect for bytes
-        // note that this does not handle the case of a default value with nested bytes
-        ByteBuffer bytes = ((ByteBuffer) o);
-        ((Buffer) bytes).mark();
-        byte[] data = new byte[bytes.remaining()];
-        bytes.get(data);
-        ((Buffer) bytes).reset(); // put the buffer back the way we got it
-        s = new String(data, StandardCharsets.ISO_8859_1);
-        char[] quoted = JsonStringEncoder.getInstance().quoteAsString(s);
-        s = "\"" + new String(quoted) + "\"";
-      } else if (o instanceof byte[]) {
-        s = new String((byte[]) o, StandardCharsets.ISO_8859_1);
-        char[] quoted = JsonStringEncoder.getInstance().quoteAsString(s);
-        s = '\"' + new String(quoted) + '\"';
-      } else {
-        s = GenericData.get().toString(o);
-      }
-      return new ObjectMapper().readTree(s);
-    } catch (IOException e) {
-      throw new SchemaBuilderException(e);
-    }
-  }
 }

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemaBuilder.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemaBuilder.java
@@ -812,4 +812,15 @@ public class TestSchemaBuilder {
         schema.getField("double").defaultVal());
   }
 
+  @Test
+  public void testNanDefaultValuesForFloatAndDouble() {
+    Double doubleNan = Double.NaN;
+    Float floatNan = Float.NaN;
+    Schema schema = SchemaBuilder.record("r").fields().name("doubleNan").type().doubleType().doubleDefault(doubleNan)
+      .name("floatNan").type().floatType().floatDefault(floatNan).endRecord();
+
+    Assert.assertEquals(floatNan, schema.getField("floatNan").defaultVal());
+    Assert.assertEquals(doubleNan, schema.getField("doubleNan").defaultVal());
+  }
+
 }

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemaBuilder.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemaBuilder.java
@@ -817,10 +817,10 @@ public class TestSchemaBuilder {
     Double doubleNan = Double.NaN;
     Float floatNan = Float.NaN;
     Schema schema = SchemaBuilder.record("r").fields().name("doubleNan").type().doubleType().doubleDefault(doubleNan)
-      .name("floatNan").type().floatType().floatDefault(floatNan).endRecord();
+        .name("floatNan").type().floatType().floatDefault(floatNan).endRecord();
 
-    Assert.assertEquals(floatNan, schema.getField("floatNan").defaultVal());
-    Assert.assertEquals(doubleNan, schema.getField("doubleNan").defaultVal());
+    Assert.assertEquals("float field default not being NaN", floatNan, schema.getField("floatNan").defaultVal());
+    Assert.assertEquals("float field default not being NaN", doubleNan, schema.getField("doubleNan").defaultVal());
   }
 
 }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x]  My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO-2858) issues and references them in the PR title. 
  - https://issues.apache.org/jira/browse/AVRO-2858

### Tests

- [x]  My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
testNanDefaultValuesForFloatAndDouble

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

