### PR TITLE
AVRO-3031: Update for avrogencpp to handle C++ reserved words more broadly

### DIFF
--- a/lang/c++/CMakeLists.txt
+++ b/lang/c++/CMakeLists.txt
@@ -153,6 +153,7 @@ gen (tree1 tr1)
 gen (tree2 tr2)
 gen (crossref cr)
 gen (primitivetypes pt)
+gen (cpp_reserved_words cppres)
 
 add_executable (avrogencpp impl/avrogencpp.cc)
 target_link_libraries (avrogencpp avrocpp_s ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES})
@@ -177,6 +178,9 @@ unittest (DataFileTests)
 unittest (JsonTests)
 unittest (AvrogencppTests)
 unittest (CompilerTests)
+unittest (AvrogencppTestReservedWords)
+
+add_dependencies (AvrogencppTestReservedWords cpp_reserved_words_hh)
 
 add_dependencies (AvrogencppTests bigrecord_hh bigrecord_r_hh bigrecord2_hh
     tweet_hh

--- a/lang/c++/impl/avrogencpp.cc
+++ b/lang/c++/impl/avrogencpp.cc
@@ -125,7 +125,7 @@ public:
     void generate(const ValidSchema& schema);
 };
 
-static string decorate(const avro::Name& name)
+static string decorate(const std::string &name)
 {
     static const char * cppReservedWords[] = {
         "alignas", "alignof", "and", "and_eq", "asm", "auto", "bitand", "bitor", "bool", "break",
@@ -142,9 +142,14 @@ static string decorate(const avro::Name& name)
     };
 
     for (size_t i = 0; i < sizeof(cppReservedWords)/sizeof(cppReservedWords[0]); i++)
-        if (strcmp(name.simpleName().c_str(), cppReservedWords[i]) == 0)
-            return name.simpleName() + '_';
-    return name.simpleName();
+        if (strcmp(name.c_str(), cppReservedWords[i]) == 0)
+            return name + '_';
+    return name;
+}
+
+static string decorate(const avro::Name& name)
+{
+    return decorate(name.simpleName());
 }
 
 string CodeGen::fullname(const string& name) const
@@ -263,12 +268,15 @@ string CodeGen::generateRecordType(const NodePtr& n)
         }
     }
     for (size_t i = 0; i < c; ++i) {
+        // the nameAt(i) does not take c++ reserved words into account
+        // so we need to call decorate on it
+        std::string decoratedNameAt = decorate(n->nameAt(i));
         if (! noUnion_ && n->leafAt(i)->type() == avro::AVRO_UNION) {
-            os_ << "    " << n->nameAt(i) << "_t";
+            os_ << "    " << decoratedNameAt << "_t";
         } else {
             os_ << "    " << types[i];
         }
-        os_ << ' ' << n->nameAt(i) << ";\n";
+        os_ << ' ' << decoratedNameAt << ";\n";
     }
 
     os_ << "    " << decoratedName << "()";
@@ -277,9 +285,14 @@ string CodeGen::generateRecordType(const NodePtr& n)
     }
     os_ << "\n";
     for (size_t i = 0; i < c; ++i) {
-        os_ << "        " << n->nameAt(i) << "(";
+        // the nameAt(i) does not take c++ reserved words into account
+        // so we need to call decorate on it
+        std::string decoratedNameAt = decorate(n->nameAt(i));
+        os_ << "        " << decoratedNameAt << "(";
         if (! noUnion_ && n->leafAt(i)->type() == avro::AVRO_UNION) {
-            os_ << n->nameAt(i) << "_t";
+            // the nameAt(i) does not take c++ reserved words into account
+            // so we need to call decorate on it
+            os_ << decoratedNameAt << "_t";
         } else {
             os_ << types[i];
         }
@@ -526,7 +539,10 @@ void CodeGen::generateEnumTraits(const NodePtr& n)
 {
     string dname = decorate(n->name());
     string fn = fullname(dname);
-    string last = n->nameAt(n->names() - 1);
+
+    // the nameAt(i) does not take c++ reserved words into account
+    // so we need to call decorate on it
+    string last = decorate(n->nameAt(n->names() - 1));
 
     os_ << "template<> struct codec_traits<" << fn << "> {\n"
         << "    static void encode(Encoder& e, " << fn << " v) {\n"
@@ -563,7 +579,10 @@ void CodeGen::generateRecordTraits(const NodePtr& n)
         << "    static void encode(Encoder& e, const " << fn << "& v) {\n";
 
     for (size_t i = 0; i < c; ++i) {
-        os_ << "        avro::encode(e, v." << n->nameAt(i) << ");\n";
+        // the nameAt(i) does not take c++ reserved words into account
+        // so we need to call decorate on it
+        std::string decoratedNameAt = decorate(n->nameAt(i));
+        os_ << "        avro::encode(e, v." << decoratedNameAt << ");\n";
     }
 
     os_ << "    }\n"
@@ -575,8 +594,11 @@ void CodeGen::generateRecordTraits(const NodePtr& n)
     os_ << "                it != fo.end(); ++it) {\n";
     os_ << "                switch (*it) {\n";
     for (size_t i = 0; i < c; ++i) {
+        // the nameAt(i) does not take c++ reserved words into account
+        // so we need to call decorate on it
+        std::string decoratedNameAt = decorate(n->nameAt(i));
         os_ << "                case " << i << ":\n";
-        os_ << "                    avro::decode(d, v." << n->nameAt(i) << ");\n";
+        os_ << "                    avro::decode(d, v." << decoratedNameAt << ");\n";
         os_ << "                    break;\n";
     }
     os_ << "                default:\n";
@@ -586,7 +608,10 @@ void CodeGen::generateRecordTraits(const NodePtr& n)
     os_ << "        } else {\n";
 
     for (size_t i = 0; i < c; ++i) {
-        os_ << "            avro::decode(d, v." << n->nameAt(i) << ");\n";
+        // the nameAt(i) does not take c++ reserved words into account
+        // so we need to call decorate on it
+        std::string decoratedNameAt = decorate(n->nameAt(i));
+        os_ << "            avro::decode(d, v." << decoratedNameAt << ");\n";
     }
     os_ << "        }\n";
 

--- a/lang/c++/jsonschemas/cpp_reserved_words
+++ b/lang/c++/jsonschemas/cpp_reserved_words
@@ -1,0 +1,270 @@
+{
+  "type" : "record",
+  "name" : "Words",
+  "namespace" : "org.apache.avro.example",
+  "fields" : [ {
+    "name" : "alignas",
+    "type" : "string"
+  }, {
+    "name" : "alignof",
+    "type" : "string"
+  }, {
+    "name" : "and",
+    "type" : "string"
+  }, {
+    "name" : "and_eq",
+    "type" : "string"
+  }, {
+    "name" : "asm",
+    "type" : "string"
+  }, {
+    "name" : "atomic_cancel",
+    "type" : "string"
+  }, {
+    "name" : "atomic_commit",
+    "type" : "string"
+  }, {
+    "name" : "atomic_noexcept",
+    "type" : "string"
+  }, {
+    "name" : "auto",
+    "type" : "string"
+  }, {
+    "name" : "bitand",
+    "type" : "string"
+  }, {
+    "name" : "bitor",
+    "type" : "string"
+  }, {
+    "name" : "bool",
+    "type" : "string"
+  }, {
+    "name" : "break",
+    "type" : "string"
+  }, {
+    "name" : "case",
+    "type" : "string"
+  }, {
+    "name" : "catch",
+    "type" : "string"
+  }, {
+    "name" : "char",
+    "type" : "string"
+  }, {
+    "name" : "char8_t",
+    "type" : "string"
+  }, {
+    "name" : "char16_t",
+    "type" : "string"
+  }, {
+    "name" : "char32_t",
+    "type" : "string"
+  }, {
+    "name" : "class",
+    "type" : "string"
+  }, {
+    "name" : "compl",
+    "type" : "string"
+  }, {
+    "name" : "concept",
+    "type" : "string"
+  }, {
+    "name" : "const",
+    "type" : "string"
+  }, {
+    "name" : "consteval",
+    "type" : "string"
+  }, {
+    "name" : "constexpr",
+    "type" : "string"
+  }, {
+    "name" : "constinit",
+    "type" : "string"
+  }, {
+    "name" : "const_cast",
+    "type" : "string"
+  }, {
+    "name" : "continue",
+    "type" : "string"
+  }, {
+    "name" : "co_await",
+    "type" : "string"
+  }, {
+    "name" : "co_return",
+    "type" : "string"
+  }, {
+    "name" : "co_yield",
+    "type" : "string"
+  }, {
+    "name" : "decltype",
+    "type" : "string"
+  }, {
+    "name" : "default",
+    "type" : "string"
+  }, {
+    "name" : "delete",
+    "type" : "string"
+  }, {
+    "name" : "do",
+    "type" : "string"
+  }, {
+    "name" : "dynamic_cast",
+    "type" : "string"
+  }, {
+    "name" : "else",
+    "type" : "string"
+  }, {
+    "name" : "explicit",
+    "type" : "string"
+  }, {
+    "name" : "export",
+    "type" : "string"
+  }, {
+    "name" : "extern",
+    "type" : "string"
+  }, {
+    "name" : "for",
+    "type" : "string"
+  }, {
+    "name" : "friend",
+    "type" : "string"
+  }, {
+    "name" : "goto",
+    "type" : "string"
+  }, {
+    "name" : "if",
+    "type" : "string"
+  }, {
+    "name" : "inline",
+    "type" : "string"
+  }, {
+    "name" : "mutable",
+    "type" : "string"
+  }, {
+    "name" : "namespace",
+    "type" : "string"
+  }, {
+    "name" : "new",
+    "type" : "string"
+  }, {
+    "name" : "noexcept",
+    "type" : "string"
+  }, {
+    "name" : "not",
+    "type" : "string"
+  }, {
+    "name" : "not_eq",
+    "type" : "string"
+  }, {
+    "name" : "nullptr",
+    "type" : "string"
+  }, {
+    "name" : "operator",
+    "type" : "string"
+  }, {
+    "name" : "or",
+    "type" : "string"
+  }, {
+    "name" : "or_eq",
+    "type" : "string"
+  }, {
+    "name" : "private",
+    "type" : "string"
+  }, {
+    "name" : "protected",
+    "type" : "string"
+  }, {
+    "name" : "public",
+    "type" : "string"
+  }, {
+    "name" : "reflexpr",
+    "type" : "string"
+  }, {
+    "name" : "register",
+    "type" : "string"
+  }, {
+    "name" : "reinterpret_cast",
+    "type" : "string"
+  }, {
+    "name" : "requires",
+    "type" : "string"
+  }, {
+    "name" : "return",
+    "type" : "string"
+  }, {
+    "name" : "short",
+    "type" : "string"
+  }, {
+    "name" : "signed",
+    "type" : "string"
+  }, {
+    "name" : "sizeof",
+    "type" : "string"
+  }, {
+    "name" : "static",
+    "type" : "string"
+  }, {
+    "name" : "static_assert",
+    "type" : "string"
+  }, {
+    "name" : "static_cast",
+    "type" : "string"
+  }, {
+    "name" : "struct",
+    "type" : "string"
+  }, {
+    "name" : "switch",
+    "type" : "string"
+  }, {
+    "name" : "synchronized",
+    "type" : "string"
+  }, {
+    "name" : "template",
+    "type" : "string"
+  }, {
+    "name" : "this",
+    "type" : "string"
+  }, {
+    "name" : "thread_local",
+    "type" : "string"
+  }, {
+    "name" : "throw",
+    "type" : "string"
+  }, {
+    "name" : "try",
+    "type" : "string"
+  }, {
+    "name" : "typedef",
+    "type" : "string"
+  }, {
+    "name" : "typeid",
+    "type" : "string"
+  }, {
+    "name" : "typename",
+    "type" : "string"
+  }, {
+    "name" : "unsigned",
+    "type" : "string"
+  }, {
+    "name" : "using",
+    "type" : "string"
+  }, {
+    "name" : "virtual",
+    "type" : "string"
+  }, {
+    "name" : "volatile",
+    "type" : "string"
+  }, {
+    "name" : "wchar_t",
+    "type" : "string"
+  }, {
+    "name" : "while",
+    "type" : "string"
+  }, {
+    "name" : "xor",
+    "type" : "string"
+  }, {
+    "name" : "xor_eq",
+    "type" : "string"
+  } ]
+}

--- a/lang/c++/test/AvrogencppTestReservedWords.cc
+++ b/lang/c++/test/AvrogencppTestReservedWords.cc
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "cpp_reserved_words.hh"
+
+#include "Compiler.hh"
+
+#include <fstream>
+#include <boost/test/included/unit_test_framework.hpp>
+
+#ifdef min
+#undef min
+#endif
+
+#ifdef max
+#undef max
+#endif
+
+
+using std::unique_ptr;
+using std::map;
+using std::string;
+using std::vector;
+using std::ifstream;
+
+using avro::ValidSchema;
+using avro::OutputStream;
+using avro::InputStream;
+using avro::Encoder;
+using avro::Decoder;
+using avro::EncoderPtr;
+using avro::DecoderPtr;
+using avro::memoryInputStream;
+using avro::memoryOutputStream;
+using avro::binaryEncoder;
+using avro::validatingEncoder;
+using avro::binaryDecoder;
+using avro::validatingDecoder;
+
+
+void testCppReservedWords()
+{
+    // Simply including the generated header is enough to test this.
+    // the header will not compile if reserved words were used
+}
+
+boost::unit_test::test_suite*
+init_unit_test_suite(int argc, char* argv[])
+{
+    boost::unit_test::test_suite* ts = BOOST_TEST_SUITE("Code generator tests");
+    ts->add(BOOST_TEST_CASE(testCppReservedWords));
+    return ts;
+}
+


### PR DESCRIPTION
https://issues.apache.org/jira/browse/AVRO-3031

If avrogencpp encounters a schema with reserved words in it, it will happily generate a header with fields that are reserved words.

The decorate function in avrogencpp was overloaded a reference to an std::string or const avro::Name& to allow this.
The existing decorate function is only called on types, but it should also be called on names as well, which this patch fixes

For example:
```
{
  "type" : "record",
  "name" : "Words",
  "namespace" : "org.apache.avro.example",
  "fields" : [ {
    "name" : "alignas",
    "type" : "string"
  }, {
    "name" : "alignof",
    "type" : "string"
  }, {
    "name" : "and",
    "type" : "string"
  }
  ]
}

Will generate the following header file:

struct Words {
    std::string alignas;
    std::string alignof;
    std::string and;
    Words() :
        alignas(std::string()),
        alignof(std::string()),
        and(std::string())
        { }
};
```

Which cannot be compiled by c++

With this fix, the following will be generated:

```
struct Words {
    std::string alignas_;
    std::string alignof_;
    std::string and_;
    Words() :
        alignas_(std::string()),
        alignof_(std::string()),
        and_(std::string())
        { }
};
```

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [AVRO-3031]](https://issues.apache.org/jira/browse/AVRO-3031) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests:
      * Unit tests with a schema that uses all of the reserved words that avrogencpp uses.
      * The unit test will fail to compile with the generated header file without this fix.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
