### PR TITLE
AVRO-2988: C: Include required libraries in Libs.private

### DIFF
--- a/lang/c/src/CMakeLists.txt
+++ b/lang/c/src/CMakeLists.txt
@@ -123,6 +123,13 @@ install(TARGETS avro-static avro-shared
 endif(WIN32)
 
 # Install pkg-config file
+get_target_property(avro-static-libraries avro-static LINK_LIBRARIES)
+foreach(lib ${avro-static-libraries})
+    if(${lib} MATCHES "^[A-Za-z0-9_]+$")
+        list(APPEND CODEC_LIBRARIES_STATIC_LIST "${CMAKE_LINK_LIBRARY_FLAG}${lib}")
+    endif()
+endforeach()
+string(REPLACE ";" " " CODEC_LIBRARIES_STATIC "${CODEC_LIBRARIES_STATIC_LIST}")
 
 set(prefix ${CMAKE_INSTALL_PREFIX})
 set(VERSION ${AVRO_VERSION})

--- a/lang/c/src/avro-c.pc.in
+++ b/lang/c/src/avro-c.pc.in
@@ -3,5 +3,6 @@ Description: C library for parsing Avro data
 Version: @VERSION@
 URL: https://avro.apache.org/
 Libs: -L@prefix@/lib -lavro
+Libs.private: @CODEC_LIBRARIES_STATIC@
 Cflags: -I@prefix@/include
 Requires: @CODEC_PKG@


### PR DESCRIPTION
Changes this:

    ; pkg-config --libs --static avro-c
    -L/install/dir -lavro

Into this:

    ; pkg-config --libs --static avro-c
    -L/install/dir -lavro -lzma -ljansson -lpthreads

Assuming those are needed to link statically; pthreads may
or may not be there depending on the system, and so on.
