### PR TITLE
AVRO-2914: Remove Python 2 Support

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -6,7 +6,6 @@ The following packages must be installed before Avro can be built:
 
  - Java: JDK 1.8, Maven 2 or better, protobuf-compile
  - PHP: php5, phpunit, php5-gmp
- - Python 2: 2.7 or greater, python-setuptools for dist target
  - Python 3: 3.5 or greater
  - C: gcc, cmake, asciidoc, source-highlight, Jansson, pkg-config
  - C++: cmake 3.7.2 or greater, g++, flex, bison, libboost-dev

--- a/doc/src/content/xdocs/gettingstartedpython.xml
+++ b/doc/src/content/xdocs/gettingstartedpython.xml
@@ -38,7 +38,7 @@
       <p>
         A package called "avro-python3" had been provided to support
         Python 3 previously, but the codebase was consolidated into
-        the "avro" package and that supports both Python 2 and 3 now.
+        the "avro" package that supports Python 3 now.
 
         The avro-python3 package will be removed in the near future,
         so users should use the "avro" package instead.
@@ -70,8 +70,8 @@ $ python3 -m pip install avro
       <source>
 $ tar xvf avro-&AvroVersion;.tar.gz
 $ cd avro-&AvroVersion;
-$ python setup.py install
-$ python
+$ python3 setup.py install
+$ python3
 >>> import avro # should not raise ImportError
       </source>
       <p>
@@ -81,7 +81,7 @@ $ python
       <source>
 $ cd lang/py/
 $ python3 -m pip install -e .
-$ python
+$ python3
       </source>
     </section>
 

--- a/lang/py/avro/__init__.py
+++ b/lang/py/avro/__init__.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/lang/py/avro/codecs.py
+++ b/lang/py/avro/codecs.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/lang/py/avro/constants.py
+++ b/lang/py/avro/constants.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/lang/py/avro/datafile.py
+++ b/lang/py/avro/datafile.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/lang/py/avro/errors.py
+++ b/lang/py/avro/errors.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/lang/py/avro/io.py
+++ b/lang/py/avro/io.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/lang/py/avro/ipc.py
+++ b/lang/py/avro/ipc.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/lang/py/avro/protocol.py
+++ b/lang/py/avro/protocol.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/lang/py/avro/schema.py
+++ b/lang/py/avro/schema.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one
@@ -1119,8 +1121,6 @@ def parse(json_string, validate_enum_symbols=True):
         msg = 'Error parsing JSON: {}, error = {}'.format(json_string, e)
         new_exception = avro.errors.SchemaParseException(msg)
         traceback = sys.exc_info()[2]
-        if not hasattr(new_exception, 'with_traceback'):
-            raise (new_exception, None, traceback)  # Python 2 syntax
         raise new_exception.with_traceback(traceback)
 
     # Initialize the names object

--- a/lang/py/avro/test/__init__.py
+++ b/lang/py/avro/test/__init__.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/lang/py/avro/test/av_bench.py
+++ b/lang/py/avro/test/av_bench.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/lang/py/avro/test/gen_interop_data.py
+++ b/lang/py/avro/test/gen_interop_data.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/lang/py/avro/test/mock_tether_parent.py
+++ b/lang/py/avro/test/mock_tether_parent.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/lang/py/avro/test/sample_http_client.py
+++ b/lang/py/avro/test/sample_http_client.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/lang/py/avro/test/sample_http_server.py
+++ b/lang/py/avro/test/sample_http_server.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/lang/py/avro/test/test_datafile.py
+++ b/lang/py/avro/test/test_datafile.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/lang/py/avro/test/test_datafile_interop.py
+++ b/lang/py/avro/test/test_datafile_interop.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/lang/py/avro/test/test_init.py
+++ b/lang/py/avro/test/test_init.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/lang/py/avro/test/test_io.py
+++ b/lang/py/avro/test/test_io.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/lang/py/avro/test/test_ipc.py
+++ b/lang/py/avro/test/test_ipc.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/lang/py/avro/test/test_protocol.py
+++ b/lang/py/avro/test/test_protocol.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/lang/py/avro/test/test_schema.py
+++ b/lang/py/avro/test/test_schema.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/lang/py/avro/test/test_script.py
+++ b/lang/py/avro/test/test_script.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/lang/py/avro/test/test_tether_task.py
+++ b/lang/py/avro/test/test_tether_task.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/lang/py/avro/test/test_tether_task_runner.py
+++ b/lang/py/avro/test/test_tether_task_runner.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/lang/py/avro/test/test_tether_word_count.py
+++ b/lang/py/avro/test/test_tether_word_count.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/lang/py/avro/test/txsample_http_client.py
+++ b/lang/py/avro/test/txsample_http_client.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/lang/py/avro/test/txsample_http_server.py
+++ b/lang/py/avro/test/txsample_http_server.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/lang/py/avro/test/word_count_task.py
+++ b/lang/py/avro/test/word_count_task.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/lang/py/avro/tether/__init__.py
+++ b/lang/py/avro/tether/__init__.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/lang/py/avro/tether/tether_task.py
+++ b/lang/py/avro/tether/tether_task.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/lang/py/avro/tether/tether_task_runner.py
+++ b/lang/py/avro/tether/tether_task_runner.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/lang/py/avro/tether/util.py
+++ b/lang/py/avro/tether/util.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/lang/py/avro/timezones.py
+++ b/lang/py/avro/timezones.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/lang/py/avro/tool.py
+++ b/lang/py/avro/tool.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/lang/py/avro/txipc.py
+++ b/lang/py/avro/txipc.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/lang/py/build.sh
+++ b/lang/py/build.sh
@@ -47,7 +47,7 @@ interop-data-generate() {
 interop-data-test() {
   mkdir -p avro/test/interop ../../build/interop/data
   cp -r ../../build/interop/data avro/test/interop
-  python -m unittest avro.test.test_datafile_interop
+  python3 -m unittest avro.test.test_datafile_interop
 }
 
 lint() {

--- a/lang/py/scripts/avro
+++ b/lang/py/scripts/avro
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/lang/py/setup.cfg
+++ b/lang/py/setup.cfg
@@ -31,7 +31,6 @@ url = https://avro.apache.org/
 license = Apache License 2.0
 classifiers =
     License :: OSI Approved :: Apache Software License
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
@@ -51,7 +50,7 @@ install_requires =
 zip_safe = true
 scripts =
     scripts/avro
-python_requires = >=2.7
+python_requires = >=3.5
 
 [options.package_data]
 avro =

--- a/lang/py/setup.py
+++ b/lang/py/setup.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# -*- mode: python -*-
+# -*- coding: utf-8 -*-
 
 ##
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/lang/py/tox.ini
+++ b/lang/py/tox.ini
@@ -20,7 +20,6 @@ envlist =
     # Fastest checks first
     lint
     typechecks
-    py27
     py35
     py36
     py37

--- a/lang/py3/avro/schemanormalization.py
+++ b/lang/py3/avro/schemanormalization.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- mode: python -*-
 # -*- coding: utf-8 -*-
 

--- a/lang/py3/avro/tests/test_normalization.py
+++ b/lang/py3/avro/tests/test_normalization.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- mode: python -*-
 # -*- coding: utf-8 -*-
 

--- a/lang/py3/setup.py
+++ b/lang/py3/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- mode: python -*-
 # -*- coding: utf-8 -*-
 

--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -53,11 +53,7 @@ RUN apt-get -qqy update \
                                                  mypy \
                                                  openjdk-8-jdk \
                                                  perl \
-                                                 python \
-                                                 python-pip \
-                                                 python-setuptools \
-                                                 python-snappy \
-                                                 python-wheel \
+                                                 python3 \
                                                  python3-pip \
                                                  python3-setuptools \
                                                  python3-snappy \
@@ -141,10 +137,6 @@ RUN curl -sSL https://cpanmin.us \
 
 # Install Python packages
 ENV PIP_NO_CACHE_DIR=off
-
-# Install Python2 packages
-RUN python2 -m pip install --upgrade pip setuptools wheel \
- && python2 -m pip install zstandard
 
 # Install Python3 packages
 RUN python3 -m pip install --upgrade pip setuptools wheel \

--- a/share/test/interop/bin/test_rpc_interop.sh
+++ b/share/test/interop/bin/test_rpc_interop.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -25,10 +25,6 @@ java_tool() {
   java -jar "lang/java/tools/target/avro-tools-$VERSION.jar" "$@"
 }
 
-py_tool() {
-  PYTHONPATH=lang/py python2 -m avro.tool "$@"
-}
-
 py3_tool() {
   PYTHONPATH=lang/py3 python3 -m avro.tool "$@"
 }
@@ -36,6 +32,8 @@ py3_tool() {
 ruby_tool() {
   ruby -Ilang/ruby/lib lang/ruby/test/tool.rb "$@"
 }
+
+tools=( {java,py3,ruby}_tool )
 
 proto=share/test/schemas/simple.avpr
 
@@ -50,12 +48,12 @@ cleanup() {
 
 trap 'cleanup' EXIT
 
-for server in {java,py,py3,ruby}_tool; do
+for server in "${tools[@]}"; do
   for msgDir in share/test/interop/rpc/*; do
     msg="${msgDir##*/}"
     for c in "$msgDir/"*; do
       echo "TEST: $c"
-      for client in {java,py,py3,ruby}_tool; do
+      for client in "${tools[@]}"; do
         rm -rf "$portfile"
         "$server" rpcreceive 'http://127.0.0.1:0/' "$proto" "$msg" \
           -file "$c/response.avro" > "$portfile" &


### PR DESCRIPTION
### Jira

This PR…

- [x] …addresses [AVRO-2914](https://issues.apache.org/jira/browse/AVRO-2914).
- [x] …references AVRO-2914 in the PR title.
- [x] …adds no dependencies.

### Tests

- [x] This PR configures tox not to test in Python 2 anymore.

### Commits

- [x] My commits all reference AVRO-2914 in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)"

### Documentation

- [x] This PR removes documentation that is Python 2 specific, and updates documentation to explicitly indicate python3 where appropriate.