### PR TITLE
AVRO-3023: Test against Ruby 3.0

### DIFF
--- a/.github/workflows/test-lang-ruby.yml
+++ b/.github/workflows/test-lang-ruby.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
 
@@ -81,7 +81,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
 

--- a/.github/workflows/test-lang-ruby.yml
+++ b/.github/workflows/test-lang-ruby.yml
@@ -37,6 +37,7 @@ jobs:
         - '2.5'
         - '2.6'
         - '2.7'
+        - '3.0'
     steps:
       - uses: actions/checkout@v2
 
@@ -76,6 +77,7 @@ jobs:
         - '2.5'
         - '2.6'
         - '2.7'
+        - '3.0'
     steps:
       - uses: actions/checkout@v2
 

--- a/lang/ruby/Gemfile
+++ b/lang/ruby/Gemfile
@@ -22,6 +22,8 @@ gem 'zstd-ruby'
 gem 'test-unit'
 # parallel 1.20.0 requires Ruby 2.5+
 gem 'parallel', '<= 1.19.2'
+# webrick is no longer included with Ruby 3.0+
+gem 'webrick'
 
 # rubocop 0.82 requires Ruby 2.4+
 gem 'rubocop', '<= 0.81'


### PR DESCRIPTION
[AVRO-3023](https://issues.apache.org/jira/browse/AVRO-3023): Test against Ruby 3.0.

Ruby 3.0 was released 12/25/2020: [announcement](https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/)

`actions/setup-ruby` has not been updated to support Ruby 3.0. Based on this [issue](https://github.com/actions/setup-ruby/issues/80), it looks like [ruby/setup-ruby](https://github.com/ruby/setup-ruby) will be preferred and we should switch to it. That action also has built-in support for dependency caching. We should consider trying that instead of `actions/cache` but I have not done that here in order to keep this change minimal.
