### PR TITLE
AVRO-1846: fix memory alignment issues (performance degredation & crashes)

### DIFF
--- a/lang/c/src/avro/basics.h
+++ b/lang/c/src/avro/basics.h
@@ -53,7 +53,7 @@ typedef enum avro_class_t avro_class_t;
 struct avro_obj_t {
 	avro_type_t type;
 	avro_class_t class_type;
-	volatile int  refcount;
+	volatile long  refcount;
 };
 
 #define avro_classof(obj)     ((obj)->class_type)

--- a/lang/c/src/avro/refcount.h
+++ b/lang/c/src/avro/refcount.h
@@ -35,7 +35,7 @@ extern "C" {
  */
 
 static inline void
-avro_refcount_set(volatile int *refcount, int value);
+avro_refcount_set(volatile long *refcount, int value);
 
 /**
  * Increments a reference count, ensuring that its value doesn't
@@ -43,7 +43,7 @@ avro_refcount_set(volatile int *refcount, int value);
  */
 
 static inline void
-avro_refcount_inc(volatile int *refcount);
+avro_refcount_inc(volatile long *refcount);
 
 /**
  * Decrements a reference count, and returns whether the resulting
@@ -51,7 +51,7 @@ avro_refcount_inc(volatile int *refcount);
  */
 
 static inline int
-avro_refcount_dec(volatile int *refcount);
+avro_refcount_dec(volatile long *refcount);
 
 
 /*-----------------------------------------------------------------------
@@ -59,13 +59,13 @@ avro_refcount_dec(volatile int *refcount);
  */
 #if defined(AVRO_NON_ATOMIC_REFCOUNT)
 static inline void
-avro_refcount_set(volatile int *refcount, int value)
+avro_refcount_set(volatile long *refcount, int value)
 {
 	*refcount = value;
 }
 
 static inline void
-avro_refcount_inc(volatile int *refcount)
+avro_refcount_inc(volatile long *refcount)
 {
 	if (*refcount != (int) -1) {
 		*refcount += 1;
@@ -73,7 +73,7 @@ avro_refcount_inc(volatile int *refcount)
 }
 
 static inline int
-avro_refcount_dec(volatile int *refcount)
+avro_refcount_dec(volatile long *refcount)
 {
 	if (*refcount != (int) -1) {
 		*refcount -= 1;
@@ -91,13 +91,13 @@ avro_refcount_dec(volatile int *refcount)
 #include <libkern/OSAtomic.h>
 
 static inline void
-avro_refcount_set(volatile int *refcount, int value)
+avro_refcount_set(volatile long *refcount, int value)
 {
 	*refcount = value;
 }
 
 static inline void
-avro_refcount_inc(volatile int *refcount)
+avro_refcount_inc(volatile long *refcount)
 {
 	if (*refcount != (int) -1) {
 		OSAtomicIncrement32(refcount);
@@ -105,7 +105,7 @@ avro_refcount_inc(volatile int *refcount)
 }
 
 static inline int
-avro_refcount_dec(volatile int *refcount)
+avro_refcount_dec(volatile long *refcount)
 {
 	if (*refcount != (int) -1) {
 		return (OSAtomicDecrement32(refcount) == 0);
@@ -122,13 +122,13 @@ avro_refcount_dec(volatile int *refcount)
 || defined(__clang__)
 
 static inline void
-avro_refcount_set(volatile int *refcount, int value)
+avro_refcount_set(volatile long *refcount, int value)
 {
 	*refcount = value;
 }
 
 static inline void
-avro_refcount_inc(volatile int *refcount)
+avro_refcount_inc(volatile long *refcount)
 {
 	if (*refcount != (int) -1) {
 		__sync_add_and_fetch(refcount, 1);
@@ -136,7 +136,7 @@ avro_refcount_inc(volatile int *refcount)
 }
 
 static inline int
-avro_refcount_dec(volatile int *refcount)
+avro_refcount_dec(volatile long *refcount)
 {
 	if (*refcount != (int) -1) {
 		return (__sync_sub_and_fetch(refcount, 1) == 0);
@@ -164,13 +164,13 @@ avro_refcount_dec(volatile int *refcount)
 #endif
 
 static inline void
-avro_refcount_set(volatile int *refcount, int value)
+avro_refcount_set(volatile long *refcount, int value)
 {
 	*refcount = value;
 }
 
 static inline void
-avro_refcount_inc(volatile int *refcount)
+avro_refcount_inc(volatile long *refcount)
 {
 	if (*refcount != (int) -1) {
 		__asm__ __volatile__ ("lock ; inc"REFCOUNT_SS" %0"
@@ -180,7 +180,7 @@ avro_refcount_inc(volatile int *refcount)
 }
 
 static inline int
-avro_refcount_dec(volatile int *refcount)
+avro_refcount_dec(volatile long *refcount)
 {
 	if (*refcount != (int) -1) {
 		char result;
@@ -202,7 +202,7 @@ avro_refcount_dec(volatile int *refcount)
 #elif defined(__GNUC__) && defined(__ppc__)
 
 static inline int
-avro_refcount_LL_int(volatile int *ptr)
+avro_refcount_LL_int(volatile long *ptr)
 {
 	int val;
 	__asm__ __volatile__ ("lwarx %[val],0,%[ptr]"
@@ -215,7 +215,7 @@ avro_refcount_LL_int(volatile int *ptr)
 
 /* Returns non-zero if the store was successful, zero otherwise. */
 static inline int
-avro_refcount_SC_int(volatile int *ptr, int val)
+avro_refcount_SC_int(volatile long *ptr, int val)
 {
 	int ret = 1; /* init to non-zero, will be reset to 0 if SC was successful */
 	__asm__ __volatile__ ("stwcx. %[val],0,%[ptr];\n"
@@ -229,13 +229,13 @@ avro_refcount_SC_int(volatile int *ptr, int val)
 }
 
 static inline void
-avro_refcount_set(volatile int *refcount, int value)
+avro_refcount_set(volatile long *refcount, int value)
 {
 	*refcount = value;
 }
 
 static inline void
-avro_refcount_inc(volatile int *refcount)
+avro_refcount_inc(volatile long *refcount)
 {
 	int prev;
 	do {
@@ -247,7 +247,7 @@ avro_refcount_inc(volatile int *refcount)
 }
 
 static inline int
-avro_refcount_dec(volatile int *refcount)
+avro_refcount_dec(volatile long *refcount)
 {
 	int prev;
 	do {
@@ -273,13 +273,13 @@ avro_refcount_dec(volatile int *refcount)
 #endif // __cplusplus
 
 static inline void
-avro_refcount_set(volatile int *refcount, int value)
+avro_refcount_set(volatile long *refcount, int value)
 {
 	*refcount = value;
 }
 
 static inline void
-avro_refcount_inc(volatile int *refcount)
+avro_refcount_inc(volatile long *refcount)
 {
 	if (*refcount != (int) -1) {
 		_InterlockedIncrement((volatile long *) refcount);
@@ -287,7 +287,7 @@ avro_refcount_inc(volatile int *refcount)
 }
 
 static inline int
-avro_refcount_dec(volatile int *refcount)
+avro_refcount_dec(volatile long *refcount)
 {
 	if (*refcount != (int) -1) {
 		return (_InterlockedDecrement((volatile long *) refcount) == 0);

--- a/lang/c/src/generic.c
+++ b/lang/c/src/generic.c
@@ -57,7 +57,7 @@ avro_generic_value_new(avro_value_iface_t *iface, avro_value_t *dest)
 	avro_generic_value_iface_t  *giface =
 	    container_of(iface, avro_generic_value_iface_t, parent);
 	size_t  instance_size = avro_value_instance_size(giface);
-	void  *self = avro_malloc(instance_size + sizeof(volatile int));
+	void  *self = avro_malloc(instance_size + sizeof(volatile long));
 	if (self == NULL) {
 		avro_set_error(strerror(ENOMEM));
 		dest->iface = NULL;
@@ -65,8 +65,8 @@ avro_generic_value_new(avro_value_iface_t *iface, avro_value_t *dest)
 		return ENOMEM;
 	}
 
-	volatile int  *refcount = (volatile int *) self;
-	self = (char *) self + sizeof(volatile int);
+	volatile long  *refcount = (volatile long *) self;
+	self = (char *) self + sizeof(volatile long);
 
 	*refcount = 1;
 	rval = avro_value_init(giface, self);
@@ -90,8 +90,8 @@ avro_generic_value_free(const avro_value_iface_t *iface, void *self)
 		    container_of(iface, avro_generic_value_iface_t, parent);
 		size_t  instance_size = avro_value_instance_size(giface);
 		avro_value_done(giface, self);
-		self = (char *) self - sizeof(volatile int);
-		avro_free(self, instance_size + sizeof(volatile int));
+		self = (char *) self - sizeof(volatile long);
+		avro_free(self, instance_size + sizeof(volatile long));
 	}
 }
 
@@ -102,7 +102,7 @@ avro_generic_value_incref(avro_value_t *value)
 	 * This only works if you pass in the top-level value.
 	 */
 
-	volatile int  *refcount = (volatile int *) ((char *) value->self - sizeof(volatile int));
+	volatile long  *refcount = (volatile long *) ((char *) value->self - sizeof(volatile long));
 	avro_refcount_inc(refcount);
 }
 
@@ -113,7 +113,7 @@ avro_generic_value_decref(avro_value_t *value)
 	 * This only works if you pass in the top-level value.
 	 */
 
-	volatile int  *refcount = (volatile int *) ((char *) value->self - sizeof(volatile int));
+	volatile long  *refcount = (volatile long *) ((char *) value->self - sizeof(volatile long));
 	if (avro_refcount_dec(refcount)) {
 		avro_generic_value_free(value->iface, value->self);
 	}
@@ -147,7 +147,7 @@ struct avro_generic_link_value_iface {
 	avro_generic_value_iface_t  parent;
 
 	/** The reference count for this interface. */
-	volatile int  refcount;
+	volatile long  refcount;
 
 	/** The schema for this interface. */
 	avro_schema_t  schema;
@@ -1910,7 +1910,7 @@ avro_generic_string_new_length(avro_value_t *value, const char *str, size_t size
 
 typedef struct avro_generic_array_value_iface {
 	avro_generic_value_iface_t  parent;
-	volatile int  refcount;
+	volatile long  refcount;
 	avro_schema_t  schema;
 	avro_generic_value_iface_t  *child_giface;
 } avro_generic_array_value_iface_t;
@@ -2162,7 +2162,7 @@ avro_generic_array_class(avro_schema_t schema, memoize_state_t *state)
 
 typedef struct avro_generic_enum_value_iface {
 	avro_generic_value_iface_t  parent;
-	volatile int  refcount;
+	volatile long  refcount;
 	avro_schema_t  schema;
 } avro_generic_enum_value_iface_t;
 
@@ -2335,7 +2335,7 @@ avro_generic_enum_class(avro_schema_t schema)
 
 typedef struct avro_generic_fixed_value_iface {
 	avro_generic_value_iface_t  parent;
-	volatile int  refcount;
+	volatile long  refcount;
 	avro_schema_t  schema;
 	size_t  data_size;
 } avro_generic_fixed_value_iface_t;
@@ -2545,7 +2545,7 @@ avro_generic_fixed_class(avro_schema_t schema)
 
 typedef struct avro_generic_map_value_iface {
 	avro_generic_value_iface_t  parent;
-	volatile int  refcount;
+	volatile long  refcount;
 	avro_schema_t  schema;
 	avro_generic_value_iface_t  *child_giface;
 } avro_generic_map_value_iface_t;
@@ -2833,7 +2833,7 @@ avro_generic_map_class(avro_schema_t schema, memoize_state_t *state)
 
 typedef struct avro_generic_record_value_iface {
 	avro_generic_value_iface_t  parent;
-	volatile int  refcount;
+	volatile long  refcount;
 	avro_schema_t  schema;
 
 	/** The total size of each value struct for this record. */
@@ -3209,7 +3209,7 @@ error:
 
 typedef struct avro_generic_union_value_iface {
 	avro_generic_value_iface_t  parent;
-	volatile int  refcount;
+	volatile long  refcount;
 	avro_schema_t  schema;
 
 	/** The total size of each value struct for this union. */

--- a/lang/c/src/generic.c
+++ b/lang/c/src/generic.c
@@ -3192,11 +3192,11 @@ error:
  * union
  */
 
-#ifndef DEBUG_BRANCHES_OFFSETS
-#define DEBUG_BRANCHES_OFFSETS 0
+#ifndef DEBUG_BRANCHES
+#define DEBUG_BRANCHES 0
 #endif
 
-#if DEBUG_BRANCHES_OFFSETS
+#if DEBUG_BRANCHES
 #include <stdio.h>
 #endif
 

--- a/lang/c/src/io.c
+++ b/lang/c/src/io.c
@@ -34,12 +34,12 @@ typedef enum avro_io_type_t avro_io_type_t;
 
 struct avro_reader_t_ {
 	avro_io_type_t type;
-	volatile int  refcount;
+	volatile long  refcount;
 };
 
 struct avro_writer_t_ {
 	avro_io_type_t type;
-	volatile int  refcount;
+	volatile long  refcount;
 };
 
 struct _avro_reader_file_t {

--- a/lang/c/src/resolved-reader.c
+++ b/lang/c/src/resolved-reader.c
@@ -52,7 +52,7 @@ struct avro_resolved_reader {
 	avro_value_iface_t  parent;
 
 	/** The reference count for this interface. */
-	volatile int  refcount;
+	volatile long  refcount;
 
 	/** The writer schema. */
 	avro_schema_t  wschema;
@@ -136,20 +136,20 @@ avro_resolved_reader_new_value(avro_value_iface_t *viface,
 	int  rval;
 	avro_resolved_reader_t  *iface =
 	    container_of(viface, avro_resolved_reader_t, parent);
-	void  *self = avro_malloc(iface->instance_size + sizeof(volatile int));
+	void  *self = avro_malloc(iface->instance_size + sizeof(volatile long));
 	if (self == NULL) {
 		value->iface = NULL;
 		value->self = NULL;
 		return ENOMEM;
 	}
 
-	memset(self, 0, iface->instance_size + sizeof(volatile int));
-	volatile int  *refcount = (volatile int *) self;
-	self = (char *) self + sizeof(volatile int);
+	memset(self, 0, iface->instance_size + sizeof(volatile long));
+	volatile long  *refcount = (volatile long *) self;
+	self = (char *) self + sizeof(volatile long);
 
 	rval = avro_resolved_reader_init(iface, self);
 	if (rval != 0) {
-		avro_free(self, iface->instance_size + sizeof(volatile int));
+		avro_free(self, iface->instance_size + sizeof(volatile long));
 		value->iface = NULL;
 		value->self = NULL;
 		return rval;
@@ -173,8 +173,8 @@ avro_resolved_reader_free_value(const avro_value_iface_t *viface, void *vself)
 		avro_value_decref(self);
 	}
 
-	vself = (char *) vself - sizeof(volatile int);
-	avro_free(vself, iface->instance_size + sizeof(volatile int));
+	vself = (char *) vself - sizeof(volatile long);
+	avro_free(vself, iface->instance_size + sizeof(volatile long));
 }
 
 static void
@@ -184,7 +184,7 @@ avro_resolved_reader_incref(avro_value_t *value)
 	 * This only works if you pass in the top-level value.
 	 */
 
-	volatile int  *refcount = (volatile int *) ((char *) value->self - sizeof(volatile int));
+	volatile long  *refcount = (volatile long *) ((char *) value->self - sizeof(volatile long));
 	avro_refcount_inc(refcount);
 }
 
@@ -195,7 +195,7 @@ avro_resolved_reader_decref(avro_value_t *value)
 	 * This only works if you pass in the top-level value.
 	 */
 
-	volatile int  *refcount = (volatile int *) ((char *) value->self - sizeof(volatile int));
+	volatile long  *refcount = (volatile long *) ((char *) value->self - sizeof(volatile long));
 	if (avro_refcount_dec(refcount)) {
 		avro_resolved_reader_free_value(value->iface, value->self);
 	}

--- a/lang/c/src/resolved-writer.c
+++ b/lang/c/src/resolved-writer.c
@@ -52,7 +52,7 @@ struct avro_resolved_writer {
 	avro_value_iface_t  parent;
 
 	/** The reference count for this interface. */
-	volatile int  refcount;
+	volatile long  refcount;
 
 	/** The writer schema. */
 	avro_schema_t  wschema;
@@ -141,20 +141,20 @@ avro_resolved_writer_new_value(avro_value_iface_t *viface,
 	int  rval;
 	avro_resolved_writer_t  *iface =
 	    container_of(viface, avro_resolved_writer_t, parent);
-	void  *self = avro_malloc(iface->instance_size + sizeof(volatile int));
+	void  *self = avro_malloc(iface->instance_size + sizeof(volatile long));
 	if (self == NULL) {
 		value->iface = NULL;
 		value->self = NULL;
 		return ENOMEM;
 	}
 
-	memset(self, 0, iface->instance_size + sizeof(volatile int));
-	volatile int  *refcount = (volatile int *) self;
-	self = (char *) self + sizeof(volatile int);
+	memset(self, 0, iface->instance_size + sizeof(volatile long));
+	volatile long  *refcount = (volatile long *) self;
+	self = (char *) self + sizeof(volatile long);
 
 	rval = avro_resolved_writer_init(iface, self);
 	if (rval != 0) {
-		avro_free(self, iface->instance_size + sizeof(volatile int));
+		avro_free(self, iface->instance_size + sizeof(volatile long));
 		value->iface = NULL;
 		value->self = NULL;
 		return rval;
@@ -178,8 +178,8 @@ avro_resolved_writer_free_value(const avro_value_iface_t *viface, void *vself)
 		avro_value_decref(self);
 	}
 
-	vself = (char *) vself - sizeof(volatile int);
-	avro_free(vself, iface->instance_size + sizeof(volatile int));
+	vself = (char *) vself - sizeof(volatile long);
+	avro_free(vself, iface->instance_size + sizeof(volatile long));
 }
 
 static void
@@ -189,7 +189,7 @@ avro_resolved_writer_incref(avro_value_t *value)
 	 * This only works if you pass in the top-level value.
 	 */
 
-	volatile int  *refcount = (volatile int *) ((char *) value->self - sizeof(volatile int));
+	volatile long  *refcount = (volatile long *) ((char *) value->self - sizeof(volatile long));
 	avro_refcount_inc(refcount);
 }
 
@@ -200,7 +200,7 @@ avro_resolved_writer_decref(avro_value_t *value)
 	 * This only works if you pass in the top-level value.
 	 */
 
-	volatile int  *refcount = (volatile int *) ((char *) value->self - sizeof(volatile int));
+	volatile long  *refcount = (volatile long *) ((char *) value->self - sizeof(volatile long));
 	if (avro_refcount_dec(refcount)) {
 		avro_resolved_writer_free_value(value->iface, value->self);
 	}

--- a/lang/c/src/wrapped-buffer.c
+++ b/lang/c/src/wrapped-buffer.c
@@ -25,7 +25,7 @@
 #include "avro/refcount.h"
 
 struct avro_wrapped_copy {
-	volatile int  refcount;
+	volatile long  refcount;
 	size_t  allocated_size;
 };
 


### PR DESCRIPTION
This fixes some unaligned memory access issues, which cause an immediate crash with SIGBUS on certain architectures (e.g. sparcv9, as the Jira ticket indicates), as well as performance degredation in most others. This effectively fixes two issues with the existing code:
- The refcount was kept in a (32-bit) `int`, and then access to the data is shifted by 32-bits as well; the commit included changes this to a `long`, which is equal to `sizeof(void *)` on all Unices (and e.g. 32-bit on x86, but 64-bit on x86_64 and sparcv9).
- Record fields are accessed using an offset (`field_offset`), which was set to the previous field's size. If the previous field was e.g. an `int` (i.e. int32_t), or a boolean (int) etc., then access past it would be unaligned (i.e. `int` followed by a `long` => `int` at offset 0, `long` at offset 4). This commit rounds up the "field size" to a multiple of pointer size. In C terms, Avro kept records in memory as a packed structure, while this commit modifies this to add paddings so that fields always start on the right boundary.

This has been tested (built & ran tests, including memcheck/Valgrind) on both x86_64 (amd64) and sparcv9 (sparc64) on Linux/GCC. I have unfortunately not tested it with any real world code, or benchmarked the performance benefits on popular 64-bit architectures (like x86_64 or aarch64).

### Jira

- [x] My PR addresses [AVRO-1846](https://issues.apache.org/jira/browse/AVRO-1846)

### Tests

- [x] My PR does not need testing for this extremely good reason: all code covered by existing tests

### Commits

- [x] My commits all reference Jira issues in their subject lines, with the exception the first one, which is a tiny define rename not associated with any issue.