### PR TITLE
AVRO-2891: Expose last sync offset written on DataFileWriter

### DIFF
--- a/lang/c++/CMakeLists.txt
+++ b/lang/c++/CMakeLists.txt
@@ -46,6 +46,11 @@ if (WIN32 AND NOT CYGWIN AND NOT MSYS)
     add_definitions (/EHa)
     add_definitions (
         -DNOMINMAX
+        -DBOOST_REGEX_DYN_LINK
+        -DBOOST_FILESYSTEM_DYN_LINK
+        -DBOOST_SYSTEM_DYN_LINK
+        -DBOOST_IOSTREAMS_DYN_LINK
+        -DBOOST_PROGRAM_OPTIONS_DYN_LINK
         -DBOOST_ALL_NO_LIB)
 else()
 # Replease c++11 with c++17 below in case C++ 17 should be used
@@ -65,7 +70,7 @@ endif ()
 
 
 find_package (Boost 1.38 REQUIRED
-    COMPONENTS filesystem iostreams program_options regex system zlib)
+    COMPONENTS filesystem iostreams program_options regex system)
 
 find_package(Snappy)
 if (SNAPPY_FOUND)

--- a/lang/c++/CMakeLists.txt
+++ b/lang/c++/CMakeLists.txt
@@ -46,11 +46,6 @@ if (WIN32 AND NOT CYGWIN AND NOT MSYS)
     add_definitions (/EHa)
     add_definitions (
         -DNOMINMAX
-        -DBOOST_REGEX_DYN_LINK
-        -DBOOST_FILESYSTEM_DYN_LINK
-        -DBOOST_SYSTEM_DYN_LINK
-        -DBOOST_IOSTREAMS_DYN_LINK
-        -DBOOST_PROGRAM_OPTIONS_DYN_LINK
         -DBOOST_ALL_NO_LIB)
 else()
 # Replease c++11 with c++17 below in case C++ 17 should be used
@@ -70,7 +65,7 @@ endif ()
 
 
 find_package (Boost 1.38 REQUIRED
-    COMPONENTS filesystem iostreams program_options regex system)
+    COMPONENTS filesystem iostreams program_options regex system zlib)
 
 find_package(Snappy)
 if (SNAPPY_FOUND)

--- a/lang/c++/api/DataFile.hh
+++ b/lang/c++/api/DataFile.hh
@@ -73,6 +73,7 @@ class AVRO_DECL DataFileWriterBase : boost::noncopyable {
     typedef std::map<std::string, std::vector<uint8_t> > Metadata;
 
     Metadata metadata_;
+    int64_t lastSync_;
 
     static std::unique_ptr<OutputStream> makeStream(const char* filename);
     static DataFileSync makeSync();
@@ -101,6 +102,11 @@ public:
      * inserted.
      */
     void syncIfNeeded();
+
+    /**
+     * Returns offset to the last sync marker written.
+     */
+    uint64_t getLastSync();
 
     /**
      * Increments the object count.
@@ -160,6 +166,12 @@ public:
         avro::encode(base_->encoder(), datum);
         base_->incr();
     }
+
+    /**
+     * Returns offset to the last sync marker written.
+     */
+    uint64_t getLastSync() { return base_->getLastSync(); }
+
 
     /**
      * Closes the current file. Once closed this datafile object cannot be

--- a/lang/c++/api/DataFile.hh
+++ b/lang/c++/api/DataFile.hh
@@ -104,9 +104,9 @@ public:
     void syncIfNeeded();
 
     /**
-     * Returns offset to the last sync marker written.
+     * Returns the byte offset (within the current file) of the start of the current block being written.
      */
-    uint64_t getLastSync();
+    uint64_t getCurrentBlockStart();
 
     /**
      * Increments the object count.
@@ -168,9 +168,9 @@ public:
     }
 
     /**
-     * Returns offset to the last sync marker written.
+     *  Returns the byte offset (within the current file) of the start of the current block being written.
      */
-    uint64_t getLastSync() { return base_->getLastSync(); }
+    uint64_t getCurrentBlockStart() { return base_->getCurrentBlockStart(); }
 
 
     /**

--- a/lang/c++/impl/DataFile.cc
+++ b/lang/c++/impl/DataFile.cc
@@ -233,7 +233,7 @@ void DataFileWriterBase::syncIfNeeded()
     }
 }
 
-uint64_t DataFileWriterBase::getLastSync()
+uint64_t DataFileWriterBase::getCurrentBlockStart()
 {
     return lastSync_;
 }

--- a/lang/c++/test/DataFileTests.cc
+++ b/lang/c++/test/DataFileTests.cc
@@ -897,7 +897,7 @@ void testReadRecordEfficientlyUsingLastSync(avro::Codec codec) {
     const char* filename = "test_readRecordUsingLastSync.df";
     
     int numberOfRecords = 100;
-    int recordToRead = 37;  // random record to read efficiently
+    int recordToRead = 37;  // pick specific record to read efficiently
     int syncPointWithRecord = 0;
     int finalSync = 0;
     int recordsUptoLastSync = 0;
@@ -936,7 +936,7 @@ void testReadRecordEfficientlyUsingLastSync(avro::Codec codec) {
         size_t length = 0;
         bool hasRead = seekableInputStream->next(&pData, &length);
 
-        // keep it simple, assume we've got in all data we want
+        // keep it simple, assume we've got in all data we want. We have a high buffersize to ensure this above.
         BOOST_CHECK_GE(length, firstSyncPoint);
         BOOST_CHECK_GE(length, finalSync);
 
@@ -954,6 +954,8 @@ void testReadRecordEfficientlyUsingLastSync(avro::Codec codec) {
         std::unique_ptr<avro::InputStream> inputStream = avro::memoryInputStream(stitchedData.data(), stitchedData.size());
 
         int recordsUptoRecordToRead = recordToRead - recordsUptoLastSync;
+
+        // Ensure this is not the first record in the chunk.
         BOOST_CHECK_GT(recordsUptoRecordToRead, 0);
 
         avro::DataFileReader<TestRecord> df(std::move(inputStream));

--- a/lang/c++/test/DataFileTests.cc
+++ b/lang/c++/test/DataFileTests.cc
@@ -162,6 +162,21 @@ static const char ischWithDoc[] =
         "\"doc\": \"extra slashes\\\\\\\\\"}"
     "]}";
 
+static const char schemaWithIdAndString[] = R"({
+       "type":"record",
+       "name":"R",
+       "fields":[
+          {
+             "name":"s1",
+             "type":"string"
+          },
+          {
+             "name":"id",
+             "type":"long"
+          }
+       ]
+    })";
+
 string toString(const ValidSchema& s)
 {
     ostringstream oss;
@@ -787,23 +802,8 @@ void testLastSync(avro::Codec codec) {
     // This test does validates equivalence of the lastSync API on the writer and the previousSync() returned by the reader for every record read.
     //
 
-    const char* schema = R"({
-       "type":"record",
-       "name":"R",
-       "fields":[
-          {
-             "name":"s1",
-             "type":"string"
-          },
-          {
-             "name":"id",
-             "type":"long"
-          }
-       ]
-    })";
-
     avro::ValidSchema writerSchema =
-        avro::compileJsonSchemaFromString(schema);
+        avro::compileJsonSchemaFromString(schemaWithIdAndString);
     
     const size_t stringLen = 100;
     char largeString[stringLen + 1];
@@ -844,7 +844,7 @@ void testLastSync(avro::Codec codec) {
         df.close();
     }
 
-    // Validate sync points returned by the writer using the lastSync API and the reader are the same for every record
+    // Validate that the sync points returned by the writer using the lastSync API and the reader are the same for every record
     {
         avro::DataFileReader<TestRecord> df(filename);
         TestRecord readRecord("", 0);
@@ -876,6 +876,103 @@ void testLastSync(avro::Codec codec) {
     }
 }
 
+
+void testReadRecordEfficientlyUsingLastSync(avro::Codec codec) {
+
+    //
+    // This test highlights a motivating use case for the lastSync API on the DataFileWriter.
+    //
+
+    avro::ValidSchema writerSchema =
+        avro::compileJsonSchemaFromString(schemaWithIdAndString);
+
+    const size_t stringLen = 100;
+    char largeString[stringLen + 1];
+    for(size_t i = 0; i < stringLen; i++) {
+        largeString[i] = 'a';
+    }
+
+    largeString[stringLen] = '\0';
+
+    const char* filename = "test_readRecordUsingLastSync.df";
+    
+    int numberOfRecords = 100;
+    int recordToRead = 37;  // random record to read efficiently
+    int syncPointWithRecord = 0;
+    int finalSync = 0;
+    int recordsUptoLastSync = 0;
+    int firstSyncPoint = 0;
+    {
+        avro::DataFileWriter<TestRecord> df(filename,
+            writerSchema, 1024, codec);
+
+        firstSyncPoint = df.getLastSync();
+        syncPointWithRecord = firstSyncPoint;
+        for(int i = 0; i < numberOfRecords; i++)
+        {
+            df.write(TestRecord(largeString, (int64_t)i));
+
+            // During the write, gather all the sync boundaries from the lastSync() API
+            int recordsWritten = i + 1;
+            if((recordsWritten <= recordToRead) && (df.getLastSync() != syncPointWithRecord))
+            {
+                recordsUptoLastSync = i;    // 1 less than total number of records written, since the sync block is sealed before a write
+                syncPointWithRecord = df.getLastSync();
+
+                //::printf("\nPast sync point %llu, total rows upto sync %d", syncPointWithRecord, recordsUptoLastSync);
+            }
+        }
+
+        finalSync = df.getLastSync();
+        df.flush();
+        df.close();
+    }
+
+    // Validate that we're able to stitch together {header block | specific block with record} and read the specific record from the stitched block
+    {
+        std::unique_ptr<avro::SeekableInputStream> seekableInputStream = avro::fileSeekableInputStream(filename, 1000000);
+
+        const uint8_t* pData = nullptr;
+        size_t length = 0;
+        bool hasRead = seekableInputStream->next(&pData, &length);
+
+        // keep it simple, assume we've got in all data we want
+        BOOST_CHECK_GE(length, firstSyncPoint);
+        BOOST_CHECK_GE(length, finalSync);
+
+        std::vector<uint8_t> stitchedData;
+        // reserve space for header and data from specific block
+        stitchedData.reserve(firstSyncPoint + (finalSync - syncPointWithRecord));
+
+        // Copy header of the file
+        std::copy(pData, pData + firstSyncPoint, std::back_inserter(stitchedData));
+
+        // Copy data from the sync block containing the record of interest
+        std::copy(pData + syncPointWithRecord, pData + finalSync, std::back_inserter(stitchedData));
+
+        // Convert to inputStream
+        std::unique_ptr<avro::InputStream> inputStream = avro::memoryInputStream(stitchedData.data(), stitchedData.size());
+
+        int recordsUptoRecordToRead = recordToRead - recordsUptoLastSync;
+        BOOST_CHECK_GT(recordsUptoRecordToRead, 0);
+
+        avro::DataFileReader<TestRecord> df(std::move(inputStream));
+        TestRecord readRecord("", 0);
+        //::printf("\nReading %d rows until specific record is reached", recordsUptoRecordToRead);
+        for(int index = 0; index < recordsUptoRecordToRead; index++)
+        {
+            BOOST_CHECK_EQUAL(df.read(readRecord), true);
+
+            int64_t expectedId = (recordToRead - recordsUptoRecordToRead + index);
+            BOOST_CHECK_EQUAL(expectedId, readRecord.id);
+        }
+
+        // read specific record
+        BOOST_CHECK_EQUAL(df.read(readRecord), true);
+        BOOST_CHECK_EQUAL(recordToRead, readRecord.id);
+    }
+}
+
 void testLastSyncNullCodec()
 {
     BOOST_TEST_CHECKPOINT(__func__);
@@ -893,6 +990,26 @@ void testLastSyncSnappyCodec()
 {
     BOOST_TEST_CHECKPOINT(__func__);
     testLastSync(avro::SNAPPY_CODEC);
+}
+#endif
+
+void testReadRecordEfficientlyUsingLastSyncNullCodec()
+{
+    BOOST_TEST_CHECKPOINT(__func__);
+    testReadRecordEfficientlyUsingLastSync(avro::NULL_CODEC);
+}
+
+void testReadRecordEfficientlyUsingLastSyncDeflateCodec()
+{
+    BOOST_TEST_CHECKPOINT(__func__);
+    testReadRecordEfficientlyUsingLastSync(avro::DEFLATE_CODEC);
+}
+
+#ifdef SNAPPY_CODEC_AVAILABLE
+void testReadRecordEfficientlyUsingLastSyncSnappyCodec()
+{
+    BOOST_TEST_CHECKPOINT(__func__);
+    testReadRecordEfficientlyUsingLastSync(avro::SNAPPY_CODEC);
 }
 #endif
 
@@ -1038,6 +1155,14 @@ init_unit_test_suite(int argc, char *argv[])
         add(BOOST_TEST_CASE(&testLastSyncSnappyCodec));
 #endif
 
+    boost::unit_test::framework::master_test_suite().
+        add(BOOST_TEST_CASE(&testReadRecordEfficientlyUsingLastSyncNullCodec));
+    boost::unit_test::framework::master_test_suite().
+        add(BOOST_TEST_CASE(&testReadRecordEfficientlyUsingLastSyncDeflateCodec));
+#ifdef SNAPPY_CODEC_AVAILABLE
+    boost::unit_test::framework::master_test_suite().
+        add(BOOST_TEST_CASE(&testReadRecordEfficientlyUsingLastSyncSnappyCodec));
+#endif
 
     return 0;
 }

--- a/lang/c++/test/DataFileTests.cc
+++ b/lang/c++/test/DataFileTests.cc
@@ -820,25 +820,25 @@ void testLastSync(avro::Codec codec) {
         avro::DataFileWriter<TestRecord> df(filename,
             writerSchema, 1024, codec);
 
-        uint64_t lastSync = df.getLastSync();
+        uint64_t lastSync = df.getCurrentBlockStart();
         syncMetadata.push_back(std::pair<uint64_t, int>(lastSync, 0));
         for(int i = 0; i < numberOfRecords; i++)
         {
             df.write(TestRecord(largeString, (int64_t)i));
             
             // During the write, gather all the sync boundaries from the lastSync() API
-            if(df.getLastSync() != lastSync)
+            if(df.getCurrentBlockStart() != lastSync)
             {
                 int recordsUptoSync = i;    // 1 less than total number of records written, since the sync block is sealed before a write
                 syncMetadata.push_back(std::pair<uint64_t, int>(lastSync, recordsUptoSync));
-                lastSync = df.getLastSync();
+                lastSync = df.getCurrentBlockStart();
 
-                //::printf("\nPast sync point %llu, total rows upto sync %d", lastSync, recordsUptoSync);
+                //::printf("\nPast current block start %llu, total rows upto sync %d", lastSync, recordsUptoSync);
             }
         }
 
-        //::printf("\nPast sync point %llu, total rows upto sync %d", df.getLastSync(), numberOfRecords);
-        syncMetadata.push_back(std::pair<uint64_t, int>(df.getLastSync(), numberOfRecords));
+        //::printf("\nPast current block start %llu, total rows upto sync %d", df.getCurrentBlockStart(), numberOfRecords);
+        syncMetadata.push_back(std::pair<uint64_t, int>(df.getCurrentBlockStart(), numberOfRecords));
 
         df.flush();
         df.close();
@@ -906,7 +906,7 @@ void testReadRecordEfficientlyUsingLastSync(avro::Codec codec) {
         avro::DataFileWriter<TestRecord> df(filename,
             writerSchema, 1024, codec);
 
-        firstSyncPoint = df.getLastSync();
+        firstSyncPoint = df.getCurrentBlockStart();
         syncPointWithRecord = firstSyncPoint;
         for(int i = 0; i < numberOfRecords; i++)
         {
@@ -914,16 +914,16 @@ void testReadRecordEfficientlyUsingLastSync(avro::Codec codec) {
 
             // During the write, gather all the sync boundaries from the lastSync() API
             int recordsWritten = i + 1;
-            if((recordsWritten <= recordToRead) && (df.getLastSync() != syncPointWithRecord))
+            if((recordsWritten <= recordToRead) && (df.getCurrentBlockStart() != syncPointWithRecord))
             {
                 recordsUptoLastSync = i;    // 1 less than total number of records written, since the sync block is sealed before a write
-                syncPointWithRecord = df.getLastSync();
+                syncPointWithRecord = df.getCurrentBlockStart();
 
-                //::printf("\nPast sync point %llu, total rows upto sync %d", syncPointWithRecord, recordsUptoLastSync);
+                //::printf("\nPast current block start %llu, total rows upto sync %d", syncPointWithRecord, recordsUptoLastSync);
             }
         }
 
-        finalSync = df.getLastSync();
+        finalSync = df.getCurrentBlockStart();
         df.flush();
         df.close();
     }


### PR DESCRIPTION
AVRO-2891: Expose last sync offset written on DataFileWriter

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2891

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
A new test has been added for all three codec types: DataFileTests::testLastSync

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
