### PR TITLE
AVRO-2999: Optimize Ruby union encoding

### DIFF
--- a/lang/ruby/lib/avro/io.rb
+++ b/lang/ruby/lib/avro/io.rb
@@ -582,12 +582,15 @@ module Avro
       end
 
       def write_union(writers_schema, datum, encoder)
-        index_of_schema = -1
-        found = writers_schema.schemas.
-          find{|e| index_of_schema += 1; found = Schema.validate(e, datum) }
-        unless found  # Because find_index doesn't exist in 1.8.6
+        index_of_schema = writers_schema.schemas.find_index do |schema|
+          # Optimize away expensive validation calls for the common null type
+          schema.type_sym == :null ? datum.nil? : Schema.validate(schema, datum)
+        end
+
+        unless index_of_schema
           raise AvroTypeError.new(writers_schema, datum)
         end
+
         encoder.write_long(index_of_schema)
         write_data(writers_schema.schemas[index_of_schema], datum, encoder)
       end

--- a/lang/ruby/lib/avro/schema.rb
+++ b/lang/ruby/lib/avro/schema.rb
@@ -36,6 +36,8 @@ module Avro
     LONG_MIN_VALUE = -(1 << 63)
     LONG_MAX_VALUE = (1 << 63) - 1
 
+    DEFAULT_VALIDATE_OPTIONS = { recursive: true, encoded: false }.freeze
+
     def self.parse(json_string)
       real_parse(MultiJson.load(json_string), {})
     end
@@ -109,7 +111,7 @@ module Avro
     end
 
     # Determine if a ruby datum is an instance of a schema
-    def self.validate(expected_schema, logical_datum, options = { recursive: true, encoded: false })
+    def self.validate(expected_schema, logical_datum, options = DEFAULT_VALIDATE_OPTIONS)
       SchemaValidator.validate!(expected_schema, logical_datum, options)
       true
     rescue SchemaValidator::ValidationError

--- a/lang/ruby/lib/avro/schema_validator.rb
+++ b/lang/ruby/lib/avro/schema_validator.rb
@@ -71,8 +71,6 @@ module Avro
 
     class << self
       def validate!(expected_schema, logical_datum, options = DEFAULT_VALIDATION_OPTIONS)
-        options ||= {}
-
         result = Result.new
         if options.fetch(:recursive, true)
           validate_recursive(expected_schema, logical_datum, ROOT_IDENTIFIER, result, options)

--- a/lang/ruby/test/test_schema_validator.rb
+++ b/lang/ruby/test/test_schema_validator.rb
@@ -17,7 +17,7 @@
 require 'test_help'
 
 class TestSchemaValidator < Test::Unit::TestCase
-  def validate!(schema, value, options=nil)
+  def validate!(schema, value, options = {})
     Avro::SchemaValidator.validate!(schema, value, options)
   end
 


### PR DESCRIPTION
This optimizes several bottlenecks when encoding unions in the Avro Ruby
library:

1) Validation calls repeatedly allocate constant hashes
2) Validation calls repeatedly allocate constant strings
3) Validation calls are expensive and can be avoided when determining
   of a datum matches a null union member type (a common pattern for
   "optional" fields)

Optimizing these codepaths reduces memory allocations by 78% and
improves throughput 1.9X in our encoding benchmarks.

Note: Encoding unions is still expensive because the code must
determine which member of the union a datum is targeting. Allowing
clients to explicitly specify this would speed up serialization even
further but that requires a larger API change.

/cc @tjwp 