### PR TITLE
AVRO-2849: Update spec to clarify valid namespaces

### DIFF
--- a/doc/src/content/xdocs/spec.xml
+++ b/doc/src/content/xdocs/spec.xml
@@ -132,7 +132,7 @@
 		  impacts sort ordering of this record (optional).
 		  Valid values are "ascending" (the default),
 		  "descending", or "ignore".  For more details on how
-		  this is used, see the the <a href="#order">sort
+		  this is used, see the <a href="#order">sort
 		  order</a> section below.</li>
 		<li><code>aliases:</code> a JSON array of strings, providing
 		  alternate names for this field (optional).</li>
@@ -284,6 +284,10 @@
         null namespace.
         Equality of names (including field names and enum symbols)
         as well as fullnames is case-sensitive.</p>
+        <p> The null namespace may not be used in a dot-separated
+        sequence of names.  So the grammar for a namespace
+        is:</p>
+        <p>&nbsp;&nbsp;<code>&lt;empty&gt; | &lt;name&gt;[(&lt;dot&gt;&lt;name&gt;)*]</code></p>
         <p>In record, enum and fixed definitions, the fullname is
         determined in one of the following ways:</p>
 	<ul>


### PR DESCRIPTION
 My PR addresses the following [AVRO-2849] (https://issues.apache.org/jira/projects/AVRO/issues/AVRO-2849).  It clarifies that the empty namespace can only be used by itself.


### Tests
- I built the documentation using ant and forrest and verified layout with links2 browser

