### PR TITLE
avrogencpp has tabs in CodeGen::generateEnumTraits, which is inconsistent with the rest of the generated code.

### DIFF
--- a/lang/c++/impl/avrogencpp.cc
+++ b/lang/c++/impl/avrogencpp.cc
@@ -524,31 +524,31 @@ string CodeGen::generateDeclaration(const NodePtr& n)
 
 void CodeGen::generateEnumTraits(const NodePtr& n)
 {
-	string dname = decorate(n->name());
-	string fn = fullname(dname);
-	string last = n->nameAt(n->names() - 1);
+    string dname = decorate(n->name());
+    string fn = fullname(dname);
+    string last = n->nameAt(n->names() - 1);
 
-	os_ << "template<> struct codec_traits<" << fn << "> {\n"
-		<< "    static void encode(Encoder& e, " << fn << " v) {\n"
-		<< "		if (v > " << fn << "::" << last << ")\n"
-		<< "		{\n"
-		<< "			std::ostringstream error;\n"
-		<< "			error << \"enum value \" << static_cast<unsigned>(v) << \" is out of bound for " << fn << " and cannot be encoded\";\n"
-		<< "			throw avro::Exception(error.str());\n"
-		<< "		}\n"
-		<< "        e.encodeEnum(static_cast<size_t>(v));\n"
-		<< "    }\n"
-		<< "    static void decode(Decoder& d, " << fn << "& v) {\n"
-		<< "		size_t index = d.decodeEnum();\n"
-		<< "		if (index > static_cast<size_t>(" << fn << "::" << last << "))\n"
-		<< "		{\n"
-		<< "			std::ostringstream error;\n"
-		<< "			error << \"enum value \" << index << \" is out of bound for " << fn << " and cannot be decoded\";\n"
-		<< "			throw avro::Exception(error.str());\n"
-		<< "		}\n"
-		<< "        v = static_cast<" << fn << ">(index);\n"
-		<< "    }\n"
-		<< "};\n\n";
+    os_ << "template<> struct codec_traits<" << fn << "> {\n"
+        << "    static void encode(Encoder& e, " << fn << " v) {\n"
+        << "        if (v > " << fn << "::" << last << ")\n"
+        << "        {\n"
+        << "            std::ostringstream error;\n"
+        << "            error << \"enum value \" << static_cast<unsigned>(v) << \" is out of bound for " << fn << " and cannot be encoded\";\n"
+        << "            throw avro::Exception(error.str());\n"
+        << "        }\n"
+        << "        e.encodeEnum(static_cast<size_t>(v));\n"
+        << "    }\n"
+        << "    static void decode(Decoder& d, " << fn << "& v) {\n"
+        << "        size_t index = d.decodeEnum();\n"
+        << "        if (index > static_cast<size_t>(" << fn << "::" << last << "))\n"
+        << "        {\n"
+        << "            std::ostringstream error;\n"
+        << "            error << \"enum value \" << index << \" is out of bound for " << fn << " and cannot be decoded\";\n"
+        << "            throw avro::Exception(error.str());\n"
+        << "        }\n"
+        << "        v = static_cast<" << fn << ">(index);\n"
+        << "    }\n"
+        << "};\n\n";
 }
 
 void CodeGen::generateRecordTraits(const NodePtr& n)


### PR DESCRIPTION
avrogencpp has tabs in CodeGen::generateEnumTraits, which is inconsistent with the rest of the generated code.

This commit replaces all of the tabs in the CodeGen::generateEnumTraits function with 4 spaces to match the formatting of the rest of the file as well as the rest of the generated code.

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).


### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: 
     This PR changes the whitespace in the generated avrogencpp code, which I did not find unit tests for.

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
