### PR TITLE
AVRO-2519: Prevent resource leak in NettyTransceiver

### DIFF
--- a/lang/java/ipc-netty/src/main/java/org/apache/avro/ipc/netty/NettyTransceiver.java
+++ b/lang/java/ipc-netty/src/main/java/org/apache/avro/ipc/netty/NettyTransceiver.java
@@ -199,6 +199,8 @@ public class NettyTransceiver extends Transceiver {
         channelFuture.channel().close();
       }
 
+      workerGroup.shutdownGracefully();
+
       if (e instanceof IOException)
         throw (IOException) e;
       if (e instanceof RuntimeException)


### PR DESCRIPTION
### Jira

- [ ] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2519
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does

### Description

AVRO-2519 describes a resource leak in NettyTransceiver that was prevalent before the upgrade from netty 3 to 4. However, during the upgrade, basically the same resource leak occurred. If an exception occurs in the constructor of the `NettyTransceiver`, the `workerGroup` of that `NettyTransceiver` will not be shut down properly, and idle Threads will accumulate in the JVM.

No new test case has been provided, since the current change should be covered by existing tests. If tests are desired, please provide me with a hint on what to test for.

Note: an alternative solution could be to declare the `workerGroup` member of `NettyTransceiver` as `protected static`, (and hence shared between all possible `NettyTransceiver` instances).

Should there be plans for a release 1.9.3, please let me know; I can gladly provide a PR to patch the issue in the 1.9 branch.
