### PR TITLE
AVRO-2471: Generate specific conversions from LogicalType

### DIFF
--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
@@ -331,51 +331,6 @@ public class SpecificCompiler {
     return result;
   }
 
-  private Set<String> getClassNamesOfPrimitiveFields(Schema schema) {
-    Set<String> result = new HashSet<>();
-    getClassNamesOfPrimitiveFields(schema, result, new HashSet<>());
-    return result;
-  }
-
-  private void getClassNamesOfPrimitiveFields(Schema schema, Set<String> result, Set<Schema> seenSchemas) {
-    if (seenSchemas.contains(schema)) {
-      return;
-    }
-    seenSchemas.add(schema);
-    switch (schema.getType()) {
-    case RECORD:
-      for (Schema.Field field : schema.getFields()) {
-        getClassNamesOfPrimitiveFields(field.schema(), result, seenSchemas);
-      }
-      break;
-    case MAP:
-      getClassNamesOfPrimitiveFields(schema.getValueType(), result, seenSchemas);
-      break;
-    case ARRAY:
-      getClassNamesOfPrimitiveFields(schema.getElementType(), result, seenSchemas);
-      break;
-    case UNION:
-      for (Schema s : schema.getTypes())
-        getClassNamesOfPrimitiveFields(s, result, seenSchemas);
-      break;
-    case NULL:
-      break;
-    case ENUM:
-    case FIXED:
-    case STRING:
-    case BYTES:
-    case INT:
-    case LONG:
-    case FLOAT:
-    case DOUBLE:
-    case BOOLEAN:
-      result.add(javaType(schema, true));
-      break;
-    default:
-      throw new RuntimeException("Unknown type: " + schema);
-    }
-  }
-
   private void initializeVelocity() {
     this.velocityEngine = new VelocityEngine();
 

--- a/lang/java/compiler/src/test/java/org/apache/avro/compiler/specific/TestSpecificCompiler.java
+++ b/lang/java/compiler/src/test/java/org/apache/avro/compiler/specific/TestSpecificCompiler.java
@@ -17,10 +17,11 @@
  */
 package org.apache.avro.compiler.specific;
 
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertThat;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.equalTo;
 
@@ -525,6 +526,26 @@ public class TestSpecificCompiler {
     final Collection<String> usedConversionClasses = compiler.getUsedConversionClasses(schemaWithNullableDecimal1);
     Assert.assertEquals(1, usedConversionClasses.size());
     Assert.assertEquals("org.apache.avro.Conversions.DecimalConversion", usedConversionClasses.iterator().next());
+  }
+
+  @Test
+  public void testGetUsedConversionClassesForNullableTimestamps() throws Exception {
+    SpecificCompiler compiler = createCompiler();
+
+    // timestamp-millis and timestamp-micros used to cause collisions when both were
+    // present or
+    // added as converters (AVRO-2481).
+    final Schema tsMillis = LogicalTypes.timestampMillis().addToSchema(Schema.create(Schema.Type.LONG));
+    final Schema tsMicros = LogicalTypes.timestampMicros().addToSchema(Schema.create(Schema.Type.LONG));
+
+    final Collection<String> conversions = compiler.getUsedConversionClasses(SchemaBuilder.record("WithTimestamps")
+        .fields().name("tsMillis").type(tsMillis).noDefault().name("tsMillisOpt").type().unionOf().nullType().and()
+        .type(tsMillis).endUnion().noDefault().name("tsMicros").type(tsMicros).noDefault().name("tsMicrosOpt").type()
+        .unionOf().nullType().and().type(tsMicros).endUnion().noDefault().endRecord());
+
+    Assert.assertEquals(2, conversions.size());
+    assertThat(conversions, hasItem("org.apache.avro.data.TimeConversions.TimestampMillisConversion"));
+    assertThat(conversions, hasItem("org.apache.avro.data.TimeConversions.TimestampMicrosConversion"));
   }
 
   @Test

--- a/lang/java/compiler/src/test/java/org/apache/avro/compiler/specific/TestSpecificCompiler.java
+++ b/lang/java/compiler/src/test/java/org/apache/avro/compiler/specific/TestSpecificCompiler.java
@@ -533,8 +533,7 @@ public class TestSpecificCompiler {
     SpecificCompiler compiler = createCompiler();
 
     // timestamp-millis and timestamp-micros used to cause collisions when both were
-    // present or
-    // added as converters (AVRO-2481).
+    // present or added as converters (AVRO-2481).
     final Schema tsMillis = LogicalTypes.timestampMillis().addToSchema(Schema.create(Schema.Type.LONG));
     final Schema tsMicros = LogicalTypes.timestampMicros().addToSchema(Schema.create(Schema.Type.LONG));
 

--- a/lang/java/tools/src/test/compiler/output-string/avro/examples/baseball/FieldTest.java
+++ b/lang/java/tools/src/test/compiler/output-string/avro/examples/baseball/FieldTest.java
@@ -22,6 +22,8 @@ public class FieldTest extends org.apache.avro.specific.SpecificRecordBase imple
   private static SpecificData MODEL$ = new SpecificData();
 static {
     MODEL$.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimestampMillisConversion());
+    MODEL$.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimeMicrosConversion());
+    MODEL$.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimestampMicrosConversion());
     MODEL$.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimeMillisConversion());
   }
 


### PR DESCRIPTION
Instead of collecting the types of primitive datum that appear in a generated class, use the model to find the appropriate Conversion<?> instances that should be used for logical types.

### Jira

- [ ] My PR addresses [AVRO-2471](https://issues.apache.org/jira/browse/AVRO-XXX)
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
