### PR TITLE
AVRO-2556: Move to Ruby 2.5.8

### DIFF
--- a/lang/ruby/build.sh
+++ b/lang/ruby/build.sh
@@ -22,10 +22,11 @@ cd "$(dirname "$0")"
 
 # maintain our gems here
 export GEM_HOME="$PWD/.gem/"
-export PATH="$GEM_HOME/bin:$PATH"
+export PATH="/usr/local/rbenv/shims:$GEM_HOME/bin:$PATH"
 
 # bootstrap bundler
 gem install --no-document -v 1.17.3 bundler
+rbenv rehash
 bundle install
 
 for target in "$@"

--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -32,7 +32,6 @@ RUN apt-get -qqy update \
                                                  asciidoc \
                                                  bison \
                                                  bzip2 \
-                                                 bundler \
                                                  cmake \
                                                  cppcheck \
                                                  curl \
@@ -46,8 +45,10 @@ RUN apt-get -qqy update \
                                                  libfreetype6-dev \
                                                  libglib2.0-dev \
                                                  libjansson-dev \
+                                                 libreadline-dev \
                                                  libsnappy-dev \
                                                  libsnappy1v5 \
+                                                 libssl-dev \
                                                  make \
                                                  mypy \
                                                  openjdk-8-jdk \
@@ -57,9 +58,6 @@ RUN apt-get -qqy update \
                                                  python3-setuptools \
                                                  python3-snappy \
                                                  python3-wheel \
-                                                 rake \
-                                                 ruby \
-                                                 ruby-dev \
                                                  source-highlight \
                                                  subversion \
                                                  valgrind \
@@ -182,9 +180,20 @@ RUN curl -sSLO https://packages.microsoft.com/config/ubuntu/16.04/packages-micro
  && apt-get -qqy clean \
  && rm -rf /var/lib/apt/lists
 
-# Install Ruby modules
+# Install Ruby
+ENV RBENV_ROOT /usr/local/rbenv
+RUN git clone https://github.com/rbenv/rbenv.git /usr/local/rbenv \
+  && git clone https://github.com/rbenv/ruby-build.git /usr/local/rbenv/plugins/ruby-build \
+  && /usr/local/rbenv/plugins/ruby-build/install.sh \
+  && echo 'eval "$(rbenv init -)"' >> /etc/profile.d/rbenv.sh \
+  && echo 'eval "$(rbenv init -)"' >> /etc/bash.bashrc
+ENV PATH /usr/local/rbenv/bin:$PATH
+RUN rbenv install 2.5.8 && rbenv global 2.5.8 \
+  && rbenv exec gem install bundler -v 1.17.3 --no-document
 COPY lang/ruby/Gemfile /tmp
-RUN bundle install --gemfile=/tmp/Gemfile
+RUN rbenv exec bundle install --gemfile=/tmp/Gemfile \
+  && chgrp -R staff /usr/local/rbenv \
+  && chmod -R g+rw /usr/local/rbenv
 
 # Note: This "ubertool" container has two JDK versions:
 # - OpenJDK 8 (installed as a package and available at /usr/bin/java)


### PR DESCRIPTION
This change addresses issue [https://issues.apache.org/jira/browse/AVRO-2665](https://issues.apache.org/jira/browse/AVRO-2665).

The Ruby version used in the build is updated to 2.5.8. This is the latest patch level for the earliest major release that is still receiving updates.

The Ruby version (2.3) coming from the base image is removed and Ruby packages for earlier versions are no longer included.

Ruby is installed using [rbenv](https://github.com/rbenv/rbenv). There are many different installer options for Ruby. I don't have a strong preference for any of them, but this choice makes it easy to install and run with additional Rubies to test with different versions. E.g. `rbenv install 2.6.6`.

I debated also adding the latest for the other supported major releases (2.6.6 and 2.7.1) and script to run tests with each version. I may still add that separately later.