### PR TITLE
AVRO-2908: Skip enum using in.readEnum instead of in.readInt

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/generic/GenericDatumReader.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/generic/GenericDatumReader.java
@@ -568,7 +568,7 @@ public class GenericDatumReader<D> implements DatumReader<D> {
         skip(field.schema(), in);
       break;
     case ENUM:
-      in.readInt();
+      in.readEnum();
       break;
     case ARRAY:
       Schema elementType = schema.getElementType();

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSkipEnumSchema.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSkipEnumSchema.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.avro;
+
+import org.apache.avro.generic.GenericData.EnumSymbol;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.io.EncoderFactory;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+/**
+ * See AVRO-2908
+ */
+public class TestSkipEnumSchema {
+  @Test
+  public void testSkipEnum() throws IOException {
+    Schema enumSchema = SchemaBuilder.builder().enumeration("enum").symbols("en1", "en2");
+    EnumSymbol enumSymbol = new EnumSymbol(enumSchema, "en1");
+
+    GenericDatumWriter<EnumSymbol> datumWriter = new GenericDatumWriter<>(enumSchema);
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    Encoder encoder = EncoderFactory.get().validatingEncoder(enumSchema,
+        EncoderFactory.get().binaryEncoder(byteArrayOutputStream, null));
+    datumWriter.write(enumSymbol, encoder);
+    encoder.flush();
+
+    Decoder decoder = DecoderFactory.get().validatingDecoder(enumSchema,
+        DecoderFactory.get().binaryDecoder(byteArrayOutputStream.toByteArray(), null));
+
+    GenericDatumReader.skip(enumSchema, decoder);
+  }
+}

--- a/lang/java/avro/src/test/java/org/apache/avro/generic/TestSkipEnumSchema.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/generic/TestSkipEnumSchema.java
@@ -15,11 +15,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.avro;
+package org.apache.avro.generic;
 
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericData.EnumSymbol;
-import org.apache.avro.generic.GenericDatumReader;
-import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.Encoder;


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2908
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  - TestSkipEnumSchema

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
