### PR TITLE
AVRO-2984: Optimize memory allocation during Ruby serialization

### DIFF
--- a/lang/ruby/lib/avro/io.rb
+++ b/lang/ruby/lib/avro/io.rb
@@ -510,6 +510,8 @@ module Avro
 
     # DatumWriter for generic ruby objects
     class DatumWriter
+      VALIDATION_OPTIONS = { recursive: false, encoded: true }.freeze
+
       attr_accessor :writers_schema
       def initialize(writers_schema=nil)
         @writers_schema = writers_schema
@@ -522,7 +524,7 @@ module Avro
       def write_data(writers_schema, logical_datum, encoder)
         datum = writers_schema.type_adapter.encode(logical_datum)
 
-        unless Schema.validate(writers_schema, datum, { recursive: false, encoded: true })
+        unless Schema.validate(writers_schema, datum, VALIDATION_OPTIONS)
           raise AvroTypeError.new(writers_schema, datum)
         end
 

--- a/lang/ruby/lib/avro/schema_validator.rb
+++ b/lang/ruby/lib/avro/schema_validator.rb
@@ -24,14 +24,8 @@ module Avro
     BOOLEAN_VALUES = [true, false].freeze
 
     class Result
-      attr_reader :errors
-
-      def initialize
-        @errors = []
-      end
-
       def <<(error)
-        @errors << error
+        errors << error
       end
 
       def add_error(path, message)
@@ -39,11 +33,16 @@ module Avro
       end
 
       def failure?
-        @errors.any?
+        defined?(@errors) && errors.any?
       end
 
       def to_s
-        errors.join("\n")
+        failure? ? errors.join("\n") : ''
+      end
+
+      def errors
+        # Use less memory for success results by lazily creating the errors array
+        @errors ||= []
       end
     end
 


### PR DESCRIPTION
This optimizes Ruby datum writing by avoiding an unnecessary hash allocation for constant validation options and avoids an unnecessary array allocation for success datum validation results. These optimizations are on the hot path for writing messages.

This is purely an implementation performance optimization so no new tests or documentation should be required.

/cc @tjwp 