### PR TITLE
AVRO-3028: Records encode fields that equal the default

### DIFF
--- a/doc/src/content/xdocs/spec.xml
+++ b/doc/src/content/xdocs/spec.xml
@@ -104,14 +104,17 @@
                   for users (optional).</li>
 		<li><code>type:</code> a <a href="#schemas">schema</a>, as defined above</li>
 		<li><code>default:</code> A default value for this
-		  field, used when reading instances that lack this
-		  field (optional).  Permitted values depend on the
-		  field's schema type, according to the table below.
-		  Default values for union fields correspond to the
-		  first schema in the union. Default values for bytes
-		  and fixed fields are JSON strings, where Unicode
-		  code points 0-255 are mapped to unsigned 8-bit byte
-		  values 0-255.
+      field, only used when reading instances that lack
+      the field for schema evolution purposes. The
+      presence of a default value does not make the
+      field optional at encoding time. Permitted values
+      depend on the field's schema type, according to the
+      table below. Default values for union fields correspond
+      to the first schema in the union. Default values for bytes
+      and fixed fields are JSON strings, where Unicode
+      code points 0-255 are mapped to unsigned 8-bit byte
+      values 0-255. Avro encodes a field even if its
+      value is equal to its default.
 		  <table class="right">
 		    <caption>field default values</caption>
 		    <tr><th>avro type</th><th>json type</th><th>example</th></tr>
@@ -564,7 +567,7 @@
                 followed by the serialized string:
                 <source>02 02 61</source></li>
             </ul>
-            <p><em>NOTE</em>: Currently for C/C++ implementtions, the positions are practically an int, but theoretically a long. 
+            <p><em>NOTE</em>: Currently for C/C++ implementations, the positions are practically an int, but theoretically a long.
             In reality, we don't expect unions with 215M members </p>
           </section>
 


### PR DESCRIPTION
I believe that this is an important aspect to clarify as some other
serialization formats omit fields that equal their default for
space-efficiency reasons. I had to run a small experiment as I could not
find this information in the spec.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3028
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
