### PR TITLE
AVRO-3082: Improve interop test traceability for C# and Perl on CI

### DIFF
--- a/lang/csharp/build.sh
+++ b/lang/csharp/build.sh
@@ -74,7 +74,7 @@ do
       ;;
 
     interop-data-test)
-      LANG=en_US.UTF-8 dotnet test --filter "TestCategory=Interop"
+      LANG=en_US.UTF-8 dotnet test --filter "TestCategory=Interop" --verbosity normal
       ;;
 
     clean)

--- a/lang/csharp/src/apache/test/Interop/InteropDataTests.cs
+++ b/lang/csharp/src/apache/test/Interop/InteropDataTests.cs
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+using System;
 using System.IO;
 using NUnit.Framework;
 using Avro.File;
@@ -40,6 +41,7 @@ namespace Avro.Test.Interop
                 var codec = Path.GetFileNameWithoutExtension(avroFile).Split('_');
                 if (1 < codec.Length && !InteropDataConstants.SupportedCodecNames.Contains(codec[1]))
                 {
+                    Console.WriteLine($"Skipped: {avroFile}");
                     continue;
                 }
 
@@ -53,6 +55,8 @@ namespace Avro.Test.Interop
                     }
                     Assert.AreNotEqual(0, i);
                 }
+
+                Console.WriteLine($"Succeeded: {avroFile}");
             }
         }
     }

--- a/lang/perl/xt/interop.t
+++ b/lang/perl/xt/interop.t
@@ -30,11 +30,14 @@ for my $path (glob '../../build/interop/data/*.avro') {
     my $idx = rindex $fn, '_';
     if (-1 < $idx) {
         my $codec = substr $fn, $idx + 1;
-        next unless $Avro::DataFile::ValidCodec{$codec};
+        unless ($Avro::DataFile::ValidCodec{$codec}) {
+            diag("Skipped: ${path}");
+            next;
+        }
     }
     my $fh = IO::File->new($path);
     Avro::DataFileReader->new(fh => $fh);
-    note("Succeeded to read ${path}");
+    diag("Succeeded: ${path}");
 }
 
 done_testing;


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3082
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

I ran the "Test C#" and "Test Perl" workflows in my GitHub repository and confirmed that information about checked/skipped files was displayed.

![Screenshot from 2021-03-18 18-33-39](https://user-images.githubusercontent.com/898388/111606989-29b2a480-881b-11eb-9e1c-84ed24b1b853.jpg)

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
