### PR TITLE
AVRO-2907: Fix Ruby single object encoding fingerprint and header

### DIFF
--- a/lang/ruby/lib/avro/schema.rb
+++ b/lang/ruby/lib/avro/schema.rb
@@ -181,7 +181,7 @@ module Avro
       working = crc_64_avro_fingerprint
       bytes = Array.new(8)
       8.times do |i|
-        bytes[7 - i] = (working & 0xff)
+        bytes[i] = (working & 0xff)
         working = working >> 8
       end
       bytes

--- a/lang/ruby/test/test_fingerprints.rb
+++ b/lang/ruby/test/test_fingerprints.rb
@@ -50,7 +50,7 @@ class TestFingerprints < Test::Unit::TestCase
       { "type": "int" }
     SCHEMA
 
-    assert_equal ["c3", "01", "72", "75", "d5", "1a", "3f", "39", "5c", "8f"].map{|e| e.to_i(16) },
+    assert_equal ["c3", "01", "8f", "5c", "39", "3f", "1a", "D5", "75", "72"].map{|e| e.to_i(16) },
       schema.single_object_encoding_header
   end
 end


### PR DESCRIPTION
https://issues.apache.org/jira/browse/AVRO-2907

I've compared the output of the [Ruby implementation](https://github.com/apache/avro/blob/release-1.10.0/lang/ruby/lib/avro/schema.rb#L180) (originally implemented in https://github.com/apache/avro/pull/317) to the [Java implementation](https://github.com/apache/avro/blob/release-1.10.0/lang/java/avro/src/main/java/org/apache/avro/SchemaNormalization.java#L64), and it seems like the output of the Ruby implementation of `single_object_schema_fingerprint` is reversed in comparison.

I believe that this is caused by [unnecessarily reversing the array traversal here](https://github.com/apache/avro/blob/release-1.10.0/lang/ruby/lib/avro/schema.rb#L184) during the bit mask + shift operation that constructs the little endian fingerprint for the message header - as the mask operations are already grabbing the least significant bytes first.
