### PR TITLE
AVRO-2898: Build failure without a C++ compiler (again)

### DIFF
--- a/lang/c/CMakeLists.txt
+++ b/lang/c/CMakeLists.txt
@@ -17,7 +17,7 @@
 # under the License.
 #
 cmake_minimum_required(VERSION 3.1)
-project(AvroC)
+project(AvroC C)
 enable_testing()
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR})


### PR DESCRIPTION
avro-c fails to build (again) without a C++ compiler because commit 664c2fc7fba19709c1f974055f9cf4c8a799e108 reverted the change made by commit 414a51fdc1856083bb16851f09a4c61a48796132

Fixes:
 - http://autobuild.buildroot.org/results/cfa91db53cf5502cbb6f902d1e7ad6397c8d70fd

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>