### PR TITLE
AVRO-3085: Fix PHP interop test on CI to suppress unnecessary warnings

### DIFF
--- a/lang/php/test/InterOpTest.php
+++ b/lang/php/test/InterOpTest.php
@@ -45,20 +45,24 @@ class InterOpTest extends TestCase
         }
 
         while ($file = readdir($dh)) {
-            if (0 < preg_match('/^[a-z]+(_deflate|_snappy|_zstandard|_bzip2)?\.avro$/', $file)) {
+            if (preg_match('/^[a-z]+(_deflate|_snappy|_zstandard|_bzip2)?\.avro$/', $file)) {
                 $data_files [] = implode(DIRECTORY_SEPARATOR, array($data_dir, $file));
+            } else if (preg_match('/[^.]/', $file)) {
+                echo "Skipped: $data_dir/$file", PHP_EOL;
             }
         }
         closedir($dh);
 
         $ary = array();
         foreach ($data_files as $df) {
+            echo "Reading: $df", PHP_EOL;
             $ary [] = array($df);
         }
         return $ary;
     }
 
     /**
+     * @coversNothing
      * @dataProvider file_name_provider
      */
     public function test_read($file_name)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3085
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

I ran the "Test PHP" workflow in my GitHub repository and confirmed the warning messages in question were suppressed and the checked/skipped file paths were displayed.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
