### PR TITLE
AVRO-3065: Introduce UUID logical type to Python implementation

### DIFF
--- a/lang/py/avro/constants.py
+++ b/lang/py/avro/constants.py
@@ -28,6 +28,7 @@ TIMESTAMP_MICROS = "timestamp-micros"
 TIMESTAMP_MILLIS = "timestamp-millis"
 TIME_MICROS = "time-micros"
 TIME_MILLIS = "time-millis"
+UUID = "uuid"
 
 SUPPORTED_LOGICAL_TYPE = [
     DATE,
@@ -35,5 +36,6 @@ SUPPORTED_LOGICAL_TYPE = [
     TIMESTAMP_MICROS,
     TIMESTAMP_MILLIS,
     TIME_MICROS,
-    TIME_MILLIS
+    TIME_MILLIS,
+    UUID
 ]

--- a/lang/py/avro/schema.py
+++ b/lang/py/avro/schema.py
@@ -47,6 +47,7 @@ import json
 import math
 import re
 import sys
+import uuid
 import warnings
 
 import avro.constants
@@ -1069,6 +1070,33 @@ class TimestampMicrosSchema(LogicalSchema, PrimitiveSchema):
     def __eq__(self, that):
         return self.props == that.props
 
+
+#
+# uuid Type
+#
+
+
+class UUIDSchema(LogicalSchema, PrimitiveSchema):
+    def __init__(self, other_props=None):
+        LogicalSchema.__init__(self, avro.constants.UUID)
+        PrimitiveSchema.__init__(self, 'string', other_props)
+
+    def to_json(self, names=None):
+        return self.props
+
+    def validate(self, datum):
+        try:
+            val = uuid.UUID(datum, version=4)
+        except ValueError:
+            # If it's a value error, then the string 
+            # is not a valid hex code for a UUID.
+            return False
+
+        return self
+
+    def __eq__(self, that):
+        return self.props == that.props
+
 #
 # Module Methods
 #
@@ -1099,6 +1127,7 @@ def make_logical_schema(logical_type, type_, other_props):
         (avro.constants.TIMESTAMP_MILLIS, 'long'): TimestampMillisSchema,
         (avro.constants.TIME_MICROS, 'long'): TimeMicrosSchema,
         (avro.constants.TIME_MILLIS, 'int'): TimeMillisSchema,
+        (avro.constants.UUID, 'string'): UUIDSchema,
     }
     try:
         schema_type = logical_types.get((logical_type, type_), None)

--- a/lang/py/avro/schema.py
+++ b/lang/py/avro/schema.py
@@ -1086,11 +1086,11 @@ class UUIDSchema(LogicalSchema, PrimitiveSchema):
 
     def validate(self, datum):
         try:
-            val = uuid.UUID(datum, version=4)
+            val = uuid.UUID(datum)
         except ValueError:
             # If it's a value error, then the string
             # is not a valid hex code for a UUID.
-            return False
+            return None
 
         return self
 

--- a/lang/py/avro/schema.py
+++ b/lang/py/avro/schema.py
@@ -1088,7 +1088,7 @@ class UUIDSchema(LogicalSchema, PrimitiveSchema):
         try:
             val = uuid.UUID(datum, version=4)
         except ValueError:
-            # If it's a value error, then the string 
+            # If it's a value error, then the string
             # is not a valid hex code for a UUID.
             return False
 

--- a/lang/py/avro/test/test_io.py
+++ b/lang/py/avro/test/test_io.py
@@ -80,7 +80,8 @@ SCHEMAS_TO_VALIDATE = (
         '{"type": "long", "logicalType": "timestamp-micros"}',
         datetime.datetime(2000, 1, 18, 2, 2, 1, 123499, tzinfo=avro.timezones.tst)
     ),
-    ('{"type": "string", "logicalType": "uuid"}', u'570feebe-2bbc-4937-98df-285944e1dbbd'),
+    ('{"type": "string", "logicalType": "uuid"}', u'a4818e1c-8e59-11eb-8dcd-0242ac130003'),  # UUID1
+    ('{"type": "string", "logicalType": "uuid"}', u'570feebe-2bbc-4937-98df-285944e1dbbd'),  # UUID4
     ('{"type": "string", "logicalType": "unknown-logical-type"}', u'12345abcd'),
     ('{"type": "string", "logicalType": "timestamp-millis"}', u'12345abcd'),
     ("""\

--- a/lang/py/avro/test/test_io.py
+++ b/lang/py/avro/test/test_io.py
@@ -80,7 +80,7 @@ SCHEMAS_TO_VALIDATE = (
         '{"type": "long", "logicalType": "timestamp-micros"}',
         datetime.datetime(2000, 1, 18, 2, 2, 1, 123499, tzinfo=avro.timezones.tst)
     ),
-    ('{"type": "string", "logicalType": "uuid"}', u'12345abcd'),
+    ('{"type": "string", "logicalType": "uuid"}', u'570feebe-2bbc-4937-98df-285944e1dbbd'),
     ('{"type": "string", "logicalType": "unknown-logical-type"}', u'12345abcd'),
     ('{"type": "string", "logicalType": "timestamp-millis"}', u'12345abcd'),
     ("""\

--- a/lang/py/avro/test/test_schema.py
+++ b/lang/py/avro/test/test_schema.py
@@ -220,10 +220,11 @@ TIMESTAMPMICROS_LOGICAL_TYPE = [
     ValidTestSchema({"type": "long", "logicalType": "timestamp-micros"})
 ]
 
+UUID_LOGICAL_TYPE = [
+    ValidTestSchema({"type": "string", "logicalType": "uuid"})
+]
+
 IGNORED_LOGICAL_TYPE = [
-    ValidTestSchema(
-        {"type": "string", "logicalType": "uuid"},
-        warnings=[avro.errors.IgnoredLogicalType('Unknown uuid, using string.')]),
     ValidTestSchema(
         {"type": "string", "logicalType": "unknown-logical-type"},
         warnings=[avro.errors.IgnoredLogicalType('Unknown unknown-logical-type, using string.')]),
@@ -303,6 +304,7 @@ EXAMPLES += TIMEMILLIS_LOGICAL_TYPE
 EXAMPLES += TIMEMICROS_LOGICAL_TYPE
 EXAMPLES += TIMESTAMPMILLIS_LOGICAL_TYPE
 EXAMPLES += TIMESTAMPMICROS_LOGICAL_TYPE
+EXAMPLES += UUID_LOGICAL_TYPE
 EXAMPLES += IGNORED_LOGICAL_TYPE
 
 VALID_EXAMPLES = [e for e in EXAMPLES if getattr(e, "valid", False)]


### PR DESCRIPTION
This PR introduces the UUID logical type implementation that was missing in the
primary python implementation. A new `UUIDSchema` has been introduced that
validates for valid UUID4 string values.

Closes: https://issues.apache.org/jira/browse/AVRO-3065

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-3065: Add support for uuid logical type to Python implementation"
  - https://issues.apache.org/jira/browse/AVRO-3065
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests:
  - Test for valid UUID Logical Type in Schema
  - Test for valid UUID in values
 
### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
