### PR TITLE
AVRO-2676: DeprecationWarning on import avro-python3

### DIFF
--- a/lang/py3/avro/__init__.py
+++ b/lang/py3/avro/__init__.py
@@ -20,8 +20,11 @@
 
 __all__ = ('schema', 'io', 'datafile', 'protocol', 'ipc')
 
-
 import pkgutil
+import warnings
 
 __version__ = (pkgutil.get_data(__name__, 'VERSION.txt') or b'0.0.1+unknown').decode().strip()
 VERSION = __version__
+
+warnings.warn("`avro-python3` is deprecated. Please use the `avro` package instead.",
+              DeprecationWarning)


### PR DESCRIPTION
### Jira

This PR…
- [x] …addresses [AVRO-2676](https://issues.apache.org/jira/browse/AVRO-2676).
- [x] …references the ticket in the PR title.
- [x] …adds no dependencies.

### Tests

- [x] …requires no testing

### Commits

- [x] Commits all reference the ticket issues in their subject lines.

### Documentation

- [x] Documentation regarding deprecating this implementation was already merged in a previous changeset.