### PR TITLE
Bump jetty.version from 9.4.34.v20201102 to 9.4.35.v2020112 in /lang/java

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,25 +22,35 @@ updates:
   - package-ecosystem: "nuget"
     directory: "/lang/csharp/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
+    open-pull-requests-limit: 20
 
   - package-ecosystem: "maven"
     directory: "/lang/java/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
+    open-pull-requests-limit: 50
 
   - package-ecosystem: "npm"
     directory: "/lang/js"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
+    open-pull-requests-limit: 20
 
   - package-ecosystem: "pip"
     directory: "/lang/py/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
+    open-pull-requests-limit: 20
 
   - package-ecosystem: "bundler"
     directory: "/lang/ruby/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
+    open-pull-requests-limit: 20
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,11 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
+    ignore:
+      # Jetty >= 10 requires JDK 11
+      - dependency-name: "jetty*"
+        versions:
+          - ">= 10.0.0"
     open-pull-requests-limit: 50
 
   - package-ecosystem: "npm"

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -43,7 +43,7 @@
     <jackson.version>2.11.3</jackson.version>
     <jackson.databind.version>2.11.3</jackson.databind.version>
     <servlet-api.version>4.0.1</servlet-api.version>
-    <jetty.version>9.4.34.v20201102</jetty.version>
+    <jetty.version>9.4.35.v20201120</jetty.version>
     <jopt-simple.version>5.0.4</jopt-simple.version>
     <junit.version>4.13.1</junit.version>
     <netty.version>4.1.54.Final</netty.version>


### PR DESCRIPTION
R: @RyanSkraba 