### PR TITLE
AVRO-2032: Teach JsonEncoder how to deserialize Double.Nan, and

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/io/JsonDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/JsonDecoder.java
@@ -197,6 +197,8 @@ public class JsonDecoder extends ParsingDecoder implements Parser.ActionHandler 
       double result = in.getDoubleValue();
       in.nextToken();
       return result;
+    } else if (in.currentToken() == JsonToken.VALUE_STRING) {
+      return Double.parseDouble(in.getText());
     } else {
       throw error("double");
     }


### PR DESCRIPTION
Double.POSITIVE_INFINITY and Double.NEGATIVE_INFINITY

When using the JsonDecoder to deserialize these three cases (NaN,
positive infinity, and negative infinity), JsonEncoder throws
AvroTypeException the following message: "Expected double. Got VALUE_STRING".

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-2032: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2032
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests:
    TestJsonDecoder.testNaN and TestJsonDecoder.testInfinity


### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
