### PR TITLE
AVRO-3036: add schema matching for bytes decimal logical type in Ruby

### DIFF
--- a/lang/ruby/lib/avro/schema.rb
+++ b/lang/ruby/lib/avro/schema.rb
@@ -500,11 +500,13 @@ module Avro
       end
 
       def match_schema?(schema)
+        return true if super
+
         if logical_type == DECIMAL_LOGICAL_TYPE && schema.logical_type == DECIMAL_LOGICAL_TYPE
           return precision == schema.precision && (scale || 0) == (schema.scale || 0)
         end
 
-        return super
+        false
       end
     end
 
@@ -532,11 +534,13 @@ module Avro
       end
 
       def match_schema?(schema)
+        return true if super && size == schema.size
+
         if logical_type == DECIMAL_LOGICAL_TYPE && schema.logical_type == DECIMAL_LOGICAL_TYPE
           return precision == schema.precision && (scale || 0) == (schema.scale || 0)
         end
 
-        super && size == schema.size
+        false
       end
     end
 

--- a/lang/ruby/lib/avro/schema.rb
+++ b/lang/ruby/lib/avro/schema.rb
@@ -77,7 +77,9 @@ module Avro
           case type_sym
           when :fixed
             size = json_obj['size']
-            return FixedSchema.new(name, namespace, size, names, logical_type, aliases)
+            precision = json_obj['precision']
+            scale = json_obj['scale']
+            return FixedSchema.new(name, namespace, size, names, logical_type, aliases, precision, scale)
           when :enum
             symbols = json_obj['symbols']
             doc     = json_obj['doc']
@@ -284,6 +286,10 @@ module Avro
 
       def match_fullname?(name)
         name == fullname || fullname_aliases.include?(name)
+      end
+
+      def match_schema?(schema)
+        type_sym == schema.type_sym && match_fullname?(schema.fullname)
       end
     end
 
@@ -494,13 +500,8 @@ module Avro
       end
 
       def match_schema?(schema)
-        if type_sym == schema.type_sym
-          return false if logical_type != schema.logical_type
-
-          if logical_type == DECIMAL_LOGICAL_TYPE
-            return false if precision != schema.precision
-            return false if (scale || 0) != (schema.scale || 0)
-          end
+        if logical_type == DECIMAL_LOGICAL_TYPE && schema.logical_type == DECIMAL_LOGICAL_TYPE
+          return precision == schema.precision && (scale || 0) == (schema.scale || 0)
         end
 
         return super
@@ -508,19 +509,34 @@ module Avro
     end
 
     class FixedSchema < NamedSchema
-      attr_reader :size
-      def initialize(name, space, size, names=nil, logical_type=nil, aliases=nil)
+      attr_reader :size, :precision, :scale
+      def initialize(name, space, size, names=nil, logical_type=nil, aliases=nil, precision=nil, scale=nil)
         # Ensure valid cto args
         unless size.is_a?(Integer)
           raise AvroError, 'Fixed Schema requires a valid integer for size property.'
         end
         super(:fixed, name, space, names, nil, logical_type, aliases)
         @size = size
+        @precision = precision
+        @scale = scale
       end
 
       def to_avro(names=Set.new)
         avro = super
-        avro.is_a?(Hash) ? avro.merge('size' => size) : avro
+        return avro if avro.is_a?(String)
+
+        avro['size'] = size
+        avro['precision'] = precision if precision
+        avro['scale'] = scale if scale
+        avro
+      end
+
+      def match_schema?(schema)
+        if logical_type == DECIMAL_LOGICAL_TYPE && schema.logical_type == DECIMAL_LOGICAL_TYPE
+          return precision == schema.precision && (scale || 0) == (schema.scale || 0)
+        end
+
+        super && size == schema.size
       end
     end
 

--- a/lang/ruby/lib/avro/schema_compatibility.rb
+++ b/lang/ruby/lib/avro/schema_compatibility.rb
@@ -46,7 +46,7 @@ module Avro
       end
 
       if w_type == r_type
-        return true if Schema::PRIMITIVE_TYPES_SYM.include?(r_type)
+        return readers_schema.match_schema?(writers_schema) if Schema::PRIMITIVE_TYPES_SYM.include?(r_type)
 
         case r_type
         when :record

--- a/lang/ruby/lib/avro/schema_compatibility.rb
+++ b/lang/ruby/lib/avro/schema_compatibility.rb
@@ -49,21 +49,14 @@ module Avro
         return readers_schema.match_schema?(writers_schema) if Schema::PRIMITIVE_TYPES_SYM.include?(r_type)
 
         case r_type
-        when :record
-          return readers_schema.match_fullname?(writers_schema.fullname)
-        when :error
-          return readers_schema.match_fullname?(writers_schema.fullname)
         when :request
           return true
-        when :fixed
-          return readers_schema.match_fullname?(writers_schema.fullname) &&
-            writers_schema.size == readers_schema.size
-        when :enum
-          return readers_schema.match_fullname?(writers_schema.fullname)
         when :map
           return match_schemas(writers_schema.values, readers_schema.values)
         when :array
           return match_schemas(writers_schema.items, readers_schema.items)
+        else
+          return readers_schema.match_schema?(writers_schema)
         end
       end
 
@@ -80,7 +73,11 @@ module Avro
         return true
       end
 
-      return false
+      if readers_schema.respond_to?(:match_schema?)
+        readers_schema.match_schema?(writers_schema)
+      else
+        false
+      end
     end
 
     class Checker

--- a/lang/ruby/test/test_schema.rb
+++ b/lang/ruby/test/test_schema.rb
@@ -541,6 +541,76 @@ class TestSchema < Test::Unit::TestCase
                  exception.to_s)
   end
 
+  def test_fixed_decimal_to_include_precision_scale
+    schema = Avro::Schema.parse <<-SCHEMA
+      {
+        "type": "fixed",
+        "name": "aFixed",
+        "logicalType": "decimal",
+        "size": 4,
+        "precision": 9,
+        "scale": 2
+      }
+    SCHEMA
+
+    schema_hash =
+      {
+        'type' => 'fixed',
+        'name' => 'aFixed',
+        'logicalType' => 'decimal',
+        'size' => 4,
+        'precision' => 9,
+        'scale' => 2
+      }
+
+    assert_equal schema_hash, schema.to_avro
+  end
+
+  def test_fixed_decimal_to_include_precision_no_scale
+    schema = Avro::Schema.parse <<-SCHEMA
+      {
+        "type": "fixed",
+        "name": "aFixed",
+        "logicalType": "decimal",
+        "size": 4,
+        "precision": 9
+      }
+    SCHEMA
+
+    schema_hash =
+      {
+        'type' => 'fixed',
+        'name' => 'aFixed',
+        'logicalType' => 'decimal',
+        'size' => 4,
+        'precision' => 9
+      }
+
+    assert_equal schema_hash, schema.to_avro
+  end
+
+  # Note: this is not valid but validation is not yet implemented
+  def test_fixed_decimal_to_without_precision_scale
+    schema = Avro::Schema.parse <<-SCHEMA
+      {
+        "type": "fixed",
+        "size": 4,
+        "name": "aFixed",
+        "logicalType": "decimal"
+      }
+    SCHEMA
+
+    schema_hash =
+      {
+        'type' => 'fixed',
+        'name' => 'aFixed',
+        'logicalType' => 'decimal',
+        'size' => 4
+      }
+
+    assert_equal schema_hash, schema.to_avro
+  end
+
   def test_bytes_decimal_to_include_precision_scale
     schema = Avro::Schema.parse <<-SCHEMA
       {

--- a/lang/ruby/test/test_schema_compatibility.rb
+++ b/lang/ruby/test/test_schema_compatibility.rb
@@ -292,6 +292,29 @@ class TestSchemaCompatibility < Test::Unit::TestCase
     assert_false(can_read?(writer_schema, reader_schema))
   end
 
+  def test_bytes_decimal
+    bytes_decimal_schema = Avro::Schema.
+      parse('{"type":"bytes", "logicalType":"decimal", "precision":4, "scale":4}')
+    bytes2_decimal_schema = Avro::Schema.
+      parse('{"type":"bytes", "logicalType":"decimal", "precision":4, "scale":4}')
+    bytes_decimal_no_scale_schema = Avro::Schema.
+      parse('{"type":"bytes", "logicalType":"decimal", "precision":4}')
+    bytes2_decimal_no_scale_schema = Avro::Schema.
+      parse('{"type":"bytes", "logicalType":"decimal", "precision":4}')
+    bytes_decimal_zero_scale_schema = Avro::Schema.
+      parse('{"type":"bytes", "logicalType":"decimal", "precision":4, "scale":0}')
+    bytes_unknown_logical_type_schema = Avro::Schema.
+      parse('{"type":"bytes", "logicalType":"unknown"}')
+
+    assert_false(can_read?(bytes_schema, bytes_decimal_schema))
+    assert_false(can_read?(bytes_decimal_schema, bytes_unknown_logical_type_schema))
+    assert_false(can_read?(bytes_decimal_schema, bytes_decimal_no_scale_schema))
+    assert_false(can_read?(bytes_decimal_schema, bytes_decimal_zero_scale_schema))
+    assert_true(can_read?(bytes_decimal_zero_scale_schema, bytes_decimal_no_scale_schema))
+    assert_true(can_read?(bytes_decimal_schema, bytes2_decimal_schema))
+    assert_true(can_read?(bytes2_decimal_no_scale_schema, bytes_decimal_no_scale_schema))
+  end
+
   # Tests from lang/java/avro/src/test/java/org/apache/avro/io/parsing/TestResolvingGrammarGenerator2.java
 
   def point_2d_schema


### PR DESCRIPTION
In https://github.com/apache/avro/pull/918 it was identified that matching during schema resolution is missing for bytes decimal logical types in the Ruby implementation. (There is no support yet in the Ruby implementation for the fixed decimal.)

Instead of embedding the logic for this specific check in the `SchemaCompatibility` module, I've made a small, initial step in the direction of making this checking more object-oriented. The matching logic needed is added to the `BytesSchema` class.

### Jira

- [x] My PR addresses the following https://issues.apache.org/jira/browse/AVRO-3036

### Tests

- [x] My PR adds the following unit tests: `test_bytes_decimal` in `test_schema_compatibility.rb`

### Commits

- [x] My commits all reference Jira issues in their subject lines.
