### PR TITLE
AVRO-2932 Replace getopt_long() to compile avropipe.c and avromod.c in Windows

### DIFF
--- a/lang/c/src/CMakeLists.txt
+++ b/lang/c/src/CMakeLists.txt
@@ -138,8 +138,6 @@ add_executable(avroappend avroappend.c)
 target_link_libraries(avroappend avro-static)
 install(TARGETS avroappend RUNTIME DESTINATION bin)
 
-if (NOT WIN32)
-#TODO: Port getopt() to Windows to compile avropipe.c and avromod.c
 add_executable(avropipe avropipe.c)
 target_link_libraries(avropipe avro-static)
 install(TARGETS avropipe RUNTIME DESTINATION bin)
@@ -147,4 +145,3 @@ install(TARGETS avropipe RUNTIME DESTINATION bin)
 add_executable(avromod avromod.c)
 target_link_libraries(avromod avro-static)
 install(TARGETS avromod RUNTIME DESTINATION bin)
-endif(NOT WIN32)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
