### PR TITLE
AVRO-2881 fix double default value

### DIFF
--- a/lang/java/protobuf/src/main/java/org/apache/avro/protobuf/ProtobufData.java
+++ b/lang/java/protobuf/src/main/java/org/apache/avro/protobuf/ProtobufData.java
@@ -352,7 +352,9 @@ public class ProtobufData extends GenericData {
     case BOOL:
       return NODES.booleanNode(false);
     case FLOAT:
+      return NODES.numberNode(0.0F);
     case DOUBLE:
+      return NODES.numberNode(0.0D);
     case INT32:
     case UINT32:
     case SINT32:


### PR DESCRIPTION
https://issues.apache.org/jira/projects/AVRO/issues/AVRO-2881

When generating avro files using java's protobuf to avro conversion, double value's default is set to "0" while it should be "0.0".
This will cause import failure on BigQuery.