### PR TITLE
AVRO-3049: Add checks to BinaryDecoder for bytes length

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/io/BinaryDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/BinaryDecoder.java
@@ -91,6 +91,7 @@ public class BinaryDecoder extends Decoder {
 
   /** protected constructor for child classes */
   protected BinaryDecoder() {
+    super();
     String o = System.getProperty(MAX_BYTES_LENGTH_PROPERTY);
     int i = Integer.MAX_VALUE;
     if (o != null) {

--- a/lang/java/avro/src/main/java/org/apache/avro/io/BinaryDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/BinaryDecoder.java
@@ -307,6 +307,9 @@ public class BinaryDecoder extends Decoder {
   @Override
   public ByteBuffer readBytes(ByteBuffer old) throws IOException {
     int length = readInt();
+    if (length < 0L) {
+      throw new AvroRuntimeException("Malformed data. Length is negative: " + length);
+    }
     final ByteBuffer result;
     if (old != null && length <= old.capacity()) {
       result = old;

--- a/lang/java/avro/src/main/java/org/apache/avro/io/BinaryDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/BinaryDecoder.java
@@ -48,7 +48,7 @@ public class BinaryDecoder extends Decoder {
    * an array. Attempts to allocate larger arrays may result in OutOfMemoryError:
    * Requested array size exceeds VM limit
    */
-  private static final long MAX_ARRAY_SIZE = (long) Integer.MAX_VALUE - 8L;
+  static final long MAX_ARRAY_SIZE = (long) Integer.MAX_VALUE - 8L;
 
   private ByteSource source = null;
   // we keep the buffer and its state variables in this class and not in a
@@ -307,6 +307,9 @@ public class BinaryDecoder extends Decoder {
   @Override
   public ByteBuffer readBytes(ByteBuffer old) throws IOException {
     int length = readInt();
+    if (length > MAX_ARRAY_SIZE) {
+      throw new UnsupportedOperationException("Cannot read strings longer than " + MAX_ARRAY_SIZE + " bytes");
+    }
     if (length < 0L) {
       throw new AvroRuntimeException("Malformed data. Length is negative: " + length);
     }

--- a/lang/java/avro/src/main/java/org/apache/avro/io/BinaryDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/BinaryDecoder.java
@@ -308,7 +308,7 @@ public class BinaryDecoder extends Decoder {
   public ByteBuffer readBytes(ByteBuffer old) throws IOException {
     int length = readInt();
     if (length > MAX_ARRAY_SIZE) {
-      throw new UnsupportedOperationException("Cannot read strings longer than " + MAX_ARRAY_SIZE + " bytes");
+      throw new UnsupportedOperationException("Cannot read arrays longer than " + MAX_ARRAY_SIZE + " bytes");
     }
     if (length < 0L) {
       throw new AvroRuntimeException("Malformed data. Length is negative: " + length);

--- a/lang/java/avro/src/main/java/org/apache/avro/io/BinaryDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/BinaryDecoder.java
@@ -38,6 +38,13 @@ import org.slf4j.LoggerFactory;
  * required to serve its read methods. The number of unused bytes in the buffer
  * can be accessed by inputStream().remaining(), if the BinaryDecoder is not
  * 'direct'.
+ * <p/>
+ * To prevent this class from making large allocations when handling potentially
+ * pathological input data, set Java properties
+ * <tt>org.apache.avro.limits.string.maxLength</tt> and
+ * <tt>org.apache.avro.limits.bytes.maxLength</tt> before instantiating this
+ * class to limit the maximum sizes of <tt>string</tt> and <tt>bytes</tt> types
+ * handled. The default is to permit sizes up to Java's maximum array length.
  *
  * @see Encoder
  */

--- a/lang/java/avro/src/main/java/org/apache/avro/io/BinaryDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/BinaryDecoder.java
@@ -97,7 +97,8 @@ public class BinaryDecoder extends Decoder {
       try {
         i = Integer.parseUnsignedInt(o);
       } catch (NumberFormatException nfe) {
-        LoggerFactory.getLogger(BinaryDecoder.class).warn("Could not parse property " + MAX_BYTES_LENGTH_PROPERTY + ": " + o, nfe);
+        LoggerFactory.getLogger(BinaryDecoder.class)
+            .warn("Could not parse property " + MAX_BYTES_LENGTH_PROPERTY + ": " + o, nfe);
       }
     }
     maxBytesLength = i;

--- a/lang/java/avro/src/test/java/org/apache/avro/io/TestBinaryDecoder.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/io/TestBinaryDecoder.java
@@ -352,6 +352,20 @@ public class TestBinaryDecoder {
   }
 
   @Test
+  public void testHugeStringLengthEncoding() throws IOException {
+    byte[] bad = new byte[10];
+    BinaryData.encodeLong(BinaryDecoder.MAX_ARRAY_SIZE + 1, bad, 0);
+    Decoder bd = factory.binaryDecoder(bad, null);
+    String message = "";
+    try {
+      bd.readString();
+    } catch (UnsupportedOperationException e) {
+      message = e.getMessage();
+    }
+    Assert.assertEquals("Cannot read strings longer than " + BinaryDecoder.MAX_ARRAY_SIZE + " bytes", message);
+  }
+
+  @Test
   public void testNegativeBytesLengthEncoding() throws IOException {
     byte[] bad = new byte[] { (byte) 1 };
     Decoder bd = factory.binaryDecoder(bad, null);
@@ -362,6 +376,20 @@ public class TestBinaryDecoder {
       message = e.getMessage();
     }
     Assert.assertEquals("Malformed data. Length is negative: -1", message);
+  }
+
+  @Test
+  public void testHugeBytesLengthEncoding() throws IOException {
+    byte[] bad = new byte[10];
+    BinaryData.encodeLong(BinaryDecoder.MAX_ARRAY_SIZE + 1, bad, 0);
+    Decoder bd = factory.binaryDecoder(bad, null);
+    String message = "";
+    try {
+      bd.readBytes(null);
+    } catch (UnsupportedOperationException e) {
+      message = e.getMessage();
+    }
+    Assert.assertEquals("Cannot read strings longer than " + BinaryDecoder.MAX_ARRAY_SIZE + " bytes", message);
   }
 
   @Test(expected = UnsupportedOperationException.class)

--- a/lang/java/avro/src/test/java/org/apache/avro/io/TestBinaryDecoder.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/io/TestBinaryDecoder.java
@@ -339,12 +339,25 @@ public class TestBinaryDecoder {
   }
 
   @Test
-  public void testNegativeLengthEncoding() throws IOException {
+  public void testNegativeStringLengthEncoding() throws IOException {
     byte[] bad = new byte[] { (byte) 1 };
     Decoder bd = factory.binaryDecoder(bad, null);
     String message = "";
     try {
       bd.readString();
+    } catch (AvroRuntimeException e) {
+      message = e.getMessage();
+    }
+    Assert.assertEquals("Malformed data. Length is negative: -1", message);
+  }
+
+  @Test
+  public void testNegativeBytesLengthEncoding() throws IOException {
+    byte[] bad = new byte[] { (byte) 1 };
+    Decoder bd = factory.binaryDecoder(bad, null);
+    String message = "";
+    try {
+      bd.readBytes(null);
     } catch (AvroRuntimeException e) {
       message = e.getMessage();
     }

--- a/lang/java/avro/src/test/java/org/apache/avro/io/TestBinaryDecoder.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/io/TestBinaryDecoder.java
@@ -339,7 +339,7 @@ public class TestBinaryDecoder {
   }
 
   @Test
-  public void testNegativeStringLengthEncoding() throws IOException {
+  public void testNegativeStringLength() throws IOException {
     byte[] bad = new byte[] { (byte) 1 };
     Decoder bd = factory.binaryDecoder(bad, null);
     String message = "";
@@ -352,7 +352,7 @@ public class TestBinaryDecoder {
   }
 
   @Test
-  public void testHugeStringLengthEncoding() throws IOException {
+  public void testStringMaxArraySize() throws IOException {
     byte[] bad = new byte[10];
     BinaryData.encodeLong(BinaryDecoder.MAX_ARRAY_SIZE + 1, bad, 0);
     Decoder bd = factory.binaryDecoder(bad, null);
@@ -366,7 +366,7 @@ public class TestBinaryDecoder {
   }
 
   @Test
-  public void testNegativeBytesLengthEncoding() throws IOException {
+  public void testNegativeBytesLength() throws IOException {
     byte[] bad = new byte[] { (byte) 1 };
     Decoder bd = factory.binaryDecoder(bad, null);
     String message = "";
@@ -379,7 +379,7 @@ public class TestBinaryDecoder {
   }
 
   @Test
-  public void testHugeBytesLengthEncoding() throws IOException {
+  public void testBytesMaxArraySize() throws IOException {
     byte[] bad = new byte[10];
     BinaryData.encodeLong(BinaryDecoder.MAX_ARRAY_SIZE + 1, bad, 0);
     Decoder bd = factory.binaryDecoder(bad, null);

--- a/lang/java/avro/src/test/java/org/apache/avro/io/TestBinaryDecoder.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/io/TestBinaryDecoder.java
@@ -343,9 +343,7 @@ public class TestBinaryDecoder {
     byte[] bad = new byte[] { (byte) 1 };
     Decoder bd = factory.binaryDecoder(bad, null);
 
-    Assert.assertThrows("Malformed data. Length is negative: -1",
-                        AvroRuntimeException.class,
-                        bd::readString);
+    Assert.assertThrows("Malformed data. Length is negative: -1", AvroRuntimeException.class, bd::readString);
   }
 
   @Test
@@ -355,8 +353,7 @@ public class TestBinaryDecoder {
     Decoder bd = factory.binaryDecoder(bad, null);
 
     Assert.assertThrows("Cannot read strings longer than " + BinaryDecoder.MAX_ARRAY_SIZE + " bytes",
-                        UnsupportedOperationException.class,
-                        bd::readString);
+        UnsupportedOperationException.class, bd::readString);
   }
 
   @Test
@@ -364,9 +361,7 @@ public class TestBinaryDecoder {
     byte[] bad = new byte[] { (byte) 1 };
     Decoder bd = factory.binaryDecoder(bad, null);
 
-    Assert.assertThrows("Malformed data. Length is negative: -1",
-                        AvroRuntimeException.class,
-                        () -> bd.readBytes(null));
+    Assert.assertThrows("Malformed data. Length is negative: -1", AvroRuntimeException.class, () -> bd.readBytes(null));
   }
 
   @Test
@@ -376,8 +371,7 @@ public class TestBinaryDecoder {
     Decoder bd = factory.binaryDecoder(bad, null);
 
     Assert.assertThrows("Cannot read arrays longer than " + BinaryDecoder.MAX_ARRAY_SIZE + " bytes",
-                        UnsupportedOperationException.class,
-                        () -> bd.readBytes(null));
+        UnsupportedOperationException.class, () -> bd.readBytes(null));
   }
 
   @Test
@@ -389,9 +383,8 @@ public class TestBinaryDecoder {
       System.setProperty("org.apache.avro.limits.bytes.maxLength", Long.toString(maxLength));
       Decoder bd = factory.binaryDecoder(bad, null);
 
-      Assert.assertThrows("Bytes length " + (maxLength + 1) + " exceeds maximum allowed",
-                          AvroRuntimeException.class,
-                          () -> bd.readBytes(null));
+      Assert.assertThrows("Bytes length " + (maxLength + 1) + " exceeds maximum allowed", AvroRuntimeException.class,
+          () -> bd.readBytes(null));
     } finally {
       System.clearProperty("org.apache.avro.limits.bytes.maxLength");
     }

--- a/lang/java/avro/src/test/java/org/apache/avro/io/TestBinaryDecoder.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/io/TestBinaryDecoder.java
@@ -342,13 +342,10 @@ public class TestBinaryDecoder {
   public void testNegativeStringLength() throws IOException {
     byte[] bad = new byte[] { (byte) 1 };
     Decoder bd = factory.binaryDecoder(bad, null);
-    String message = "";
-    try {
-      bd.readString();
-    } catch (AvroRuntimeException e) {
-      message = e.getMessage();
-    }
-    Assert.assertEquals("Malformed data. Length is negative: -1", message);
+
+    Assert.assertThrows("Malformed data. Length is negative: -1",
+                        AvroRuntimeException.class,
+                        bd::readString);
   }
 
   @Test
@@ -356,26 +353,20 @@ public class TestBinaryDecoder {
     byte[] bad = new byte[10];
     BinaryData.encodeLong(BinaryDecoder.MAX_ARRAY_SIZE + 1, bad, 0);
     Decoder bd = factory.binaryDecoder(bad, null);
-    String message = "";
-    try {
-      bd.readString();
-    } catch (UnsupportedOperationException e) {
-      message = e.getMessage();
-    }
-    Assert.assertEquals("Cannot read strings longer than " + BinaryDecoder.MAX_ARRAY_SIZE + " bytes", message);
+
+    Assert.assertThrows("Cannot read strings longer than " + BinaryDecoder.MAX_ARRAY_SIZE + " bytes",
+                        UnsupportedOperationException.class,
+                        bd::readString);
   }
 
   @Test
   public void testNegativeBytesLength() throws IOException {
     byte[] bad = new byte[] { (byte) 1 };
     Decoder bd = factory.binaryDecoder(bad, null);
-    String message = "";
-    try {
-      bd.readBytes(null);
-    } catch (AvroRuntimeException e) {
-      message = e.getMessage();
-    }
-    Assert.assertEquals("Malformed data. Length is negative: -1", message);
+
+    Assert.assertThrows("Malformed data. Length is negative: -1",
+                        AvroRuntimeException.class,
+                        () -> bd.readBytes(null));
   }
 
   @Test
@@ -383,13 +374,10 @@ public class TestBinaryDecoder {
     byte[] bad = new byte[10];
     BinaryData.encodeLong(BinaryDecoder.MAX_ARRAY_SIZE + 1, bad, 0);
     Decoder bd = factory.binaryDecoder(bad, null);
-    String message = "";
-    try {
-      bd.readBytes(null);
-    } catch (UnsupportedOperationException e) {
-      message = e.getMessage();
-    }
-    Assert.assertEquals("Cannot read strings longer than " + BinaryDecoder.MAX_ARRAY_SIZE + " bytes", message);
+
+    Assert.assertThrows("Cannot read arrays longer than " + BinaryDecoder.MAX_ARRAY_SIZE + " bytes",
+                        UnsupportedOperationException.class,
+                        () -> bd.readBytes(null));
   }
 
   @Test(expected = UnsupportedOperationException.class)

--- a/lang/java/avro/src/test/java/org/apache/avro/io/TestBinaryDecoder.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/io/TestBinaryDecoder.java
@@ -380,6 +380,23 @@ public class TestBinaryDecoder {
                         () -> bd.readBytes(null));
   }
 
+  @Test
+  public void testBytesMaxLengthProperty() throws IOException {
+    int maxLength = 128;
+    byte[] bad = new byte[10];
+    BinaryData.encodeLong(maxLength + 1, bad, 0);
+    try {
+      System.setProperty("org.apache.avro.limits.bytes.maxLength", Long.toString(maxLength));
+      Decoder bd = factory.binaryDecoder(bad, null);
+
+      Assert.assertThrows("Bytes length " + (maxLength + 1) + " exceeds maximum allowed",
+                          AvroRuntimeException.class,
+                          () -> bd.readBytes(null));
+    } finally {
+      System.clearProperty("org.apache.avro.limits.bytes.maxLength");
+    }
+  }
+
   @Test(expected = UnsupportedOperationException.class)
   public void testLongLengthEncoding() throws IOException {
     // Size equivalent to Integer.MAX_VALUE + 1


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3049
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

testStringMaxArraySize
testNegativeBytesLength
testBytesMaxArraySize
testBytesMaxLengthProperty

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
