### PR TITLE
AVRO-2865: Remove maven 2 support

### DIFF
--- a/lang/java/maven-plugin/pom.xml
+++ b/lang/java/maven-plugin/pom.xml
@@ -61,6 +61,14 @@
       <artifactId>maven-core</artifactId>
       <version>${maven.version}</version>
     </dependency>
+    <!-- Bump this to a higher version while maven 3.3.9 still uses 3.0.22 with a -->
+    <!-- XML injection vulnerability. -->
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>3.0.24</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>file-management</artifactId>

--- a/lang/java/maven-plugin/pom.xml
+++ b/lang/java/maven-plugin/pom.xml
@@ -57,10 +57,8 @@
 
   <dependencies>
     <dependency>
-      <!-- Maven2 classes maintained as compatibility layer -->
-      <!-- Remove once avro-maven-plugin code is upgrade to Maven3 -->
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-compat</artifactId>
+      <artifactId>maven-core</artifactId>
       <version>${maven.version}</version>
     </dependency>
     <dependency>
@@ -68,10 +66,6 @@
       <artifactId>file-management</artifactId>
       <version>${file-management.version}</version>
       <exclusions>
-        <exclusion>
-          <groupId>org.apache.maven</groupId>
-          <artifactId>maven-plugin-api</artifactId>
-        </exclusion>
         <exclusion>
           <groupId>com.google.code.findbugs</groupId>
           <artifactId>jsr305</artifactId>
@@ -84,6 +78,12 @@
       <version>${project.version}</version>
     </dependency>
     <!-- test-->
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-compat</artifactId>
+      <version>${maven.version}</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-testing</groupId>
       <artifactId>maven-plugin-testing-tools</artifactId>


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2865
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
