### PR TITLE
AVRO-2702: ResolvingGrammarGenerator Union use reader instead of writer schema

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/io/parsing/ResolvingGrammarGenerator.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/parsing/ResolvingGrammarGenerator.java
@@ -106,7 +106,7 @@ public class ResolvingGrammarGenerator extends ValidatingGrammarGenerator {
 
     } else if (action.writer.getType() == Schema.Type.UNION) {
       if (((Resolver.WriterUnion) action).unionEquiv) {
-        return simpleGen(action.writer, seen);
+        return simpleGen(action.reader, seen);
       }
       Resolver.Action[] branches = ((Resolver.WriterUnion) action).actions;
       Symbol[] symbols = new Symbol[branches.length];


### PR DESCRIPTION
Make sure you have checked _all_ steps below.



### Jira

- [x ] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2702

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

SEE FOLLOWING COMMENT - The code that was changed does not appear to be testing thoroughly as is, and it may require more extensive unit test changes than a simple one-off. 

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
