### PR TITLE
Add anchors to the c++ documentation page

### DIFF
--- a/lang/c++/MainPage.dox
+++ b/lang/c++/MainPage.dox
@@ -19,14 +19,14 @@
 /*!
 \mainpage
 
-<h2>Introduction to Avro C++</h2>
+<h2 id="Introduction">Introduction to Avro C++ <a href="#Introduction">§</a></h2>
 
 <p>Avro is a data serialization system. See
 <a href="https://avro.apache.org/docs/current/">https://avro.apache.org/docs/current/</a>
 for background information.</p>
 <p>Avro C++ is a C++ library which implements parts of the <a href="https://avro.apache.org/docs/current/spec.html"> Avro Specification</a>. The library includes the following functionality:</p>
 <ul>
-	<li>Assembling schemas programmatically.
+    <li>Assembling schemas programmatically.
     <li>A schema parser, which can parse Avro schema (written in JSON) into a Schema object.
     <li>Encoders and decoders to encode data into Avro format and decode it back using primitive functions. There are multiple implementations of encoders and decoders.
     <ul>
@@ -49,7 +49,7 @@ Presently there is no support for the following specified in Avro specification.
 
 <b>Note:</b> Prior to Avro release 1.5, some of the functionality mentioned above was available through a somewhat different API and set tools. They are partially incompatible to the present ones. They continue to be available but will be deprecated and discontinued sometime in the future. The documentation on that API can be found at <a href="https://avro.apache.org/docs/1.4.0/api/cpp/html/index.html">https://avro.apache.org/docs/1.4.0/api/cpp/html/index.html</a>
 
-<h2>Installing Avro C++</h2>
+<h2 id="Installing">Installing Avro C++ <a href="#Installing">§</a></h2>
 <h3>Supported platforms and pre-requisites</h3>
 One should be able to build Avro C++ on (1) any UNIX flavor including cygwin for Windows and (2) natively on Windows using Visual Studio. We have tested it on (1) Linux systems (Ubuntu and RHEL) and Cygwin and Visual Studio 2010 Express edition.
 
@@ -105,7 +105,7 @@ Please see the main documentation if you want to build anything more than Avro C
 
 </ol>
 
-<h2>Getting started with Avro C++</h2>
+<h2 id="GettingStarted">Getting started with Avro C++ <a href="#GettingStarted">§</a></h2>
 
 <p>Although Avro does not require use of code generation, that is the easiest
 way to get started with the Avro C++ library.
@@ -196,7 +196,7 @@ avro::memoryOutputStream() in line 27 and avro::fileInputStream()
 instead of avro::memoryInputStream() in line 35.
 <p>
 
-<h2>Reading a JSON schema</h2>
+<h2 id="ReadingJsonSchema"><a id="ReadingJsonSchema">Reading a JSON schema </a><a href="index.html#ReadingJsonSchema">§</a></h2>
 
 <p>The section above demonstrated pretty much all that's needed to
 know to get started reading and writing objects using the Avro C++
@@ -221,7 +221,7 @@ avro data, you will need the schema objects. Other uses of schema objects
 are generic data objects and schema resolution described in the following
 sections.
 
-<h2>Custom encoding and decoding</h2>
+<h2 id="CustomEncodingDecoding">Custom encoding and decoding <a href="#CustomEncodingDecoding">§</a></h2>
 
 Suppose you want to encode objects of type std::complex<double> from
 C++ standard library using the schema defined in cpx.json.
@@ -270,7 +270,7 @@ All other encoders (JSON encoder) and decoders (JSON decoder,
 resolving decoder) do know about the schema and they validate internally. So,
 fronting them with a validating encoder or validating decoder is wasteful.
 
-<h2>Generic data objects</h2>
+<h2 id="GenericDataObjects">Generic data objects <a href="#GenericDataObjects">§</a></h2>
 
 A third way to encode and decode data is to use Avro's generic datum.
 Avro's generic datum allows you to read any arbitrary data corresponding to
@@ -287,7 +287,7 @@ In this example, we encode the data using generated code and decode it with
 generic datum. Then we examine the contents of the generic datum and extract
 them. Please see \ref avro::GenericDatum for more details on how to use it.
 
-<h2>Reading data with a schema different from that of the writer</h2>
+<h2 id="ReadingDifferentSchema">Reading data with a schema different from that of the writer <a href="#ReadingDifferentSchema">§</a></h2>
 It is possible to read the data written according to one schema
 using a different schema, provided the reader's schema and the writer's
 schema are compatible according to the Avro's Schema resolution rules.
@@ -324,7 +324,7 @@ In this example, we have used a simple (somewhat artificial) projection (where t
 the reader's schema is a subset of set of fields in the writer's). But more
 complex resolutions are allowed by Avro specification.
 
-<h2>Using Avro data files</h2>
+<h2 id="UsingAvroDataFiles">Using Avro data files <a href="#UsingAvroDataFiles">§</a></h2>
 Avro specification specifies a format for data files. Avro C++ implements
 the specification. The code below demonstrates how one can use the
 Avro data file to store and retrieve a collection of objects


### PR DESCRIPTION
This Pull requests adds anchors to the sections of the avro c++ Documentation for deep linking.

Make sure you have checked _all_ steps below.

### Jira

- [x]  There is no issue for this PR.

### Tests

- [X] My PR only changes the C++ Doxygen Doc, and does not need unit tests

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
