### PR TITLE
AVRO-3072: Use ZSTD NoFinalizer classes and bump to 1.4.9-1

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/file/ZstandardLoader.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/file/ZstandardLoader.java
@@ -25,8 +25,8 @@ import com.github.luben.zstd.BufferPool;
 import com.github.luben.zstd.NoPool;
 import com.github.luben.zstd.RecyclingBufferPool;
 import com.github.luben.zstd.Zstd;
-import com.github.luben.zstd.ZstdInputStream;
-import com.github.luben.zstd.ZstdOutputStream;
+import com.github.luben.zstd.ZstdInputStreamNoFinalizer;
+import com.github.luben.zstd.ZstdOutputStreamNoFinalizer;
 
 /* causes lazier classloader initialization of ZStandard libraries, so that
  * we get NoClassDefFoundError when we try and use the Codec's compress
@@ -35,14 +35,14 @@ final class ZstandardLoader {
 
   static InputStream input(InputStream compressed, boolean useBufferPool) throws IOException {
     BufferPool pool = useBufferPool ? RecyclingBufferPool.INSTANCE : NoPool.INSTANCE;
-    return new ZstdInputStream(compressed, pool);
+    return new ZstdInputStreamNoFinalizer(compressed, pool);
   }
 
   static OutputStream output(OutputStream compressed, int level, boolean checksum, boolean useBufferPool)
       throws IOException {
     int bounded = Math.max(Math.min(level, Zstd.maxCompressionLevel()), Zstd.minCompressionLevel());
     BufferPool pool = useBufferPool ? RecyclingBufferPool.INSTANCE : NoPool.INSTANCE;
-    ZstdOutputStream zstdOutputStream = new ZstdOutputStream(compressed, pool).setLevel(bounded);
+    ZstdOutputStreamNoFinalizer zstdOutputStream = new ZstdOutputStreamNoFinalizer(compressed, pool).setLevel(bounded);
     zstdOutputStream.setCloseFrameOnFlush(false);
     zstdOutputStream.setChecksum(checksum);
     return zstdOutputStream;

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -58,7 +58,7 @@
     <easymock.version>4.2</easymock.version>
     <hamcrest.version>2.2</hamcrest.version>
     <grpc.version>1.36.0</grpc.version>
-    <zstd-jni.version>1.4.8-7</zstd-jni.version>
+    <zstd-jni.version>1.4.9-1</zstd-jni.version>
     <!-- version properties for plugins -->
     <archetype-plugin.version>3.2.0</archetype-plugin.version>
     <bundle-plugin-version>4.1.0</bundle-plugin-version>


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

ZSTD JNI library recommends to use these *NoFinalizer classes if we don't depend on Java finalizers. Apache Avro doesn't depend on the finalizer behavior because we close explicitly with `try with resource` statement. The following is a benchmark at Apache Spark usage.
- https://github.com/apache/spark/pull/31762 ([SPARK-34647][CORE] Use ZSTD JNI NoFinalizer classes and bump to 1.4.8-7)

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3072
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
This should pass all the existing test coverage.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
