### PR TITLE
AVRO-2941: adding exception that specifies the schema name

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/AvroWriteFieldException.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/AvroWriteFieldException.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.avro;
+
+/** Avro exception in case of error writing field. */
+public class AvroWriteFieldException extends AvroRuntimeException {
+
+  public AvroWriteFieldException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericDatumWriter.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericDatumWriter.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.concurrent.*;
 
 import org.apache.avro.AvroTypeException;
+import org.apache.avro.AvroWriteFieldException;
 import org.apache.avro.Schema;
 import org.apache.avro.UnresolvedUnionException;
 import org.apache.avro.io.BinaryEncoder;
@@ -293,6 +294,24 @@ public class TestGenericDatumWriter {
     Encoder encoder = EncoderFactory.get().jsonEncoder(schema, bao);
 
     writer.write(record, encoder);
+  }
+
+  @Test()
+  public void thowAvroWriteFieldExceptionWhenWriteInvalidValueForField() throws IOException {
+    String json = "{\"type\": \"record\", \"name\": \"r\", \"fields\": [" + "{ \"name\": \"f1\", \"type\": \"long\" }"
+        + "]}";
+    Schema s = new Schema.Parser().parse(json);
+    GenericRecord r = new GenericData.Record(s);
+    r.put("f1", null);
+    ByteArrayOutputStream bao = new ByteArrayOutputStream();
+    GenericDatumWriter<GenericRecord> w = new GenericDatumWriter<>(s);
+    Encoder e = EncoderFactory.get().jsonEncoder(s, bao);
+    Exception exception = assertThrows(AvroWriteFieldException.class, () -> {
+      w.write(r, e);
+    });
+    String expectedMessage = "Unable do write field f1 on r: null of long in field f1.";
+    String actualMessage = exception.getMessage();
+    assertEquals(expectedMessage, actualMessage);
   }
 
   private enum AnEnum {


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
