### PR TITLE
AVRO-2979: Pin PHP dependency tools to specific versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "minimum-stability": "stable",
   "license": "Apache-2.0",
   "require": {
-    "beberlei/composer-monorepo-plugin": "^0.16"
+    "beberlei/composer-monorepo-plugin": "0.16.5"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.1",

--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -112,7 +112,7 @@ RUN curl -sSL https://packages.sury.org/php/apt.gpg \
  && apt-get -qqy clean \
  && rm -rf /var/lib/apt/lists
 
-RUN curl -sS https://getcomposer.org/installer | php -- --version=2.0.4 --install-dir=/usr/local/bin --filename=composer
+RUN curl -sS https://getcomposer.org/installer | php -- --version=2.0.7 --install-dir=/usr/local/bin --filename=composer
 
 # Install Perl modules
 RUN apt-get -qqy update \


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2979
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: Fixes the build.

### Commits

- [X My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
