### PR TITLE
AVRO-2633 - csharp include schema doc

### DIFF
--- a/lang/csharp/src/apache/main/Schema/NamedSchema.cs
+++ b/lang/csharp/src/apache/main/Schema/NamedSchema.cs
@@ -78,6 +78,7 @@ namespace Avro
         internal static NamedSchema NewInstance(JObject jo, PropertyMap props, SchemaNames names, string encspace)
         {
             string type = JsonHelper.GetRequiredString(jo, "type");
+            string doc = JsonHelper.GetOptionalString(jo, "doc");
             switch (type)
             {
                 case "fixed":
@@ -90,7 +91,7 @@ namespace Avro
                     return RecordSchema.NewInstance(Type.Error, jo, props, names, encspace);
                 default:
                     NamedSchema result;
-                    if (names.TryGetValue(type, null, encspace, out result))
+                    if (names.TryGetValue(type, null, encspace, doc, out result))
                         return result;
                     return null;
             }
@@ -128,7 +129,8 @@ namespace Avro
         {
             String n = JsonHelper.GetOptionalString(jtok, "name");      // Changed this to optional string for anonymous records in messages
             String ns = JsonHelper.GetOptionalString(jtok, "namespace");
-            return new SchemaName(n, ns, encspace);
+            String d = JsonHelper.GetOptionalString(jtok, "doc");
+            return new SchemaName(n, ns, encspace, d);
         }
 
         /// <summary>
@@ -136,7 +138,7 @@ namespace Avro
         /// </summary>
         /// <param name="jtok">JSON object to read</param>
         /// <param name="space">namespace of the name this alias is for</param>
-        /// <param name="encspace">enclosing namespace of the name this alias is for</param>
+        /// <param name="encspace">enclosing namespace of the name this alias is for</param>        
         /// <returns>List of SchemaName that represents the list of alias. If no 'aliases' specified, then it returns null.</returns>
         protected static IList<SchemaName> GetAliases(JToken jtok, string space, string encspace)
         {
@@ -153,7 +155,7 @@ namespace Avro
                 if (jalias.Type != JTokenType.String)
                     throw new SchemaParseException($"Aliases must be of format JSON array of strings at '{jtok.Path}'");
 
-                aliases.Add(new SchemaName((string)jalias, space, encspace));
+                aliases.Add(new SchemaName((string)jalias, space, encspace, null));
             }
             return aliases;
         }

--- a/lang/csharp/src/apache/main/Schema/Schema.cs
+++ b/lang/csharp/src/apache/main/Schema/Schema.cs
@@ -166,7 +166,7 @@ namespace Avro
                 if (null != ps) return ps;
 
                 NamedSchema schema = null;
-                if (names.TryGetValue(value, null, encspace, out schema)) return schema;
+                if (names.TryGetValue(value, null, encspace, null, out schema)) return schema;
 
                 throw new SchemaParseException($"Undefined name: {value} at '{jtok.Path}'");
             }

--- a/lang/csharp/src/apache/main/Schema/SchemaName.cs
+++ b/lang/csharp/src/apache/main/Schema/SchemaName.cs
@@ -21,7 +21,7 @@ using System.Collections.Generic;
 namespace Avro
 {
     /// <summary>
-    /// Class to store schema name, namespace and enclosing namespace
+    /// Class to store schema name, namespace, enclosing namespace and documentation
     /// </summary>
     public class SchemaName
     {
@@ -41,6 +41,11 @@ namespace Avro
         public String EncSpace { get; private set; }
 
         /// <summary>
+        /// Documentation for the schema
+        /// </summary>
+        public String Documentation { get; private set; }
+
+        /// <summary>
         /// Namespace.Name of the schema
         /// </summary>
         public String Fullname { get { return string.IsNullOrEmpty(Namespace) ? this.Name : Namespace + "." + this.Name; } }
@@ -56,7 +61,8 @@ namespace Avro
         /// <param name="name">name of the schema</param>
         /// <param name="space">namespace of the schema</param>
         /// <param name="encspace">enclosing namespace of the schema</param>
-        public SchemaName(String name, String space, String encspace)
+        /// <param name="documentation">documentation o fthe schema</param>
+        public SchemaName(String name, String space, String encspace, String documentation)
         {
             if (name == null)
             {                         // anonymous
@@ -78,6 +84,7 @@ namespace Avro
                 this.Name = parts[parts.Length - 1];
                 this.EncSpace = encspace;
             }
+            this.Documentation = documentation;
         }
 
         /// <summary>
@@ -100,6 +107,7 @@ namespace Avro
             if (null != this.Name)  // write only if not anonymous
             {
                 JsonHelper.writeIfNotNullOrEmpty(writer, "name", this.Name);
+                JsonHelper.writeIfNotNullOrEmpty(writer, "doc", this.Documentation);
                 if (!String.IsNullOrEmpty(this.Space))
                     JsonHelper.writeIfNotNullOrEmpty(writer, "namespace", this.Space);
                 else if (!String.IsNullOrEmpty(this.EncSpace)) // need to put enclosing name space for code generated classes
@@ -206,11 +214,12 @@ namespace Avro
         /// <param name="name">name of the schema</param>
         /// <param name="space">namespace of the schema</param>
         /// <param name="encspace">enclosing namespace of the schema</param>
+        /// <param name="documentation">documentation for the schema</param>
         /// <param name="schema">schema object found</param>
         /// <returns>true if name is found in the map, false otherwise</returns>
-        public bool TryGetValue(string name, string space, string encspace, out NamedSchema schema)
+        public bool TryGetValue(string name, string space, string encspace, string documentation, out NamedSchema schema)
         {
-            SchemaName schemaname = new SchemaName(name, space, encspace);
+            SchemaName schemaname = new SchemaName(name, space, encspace, documentation);
             return Names.TryGetValue(schemaname, out schema);
         }
 

--- a/lang/csharp/src/apache/test/Schema/SchemaTests.cs
+++ b/lang/csharp/src/apache/test/Schema/SchemaTests.cs
@@ -69,8 +69,12 @@ namespace Avro.Test
             typeof(SchemaParseException), Description = "No fields")]
         [TestCase("{\"type\":\"record\",\"name\":\"LongList\", \"fields\": \"hi\"}",
             typeof(SchemaParseException), Description = "Fields not an array")]
-        [TestCase("[{\"type\": \"record\",\"name\": \"Test\",\"namespace\":\"ns1\",\"fields\": [{\"name\": \"f\",\"type\": \"long\"}]}," + 
+        [TestCase("[{\"type\": \"record\",\"name\": \"Test\",\"namespace\":\"ns1\",\"fields\": [{\"name\": \"f\",\"type\": \"long\"}]}," +
                    "{\"type\": \"record\",\"name\": \"Test\",\"namespace\":\"ns2\",\"fields\": [{\"name\": \"f\",\"type\": \"long\"}]}]")]
+
+        // Doc
+        [TestCase("{\"type\": \"record\",\"name\": \"Test\",\"doc\": \"Test Doc\",\"fields\": [{\"name\": \"f\",\"type\": \"long\"}]}")]
+
         // Enum
         [TestCase("{\"type\": \"enum\", \"name\": \"Test\", \"symbols\": [\"A\", \"B\"]}")]
         [TestCase("{\"type\": \"enum\", \"name\": \"Status\", \"symbols\": \"Normal Caution Critical\"}",
@@ -250,7 +254,7 @@ namespace Avro.Test
         }
 
         [TestCase("{\"type\": \"enum\", \"name\": \"Test\", \"symbols\": [\"Unknown\", \"A\", \"B\"], \"default\": \"Unknown\" }", "Unknown")]
-        public void TestEnumDefault(string s, string expectedToken) 
+        public void TestEnumDefault(string s, string expectedToken)
         {
             var es = Schema.Parse(s) as EnumSchema;
             Assert.IsNotNull(es);
@@ -348,7 +352,7 @@ namespace Avro.Test
         [TestCase("a", "o.a.h", ExpectedResult = "o.a.h.a")]
         public string testFullname(string s1, string s2)
         {
-            var name = new SchemaName(s1, s2, null);
+            var name = new SchemaName(s1, s2, null, null);
             return name.Fullname;
         }
 


### PR DESCRIPTION
This PR preserves the schema "doc" attributes when serializing the schema to json.  The existing code would parse and include the documentation, but it wasn't passed along when serializing the schema.

### Jira

Jira Issue AVRO-2633  - C# - AvroGen tool - Document for record type is not included in the Schema field.  

https://issues.apache.org/jira/projects/AVRO/issues/AVRO-2633

This pull request makes preserves the schema documentation when serializing the schema.

### Tests

My PR adds a new test case to SchemaTests.TestBasic
My PR adjusts SchemaTests.testFullName to use a modified constructor

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

C# XML comments were updated for all modified methods