### PR TITLE
AVRO-1461: Distribute Perl API on CPAN

### DIFF
--- a/lang/perl/Makefile.PL
+++ b/lang/perl/Makefile.PL
@@ -50,4 +50,18 @@ unless ($Config{use64bitint}) {
 }
 auto_set_repository();
 
+my %packages = (
+    'Avro'                    => 'lib/Avro.pm',
+    'Avro::BinaryDecoder'     => 'lib/Avro/BinaryDecoder.pm',
+    'Avro::BinaryEncoder'     => 'lib/Avro/BinaryEncoder.pm',
+    'Avro::DataFile'          => 'lib/Avro/DataFile.pm',
+    'Avro::DataFileReader'    => 'lib/Avro/DataFileReader.pm',
+    'Avro::DataFileWriter'    => 'lib/Avro/DataFileWriter.pm',
+    'Avro::Protocol'          => 'lib/Avro/Protocol.pm',
+    'Avro::Protocol::Message' => 'lib/Avro/Protocol/Message.pm',
+    'Avro::Schema'            => 'lib/Avro/Schema.pm',
+);
+my %provides = map { $_ => { file => $packages{$_}, version => $version } } keys %packages;
+provides(%provides);
+
 WriteMakefile(PM_FILTER => "sed -e 's/\+\+MODULE_VERSION\+\+/$version/'");


### PR DESCRIPTION
Fix Makefile.PL so that PAUSE can identify Avro packages and corresponding files

cc @iemejia @RyanSkraba

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-1461
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No additional test, since it's a fix for a build script. I ran `./build.sh dist` and uploaded the generated Perl distribution tarball to PAUSE, and confirmed that it was published via CPAN successfully.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
