### PR TITLE
AVRO-2994: Update maven tool in docker build

### DIFF
--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -49,7 +49,6 @@ RUN apt-get -qqy update \
                                                  libsnappy-dev \
                                                  libsnappy1v5 \
                                                  make \
-                                                 maven \
                                                  mypy \
                                                  openjdk-8-jdk \
                                                  perl \
@@ -67,6 +66,36 @@ RUN apt-get -qqy update \
                                                  vim \
  && apt-get -qqy clean \
  && rm -rf /var/lib/apt/lists
+
+# Install a maven release  -------------------------------------------
+# Inspired from https://github.com/apache/accumulo-docker/blob/master/Dockerfile#L53
+
+ENV MAVEN_VERSION 3.6.3
+ENV APACHE_DIST_URLS \
+  https://www.apache.org/dyn/closer.cgi?action=download&filename= \
+  # if the version is outdated (or we're grabbing the .asc file), we might have to pull from the dist/archive :/
+  https://www-us.apache.org/dist/ \
+  https://www.apache.org/dist/ \
+  https://archive.apache.org/dist/
+RUN set -eux; \
+  download() { \
+    local f="$1"; shift; \
+    local distFile="$1"; shift; \
+    local success=; \
+    local distUrl=; \
+    for distUrl in $APACHE_DIST_URLS; do \
+      if wget -nv -O "$f" "$distUrl$distFile"; then \
+        success=1; \
+        break; \
+      fi; \
+    done; \
+    [ -n "$success" ]; \
+  }; \
+  download "maven.tar.gz" "maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz"; \
+  tar xzf "maven.tar.gz" -C /tmp/; \
+  mv /tmp/apache-maven-$MAVEN_VERSION /opt/maven; \
+  rm "maven.tar.gz"
+ENV PATH="/opt/maven/bin:${PATH}"
 
 # Install nodejs 6
 RUN curl -sSL https://deb.nodesource.com/setup_10.x \


### PR DESCRIPTION
It looks like the build currently fails when the maven update was applied due to a spotless maven plugin bug.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2994
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
