### PR TITLE
AVRO-2998: Schema validation for Ruby hashes with symbol keys

### DIFF
--- a/lang/ruby/lib/avro/schema_validator.rb
+++ b/lang/ruby/lib/avro/schema_validator.rb
@@ -94,7 +94,8 @@ module Avro
           fail TypeMismatchError unless datum.is_a?(Hash)
           expected_schema.fields.each do |field|
             deeper_path = deeper_path_for_hash(field.name, path)
-            validate_recursive(field.type, datum[field.name], deeper_path, result, options)
+            nested_value = datum.key?(field.name) ? datum[field.name] : datum[field.name.to_sym]
+            validate_recursive(field.type, nested_value, deeper_path, result, options)
           end
           if options[:fail_on_extra_fields]
             datum_fields = datum.keys.map(&:to_s)

--- a/lang/ruby/test/test_schema_validator.rb
+++ b/lang/ruby/test/test_schema_validator.rb
@@ -196,6 +196,12 @@ class TestSchemaValidator < Test::Unit::TestCase
     assert_valid_schema(schema, [{ 'sub' => nil }], [{ 'sub' => 1 }])
   end
 
+  def test_validate_record_with_symbol_keys
+    schema = hash_to_schema(type: 'record', name: 'name', fields: [{ type: 'int', name: 'sub' }])
+
+    assert_valid_schema(schema, [{ sub: 1 }], [{ sub: '1' }])
+  end
+
   def test_validate_shallow_record
     schema = hash_to_schema(
       type: 'record', name: 'name', fields: [{ type: 'int', name: 'sub' }]


### PR DESCRIPTION
AVRO-2749 added support for serializing Ruby hashes with symbol keys but they were still considered invalid. This PR fixes schema validation to also accept hashes with symbol keys.

/cc @tjwp 
