### PR TITLE
AVRO-3004 Drop support for Python 3.5

### DIFF
--- a/lang/py/setup.cfg
+++ b/lang/py/setup.cfg
@@ -35,6 +35,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Development Status :: 5 - Production/Stable
 
 [bdist_wheel]

--- a/lang/py/setup.cfg
+++ b/lang/py/setup.cfg
@@ -32,7 +32,6 @@ license_file = avro/LICENSE
 license = Apache License 2.0
 classifiers =
     License :: OSI Approved :: Apache Software License
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
@@ -55,7 +54,7 @@ install_requires =
 zip_safe = true
 scripts =
     scripts/avro
-python_requires = >=3.5
+python_requires = >=3.6
 
 [options.package_data]
 avro =

--- a/lang/py/tox.ini
+++ b/lang/py/tox.ini
@@ -20,11 +20,9 @@ envlist =
     # Fastest checks first
     lint
     typechecks
-    py35
     py36
     py37
     py38
-    pypy3.5
     pypy3.6
 
 

--- a/lang/py/tox.ini
+++ b/lang/py/tox.ini
@@ -23,7 +23,9 @@ envlist =
     py36
     py37
     py38
+    py39
     pypy3.6
+    pypy3.7
 
 
 [coverage:run]


### PR DESCRIPTION
This PR removes 3.5 support from build and setup, including classifiers

Closes: AVRO-3004 (https://issues.apache.org/jira/browse/AVRO-3004)

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the issue "AVRO-3004 Drop support for Python 3.5"
  - https://issues.apache.org/jira/browse/AVRO-3004

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
**NA**