### PR TITLE
AVRO-3024: Remove references to Jackson databind

### DIFF
--- a/lang/java/archetypes/avro-service-archetype/src/main/pom/pom.xml
+++ b/lang/java/archetypes/avro-service-archetype/src/main/pom/pom.xml
@@ -31,7 +31,6 @@
 
     <avro.version>${project.version}</avro.version>
     <jackson.version>${jackson.version}</jackson.version>
-    <jackson.databind.version>${jackson.databind.version}</jackson.databind.version>
     <junit.version>${junit.version}</junit.version>
     <logback.version>1.0.0</logback.version>
     <slf4j.version>${slf4j.version}</slf4j.version>
@@ -61,7 +60,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>\${jackson.databind.version}</version>
+      <version>\${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/lang/java/maven-plugin/src/test/resources/unit/idl/pom-injecting-velocity-tools.xml
+++ b/lang/java/maven-plugin/src/test/resources/unit/idl/pom-injecting-velocity-tools.xml
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson.databind.version}</version>
+      <version>${jackson.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/lang/java/maven-plugin/src/test/resources/unit/idl/pom.xml
+++ b/lang/java/maven-plugin/src/test/resources/unit/idl/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson.databind.version}</version>
+      <version>${jackson.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/lang/java/maven-plugin/src/test/resources/unit/protocol/pom-injecting-velocity-tools.xml
+++ b/lang/java/maven-plugin/src/test/resources/unit/protocol/pom-injecting-velocity-tools.xml
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson.databind.version}</version>
+      <version>${jackson.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/lang/java/maven-plugin/src/test/resources/unit/protocol/pom.xml
+++ b/lang/java/maven-plugin/src/test/resources/unit/protocol/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson.databind.version}</version>
+      <version>${jackson.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/lang/java/maven-plugin/src/test/resources/unit/schema/pom-injecting-velocity-tools.xml
+++ b/lang/java/maven-plugin/src/test/resources/unit/schema/pom-injecting-velocity-tools.xml
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson.databind.version}</version>
+      <version>${jackson.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/lang/java/maven-plugin/src/test/resources/unit/schema/pom.xml
+++ b/lang/java/maven-plugin/src/test/resources/unit/schema/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson.databind.version}</version>
+      <version>${jackson.version}</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Did a git bisect, and found out that my commit broke master:

```
MacBook-Pro-van-Fokko:avro fokkodriesprong$ git bisect good
5412eca32406e3a5d8579400bc6c3843ff5fb206 is the first bad commit
commit 5412eca32406e3a5d8579400bc6c3843ff5fb206
Author: Fokko Driesprong <fokko@apache.org>
Date:   Wed Jan 13 10:59:05 2021 +0100

    AVRO-3024: Bump Jackson to 2.11.4

    To consolidate the versions

 lang/java/pom.xml | 5 ++---
 1 file changed, 2 insertions(+), 3 deletions(-)
```

Turns out that there are still references to the jackson.databind property

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
