### PR TITLE
AVRO-2925: add support for UUID in compiler

### DIFF
--- a/lang/java/compiler/src/main/javacc/org/apache/avro/compiler/idl/idl.jj
+++ b/lang/java/compiler/src/main/javacc/org/apache/avro/compiler/idl/idl.jj
@@ -243,6 +243,7 @@ TOKEN :
 | < TIMESTAMP: "timestamp_ms" >
 | < DECIMAL: "decimal" >
 | < LOCAL_TIMESTAMP: "local_timestamp_ms" >
+| < UUID: "uuid" >
 }
 
 /* LITERALS */
@@ -254,7 +255,7 @@ TOKEN :
     (   <DECIMAL_LITERAL> (["l","L"])?
       | <HEX_LITERAL> (["l","L"])?
       | <OCTAL_LITERAL> (["l","L"])?
-        )  
+        )
   >
 |
   < #DECIMAL_LITERAL: ["1"-"9"] (["0"-"9"])* >
@@ -1180,7 +1181,7 @@ Protocol ImportIdl() : {
   <IDL> importFile = JsonString() ";"
     {
       try {
-        Idl idl = new Idl(findFile(importFile), this); 
+        Idl idl = new Idl(findFile(importFile), this);
         try {
           return idl.CompilationUnit();
         } finally {
@@ -1188,7 +1189,7 @@ Protocol ImportIdl() : {
         }
       } catch (IOException e) {
         throw error("Error importing "+importFile+": "+e, token);
-      }        
+      }
     }
 }
 
@@ -1208,7 +1209,7 @@ Protocol ImportProtocol() : {
         }
       } catch (IOException e) {
         throw error("Error importing "+importFile+": "+e, token);
-      }        
+      }
     }
 }
 
@@ -1231,7 +1232,7 @@ Schema ImportSchema() : {
         }
       } catch (IOException e) {
         throw error("Error importing "+importFile+": "+e, token);
-      }        
+      }
     }
 }
 
@@ -1319,11 +1320,11 @@ void VariableDeclarator(Schema type, List<Field> fields):
 }
 {
     ( SchemaProperty(props) )*
-    
+
   name = Identifier()
 
     [ <EQUALS> defaultValue=Json() ]
-    
+
   {
     Field.Order order = Field.Order.ASCENDING;
     for (String key : props.keySet())
@@ -1378,7 +1379,7 @@ private Message MessageDeclaration(Protocol p, Map<String, JsonNode> props):
     return oneWay
     ? p.createMessage(name, msgDoc, props, request)
     : p.createMessage(name, msgDoc, props, request, response, errors);
-    
+
   }
 }
 
@@ -1500,6 +1501,7 @@ Schema PrimitiveType():
 | "timestamp_ms" { return LogicalTypes.timestampMillis().addToSchema(Schema.create(Type.LONG)); }
 | "local_timestamp_ms" { return LogicalTypes.localTimestampMillis().addToSchema(Schema.create(Type.LONG)); }
 | "decimal" { return DecimalTypeProperties(); }
+| "uuid" {return LogicalTypes.uuid().addToSchema(Schema.create(Type.STRING));}
 }
 
 Schema DecimalTypeProperties():

--- a/lang/java/compiler/src/test/idl/input/uuid.avdl
+++ b/lang/java/compiler/src/test/idl/input/uuid.avdl
@@ -1,0 +1,17 @@
+@namespace("org.apache.avro")
+protocol MyProtocol {
+    record APlaygroundEvent {
+
+    /**
+     * Documentation must be provided for each attribute
+     */
+    uuid identifier;
+
+
+    /**
+     * a nullable uuid field
+     */
+
+    union { null, uuid } optionalString;
+  }
+}

--- a/lang/java/compiler/src/test/idl/input/uuid.avdl
+++ b/lang/java/compiler/src/test/idl/input/uuid.avdl
@@ -16,6 +16,12 @@
  * limitations under the License.
  */
 
+
+
+/**
+Testing UUID fields
+*/
+
 @namespace("org.apache.avro")
 protocol MyProtocol {
     record APlaygroundEvent {

--- a/lang/java/compiler/src/test/idl/input/uuid.avdl
+++ b/lang/java/compiler/src/test/idl/input/uuid.avdl
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @namespace("org.apache.avro")
 protocol MyProtocol {
     record APlaygroundEvent {

--- a/lang/java/compiler/src/test/idl/output/uuid.avpr
+++ b/lang/java/compiler/src/test/idl/output/uuid.avpr
@@ -1,0 +1,24 @@
+{
+  "protocol" : "MyProtocol",
+  "namespace" : "org.apache.avro",
+  "types" : [ {
+    "type" : "record",
+    "name" : "APlaygroundEvent",
+    "fields" : [ {
+      "name" : "identifier",
+      "type" : {
+        "type" : "string",
+        "logicalType" : "uuid"
+      },
+      "doc" : "* Documentation must be provided for each attribute"
+    }, {
+      "name" : "optionalString",
+      "type" : [ "null", {
+        "type" : "string",
+        "logicalType" : "uuid"
+      } ],
+      "doc" : "* a nullable uuid field"
+    } ]
+  } ],
+  "messages" : { }
+}

--- a/lang/java/compiler/src/test/idl/output/uuid.avpr
+++ b/lang/java/compiler/src/test/idl/output/uuid.avpr
@@ -1,6 +1,7 @@
 {
   "protocol" : "MyProtocol",
   "namespace" : "org.apache.avro",
+  "doc" : "Testing UUID fields",
   "types" : [ {
     "type" : "record",
     "name" : "APlaygroundEvent",


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues 
  - https://issues.apache.org/jira/browse/AVRO-2925


### Tests

- [x] My PR adds the following unit tests 
- unit tests to validate compiling idl file with uuid to avpr according to Avro 1.10.0 UUID logical type.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x]  No new documentation needed
