### PR TITLE
AVRO-3057: Bump zstd-jni from 1.4.8-6 to 1.4.8-7 in /lang/java

### DIFF
--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -58,7 +58,7 @@
     <easymock.version>4.2</easymock.version>
     <hamcrest.version>2.2</hamcrest.version>
     <grpc.version>1.36.0</grpc.version>
-    <zstd-jni.version>1.4.8-6</zstd-jni.version>
+    <zstd-jni.version>1.4.8-7</zstd-jni.version>
     <!-- version properties for plugins -->
     <archetype-plugin.version>3.2.0</archetype-plugin.version>
     <bundle-plugin-version>4.1.0</bundle-plugin-version>


### PR DESCRIPTION
R: @RyanSkraba 