### PR TITLE
AVRO-3000: Avoid unnecessary schema compatibility checks

### DIFF
--- a/lang/ruby/lib/avro/schema_compatibility.rb
+++ b/lang/ruby/lib/avro/schema_compatibility.rb
@@ -15,6 +15,9 @@
 # limitations under the License.
 module Avro
   module SchemaCompatibility
+    INT_COERCIBLE_TYPES_SYM = [:long, :float, :double].freeze
+    LONG_COERCIBLE_TYPES_SYM = [:float, :double].freeze
+
     # Perform a full, recursive check that a datum written using the writers_schema
     # can be read using the readers_schema.
     def self.can_read?(writers_schema, readers_schema)
@@ -31,6 +34,9 @@ module Avro
     # be read using the readers_schema. This check includes matching the types,
     # including schema promotion, and matching the full name (including aliases) for named types.
     def self.match_schemas(writers_schema, readers_schema)
+      # Bypass deeper checks if the schemas are the same Ruby objects
+      return true if writers_schema.equal?(readers_schema)
+
       w_type = writers_schema.type_sym
       r_type = readers_schema.type_sym
 
@@ -62,9 +68,9 @@ module Avro
       end
 
       # Handle schema promotion
-      if w_type == :int && [:long, :float, :double].include?(r_type)
+      if w_type == :int && INT_COERCIBLE_TYPES_SYM.include?(r_type)
         return true
-      elsif w_type == :long && [:float, :double].include?(r_type)
+      elsif w_type == :long && LONG_COERCIBLE_TYPES_SYM.include?(r_type)
         return true
       elsif w_type == :float && r_type == :double
         return true

--- a/lang/ruby/test/test_schema_compatibility.rb
+++ b/lang/ruby/test/test_schema_compatibility.rb
@@ -25,7 +25,9 @@ class TestSchemaCompatibility < Test::Unit::TestCase
   end
 
   def test_compatible_reader_writer_pairs
+    cached_schema = a_int_record1_schema
     [
+      cached_schema, cached_schema,
       long_schema, int_schema,
       float_schema, int_schema,
       float_schema, long_schema,


### PR DESCRIPTION
Ruby Avro decoding spends a fair amount of time validating that the
reader and writer schemas are compatible. These checks are
unnecessary for the fairly common case of the reader and writer schemas
being the same Avro::Schema instance. This improves the throughput
of our Avro decoding benchmarks by 1.3X.

While I was in here I removed repeated allocations of constant arrays in the `Avro:: SchemaCompatibility` module.

/cc @tjwp 