### PR TITLE
AVRO-2983: Set Span length of ArrayPool Rent buffer

### DIFF
--- a/lang/csharp/src/apache/main/IO/BinaryDecoder.notnetstandard2.0.cs
+++ b/lang/csharp/src/apache/main/IO/BinaryDecoder.notnetstandard2.0.cs
@@ -68,7 +68,7 @@ namespace Avro.IO
             int length = ReadInt();
             Span<byte> buffer = length <= StackallocThreshold ?
                 stackalloc byte[length] :
-                (bufferArray = ArrayPool<byte>.Shared.Rent(length));
+                (bufferArray = ArrayPool<byte>.Shared.Rent(length)).AsSpan(0, length);
 
             Read(buffer);
 

--- a/lang/csharp/src/apache/test/Avro.test.csproj
+++ b/lang/csharp/src/apache/test/Avro.test.csproj
@@ -44,6 +44,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
ArrayPool<T>.Rent(Int32) returns a buffer that is at least
minimumLength in length, but can be more.  The span that is used is
read into until it is empty. When this buffer returned from ArrayPool
is not exactly the same as the requested minimumLength this causes an
Avro.AvroException : End of stream reached

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2983

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  - Avro.Test.BinaryCodecTests.TestLargeString which generates a 16KB buffer in array pool and then tries to read 16000 string, and this shows how the system currently fails and the patch fixes.  The existing unit tests for string reading didn't catch this because the ArrayPool was in a clean state for each of those reads, this simulates a real world case where the ArrayPool contains buffers of different sizes.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
