### PR TITLE
AVRO-2957: Pin ruby 'parallel' dependency for Ruby 2.3 support

### DIFF
--- a/lang/ruby/Gemfile
+++ b/lang/ruby/Gemfile
@@ -20,6 +20,9 @@ gem 'multi_json'
 gem 'snappy'
 gem 'zstd-ruby'
 gem 'test-unit'
+# parallel 1.20.0 requires Ruby 2.5+
+gem 'parallel', '<= 1.19.2'
+
 # rubocop 0.82 requires Ruby 2.4+
 gem 'rubocop', '<= 0.81'
 

--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -112,7 +112,7 @@ RUN curl -sSL https://packages.sury.org/php/apt.gpg \
  && apt-get -qqy clean \
  && rm -rf /var/lib/apt/lists
 
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+RUN curl -sS https://getcomposer.org/installer | php -- --version=2.0.4 --install-dir=/usr/local/bin --filename=composer
 
 # Install Perl modules
 RUN apt-get -qqy update \


### PR DESCRIPTION
This is the quickest fix I found, but getting rid of the Ruby 2.3 support seems more and more obvious for the next major release! 

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-2957: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
