### PR TITLE
AVRO-2987: pkg-config has a broken `Requires:` section

### DIFF
--- a/lang/c/CMakeLists.txt
+++ b/lang/c/CMakeLists.txt
@@ -176,7 +176,7 @@ else (LZMA_FOUND)
 endif (LZMA_FOUND)
 
 set(CODEC_LIBRARIES ${ZLIB_LIBRARIES} ${LZMA_LIBRARIES} ${SNAPPY_LIBRARIES})
-set(CODEC_PKG "@ZLIB_PKG@ @LZMA_PKG@ @SNAPPY_PKG@")
+set(CODEC_PKG "${ZLIB_PKG} ${LZMA_PKG} ${SNAPPY_PKG}")
 
 # Jansson JSON library
 pkg_check_modules(JANSSON jansson>=2.3)


### PR DESCRIPTION
Code was expecting a double-interpolation from cmake which didn't
happen, leaving the Requires section like this:

    Requires: @ZLIB_PKG@ @LZMA_PKG@ @SNAPPY_PKG@

This patch fixes that:

    Requires: zlib liblzma
