### PR TITLE
AVRO-3084: Fix JavaScript interop test to read files generated by other languages on CI

### DIFF
--- a/.github/workflows/test-lang-js.yml
+++ b/.github/workflows/test-lang-js.yml
@@ -81,25 +81,27 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - name: Cache Local Maven Repository
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+      - name: Setup Python for Generating Input Data
+        uses: actions/setup-python@v2
 
-      - name: Install Java Avro for Interop Test
-        working-directory: .
-        run: mvn -B install -DskipTests
+      - name: Apt Install Compression Libs Required by Python
+        run: |
+          sudo apt-get install -qqy --no-install-recommends libbz2-dev \
+                                                            liblzma-dev \
+                                                            libsnappy-dev \
+                                                            libzstd-dev
+      - name: Install Python Dependencies
+        run: |
+          python3 -m pip install --upgrade pip setuptools tox-wheel
+          python3 -m pip install python-snappy zstandard
 
       - name: Create Interop Data Directory
         working-directory: .
         run: mkdir -p build/interop/data
 
-      - name: Generate Interop Resources
-        working-directory: lang/java/avro
-        run: mvn -B -P interop-data-generate generate-resources
+      - name: Generate Interop Data using Python
+        working-directory: lang/py
+        run: ./build.sh interop-data-generate
 
       - name: Generate Interop Data
         run: ./build.sh interop-data-generate


### PR DESCRIPTION

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3084
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

I ran the "Test JavaScript" workflow in my GitHub repository and confirmed that py.avro and py_deflate.avro were successfully generated and checked.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
