### PR TITLE
AVRO-2382: Fix VERSION constant for Ruby gem

### DIFF
--- a/lang/ruby/.gitignore
+++ b/lang/ruby/.gitignore
@@ -1,3 +1,4 @@
+lib/avro/VERSION.txt
 tmp
 data.avr
 Gemfile.lock

--- a/lang/ruby/Manifest
+++ b/lang/ruby/Manifest
@@ -6,6 +6,7 @@ Rakefile
 avro.gemspec
 interop/test_interop.rb
 lib/avro.rb
+lib/avro/VERSION.txt
 lib/avro/data_file.rb
 lib/avro/io.rb
 lib/avro/ipc.rb

--- a/lang/ruby/Rakefile
+++ b/lang/ruby/Rakefile
@@ -17,6 +17,7 @@
 require 'rubygems'
 require 'echoe'
 VERSION = File.open('../../share/VERSION.txt').read.sub('-SNAPSHOT', '.pre1').chomp
+File.write("lib/avro/VERSION.txt", VERSION)
 Echoe.new('avro', VERSION) do |p|
   p.author = "Apache Software Foundation"
   p.email = "dev@avro.apache.org"

--- a/lang/ruby/lib/avro.rb
+++ b/lang/ruby/lib/avro.rb
@@ -22,7 +22,7 @@ require 'stringio'
 require 'zlib'
 
 module Avro
-  VERSION = "FIXME"
+  VERSION = File.read("#{__dir__}/avro/VERSION.txt").freeze
 
   class AvroError < StandardError; end
 


### PR DESCRIPTION
### Jira

This change fixes a long-standing annoyance that the Ruby gem does not contain an accurate version constant. There are many ways this could have been addressed. This was the simplest option that I could come up with given the current build.

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title.
  - [https://issues.apache.org/jira/browse/AVRO-2382](https://issues.apache.org/jira/browse/AVRO-2382)

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No tests added. This replaces the "FIXME" string with a real version value. The library fails to load if we are unable to read this value.

### Commits

- [x] My commits all reference Jira issues in their subject lines.

### Documentation

N/A