### PR TITLE
AVRO-2920 Remove Python2 Polyfills

### DIFF
--- a/lang/py/avro/__init__.py
+++ b/lang/py/avro/__init__.py
@@ -19,8 +19,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division, print_function
-
 import pkgutil
 
 __all__ = ['schema', 'io', 'datafile', 'protocol', 'ipc', 'constants', 'timezones', 'codecs']

--- a/lang/py/avro/codecs.py
+++ b/lang/py/avro/codecs.py
@@ -28,8 +28,6 @@ so don't confuse it with the Python's "codecs", which is a package mainly for
 converting charsets (https://docs.python.org/3/library/codecs.html).
 """
 
-from __future__ import absolute_import, division, print_function
-
 import io
 import struct
 import sys

--- a/lang/py/avro/codecs.py
+++ b/lang/py/avro/codecs.py
@@ -28,13 +28,12 @@ so don't confuse it with the Python's "codecs", which is a package mainly for
 converting charsets (https://docs.python.org/3/library/codecs.html).
 """
 
+import abc
+import binascii
 import io
 import struct
 import sys
 import zlib
-from abc import ABCMeta, abstractmethod
-from binascii import crc32
-from struct import Struct
 
 import avro.errors
 import avro.io
@@ -42,7 +41,7 @@ import avro.io
 #
 # Constants
 #
-STRUCT_CRC32 = Struct('>I')  # big-endian unsigned int
+STRUCT_CRC32 = struct.Struct('>I')  # big-endian unsigned int
 
 
 try:
@@ -62,11 +61,10 @@ except ImportError:
     has_zstandard = False
 
 
-class Codec:
+class Codec(abc.ABC):
     """Abstract base class for all Avro codec classes."""
-    __metaclass__ = ABCMeta
 
-    @abstractmethod
+    @abc.abstractmethod
     def compress(self, data):
         """Compress the passed data.
 
@@ -76,9 +74,8 @@ class Codec:
         :rtype: tuple
         :return: compressed data and its length
         """
-        pass
 
-    @abstractmethod
+    @abc.abstractmethod
     def decompress(self, readers_decoder):
         """Read compressed data via the passed BinaryDecoder and decompress it.
 
@@ -90,7 +87,6 @@ class Codec:
         :return: a newly instantiated BinaryDecoder object that contains the
                  decompressed data which is wrapped by a StringIO
         """
-        pass
 
 
 class NullCodec(Codec):
@@ -137,7 +133,7 @@ if has_snappy:
         def compress(self, data):
             compressed_data = snappy.compress(data)
             # A 4-byte, big-endian CRC32 checksum
-            compressed_data += STRUCT_CRC32.pack(crc32(data) & 0xffffffff)
+            compressed_data += STRUCT_CRC32.pack(binascii.crc32(data) & 0xffffffff)
             return compressed_data, len(compressed_data)
 
         def decompress(self, readers_decoder):
@@ -151,7 +147,7 @@ if has_snappy:
 
         def check_crc32(self, bytes, checksum):
             checksum = STRUCT_CRC32.unpack(checksum)[0]
-            if crc32(bytes) & 0xffffffff != checksum:
+            if binascii.crc32(bytes) & 0xffffffff != checksum:
                 raise avro.errors.AvroException("Checksum failure")
 
 
@@ -175,30 +171,28 @@ if has_zstandard:
             return avro.io.BinaryDecoder(io.BytesIO(uncompressed))
 
 
-class Codecs(object):
-    @staticmethod
-    def get_codec(codec_name):
-        codec_name = codec_name.lower()
-        if codec_name == "null":
-            return NullCodec()
-        if codec_name == "deflate":
-            return DeflateCodec()
-        if codec_name == "bzip2" and has_bzip2:
-            return BZip2Codec()
-        if codec_name == "snappy" and has_snappy:
-            return SnappyCodec()
-        if codec_name == "zstandard" and has_zstandard:
-            return ZstandardCodec()
-        raise avro.errors.UnsupportedCodec("Unsupported codec: {}. (Is it installed?)"
-                                           .format(codec_name))
+def get_codec(codec_name):
+    codec_name = codec_name.lower()
+    if codec_name == "null":
+        return NullCodec()
+    if codec_name == "deflate":
+        return DeflateCodec()
+    if codec_name == "bzip2" and has_bzip2:
+        return BZip2Codec()
+    if codec_name == "snappy" and has_snappy:
+        return SnappyCodec()
+    if codec_name == "zstandard" and has_zstandard:
+        return ZstandardCodec()
+    raise avro.errors.UnsupportedCodec("Unsupported codec: {}. (Is it installed?)"
+                                       .format(codec_name))
 
-    @staticmethod
-    def supported_codec_names():
-        codec_names = ['null', 'deflate']
-        if has_bzip2:
-            codec_names.append('bzip2')
-        if has_snappy:
-            codec_names.append('snappy')
-        if has_zstandard:
-            codec_names.append('zstandard')
-        return codec_names
+
+def supported_codec_names():
+    codec_names = ['null', 'deflate']
+    if has_bzip2:
+        codec_names.append('bzip2')
+    if has_snappy:
+        codec_names.append('snappy')
+    if has_zstandard:
+        codec_names.append('zstandard')
+    return codec_names

--- a/lang/py/avro/constants.py
+++ b/lang/py/avro/constants.py
@@ -21,7 +21,6 @@
 
 """Contains Constants for Python Avro"""
 
-from __future__ import absolute_import, division, print_function
 
 DATE = "date"
 DECIMAL = "decimal"

--- a/lang/py/avro/datafile.py
+++ b/lang/py/avro/datafile.py
@@ -21,8 +21,6 @@
 
 """Read/Write Avro File Object Containers."""
 
-from __future__ import absolute_import, division, print_function
-
 import io
 import os
 import random

--- a/lang/py/avro/datafile.py
+++ b/lang/py/avro/datafile.py
@@ -59,7 +59,7 @@ SCHEMA_KEY = "avro.schema"
 #
 
 
-class _DataFile(object):
+class _DataFile:
     """Mixin for methods common to both reading and writing."""
 
     block_count = 0

--- a/lang/py/avro/datafile.py
+++ b/lang/py/avro/datafile.py
@@ -329,7 +329,6 @@ class DataFileReader(_DataFile):
         datum = self.datum_reader.read(self.datum_decoder)
         self.block_count -= 1
         return datum
-    next = __next__
 
     def close(self):
         """Close this reader."""

--- a/lang/py/avro/datafile.py
+++ b/lang/py/avro/datafile.py
@@ -26,10 +26,10 @@ import os
 import random
 import zlib
 
+import avro.codecs
 import avro.errors
 import avro.io
 import avro.schema
-from avro.codecs import Codecs
 
 #
 # Constants
@@ -48,7 +48,7 @@ META_SCHEMA = avro.schema.parse("""\
 """ % (MAGIC_SIZE, SYNC_SIZE))
 
 NULL_CODEC = 'null'
-VALID_CODECS = Codecs.supported_codec_names()
+VALID_CODECS = avro.codecs.supported_codec_names()
 VALID_ENCODINGS = ['binary']  # not used yet
 
 CODEC_KEY = "avro.codec"
@@ -193,7 +193,7 @@ class DataFileWriter(_DataFile):
 
             # write block contents
             uncompressed_data = self.buffer_writer.getvalue()
-            codec = Codecs.get_codec(self.codec)
+            codec = avro.codecs.get_codec(self.codec)
             compressed_data, compressed_data_length = codec.compress(uncompressed_data)
 
             # Write length of block
@@ -305,7 +305,7 @@ class DataFileReader(_DataFile):
 
     def _read_block_header(self):
         self.block_count = self.raw_decoder.read_long()
-        codec = Codecs.get_codec(self.codec)
+        codec = avro.codecs.get_codec(self.codec)
         self._datum_decoder = codec.decompress(self.raw_decoder)
 
     def _skip_sync(self):

--- a/lang/py/avro/io.py
+++ b/lang/py/avro/io.py
@@ -34,8 +34,8 @@ uses the following mapping:
   * Schema records are implemented as dict.
   * Schema arrays are implemented as list.
   * Schema maps are implemented as dict.
-  * Schema strings are implemented as unicode.
-  * Schema bytes are implemented as str.
+  * Schema strings are implemented as str.
+  * Schema bytes are implemented as bytes.
   * Schema ints are implemented as int.
   * Schema longs are implemented as long.
   * Schema floats are implemented as float.
@@ -95,16 +95,6 @@ from struct import Struct
 
 import avro.errors
 from avro import constants, timezones
-
-try:
-    unicode
-except NameError:
-    unicode = str
-
-try:
-    basestring  # type: ignore
-except NameError:
-    basestring = (bytes, unicode)
 
 try:
     long
@@ -346,7 +336,7 @@ class BinaryDecoder:
         A string is encoded as a long followed by
         that many bytes of UTF-8 encoded character data.
         """
-        return unicode(self.read_bytes(), "utf-8")
+        return self.read_bytes().decode("utf-8")
 
     def read_date_from_int(self):
         """

--- a/lang/py/avro/io.py
+++ b/lang/py/avro/io.py
@@ -233,7 +233,7 @@ _ITERATORS['error'] = _ITERATORS['request'] = _ITERATORS['record']
 # Decoder/Encoder
 #
 
-class BinaryDecoder(object):
+class BinaryDecoder:
     """Read leaf values."""
 
     def __init__(self, reader):
@@ -437,7 +437,7 @@ class BinaryDecoder(object):
         self.reader.seek(self.reader.tell() + n)
 
 
-class BinaryEncoder(object):
+class BinaryEncoder:
     """Write leaf values."""
 
     def __init__(self, writer):
@@ -634,7 +634,7 @@ class BinaryEncoder(object):
 #
 # DatumReader/Writer
 #
-class DatumReader(object):
+class DatumReader:
     """Deserialize Avro-encoded data into a Python data structure."""
 
     def __init__(self, writers_schema=None, readers_schema=None):
@@ -999,7 +999,7 @@ class DatumReader(object):
             raise avro.errors.AvroException(fail_msg)
 
 
-class DatumWriter(object):
+class DatumWriter:
     """DatumWriter for generic python objects."""
 
     def __init__(self, writers_schema=None):

--- a/lang/py/avro/io.py
+++ b/lang/py/avro/io.py
@@ -37,7 +37,7 @@ uses the following mapping:
   * Schema strings are implemented as str.
   * Schema bytes are implemented as bytes.
   * Schema ints are implemented as int.
-  * Schema longs are implemented as long.
+  * Schema longs are implemented as int.
   * Schema floats are implemented as float.
   * Schema doubles are implemented as float.
   * Schema booleans are implemented as bool.
@@ -95,12 +95,6 @@ from struct import Struct
 
 import avro.errors
 from avro import constants, timezones
-
-try:
-    long
-except NameError:
-    long = int
-
 
 #
 # Constants
@@ -607,8 +601,8 @@ class BinaryEncoder:
         """
         datum = datum.astimezone(tz=timezones.utc)
         timedelta = datum - datetime.datetime(1970, 1, 1, 0, 0, 0, 0, tzinfo=timezones.utc)
-        milliseconds = self._timedelta_total_microseconds(timedelta) / 1000
-        self.write_long(long(milliseconds))
+        milliseconds = self._timedelta_total_microseconds(timedelta) // 1000
+        self.write_long(milliseconds)
 
     def write_timestamp_micros_long(self, datum):
         """
@@ -618,7 +612,7 @@ class BinaryEncoder:
         datum = datum.astimezone(tz=timezones.utc)
         timedelta = datum - datetime.datetime(1970, 1, 1, 0, 0, 0, 0, tzinfo=timezones.utc)
         microseconds = self._timedelta_total_microseconds(timedelta)
-        self.write_long(long(microseconds))
+        self.write_long(microseconds)
 
 
 #
@@ -956,7 +950,7 @@ class DatumReader:
         elif field_schema.type == 'int':
             return int(default_value)
         elif field_schema.type == 'long':
-            return long(default_value)
+            return int(default_value)
         elif field_schema.type in ['float', 'double']:
             return float(default_value)
         elif field_schema.type in ['enum', 'fixed', 'string', 'bytes']:

--- a/lang/py/avro/io.py
+++ b/lang/py/avro/io.py
@@ -86,8 +86,6 @@ datum contained. This allows iteration over the child nodes
 in that datum, if there are any.
 """
 
-from __future__ import absolute_import, division, print_function
-
 import datetime
 import json
 import struct

--- a/lang/py/avro/ipc.py
+++ b/lang/py/avro/ipc.py
@@ -34,11 +34,6 @@ try:
 except ImportError:
     from http import client as httplib  # type: ignore
 
-try:
-    unicode
-except NameError:
-    unicode = str
-
 
 def _load(name):
     dir_path = os.path.dirname(__file__)
@@ -131,7 +126,7 @@ class BaseRequestor:
         request_datum['clientHash'] = local_hash
         request_datum['serverHash'] = remote_hash
         if self.send_protocol:
-            request_datum['clientProtocol'] = unicode(self.local_protocol)
+            request_datum['clientProtocol'] = str(self.local_protocol)
         HANDSHAKE_REQUESTOR_WRITER.write(request_datum, encoder)
 
     def write_call_request(self, message_name, request_datum, encoder):
@@ -301,7 +296,7 @@ class Responder:
             except AvroRemoteException as e:
                 error = e
             except Exception as e:
-                error = AvroRemoteException(unicode(e))
+                error = AvroRemoteException(str(e))
 
             # write response using local protocol
             META_WRITER.write(response_metadata, buffer_encoder)
@@ -313,7 +308,7 @@ class Responder:
                 writers_schema = local_message.errors
                 self.write_error(writers_schema, error, buffer_encoder)
         except schema.AvroException as e:
-            error = AvroRemoteException(unicode(e))
+            error = AvroRemoteException(str(e))
             buffer_encoder = avro.io.BinaryEncoder(io.BytesIO())
             META_WRITER.write(response_metadata, buffer_encoder)
             buffer_encoder.write_boolean(True)
@@ -346,7 +341,7 @@ class Responder:
                 handshake_response['match'] = 'CLIENT'
 
         if handshake_response['match'] != 'BOTH':
-            handshake_response['serverProtocol'] = unicode(self.local_protocol)
+            handshake_response['serverProtocol'] = str(self.local_protocol)
             handshake_response['serverHash'] = self.local_hash
 
         HANDSHAKE_RESPONDER_WRITER.write(handshake_response, encoder)
@@ -368,7 +363,7 @@ class Responder:
 
     def write_error(self, writers_schema, error_exception, encoder):
         datum_writer = avro.io.DatumWriter(writers_schema)
-        datum_writer.write(unicode(error_exception), encoder)
+        datum_writer.write(str(error_exception), encoder)
 
 #
 # Utility classes

--- a/lang/py/avro/ipc.py
+++ b/lang/py/avro/ipc.py
@@ -76,7 +76,7 @@ BUFFER_SIZE = 8192
 #
 
 
-class BaseRequestor(object):
+class BaseRequestor:
     """Base class for the client side of a protocol interaction."""
 
     def __init__(self, local_protocol, transceiver):
@@ -237,7 +237,7 @@ class Requestor(BaseRequestor):
         return self.request(message_name, request_datum)
 
 
-class Responder(object):
+class Responder:
     """Base class for the server side of a protocol interaction."""
 
     def __init__(self, local_protocol):
@@ -375,7 +375,7 @@ class Responder(object):
 #
 
 
-class FramedReader(object):
+class FramedReader:
     """Wrapper around a file-like object to read framed data."""
 
     def __init__(self, reader):
@@ -405,7 +405,7 @@ class FramedReader(object):
         return BIG_ENDIAN_INT_STRUCT.unpack(read)[0]
 
 
-class FramedWriter(object):
+class FramedWriter:
     """Wrapper around a file-like object to write framed data."""
 
     def __init__(self, writer):
@@ -441,7 +441,7 @@ class FramedWriter(object):
 #
 
 
-class HTTPTransceiver(object):
+class HTTPTransceiver:
     """
     A simple HTTP-based transceiver implementation.
     Useful for clients but not for servers

--- a/lang/py/avro/ipc.py
+++ b/lang/py/avro/ipc.py
@@ -21,8 +21,6 @@
 
 """Support for inter-process calls."""
 
-from __future__ import absolute_import, division, print_function
-
 import io
 import os
 from struct import Struct

--- a/lang/py/avro/protocol.py
+++ b/lang/py/avro/protocol.py
@@ -49,7 +49,7 @@ VALID_TYPE_SCHEMA_TYPES = ('enum', 'record', 'error', 'fixed')
 #
 
 
-class Protocol(object):
+class Protocol:
     """An application protocol."""
 
     def _parse_types(self, types, type_names):
@@ -171,7 +171,7 @@ class Protocol(object):
         return to_cmp == json.loads(str(that))
 
 
-class Message(object):
+class Message:
     """A Protocol message."""
 
     def _parse_request(self, request, names):

--- a/lang/py/avro/protocol.py
+++ b/lang/py/avro/protocol.py
@@ -21,8 +21,6 @@
 
 """Protocol implementation."""
 
-from __future__ import absolute_import, division, print_function
-
 import hashlib
 import json
 

--- a/lang/py/avro/protocol.py
+++ b/lang/py/avro/protocol.py
@@ -27,16 +27,6 @@ import json
 import avro.errors
 import avro.schema
 
-try:
-    unicode
-except NameError:
-    unicode = str
-
-try:
-    basestring  # type: ignore
-except NameError:
-    basestring = (bytes, unicode)
-
 #
 # Constants
 #
@@ -83,10 +73,10 @@ class Protocol:
         if not name:
             fail_msg = 'Protocols must have a non-empty name.'
             raise avro.errors.ProtocolParseException(fail_msg)
-        elif not isinstance(name, basestring):
+        elif not isinstance(name, str):
             fail_msg = 'The name property must be a string.'
             raise avro.errors.ProtocolParseException(fail_msg)
-        elif not (namespace is None or isinstance(namespace, basestring)):
+        elif not (namespace is None or isinstance(namespace, str)):
             fail_msg = 'The namespace property must be a string.'
             raise avro.errors.ProtocolParseException(fail_msg)
         elif not (types is None or isinstance(types, list)):
@@ -181,7 +171,7 @@ class Message:
         return avro.schema.RecordSchema(None, None, request, names, 'request')
 
     def _parse_response(self, response, names):
-        if isinstance(response, basestring) and names.has_name(response, None):
+        if isinstance(response, str) and names.has_name(response, None):
             return names.get_name(response, None)
         else:
             return avro.schema.make_avsc_object(response, names)

--- a/lang/py/avro/schema.py
+++ b/lang/py/avro/schema.py
@@ -51,16 +51,6 @@ from decimal import Decimal
 import avro.errors
 from avro import constants
 
-try:
-    unicode
-except NameError:
-    unicode = str
-
-try:
-    basestring  # type: ignore
-except NameError:
-    basestring = (bytes, unicode)
-
 #
 # Constants
 #
@@ -151,7 +141,7 @@ class Schema:
 
     def __init__(self, type, other_props=None):
         # Ensure valid ctor args
-        if not isinstance(type, basestring):
+        if not isinstance(type, str):
             fail_msg = 'Schema type must be a string.'
             raise avro.errors.SchemaParseException(fail_msg)
         elif type not in VALID_TYPES:
@@ -351,10 +341,10 @@ class NamedSchema(Schema):
         if not name:
             fail_msg = 'Named Schemas must have a non-empty name.'
             raise avro.errors.SchemaParseException(fail_msg)
-        elif not isinstance(name, basestring):
+        elif not isinstance(name, str):
             fail_msg = 'The name property must be a string.'
             raise avro.errors.SchemaParseException(fail_msg)
-        elif namespace is not None and not isinstance(namespace, basestring):
+        elif namespace is not None and not isinstance(namespace, str):
             fail_msg = 'The namespace property must be a string.'
             raise avro.errors.SchemaParseException(fail_msg)
 
@@ -423,7 +413,7 @@ class Field:
         if not name:
             fail_msg = 'Fields must have a non-empty name.'
             raise avro.errors.SchemaParseException(fail_msg)
-        elif not isinstance(name, basestring):
+        elif not isinstance(name, str):
             fail_msg = 'The name property must be a string.'
             raise avro.errors.SchemaParseException(fail_msg)
         elif order is not None and order not in VALID_FIELD_SORT_ORDERS:
@@ -435,7 +425,7 @@ class Field:
         self._has_default = has_default
         self._props.update(other_props or {})
 
-        if (isinstance(type, basestring) and names is not None and
+        if (isinstance(type, str) and names is not None and
                 names.has_name(type, None)):
             type_schema = names.get_name(type, None)
         else:
@@ -499,7 +489,7 @@ class PrimitiveSchema(Schema):
     _validators = {
         'null': lambda x: x is None,
         'boolean': lambda x: isinstance(x, bool),
-        'string': lambda x: isinstance(x, unicode),
+        'string': lambda x: isinstance(x, str),
         'bytes': lambda x: isinstance(x, bytes),
         'int': lambda x: isinstance(x, int) and INT_MIN_VALUE <= x <= INT_MAX_VALUE,
         'long': lambda x: isinstance(x, int) and LONG_MIN_VALUE <= x <= LONG_MAX_VALUE,
@@ -708,7 +698,7 @@ class ArraySchema(Schema):
         Schema.__init__(self, 'array', other_props)
         # Add class members
 
-        if isinstance(items, basestring) and names.has_name(items, None):
+        if isinstance(items, str) and names.has_name(items, None):
             items_schema = names.get_name(items, None)
         else:
             try:
@@ -753,7 +743,7 @@ class MapSchema(Schema):
         Schema.__init__(self, 'map', other_props)
 
         # Add class members
-        if isinstance(values, basestring) and names.has_name(values, None):
+        if isinstance(values, str) and names.has_name(values, None):
             values_schema = names.get_name(values, None)
         else:
             try:
@@ -785,7 +775,7 @@ class MapSchema(Schema):
 
     def validate(self, datum):
         """Return self if datum is a valid representation of this schema, else None."""
-        return self if isinstance(datum, dict) and all(isinstance(key, unicode) for key in datum) else None
+        return self if isinstance(datum, dict) and all(isinstance(key, str) for key in datum) else None
 
     def __eq__(self, that):
         to_cmp = json.loads(str(self))
@@ -809,7 +799,7 @@ class UnionSchema(Schema):
         # Add class members
         schema_objects = []
         for schema in schemas:
-            if isinstance(schema, basestring) and names.has_name(schema, None):
+            if isinstance(schema, str) and names.has_name(schema, None):
                 new_schema = names.get_name(schema, None)
             else:
                 try:

--- a/lang/py/avro/schema.py
+++ b/lang/py/avro/schema.py
@@ -41,15 +41,15 @@ A schema may be one of:
 """
 
 import datetime
+import decimal
 import json
 import math
 import re
 import sys
 import warnings
-from decimal import Decimal
 
+import avro.constants
 import avro.errors
-from avro import constants
 
 #
 # Constants
@@ -558,7 +558,7 @@ class BytesDecimalSchema(PrimitiveSchema, DecimalLogicalSchema):
 
     def validate(self, datum):
         """Return self if datum is a Decimal object, else None."""
-        return self if isinstance(datum, Decimal) else None
+        return self if isinstance(datum, decimal.Decimal) else None
 
     def __eq__(self, that):
         return self.props == that.props
@@ -629,7 +629,7 @@ class FixedDecimalSchema(FixedSchema, DecimalLogicalSchema):
 
     def validate(self, datum):
         """Return self if datum is a Decimal object, else None."""
-        return self if isinstance(datum, Decimal) else None
+        return self if isinstance(datum, decimal.Decimal) else None
 
     def __eq__(self, that):
         return self.props == that.props
@@ -977,7 +977,7 @@ class RecordSchema(NamedSchema):
 
 class DateSchema(LogicalSchema, PrimitiveSchema):
     def __init__(self, other_props=None):
-        LogicalSchema.__init__(self, constants.DATE)
+        LogicalSchema.__init__(self, avro.constants.DATE)
         PrimitiveSchema.__init__(self, 'int', other_props)
 
     def to_json(self, names=None):
@@ -997,7 +997,7 @@ class DateSchema(LogicalSchema, PrimitiveSchema):
 
 class TimeMillisSchema(LogicalSchema, PrimitiveSchema):
     def __init__(self, other_props=None):
-        LogicalSchema.__init__(self, constants.TIME_MILLIS)
+        LogicalSchema.__init__(self, avro.constants.TIME_MILLIS)
         PrimitiveSchema.__init__(self, 'int', other_props)
 
     def to_json(self, names=None):
@@ -1017,7 +1017,7 @@ class TimeMillisSchema(LogicalSchema, PrimitiveSchema):
 
 class TimeMicrosSchema(LogicalSchema, PrimitiveSchema):
     def __init__(self, other_props=None):
-        LogicalSchema.__init__(self, constants.TIME_MICROS)
+        LogicalSchema.__init__(self, avro.constants.TIME_MICROS)
         PrimitiveSchema.__init__(self, 'long', other_props)
 
     def to_json(self, names=None):
@@ -1037,7 +1037,7 @@ class TimeMicrosSchema(LogicalSchema, PrimitiveSchema):
 
 class TimestampMillisSchema(LogicalSchema, PrimitiveSchema):
     def __init__(self, other_props=None):
-        LogicalSchema.__init__(self, constants.TIMESTAMP_MILLIS)
+        LogicalSchema.__init__(self, avro.constants.TIMESTAMP_MILLIS)
         PrimitiveSchema.__init__(self, 'long', other_props)
 
     def to_json(self, names=None):
@@ -1056,7 +1056,7 @@ class TimestampMillisSchema(LogicalSchema, PrimitiveSchema):
 
 class TimestampMicrosSchema(LogicalSchema, PrimitiveSchema):
     def __init__(self, other_props=None):
-        LogicalSchema.__init__(self, constants.TIMESTAMP_MICROS)
+        LogicalSchema.__init__(self, avro.constants.TIMESTAMP_MICROS)
         PrimitiveSchema.__init__(self, 'long', other_props)
 
     def to_json(self, names=None):
@@ -1090,14 +1090,14 @@ def make_bytes_decimal_schema(other_props):
 def make_logical_schema(logical_type, type_, other_props):
     """Map the logical types to the appropriate literal type and schema class."""
     logical_types = {
-        (constants.DATE, 'int'): DateSchema,
-        (constants.DECIMAL, 'bytes'): make_bytes_decimal_schema,
+        (avro.constants.DATE, 'int'): DateSchema,
+        (avro.constants.DECIMAL, 'bytes'): make_bytes_decimal_schema,
         # The fixed decimal schema is handled later by returning None now.
-        (constants.DECIMAL, 'fixed'): lambda x: None,
-        (constants.TIMESTAMP_MICROS, 'long'): TimestampMicrosSchema,
-        (constants.TIMESTAMP_MILLIS, 'long'): TimestampMillisSchema,
-        (constants.TIME_MICROS, 'long'): TimeMicrosSchema,
-        (constants.TIME_MILLIS, 'int'): TimeMillisSchema,
+        (avro.constants.DECIMAL, 'fixed'): lambda x: None,
+        (avro.constants.TIMESTAMP_MICROS, 'long'): TimestampMicrosSchema,
+        (avro.constants.TIMESTAMP_MILLIS, 'long'): TimestampMillisSchema,
+        (avro.constants.TIME_MICROS, 'long'): TimeMicrosSchema,
+        (avro.constants.TIME_MILLIS, 'int'): TimeMillisSchema,
     }
     try:
         schema_type = logical_types.get((logical_type, type_), None)

--- a/lang/py/avro/schema.py
+++ b/lang/py/avro/schema.py
@@ -40,6 +40,7 @@ A schema may be one of:
   Null.
 """
 
+import abc
 import datetime
 import decimal
 import json
@@ -135,7 +136,7 @@ def _is_timezone_aware_datetime(dt):
 # Base Classes
 #
 
-class Schema:
+class Schema(abc.ABC):
     """Base class for all Schema classes."""
     _props = None
 
@@ -173,13 +174,13 @@ class Schema:
         """
         return all(getattr(self, prop) == getattr(other, prop) for prop in props)
 
+    @abc.abstractmethod
     def match(self, writer):
         """Return True if the current schema (as reader) matches the writer schema.
 
         @arg writer: the writer schema to match against.
         @return bool
         """
-        raise NotImplemented("Must be implemented by subclasses")
 
     # utility functions to manipulate properties dict
     def get_prop(self, key):
@@ -191,6 +192,7 @@ class Schema:
     def __str__(self):
         return json.dumps(self.to_json())
 
+    @abc.abstractmethod
     def to_json(self, names):
         """
         Converts the schema object into its AVRO specification representation.
@@ -199,7 +201,6 @@ class Schema:
         be aware of not re-defining schemas that are already listed
         in the parameter names.
         """
-        raise NotImplemented("Must be implemented by subclasses.")
 
     def validate(self, datum):
         """Returns the appropriate schema object if datum is valid for that schema, else None.

--- a/lang/py/avro/schema.py
+++ b/lang/py/avro/schema.py
@@ -145,7 +145,7 @@ def _is_timezone_aware_datetime(dt):
 # Base Classes
 #
 
-class Schema(object):
+class Schema:
     """Base class for all Schema classes."""
     _props = None
 
@@ -224,7 +224,7 @@ class Schema(object):
         raise Exception("Must be implemented by subclasses.")
 
 
-class Name(object):
+class Name:
     """Class to describe Avro name."""
 
     _full = None
@@ -287,7 +287,7 @@ class Name(object):
         return self.space
 
 
-class Names(object):
+class Names:
     """Track name set and default namespace during parsing."""
 
     def __init__(self, default_namespace=None):
@@ -385,7 +385,7 @@ class NamedSchema(Schema):
 #
 
 
-class LogicalSchema(object):
+class LogicalSchema:
     def __init__(self, logical_type):
         self.logical_type = logical_type
 
@@ -416,7 +416,7 @@ class DecimalLogicalSchema(LogicalSchema):
         super(DecimalLogicalSchema, self).__init__('decimal')
 
 
-class Field(object):
+class Field:
     def __init__(self, type, name, has_default, default=None,
                  order=None, names=None, doc=None, other_props=None):
         # Ensure valid ctor args

--- a/lang/py/avro/schema.py
+++ b/lang/py/avro/schema.py
@@ -40,8 +40,6 @@ A schema may be one of:
   Null.
 """
 
-from __future__ import absolute_import, division, print_function
-
 import datetime
 import json
 import math

--- a/lang/py/avro/test/gen_interop_data.py
+++ b/lang/py/avro/test/gen_interop_data.py
@@ -28,32 +28,26 @@ import avro.datafile
 import avro.io
 import avro.schema
 
-try:
-    unicode
-except NameError:
-    unicode = str
-
-
 NULL_CODEC = 'null'
 CODECS_TO_VALIDATE = avro.codecs.supported_codec_names()
 
 DATUM = {
     'intField': 12,
     'longField': 15234324,
-    'stringField': unicode('hey'),
+    'stringField': 'hey',
     'boolField': True,
     'floatField': 1234.0,
     'doubleField': -1234.0,
     'bytesField': b'12312adf',
     'nullField': None,
     'arrayField': [5.0, 0.0, 12.0],
-    'mapField': {unicode('a'): {'label': unicode('a')},
-                 unicode('bee'): {'label': unicode('cee')}},
+    'mapField': {'a': {'label': 'a'},
+                 'bee': {'label': 'cee'}},
     'unionField': 12.0,
     'enumField': 'C',
     'fixedField': b'1019181716151413',
-    'recordField': {'label': unicode('blah'),
-                    'children': [{'label': unicode('inner'), 'children': []}]},
+    'recordField': {'label': 'blah',
+                    'children': [{'label': 'inner', 'children': []}]},
 }
 
 

--- a/lang/py/avro/test/gen_interop_data.py
+++ b/lang/py/avro/test/gen_interop_data.py
@@ -20,8 +20,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division, print_function
-
 import os
 import sys
 

--- a/lang/py/avro/test/gen_interop_data.py
+++ b/lang/py/avro/test/gen_interop_data.py
@@ -23,18 +23,19 @@
 import os
 import sys
 
+import avro.codecs
 import avro.datafile
 import avro.io
 import avro.schema
-from avro.codecs import Codecs
 
 try:
     unicode
 except NameError:
     unicode = str
 
+
 NULL_CODEC = 'null'
-CODECS_TO_VALIDATE = Codecs.supported_codec_names()
+CODECS_TO_VALIDATE = avro.codecs.supported_codec_names()
 
 DATUM = {
     'intField': 12,

--- a/lang/py/avro/test/mock_tether_parent.py
+++ b/lang/py/avro/test/mock_tether_parent.py
@@ -19,8 +19,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division, print_function
-
 import socket
 import sys
 

--- a/lang/py/avro/test/mock_tether_parent.py
+++ b/lang/py/avro/test/mock_tether_parent.py
@@ -19,30 +19,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import http.server
 import socket
 import sys
 
 import avro.errors
+import avro.ipc
+import avro.protocol
 import avro.tether.tether_task
 import avro.tether.util
-from avro import ipc, protocol
-
-try:
-    import BaseHTTPServer as http_server  # type: ignore
-except ImportError:
-    from http import server as http_server  # type: ignore
-
 
 SERVER_ADDRESS = ('localhost', avro.tether.util.find_port())
 
 
-class MockParentResponder(ipc.Responder):
+class MockParentResponder(avro.ipc.Responder):
     """
     The responder for the mocked parent
     """
 
     def __init__(self):
-        ipc.Responder.__init__(self, avro.tether.tether_task.outputProtocol)
+        avro.ipc.Responder.__init__(self, avro.tether.tether_task.outputProtocol)
 
     def invoke(self, message, request):
         if message.name == 'configure':
@@ -61,19 +57,19 @@ class MockParentResponder(ipc.Responder):
         return None
 
 
-class MockParentHandler(http_server.BaseHTTPRequestHandler):
+class MockParentHandler(http.server.BaseHTTPRequestHandler):
     """Create a handler for the parent.
     """
 
     def do_POST(self):
         self.responder = MockParentResponder()
-        call_request_reader = ipc.FramedReader(self.rfile)
+        call_request_reader = avro.ipc.FramedReader(self.rfile)
         call_request = call_request_reader.read_framed_message()
         resp_body = self.responder.respond(call_request)
         self.send_response(200)
         self.send_header('Content-Type', 'avro/binary')
         self.end_headers()
-        resp_writer = ipc.FramedWriter(self.wfile)
+        resp_writer = avro.ipc.FramedWriter(self.wfile)
         resp_writer.write_framed_message(resp_body)
 
 
@@ -93,6 +89,6 @@ if __name__ == '__main__':
 
         # flush the output so it shows up in the parent process
         sys.stdout.flush()
-        parent_server = http_server.HTTPServer(SERVER_ADDRESS, MockParentHandler)
+        parent_server = http.server.HTTPServer(SERVER_ADDRESS, MockParentHandler)
         parent_server.allow_reuse_address = True
         parent_server.serve_forever()

--- a/lang/py/avro/test/sample_http_client.py
+++ b/lang/py/avro/test/sample_http_client.py
@@ -20,8 +20,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division, print_function
-
 import sys
 
 import avro.errors

--- a/lang/py/avro/test/sample_http_client.py
+++ b/lang/py/avro/test/sample_http_client.py
@@ -23,7 +23,8 @@
 import sys
 
 import avro.errors
-from avro import ipc, protocol
+import avro.ipc
+import avro.protocol
 
 MAIL_PROTOCOL_JSON = """\
 {"namespace": "example.proto",
@@ -51,14 +52,14 @@ MAIL_PROTOCOL_JSON = """\
  }
 }
 """
-MAIL_PROTOCOL = protocol.parse(MAIL_PROTOCOL_JSON)
+MAIL_PROTOCOL = avro.protocol.parse(MAIL_PROTOCOL_JSON)
 SERVER_HOST = 'localhost'
 SERVER_PORT = 9090
 
 
 def make_requestor(server_host, server_port, protocol):
-    client = ipc.HTTPTransceiver(SERVER_HOST, SERVER_PORT)
-    return ipc.Requestor(protocol, client)
+    client = avro.ipc.HTTPTransceiver(SERVER_HOST, SERVER_PORT)
+    return avro.ipc.Requestor(protocol, client)
 
 
 if __name__ == '__main__':

--- a/lang/py/avro/test/sample_http_server.py
+++ b/lang/py/avro/test/sample_http_server.py
@@ -19,8 +19,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division, print_function
-
 import avro.ipc
 import avro.protocol
 

--- a/lang/py/avro/test/test_bench.py
+++ b/lang/py/avro/test/test_bench.py
@@ -17,8 +17,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division, print_function
-
 import argparse
 import json
 import random

--- a/lang/py/avro/test/test_datafile.py
+++ b/lang/py/avro/test/test_datafile.py
@@ -30,7 +30,7 @@ import avro.datafile
 import avro.io
 import avro.schema
 
-CODECS_TO_VALIDATE = avro.codecs.Codecs.supported_codec_names()
+CODECS_TO_VALIDATE = avro.codecs.supported_codec_names()
 TEST_PAIRS = tuple((avro.schema.parse(schema), datum) for schema, datum in (
     ('"null"', None),
     ('"boolean"', True),

--- a/lang/py/avro/test/test_datafile_interop.py
+++ b/lang/py/avro/test/test_datafile_interop.py
@@ -23,7 +23,8 @@ import os
 import unittest
 
 import avro
-from avro import datafile, io
+import avro.datafile
+import avro.io
 
 _INTEROP_DATA_DIR = os.path.join(os.path.dirname(avro.__file__), 'test', 'interop', 'data')
 
@@ -37,14 +38,14 @@ class TestDataFileInterop(unittest.TestCase):
             filename = os.path.join(_INTEROP_DATA_DIR, f)
             assert os.stat(filename).st_size > 0
             base_ext = os.path.splitext(os.path.basename(f))[0].split('_', 1)
-            if len(base_ext) < 2 or base_ext[1] in datafile.VALID_CODECS:
+            if len(base_ext) < 2 or base_ext[1] in avro.datafile.VALID_CODECS:
                 print('READING %s' % f)
                 print()
 
                 # read data in binary from file
-                datum_reader = io.DatumReader()
+                datum_reader = avro.io.DatumReader()
                 with open(filename, 'rb') as reader:
-                    dfr = datafile.DataFileReader(reader, datum_reader)
+                    dfr = avro.datafile.DataFileReader(reader, datum_reader)
                     i = 0
                     for i, datum in enumerate(dfr, 1):
                         assert datum is not None

--- a/lang/py/avro/test/test_datafile_interop.py
+++ b/lang/py/avro/test/test_datafile_interop.py
@@ -19,8 +19,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division, print_function
-
 import os
 import unittest
 

--- a/lang/py/avro/test/test_io.py
+++ b/lang/py/avro/test/test_io.py
@@ -19,8 +19,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division, print_function
-
 import datetime
 import io
 import unittest

--- a/lang/py/avro/test/test_io.py
+++ b/lang/py/avro/test/test_io.py
@@ -28,15 +28,10 @@ from decimal import Decimal
 import avro.io
 from avro import schema, timezones
 
-try:
-    unicode
-except NameError:
-    unicode = str
-
 SCHEMAS_TO_VALIDATE = (
     ('"null"', None),
     ('"boolean"', True),
-    ('"string"', unicode('adsfasdf09809dsf-=adsf')),
+    ('"string"', 'adsfasdf09809dsf-=adsf'),
     ('"bytes"', b'12345abcd'),
     ('"int"', 1234),
     ('"long"', 1234),
@@ -51,9 +46,9 @@ SCHEMAS_TO_VALIDATE = (
     ('{"type": "bytes", "logicalType": "decimal", "precision": 5, "scale": 4}', Decimal('-3.1415')),
     ('{"type": "enum", "name": "Test", "symbols": ["A", "B"]}', 'B'),
     ('{"type": "array", "items": "long"}', [1, 3, 2]),
-    ('{"type": "map", "values": "long"}', {unicode('a'): 1,
-                                           unicode('b'): 3,
-                                           unicode('c'): 2}),
+    ('{"type": "map", "values": "long"}', {'a': 1,
+                                           'b': 3,
+                                           'c': 2}),
     ('["string", "null", "long"]', None),
     ('{"type": "int", "logicalType": "date"}', datetime.date(2000, 1, 1)),
     ('{"type": "int", "logicalType": "time-millis"}', datetime.time(23, 59, 59, 999000)),
@@ -101,7 +96,7 @@ SCHEMAS_TO_VALIDATE = (
                           "name": "Cons",
                           "fields": [{"name": "car", "type": "Lisp"},
                                      {"name": "cdr", "type": "Lisp"}]}]}]}
-   """, {'value': {'car': {'value': unicode('head')}, 'cdr': {'value': None}}}),
+   """, {'value': {'car': {'value': 'head'}, 'cdr': {'value': None}}}),
 )
 
 BINARY_ENCODINGS = (
@@ -128,8 +123,8 @@ DEFAULT_VALUE_EXAMPLES = (
     ('{"type": "fixed", "name": "F", "size": 2}', '"\u00FF\u00FF"', u'\xff\xff'),
     ('{"type": "enum", "name": "F", "symbols": ["FOO", "BAR"]}', '"FOO"', 'FOO'),
     ('{"type": "array", "items": "int"}', '[1, 2, 3]', [1, 2, 3]),
-    ('{"type": "map", "values": "int"}', '{"a": 1, "b": 2}', {unicode('a'): 1,
-                                                              unicode('b'): 2}),
+    ('{"type": "map", "values": "int"}', '{"a": 1, "b": 2}', {'a': 1,
+                                                              'b': 2}),
     ('["int", "null"]', '5', 5),
     ('{"type": "record", "name": "F", "fields": [{"name": "A", "type": "int"}]}',
      '{"A": 5}', {'A': 5}),

--- a/lang/py/avro/test/test_ipc.py
+++ b/lang/py/avro/test/test_ipc.py
@@ -26,9 +26,7 @@ servers yet available.
 
 import unittest
 
-# This test does import this code, to make sure it at least passes
-# compilation.
-from avro import ipc
+import avro.ipc
 
 
 class TestIPC(unittest.TestCase):
@@ -36,10 +34,10 @@ class TestIPC(unittest.TestCase):
         pass
 
     def test_server_with_path(self):
-        client_with_custom_path = ipc.HTTPTransceiver('apache.org', 80, '/service/article')
+        client_with_custom_path = avro.ipc.HTTPTransceiver('apache.org', 80, '/service/article')
         self.assertEqual('/service/article', client_with_custom_path.req_resource)
 
-        client_with_default_path = ipc.HTTPTransceiver('apache.org', 80)
+        client_with_default_path = avro.ipc.HTTPTransceiver('apache.org', 80)
         self.assertEqual('/', client_with_default_path.req_resource)
 
 

--- a/lang/py/avro/test/test_ipc.py
+++ b/lang/py/avro/test/test_ipc.py
@@ -24,8 +24,6 @@ There are currently no IPC tests within python, in part because there are no
 servers yet available.
 """
 
-from __future__ import absolute_import, division, print_function
-
 import unittest
 
 # This test does import this code, to make sure it at least passes

--- a/lang/py/avro/test/test_protocol.py
+++ b/lang/py/avro/test/test_protocol.py
@@ -28,22 +28,12 @@ import avro.errors
 import avro.protocol
 import avro.schema
 
-try:
-    unicode
-except NameError:
-    unicode = str
-
-try:
-    basestring  # type: ignore
-except NameError:
-    basestring = (bytes, unicode)
-
 
 class TestProtocol:
     """A proxy for a protocol string that provides useful test metadata."""
 
     def __init__(self, data, name='', comment=''):
-        if not isinstance(data, basestring):
+        if not isinstance(data, str):
             data = json.dumps(data)
         self.data = data
         self.name = name or data

--- a/lang/py/avro/test/test_protocol.py
+++ b/lang/py/avro/test/test_protocol.py
@@ -21,8 +21,6 @@
 
 """Test the protocol parsing logic."""
 
-from __future__ import absolute_import, division, print_function
-
 import json
 import unittest
 

--- a/lang/py/avro/test/test_protocol.py
+++ b/lang/py/avro/test/test_protocol.py
@@ -39,7 +39,7 @@ except NameError:
     basestring = (bytes, unicode)
 
 
-class TestProtocol(object):
+class TestProtocol:
     """A proxy for a protocol string that provides useful test metadata."""
 
     def __init__(self, data, name='', comment=''):

--- a/lang/py/avro/test/test_schema.py
+++ b/lang/py/avro/test/test_schema.py
@@ -44,7 +44,7 @@ except ImportError:
     pass
 
 
-class TestSchema(object):
+class TestSchema:
     """A proxy for a schema string that provides useful test metadata."""
 
     def __init__(self, data, name='', comment='', warnings=None):

--- a/lang/py/avro/test/test_schema.py
+++ b/lang/py/avro/test/test_schema.py
@@ -21,8 +21,6 @@
 
 """Test the schema parsing logic."""
 
-from __future__ import absolute_import, division, print_function
-
 import json
 import unittest
 import warnings

--- a/lang/py/avro/test/test_schema.py
+++ b/lang/py/avro/test/test_schema.py
@@ -29,16 +29,6 @@ import avro.errors
 from avro import schema
 
 try:
-    unicode
-except NameError:
-    unicode = str
-
-try:
-    basestring  # type: ignore
-except NameError:
-    basestring = (bytes, unicode)
-
-try:
     from typing import List
 except ImportError:
     pass
@@ -48,7 +38,7 @@ class TestSchema:
     """A proxy for a schema string that provides useful test metadata."""
 
     def __init__(self, data, name='', comment='', warnings=None):
-        if not isinstance(data, basestring):
+        if not isinstance(data, str):
             data = json.dumps(data)
         self.data = data
         self.name = name or data  # default to data for name
@@ -567,7 +557,7 @@ class OtherAttributesTestCase(unittest.TestCase):
         "cp_int": int,
         "cp_null": type(None),
         "cp_object": dict,
-        "cp_string": basestring,
+        "cp_string": str,
     }
 
     def __init__(self, test_schema):

--- a/lang/py/avro/test/test_schema.py
+++ b/lang/py/avro/test/test_schema.py
@@ -24,14 +24,10 @@
 import json
 import unittest
 import warnings
+from typing import List
 
 import avro.errors
-from avro import schema
-
-try:
-    from typing import List
-except ImportError:
-    pass
+import avro.schema
 
 
 class TestSchema:
@@ -46,7 +42,7 @@ class TestSchema:
         self.warnings = warnings
 
     def parse(self):
-        return schema.parse(str(self))
+        return avro.schema.parse(str(self))
 
     def __str__(self):
         return str(self.data)
@@ -66,8 +62,8 @@ PRIMITIVE_EXAMPLES = [InvalidTestSchema('"True"')]  # type: List[TestSchema]
 PRIMITIVE_EXAMPLES.append(InvalidTestSchema('True'))
 PRIMITIVE_EXAMPLES.append(InvalidTestSchema('{"no_type": "test"}'))
 PRIMITIVE_EXAMPLES.append(InvalidTestSchema('{"type": "panther"}'))
-PRIMITIVE_EXAMPLES.extend([ValidTestSchema('"{}"'.format(t)) for t in schema.PRIMITIVE_TYPES])
-PRIMITIVE_EXAMPLES.extend([ValidTestSchema({"type": t}) for t in schema.PRIMITIVE_TYPES])
+PRIMITIVE_EXAMPLES.extend([ValidTestSchema('"{}"'.format(t)) for t in avro.schema.PRIMITIVE_TYPES])
+PRIMITIVE_EXAMPLES.extend([ValidTestSchema({"type": t}) for t in avro.schema.PRIMITIVE_TYPES])
 
 FIXED_EXAMPLES = [
     ValidTestSchema({"type": "fixed", "name": "Test", "size": 1}),
@@ -318,7 +314,7 @@ class TestMisc(unittest.TestCase):
 
     def test_correct_recursive_extraction(self):
         """A recursive reference within a schema should be the same type every time."""
-        s = schema.parse('''{
+        s = avro.schema.parse('''{
             "type": "record",
             "name": "X",
             "fields": [{
@@ -329,64 +325,64 @@ class TestMisc(unittest.TestCase):
                     "fields": [{"name": "Z", "type": "X"}]}
             }]
         }''')
-        t = schema.parse(str(s.fields[0].type))
+        t = avro.schema.parse(str(s.fields[0].type))
         # If we've made it this far, the subschema was reasonably stringified; it ccould be reparsed.
         self.assertEqual("X", t.fields[0].type.name)
 
     def test_name_is_none(self):
         """When a name is None its namespace is None."""
-        self.assertIsNone(schema.Name(None, None, None).fullname)
-        self.assertIsNone(schema.Name(None, None, None).space)
+        self.assertIsNone(avro.schema.Name(None, None, None).fullname)
+        self.assertIsNone(avro.schema.Name(None, None, None).space)
 
     def test_name_not_empty_string(self):
         """A name cannot be the empty string."""
-        self.assertRaises(avro.errors.SchemaParseException, schema.Name, "", None, None)
+        self.assertRaises(avro.errors.SchemaParseException, avro.schema.Name, "", None, None)
 
     def test_name_space_specified(self):
         """Space combines with a name to become the fullname."""
         # name and namespace specified
-        fullname = schema.Name('a', 'o.a.h', None).fullname
+        fullname = avro.schema.Name('a', 'o.a.h', None).fullname
         self.assertEqual(fullname, 'o.a.h.a')
 
     def test_fullname_space_specified(self):
         """When name contains dots, namespace should be ignored."""
-        fullname = schema.Name('a.b.c.d', 'o.a.h', None).fullname
+        fullname = avro.schema.Name('a.b.c.d', 'o.a.h', None).fullname
         self.assertEqual(fullname, 'a.b.c.d')
 
     def test_name_default_specified(self):
         """Default space becomes the namespace when the namespace is None."""
-        fullname = schema.Name('a', None, 'b.c.d').fullname
+        fullname = avro.schema.Name('a', None, 'b.c.d').fullname
         self.assertEqual(fullname, 'b.c.d.a')
 
     def test_fullname_default_specified(self):
         """When a name contains dots, default space should be ignored."""
-        fullname = schema.Name('a.b.c.d', None, 'o.a.h').fullname
+        fullname = avro.schema.Name('a.b.c.d', None, 'o.a.h').fullname
         self.assertEqual(fullname, 'a.b.c.d')
 
     def test_fullname_space_default_specified(self):
         """When a name contains dots, namespace and default space should be ignored."""
-        fullname = schema.Name('a.b.c.d', 'o.a.a', 'o.a.h').fullname
+        fullname = avro.schema.Name('a.b.c.d', 'o.a.a', 'o.a.h').fullname
         self.assertEqual(fullname, 'a.b.c.d')
 
     def test_name_space_default_specified(self):
         """When name and space are specified, default space should be ignored."""
-        fullname = schema.Name('a', 'o.a.a', 'o.a.h').fullname
+        fullname = avro.schema.Name('a', 'o.a.a', 'o.a.h').fullname
         self.assertEqual(fullname, 'o.a.a.a')
 
     def test_equal_names(self):
         """Equality of names is defined on the fullname and is case-sensitive."""
-        self.assertEqual(schema.Name('a.b.c.d', None, None), schema.Name('d', 'a.b.c', None))
-        self.assertNotEqual(schema.Name('C.d', None, None), schema.Name('c.d', None, None))
+        self.assertEqual(avro.schema.Name('a.b.c.d', None, None), avro.schema.Name('d', 'a.b.c', None))
+        self.assertNotEqual(avro.schema.Name('C.d', None, None), avro.schema.Name('c.d', None, None))
 
     def test_invalid_name(self):
         """The name portion of a fullname, record field names, and enum symbols must:
            start with [A-Za-z_] and subsequently contain only [A-Za-z0-9_]"""
-        self.assertRaises(avro.errors.InvalidName, schema.Name, 'an especially spacey cowboy', None, None)
-        self.assertRaises(avro.errors.InvalidName, schema.Name, '99 problems but a name aint one', None, None)
+        self.assertRaises(avro.errors.InvalidName, avro.schema.Name, 'an especially spacey cowboy', None, None)
+        self.assertRaises(avro.errors.InvalidName, avro.schema.Name, '99 problems but a name aint one', None, None)
 
     def test_null_namespace(self):
         """The empty string may be used as a namespace to indicate the null namespace."""
-        name = schema.Name('name', "", None)
+        name = avro.schema.Name('name', "", None)
         self.assertEqual(name.fullname, "name")
         self.assertIsNone(name.space)
 
@@ -394,7 +390,7 @@ class TestMisc(unittest.TestCase):
         """A specific exception message should appear on a json parse error."""
         self.assertRaisesRegexp(avro.errors.SchemaParseException,
                                 r'Error parsing JSON: /not/a/real/file',
-                                schema.parse,
+                                avro.schema.parse,
                                 '/not/a/real/file')
 
     def test_decimal_valid_type(self):
@@ -431,8 +427,8 @@ class TestMisc(unittest.TestCase):
             "size": 8})
 
         fixed_decimal = fixed_decimal_schema.parse()
-        self.assertIsInstance(fixed_decimal, schema.FixedSchema)
-        self.assertIsInstance(fixed_decimal, schema.DecimalLogicalSchema)
+        self.assertIsInstance(fixed_decimal, avro.schema.FixedSchema)
+        self.assertIsInstance(fixed_decimal, avro.schema.DecimalLogicalSchema)
 
     def test_fixed_decimal_invalid_max_precision(self):
         # An 8 byte number can't represent every 19 digit number, so the logical
@@ -446,8 +442,8 @@ class TestMisc(unittest.TestCase):
             "size": 8})
 
         fixed_decimal = fixed_decimal_schema.parse()
-        self.assertIsInstance(fixed_decimal, schema.FixedSchema)
-        self.assertNotIsInstance(fixed_decimal, schema.DecimalLogicalSchema)
+        self.assertIsInstance(fixed_decimal, avro.schema.FixedSchema)
+        self.assertNotIsInstance(fixed_decimal, avro.schema.DecimalLogicalSchema)
 
     def test_parse_invalid_symbol(self):
         """Disabling enumschema symbol validation should allow invalid symbols to pass."""
@@ -455,7 +451,7 @@ class TestMisc(unittest.TestCase):
             "type": "enum", "name": "AVRO2174", "symbols": ["white space"]})
 
         try:
-            case = schema.parse(test_schema_string, validate_enum_symbols=True)
+            case = avro.schema.parse(test_schema_string, validate_enum_symbols=True)
         except avro.errors.InvalidName:
             pass
         else:
@@ -463,7 +459,7 @@ class TestMisc(unittest.TestCase):
                       "an invalid symbol should raise InvalidName.")
 
         try:
-            case = schema.parse(test_schema_string, validate_enum_symbols=False)
+            case = avro.schema.parse(test_schema_string, validate_enum_symbols=False)
         except avro.errors.InvalidName:
             self.fail("When enum symbol validation is disabled, "
                       "an invalid symbol should not raise InvalidName.")
@@ -523,7 +519,7 @@ class RoundTripParseTestCase(unittest.TestCase):
     def parse_round_trip(self):
         """The string of a Schema should be parseable to the same Schema."""
         parsed = self.test_schema.parse()
-        round_trip = schema.parse(str(parsed))
+        round_trip = avro.schema.parse(str(parsed))
         self.assertEqual(parsed, round_trip)
 
 
@@ -576,7 +572,7 @@ class OtherAttributesTestCase(unittest.TestCase):
     def check_attributes(self):
         """Other attributes and their types on a schema should be preserved."""
         sch = self.test_schema.parse()
-        round_trip = schema.parse(str(sch))
+        round_trip = avro.schema.parse(str(sch))
         self.assertEqual(sch.other_props, round_trip.other_props,
                          "Properties were not preserved in a round-trip parse.")
         self._check_props(sch.other_props)

--- a/lang/py/avro/test/test_script.py
+++ b/lang/py/avro/test/test_script.py
@@ -34,11 +34,6 @@ import avro.schema
 from avro.datafile import DataFileWriter
 from avro.io import DatumWriter
 
-try:
-    unicode
-except NameError:
-    unicode = str
-
 NUM_RECORDS = 7
 
 
@@ -56,13 +51,13 @@ SCHEMA = '''
 '''
 
 LOONIES = (
-    (unicode("daffy"), unicode("duck"), unicode("duck")),
-    (unicode("bugs"), unicode("bunny"), unicode("bunny")),
-    (unicode("tweety"), unicode(""), unicode("bird")),
-    (unicode("road"), unicode("runner"), unicode("bird")),
-    (unicode("wile"), unicode("e"), unicode("coyote")),
-    (unicode("pepe"), unicode("le pew"), unicode("skunk")),
-    (unicode("foghorn"), unicode("leghorn"), unicode("rooster")),
+    ("daffy", "duck", "duck"),
+    ("bugs", "bunny", "bunny"),
+    ("tweety", "", "bird"),
+    ("road", "runner", "bird"),
+    ("wile", "e", "coyote"),
+    ("pepe", "le pew", "skunk"),
+    ("foghorn", "leghorn", "rooster"),
 )
 
 
@@ -124,7 +119,7 @@ class TestCat(unittest.TestCase):
         assert len(list(reader)) == NUM_RECORDS
 
     def test_csv_header(self):
-        r = {"type": unicode("duck"), "last": unicode("duck"), "first": unicode("daffy")}
+        r = {"type": "duck", "last": "duck", "first": "daffy"}
         out = self._run("-f", "csv", "--header", raw=True)
         io_ = io.StringIO(out)
         reader = csv.DictReader(io_)
@@ -157,17 +152,17 @@ class TestCat(unittest.TestCase):
 
         # Field selection (with comma and space)
         out = self._run('--fields', 'first, last')
-        assert json.loads(out[0]) == {'first': unicode('daffy'), 'last': unicode('duck')}
+        assert json.loads(out[0]) == {'first': 'daffy', 'last': 'duck'}
 
         # Empty fields should get all
         out = self._run('--fields', '')
         assert json.loads(out[0]) == \
-            {'first': unicode('daffy'), 'last': unicode('duck'),
-             'type': unicode('duck')}
+            {'first': 'daffy', 'last': 'duck',
+             'type': 'duck'}
 
         # Non existing fields are ignored
         out = self._run('--fields', 'first,last,age')
-        assert json.loads(out[0]) == {'first': unicode('daffy'), 'last': unicode('duck')}
+        assert json.loads(out[0]) == {'first': 'daffy', 'last': 'duck'}
 
 
 class TestWrite(unittest.TestCase):
@@ -217,7 +212,7 @@ class TestWrite(unittest.TestCase):
 
         records = self.load_avro(tmp)
         assert len(records) == NUM_RECORDS
-        assert records[0]["first"] == unicode("daffy")
+        assert records[0]["first"] == "daffy"
 
         remove(tmp)
 

--- a/lang/py/avro/test/test_script.py
+++ b/lang/py/avro/test/test_script.py
@@ -19,8 +19,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division, print_function
-
 import csv
 import io
 import json

--- a/lang/py/avro/test/test_script.py
+++ b/lang/py/avro/test/test_script.py
@@ -22,17 +22,17 @@
 import csv
 import io
 import json
+import operator
+import os
+import os.path
+import subprocess
 import sys
+import tempfile
 import unittest
-from operator import itemgetter
-from os import remove
-from os.path import dirname, isfile, join
-from subprocess import check_call, check_output
-from tempfile import NamedTemporaryFile
 
+import avro.datafile
+import avro.io
 import avro.schema
-from avro.datafile import DataFileWriter
-from avro.io import DatumWriter
 
 NUM_RECORDS = 7
 
@@ -66,7 +66,7 @@ def looney_records():
         yield {"first": f, "last": l, "type": t}
 
 
-SCRIPT = join(dirname(dirname(dirname(__file__))), "scripts", "avro")
+SCRIPT = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "scripts", "avro")
 
 _JSON_PRETTY = '''{
     "first": "daffy",
@@ -78,28 +78,30 @@ _JSON_PRETTY = '''{
 def gen_avro(filename):
     schema = avro.schema.parse(SCHEMA)
     fo = open(filename, "wb")
-    writer = DataFileWriter(fo, DatumWriter(), schema)
+    writer = avro.datafile.DataFileWriter(fo, avro.io.DatumWriter(), schema)
     for record in looney_records():
         writer.append(record)
     writer.close()
     fo.close()
 
 
-def tempfile():
-    return NamedTemporaryFile(delete=False).name
+def _tempfile():
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+        pass
+    return f.name
 
 
 class TestCat(unittest.TestCase):
     def setUp(self):
-        self.avro_file = tempfile()
+        self.avro_file = _tempfile()
         gen_avro(self.avro_file)
 
     def tearDown(self):
-        if isfile(self.avro_file):
-            remove(self.avro_file)
+        if os.path.isfile(self.avro_file):
+            os.unlink(self.avro_file)
 
     def _run(self, *args, **kw):
-        out = check_output([sys.executable, SCRIPT, "cat", self.avro_file] + list(args)).decode()
+        out = subprocess.check_output([sys.executable, SCRIPT, "cat", self.avro_file] + list(args)).decode()
         if kw.get("raw"):
             return out
         return out.splitlines()
@@ -139,7 +141,7 @@ class TestCat(unittest.TestCase):
         self.assertEqual(out.strip(), _JSON_PRETTY.strip())
 
     def test_version(self):
-        check_output([sys.executable, SCRIPT, "cat", "--version"])
+        subprocess.check_output([sys.executable, SCRIPT, "cat", "--version"])
 
     def test_files(self):
         out = self._run(self.avro_file)
@@ -167,22 +169,22 @@ class TestCat(unittest.TestCase):
 
 class TestWrite(unittest.TestCase):
     def setUp(self):
-        self.json_file = tempfile() + ".json"
+        self.json_file = _tempfile() + ".json"
         fo = open(self.json_file, "w")
         for record in looney_records():
             json.dump(record, fo)
             fo.write("\n")
         fo.close()
 
-        self.csv_file = tempfile() + ".csv"
+        self.csv_file = _tempfile() + ".csv"
         fo = open(self.csv_file, "w")
         write = csv.writer(fo).writerow
-        get = itemgetter("first", "last", "type")
+        get = operator.itemgetter("first", "last", "type")
         for record in looney_records():
             write(get(record))
         fo.close()
 
-        self.schema_file = tempfile()
+        self.schema_file = _tempfile()
         fo = open(self.schema_file, "w")
         fo.write(SCHEMA)
         fo.close()
@@ -190,23 +192,23 @@ class TestWrite(unittest.TestCase):
     def tearDown(self):
         for filename in (self.csv_file, self.json_file, self.schema_file):
             try:
-                remove(filename)
+                os.unlink(filename)
             except OSError:
                 continue
 
     def _run(self, *args, **kw):
         args = [sys.executable, SCRIPT, "write", "--schema", self.schema_file] + list(args)
-        check_call(args, **kw)
+        subprocess.check_call(args, **kw)
 
     def load_avro(self, filename):
-        out = check_output([sys.executable, SCRIPT, "cat", filename]).decode()
+        out = subprocess.check_output([sys.executable, SCRIPT, "cat", filename]).decode()
         return [json.loads(o) for o in out.splitlines()]
 
     def test_version(self):
-        check_call([sys.executable, SCRIPT, "write", "--version"])
+        subprocess.check_call([sys.executable, SCRIPT, "write", "--version"])
 
     def format_check(self, format, filename):
-        tmp = tempfile()
+        tmp = _tempfile()
         with open(tmp, "wb") as fo:
             self._run(filename, "-f", format, stdout=fo)
 
@@ -214,7 +216,7 @@ class TestWrite(unittest.TestCase):
         assert len(records) == NUM_RECORDS
         assert records[0]["first"] == "daffy"
 
-        remove(tmp)
+        os.unlink(tmp)
 
     def test_write_json(self):
         self.format_check("json", self.json_file)
@@ -223,24 +225,24 @@ class TestWrite(unittest.TestCase):
         self.format_check("csv", self.csv_file)
 
     def test_outfile(self):
-        tmp = tempfile()
-        remove(tmp)
+        tmp = _tempfile()
+        os.unlink(tmp)
         self._run(self.json_file, "-o", tmp)
 
         assert len(self.load_avro(tmp)) == NUM_RECORDS
-        remove(tmp)
+        os.unlink(tmp)
 
     def test_multi_file(self):
-        tmp = tempfile()
+        tmp = _tempfile()
         with open(tmp, 'wb') as o:
             self._run(self.json_file, self.json_file, stdout=o)
         assert len(self.load_avro(tmp)) == 2 * NUM_RECORDS
-        remove(tmp)
+        os.unlink(tmp)
 
     def test_stdin(self):
-        tmp = tempfile()
+        tmp = _tempfile()
         info = open(self.json_file, "rb")
         self._run("--input-type", "json", "-o", tmp, stdin=info)
 
         assert len(self.load_avro(tmp)) == NUM_RECORDS
-        remove(tmp)
+        os.unlink(tmp)

--- a/lang/py/avro/test/test_tether_task.py
+++ b/lang/py/avro/test/test_tether_task.py
@@ -31,7 +31,6 @@ import avro.test.mock_tether_parent
 import avro.test.word_count_task
 import avro.tether.tether_task
 import avro.tether.util
-from avro import schema, tether
 
 
 class TestTetherTask(unittest.TestCase):

--- a/lang/py/avro/test/test_tether_task.py
+++ b/lang/py/avro/test/test_tether_task.py
@@ -33,11 +33,6 @@ import avro.tether.tether_task
 import avro.tether.util
 from avro import schema, tether
 
-try:
-    unicode
-except NameError:
-    unicode = str
-
 
 class TestTetherTask(unittest.TestCase):
     """
@@ -77,7 +72,7 @@ class TestTetherTask(unittest.TestCase):
             )
 
             # Serialize some data so we can send it to the input function
-            datum = unicode("This is a line of text")
+            datum = "This is a line of text"
             writer = io.BytesIO()
             encoder = avro.io.BinaryEncoder(writer)
             datum_writer = avro.io.DatumWriter(task.inschema)
@@ -97,7 +92,7 @@ class TestTetherTask(unittest.TestCase):
             )
 
             # Serialize some data so we can send it to the input function
-            datum = {"key": unicode("word"), "value": 2}
+            datum = {"key": "word", "value": 2}
             writer = io.BytesIO()
             encoder = avro.io.BinaryEncoder(writer)
             datum_writer = avro.io.DatumWriter(task.midschema)
@@ -112,7 +107,7 @@ class TestTetherTask(unittest.TestCase):
             task.complete()
 
             # try a status
-            task.status(unicode("Status message"))
+            task.status("Status message")
         finally:
             # close the process
             if not(proc is None):

--- a/lang/py/avro/test/test_tether_task.py
+++ b/lang/py/avro/test/test_tether_task.py
@@ -19,8 +19,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division, print_function
-
 import io
 import os
 import subprocess

--- a/lang/py/avro/test/test_tether_task_runner.py
+++ b/lang/py/avro/test/test_tether_task_runner.py
@@ -19,8 +19,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division, print_function
-
 import io
 import logging
 import os

--- a/lang/py/avro/test/test_tether_task_runner.py
+++ b/lang/py/avro/test/test_tether_task_runner.py
@@ -34,11 +34,6 @@ import avro.tether.tether_task
 import avro.tether.tether_task_runner
 import avro.tether.util
 
-try:
-    unicode
-except NameError:
-    unicode = str
-
 
 class TestTetherTaskRunner(unittest.TestCase):
     """unit test for a tethered task runner."""
@@ -83,12 +78,12 @@ class TestTetherTaskRunner(unittest.TestCase):
             # Test the mapper
             requestor.request("configure", {
                 "taskType": avro.tether.tether_task.TaskType.MAP,
-                "inSchema": unicode(str(runner.task.inschema)),
-                "outSchema": unicode(str(runner.task.midschema))
+                "inSchema": str(runner.task.inschema),
+                "outSchema": str(runner.task.midschema)
             })
 
             # Serialize some data so we can send it to the input function
-            datum = unicode("This is a line of text")
+            datum = "This is a line of text"
             writer = io.BytesIO()
             encoder = avro.io.BinaryEncoder(writer)
             datum_writer = avro.io.DatumWriter(runner.task.inschema)
@@ -103,12 +98,12 @@ class TestTetherTaskRunner(unittest.TestCase):
             # Test the reducer
             requestor.request("configure", {
                 "taskType": avro.tether.tether_task.TaskType.REDUCE,
-                "inSchema": unicode(str(runner.task.midschema)),
-                "outSchema": unicode(str(runner.task.outschema))}
+                "inSchema": str(runner.task.midschema),
+                "outSchema": str(runner.task.outschema)}
             )
 
             # Serialize some data so we can send it to the input function
-            datum = {"key": unicode("word"), "value": 2}
+            datum = {"key": "word", "value": 2}
             writer = io.BytesIO()
             encoder = avro.io.BinaryEncoder(writer)
             datum_writer = avro.io.DatumWriter(runner.task.midschema)

--- a/lang/py/avro/test/test_tether_word_count.py
+++ b/lang/py/avro/test/test_tether_word_count.py
@@ -35,11 +35,6 @@ import avro.io
 import avro.schema
 import avro.tether.tether_task_runner
 
-try:
-    unicode
-except NameError:
-    unicode = str
-
 _AVRO_DIR = os.path.abspath(os.path.dirname(avro.__file__))
 
 
@@ -53,9 +48,9 @@ _AVRO_VERSION = _version()
 _JAR_PATH = os.path.join(os.path.dirname(os.path.dirname(_AVRO_DIR)),
                          "java", "tools", "target", "avro-tools-{}.jar".format(_AVRO_VERSION))
 
-_LINES = (unicode("the quick brown fox jumps over the lazy dog"),
-          unicode("the cow jumps over the moon"),
-          unicode("the rain in spain falls mainly on the plains"))
+_LINES = ("the quick brown fox jumps over the lazy dog",
+          "the cow jumps over the moon",
+          "the rain in spain falls mainly on the plains")
 _IN_SCHEMA = '"string"'
 
 # The schema for the output of the mapper and reducer

--- a/lang/py/avro/test/test_tether_word_count.py
+++ b/lang/py/avro/test/test_tether_word_count.py
@@ -19,8 +19,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division, print_function
-
 import collections
 import distutils.spawn
 import os

--- a/lang/py/avro/test/word_count_task.py
+++ b/lang/py/avro/test/word_count_task.py
@@ -19,8 +19,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division, print_function
-
 import logging
 
 import avro.tether.tether_task

--- a/lang/py/avro/tether/__init__.py
+++ b/lang/py/avro/tether/__init__.py
@@ -20,8 +20,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import absolute_import, division, print_function
-
 from avro.tether.tether_task import HTTPRequestor, TaskType, TetherTask, inputProtocol, outputProtocol
 from avro.tether.tether_task_runner import TaskRunner
 from avro.tether.util import find_port

--- a/lang/py/avro/tether/tether_task.py
+++ b/lang/py/avro/tether/tether_task.py
@@ -19,8 +19,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division, print_function
-
 import collections
 import io
 import logging

--- a/lang/py/avro/tether/tether_task.py
+++ b/lang/py/avro/tether/tether_task.py
@@ -59,7 +59,7 @@ with open(pfile, 'r') as hf:
 outputProtocol = protocol.parse(prototxt)
 
 
-class Collector(object):
+class Collector:
     """
     Collector for map and reduce output values
     """
@@ -120,7 +120,7 @@ def keys_are_equal(rec1, rec2, fkeys):
     return True
 
 
-class HTTPRequestor(object):
+class HTTPRequestor:
     """
     This is a small requestor subclass I created for the HTTP protocol.
     Since the HTTP protocol isn't persistent, we need to instantiate
@@ -150,7 +150,7 @@ class HTTPRequestor(object):
         return requestor.request(*args, **param)
 
 
-class TetherTask(object):
+class TetherTask:
     """
     Base class for python tether mapreduce programs.
 

--- a/lang/py/avro/tether/tether_task.py
+++ b/lang/py/avro/tether/tether_task.py
@@ -29,7 +29,9 @@ import traceback
 
 import avro.errors
 import avro.io
-from avro import ipc, protocol, schema
+import avro.ipc
+import avro.protocol
+import avro.schema
 
 __all__ = ["TetherTask", "TaskType", "inputProtocol", "outputProtocol", "HTTPRequestor"]
 
@@ -42,7 +44,7 @@ pfile = os.path.split(__file__)[0] + os.sep + "InputProtocol.avpr"
 with open(pfile, 'r') as hf:
     prototxt = hf.read()
 
-inputProtocol = protocol.parse(prototxt)
+inputProtocol = avro.protocol.parse(prototxt)
 
 # use a named tuple to represent the tasktype enumeration
 taskschema = inputProtocol.types_dict["TaskType"]
@@ -56,7 +58,7 @@ pfile = os.path.split(__file__)[0] + os.sep + "OutputProtocol.avpr"
 with open(pfile, 'r') as hf:
     prototxt = hf.read()
 
-outputProtocol = protocol.parse(prototxt)
+outputProtocol = avro.protocol.parse(prototxt)
 
 
 class Collector:
@@ -73,8 +75,8 @@ class Collector:
         outputClient - The output client used to send messages to the parent
         """
 
-        if not isinstance(scheme, schema.Schema):
-            scheme = schema.parse(scheme)
+        if not isinstance(scheme, avro.schema.Schema):
+            scheme = avro.schema.parse(scheme)
 
         self.scheme = scheme
 
@@ -145,8 +147,8 @@ class HTTPRequestor:
         self.protocol = protocol
 
     def request(self, *args, **param):
-        transciever = ipc.HTTPTransceiver(self.server, self.port)
-        requestor = ipc.Requestor(self.protocol, transciever)
+        transciever = avro.ipc.HTTPTransceiver(self.server, self.port)
+        requestor = avro.ipc.Requestor(self.protocol, transciever)
         return requestor.request(*args, **param)
 
 
@@ -191,9 +193,9 @@ class TetherTask:
         """
         # make sure we can parse the schemas
         # Should we call fail if we can't parse the schemas?
-        self.inschema = schema.parse(inschema)
-        self.midschema = schema.parse(midschema)
-        self.outschema = schema.parse(outschema)
+        self.inschema = avro.schema.parse(inschema)
+        self.midschema = avro.schema.parse(midschema)
+        self.outschema = avro.schema.parse(outschema)
 
         # declare various variables
         self.clienTransciever = None
@@ -248,7 +250,7 @@ class TetherTask:
 
         self.log.info("TetherTask.open: Opening connection to parent server on port={0}".format(clientPort))
 
-        # self.outputClient =  ipc.Requestor(outputProtocol, self.clientTransceiver)
+        # self.outputClient =  avro.ipc.Requestor(outputProtocol, self.clientTransceiver)
         # since HTTP is stateless, a new transciever
         # is created and closed for each request. We therefore set clientTransciever to None
         # We still declare clientTransciever because for other (state) protocols we will need
@@ -282,8 +284,8 @@ class TetherTask:
         self.taskType = taskType
 
         try:
-            inSchema = schema.parse(inSchemaText)
-            outSchema = schema.parse(outSchemaText)
+            inSchema = avro.schema.parse(inSchemaText)
+            outSchema = avro.schema.parse(outSchemaText)
 
             if (taskType == TaskType.MAP):
                 self.inReader = avro.io.DatumReader(writers_schema=inSchema, readers_schema=self.inschema)

--- a/lang/py/avro/tether/tether_task.py
+++ b/lang/py/avro/tether/tether_task.py
@@ -19,6 +19,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import abc
 import collections
 import io
 import logging
@@ -152,7 +153,7 @@ class HTTPRequestor:
         return requestor.request(*args, **param)
 
 
-class TetherTask:
+class TetherTask(abc.ABC):
     """
     Base class for python tether mapreduce programs.
 
@@ -366,6 +367,7 @@ class TetherTask:
 
         self.outputClient.request("complete", dict())
 
+    @abc.abstractmethod
     def map(self, record, collector):
         """Called with input values to generate intermediat values (i.e mapper output).
 
@@ -378,8 +380,7 @@ class TetherTask:
         subclass.
         """
 
-        raise NotImplementedError("This is an abstract method which should be overloaded in the subclass")
-
+    @abc.abstractmethod
     def reduce(self, record, collector):
         """ Called with input values to generate reducer output. Inputs are sorted by the mapper
         key.
@@ -396,8 +397,7 @@ class TetherTask:
         subclass.
         """
 
-        raise NotImplementedError("This is an abstract method which should be overloaded in the subclass")
-
+    @abc.abstractmethod
     def reduceFlush(self, record, collector):
         """
         Called with the last intermediate value in each equivalence run.
@@ -408,7 +408,6 @@ class TetherTask:
         ------------------------------------------------------------------
         record - the last record on which reduce was invoked.
         """
-        raise NotImplementedError("This is an abstract method which should be overloaded in the subclass")
 
     def status(self, message):
         """

--- a/lang/py/avro/tether/tether_task_runner.py
+++ b/lang/py/avro/tether/tether_task_runner.py
@@ -19,8 +19,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division, print_function
-
 import logging
 import sys
 import threading

--- a/lang/py/avro/tether/tether_task_runner.py
+++ b/lang/py/avro/tether/tether_task_runner.py
@@ -136,7 +136,7 @@ def HTTPHandlerGen(runner):
     return TaskRunnerHTTPHandler
 
 
-class TaskRunner(object):
+class TaskRunner:
     """This class ties together the server handling the requests from
     the parent process and the instance of TetherTask which actually
     implements the logic for the mapper and reducer phases

--- a/lang/py/avro/tether/util.py
+++ b/lang/py/avro/tether/util.py
@@ -19,8 +19,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division, print_function
-
 import socket
 
 

--- a/lang/py/avro/timezones.py
+++ b/lang/py/avro/timezones.py
@@ -19,8 +19,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division, print_function
-
 from datetime import datetime, timedelta, tzinfo
 
 

--- a/lang/py/avro/timezones.py
+++ b/lang/py/avro/timezones.py
@@ -19,33 +19,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import datetime, timedelta, tzinfo
+import datetime
 
 
-class UTCTzinfo(tzinfo):
+class UTCTzinfo(datetime.tzinfo):
     def utcoffset(self, dt):
-        return timedelta(0)
+        return datetime.timedelta(0)
 
     def tzname(self, dt):
         return "UTC"
 
     def dst(self, dt):
-        return timedelta(0)
+        return datetime.timedelta(0)
 
 
 utc = UTCTzinfo()
 
 
 # Test Time Zone with fixed offset and no DST
-class TSTTzinfo(tzinfo):
+class TSTTzinfo(datetime.tzinfo):
     def utcoffset(self, dt):
-        return timedelta(hours=10)
+        return datetime.timedelta(hours=10)
 
     def tzname(self, dt):
         return "TST"
 
     def dst(self, dt):
-        return timedelta(0)
+        return datetime.timedelta(0)
 
 
 tst = TSTTzinfo()

--- a/lang/py/avro/tool.py
+++ b/lang/py/avro/tool.py
@@ -25,8 +25,6 @@ Command-line tool
 NOTE: The API for the command-line tool is experimental.
 """
 
-from __future__ import absolute_import, division, print_function
-
 import os.path
 import sys
 import threading

--- a/lang/py/scripts/avro
+++ b/lang/py/scripts/avro
@@ -19,23 +19,19 @@
 """Command line utility for reading and writing Avro files."""
 
 import csv
-import itertools
+import functools
 import json
+import optparse
 import os.path
 import sys
-from functools import partial
-from optparse import OptionGroup, OptionParser
 
 import avro
+import avro.datafile
 import avro.errors
+import avro.io
 import avro.schema
-from avro.datafile import DataFileReader, DataFileWriter
-from avro.io import DatumReader, DatumWriter
 
 _AVRO_DIR = os.path.abspath(os.path.dirname(avro.__file__))
-
-ifilter = getattr(itertools, 'ifilter', filter)
-imap = getattr(itertools, 'imap', map)
 
 
 def _version():
@@ -101,7 +97,8 @@ def print_avro(avro, opts):
 
     # Apply filter first
     if opts.filter:
-        avro = ifilter(partial(record_match, opts.filter), avro)
+        predicate = functools.partial(record_match, opts.filter)
+        avro = (r for r in avro if predicate(r))
 
     for i in range(opts.skip):
         try:
@@ -111,7 +108,8 @@ def print_avro(avro, opts):
 
     fields = parse_fields(opts.fields)
     if fields:
-        avro = imap(field_selector(fields), avro)
+        fs = field_selector(fields)
+        avro = (fs(r) for r in avro)
 
     printer = select_printer(opts.format)
     for i, record in enumerate(avro):
@@ -132,11 +130,11 @@ def cat(opts, args):
     if not args:
         raise avro.errors.UsageError("No files to show")
     for filename in args:
-        with DataFileReader(open(filename, 'rb'), DatumReader()) as avro:
+        with avro.datafile.DataFileReader(open(filename, 'rb'), avro.io.DatumReader()) as avro_:
             if opts.print_schema:
-                print_schema(avro)
+                print_schema(avro_)
                 continue
-            print_avro(avro, opts)
+            print_avro(avro_, opts)
 
 
 def _open(filename, mode):
@@ -220,7 +218,7 @@ def write(opts, files):
     except (IOError, OSError) as e:
         raise avro.errors.UsageError("Can't open file - %s" % e)
 
-    writer = DataFileWriter(getattr(out, 'buffer', out), DatumWriter(), schema)
+    writer = avro.datafile.DataFileWriter(getattr(out, 'buffer', out), avro.io.DatumWriter(), schema)
 
     for filename in (files or ["-"]):
         info = _open(filename, "rb")
@@ -231,11 +229,11 @@ def write(opts, files):
 
 
 def main(argv):
-    parser = OptionParser(description="Display/write for Avro files",
-                          version=_AVRO_VERSION,
-                          usage="usage: %prog cat|write [options] FILE [FILE...]")
+    parser = optparse.OptionParser(description="Display/write for Avro files",
+                                   version=_AVRO_VERSION,
+                                   usage="usage: %prog cat|write [options] FILE [FILE...]")
     # cat options
-    cat_options = OptionGroup(parser, "cat options")
+    cat_options = optparse.OptionGroup(parser, "cat options")
     cat_options.add_option("-n", "--count", default=float("Infinity"),
                            help="number of records to print", type=int)
     cat_options.add_option("-s", "--skip", help="number of records to skip",
@@ -254,7 +252,7 @@ def main(argv):
     parser.add_option_group(cat_options)
 
     # write options
-    write_options = OptionGroup(parser, "write options")
+    write_options = optparse.OptionGroup(parser, "write options")
     write_options.add_option("--schema", help="schema file (required)")
     write_options.add_option("--input-type",
                              help="input file(s) type (json or csv)",

--- a/lang/py/scripts/avro
+++ b/lang/py/scripts/avro
@@ -38,11 +38,6 @@ ifilter = getattr(itertools, 'ifilter', filter)
 imap = getattr(itertools, 'imap', map)
 
 try:
-    unicode
-except NameError:
-    unicode = str
-
-try:
     long
 except NameError:
     long = int
@@ -178,7 +173,7 @@ def convert(value, field):
         "long": long,
         "float": float,
         "double": float,
-        "string": unicode,
+        "string": str,
         "bytes": bytes,
         "boolean": bool,
         "null": lambda _: None,

--- a/lang/py/scripts/avro
+++ b/lang/py/scripts/avro
@@ -37,11 +37,6 @@ _AVRO_DIR = os.path.abspath(os.path.dirname(avro.__file__))
 ifilter = getattr(itertools, 'ifilter', filter)
 imap = getattr(itertools, 'imap', map)
 
-try:
-    long
-except NameError:
-    long = int
-
 
 def _version():
     with open(os.path.join(_AVRO_DIR, 'VERSION.txt')) as v:
@@ -170,7 +165,7 @@ def convert(value, field):
 
     return  {
         "int": int,
-        "long": long,
+        "long": int,
         "float": float,
         "double": float,
         "string": str,

--- a/lang/py/scripts/avro
+++ b/lang/py/scripts/avro
@@ -18,8 +18,6 @@
 
 """Command line utility for reading and writing Avro files."""
 
-from __future__ import absolute_import, division, print_function
-
 import csv
 import itertools
 import json

--- a/lang/py/setup.py
+++ b/lang/py/setup.py
@@ -20,8 +20,6 @@
 # limitations under the License.
 
 
-from __future__ import absolute_import, division, print_function
-
 import setuptools  # type: ignore
 import distutils.errors
 import glob


### PR DESCRIPTION
These polyfills add complexity, reduce performance and increase the maintenance burden. Now that Python 2 is gone, we remove them.

### Jira

This PR…
- [x] …addresses [AVRO-2920](https://issues.apache.org/jira/browse/AVRO-2920).
- [x] …references the ticket in the title.
- [x] …adds no dependencies.

### Tests

- [x] This PR's changes are covered by existing tests.

### Commits

- [x] These commits all reference Jira issues in their subject lines.
- [x] These commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":

### Documentation

- [x] Other changesets have documented that Python 2 is obsolete. This changeset does not need additional documentation.
