### PR TITLE
AVRO-2889: Temporarily disable flaky test

### DIFF
--- a/lang/py/avro/test/test_tether_task_runner.py
+++ b/lang/py/avro/test/test_tether_task_runner.py
@@ -42,7 +42,7 @@ except NameError:
 
 class TestTetherTaskRunner(unittest.TestCase):
     """unit test for a tethered task runner."""
-
+    @unittest.skip("AVRO-2889: Temporarily disable flaky test")
     def test1(self):
         # set the logging level to debug so that debug messages are printed
         logging.basicConfig(level=logging.DEBUG)


### PR DESCRIPTION
While this test is continually failing, the CI checks on travis aren't very useful.  This PR temporarily disables the tether test.

I think I might have found a better solution, but I'm proposing this temporarily while I check it out!

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2889
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
