### PR TITLE
AVRO-3008: Threading.is_alive Spelling for Py3.9

### DIFF
--- a/lang/py/avro/test/test_tether_task_runner.py
+++ b/lang/py/avro/test/test_tether_task_runner.py
@@ -128,7 +128,7 @@ class TestTetherTaskRunner(unittest.TestCase):
             time.sleep(1)
 
             # make sure the other thread terminated
-            self.assertFalse(sthread.isAlive())
+            self.assertFalse(sthread.is_alive())
 
             # shutdown the logging
             logging.shutdown()


### PR DESCRIPTION
Python dropped support for the old 'isAlive' spelling in 3.9.

### Jira

- [x] My PR addresses [AVRO-3008](https://issues.apache.org/jira/browse/AVRO-3008/).
- [x] No dependencies

### Tests

- [x] This updates an existing test to work in Python 3.9.

### Commits

- [x] Commits reference the Jira issue.
- [x] Commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] N/A
