### PR TITLE
Reduce allocation in SchemaCompatibility.match_schemas when handling schema promotion for int and long writer types

### DIFF
--- a/lang/ruby/lib/avro/schema_compatibility.rb
+++ b/lang/ruby/lib/avro/schema_compatibility.rb
@@ -15,6 +15,9 @@
 # limitations under the License.
 module Avro
   module SchemaCompatibility
+    INT_PROMOTABLE = [:long, :float, :double].freeze
+    LONG_PROMOTABLE = [:float, :double].freeze
+
     # Perform a full, recursive check that a datum written using the writers_schema
     # can be read using the readers_schema.
     def self.can_read?(writers_schema, readers_schema)
@@ -62,9 +65,9 @@ module Avro
       end
 
       # Handle schema promotion
-      if w_type == :int && [:long, :float, :double].include?(r_type)
+      if w_type == :int && INT_PROMOTABLE.include?(r_type)
         return true
-      elsif w_type == :long && [:float, :double].include?(r_type)
+      elsif w_type == :long && LONG_PROMOTABLE.include?(r_type)
         return true
       elsif w_type == :float && r_type == :double
         return true


### PR DESCRIPTION
Reduces transient object allocation during decoding. Example 

```

%TOTAL | %SELF | TOTAL | SELF | WAIT | CHILD | CALLS | NAME | ALLOCATIONS | LINE
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
  |   | 5000.00 | 5000.00 | 0.00 | 0.00 | 105000/105000 | <Class::Avro::IO::DatumReader>#match_schemas | - | 240
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
5.55% | 5.55% | 5000.00 | 5000.00 | 0.00 | 0.00 | 105000 | <Module::Avro::SchemaCompatibility>#match_schemas | 5000 | 33
Array4000 (160000 Bytes)/Users/lourens/src/github.com/Shopify/cdc/avro/lang/ruby/pkg/avro-1.11.0.pre1/lib/avro/schema_compatibility.rb:67Array1000 (40000 Bytes)/Users/lourens/src/github.com/Shopify/cdc/avro/lang/ruby/pkg/avro-1.11.0.pre1/lib/avro/schema_compatibility.rb:65 | Array | 4000 (160000 Bytes) | /Users/lourens/src/github.com/Shopify/cdc/avro/lang/ruby/pkg/avro-1.11.0.pre1/lib/avro/schema_compatibility.rb:67 | Array | 1000 (40000 Bytes) | /Users/lourens/src/github.com/Shopify/cdc/avro/lang/ruby/pkg/avro-1.11.0.pre1/lib/avro/schema_compatibility.rb:65
Array | 4000 (160000 Bytes) | /Users/lourens/src/github.com/Shopify/cdc/avro/lang/ruby/pkg/avro-1.11.0.pre1/lib/avro/schema_compatibility.rb:67
Array | 1000 (40000 Bytes) | /Users/lourens/src/github.com/Shopify/cdc/avro/lang/ruby/pkg/avro-1.11.0.pre1/lib/avro/schema_compatibility.rb:65
```