### PR TITLE
AVRO-3092: Update ubertool image to buster

### DIFF
--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -18,7 +18,7 @@
 # See BUILD.txt.
 
 # Despite this base, JDK8 is used by default.  See below.
-FROM openjdk:11-stretch
+FROM openjdk:11-buster
 WORKDIR /root
 
 ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=isolemnlysweariamuptonogood \
@@ -50,7 +50,6 @@ RUN apt-get -qqy update \
                                                  libsnappy1v5 \
                                                  make \
                                                  mypy \
-                                                 openjdk-8-jdk \
                                                  perl \
                                                  python3 \
                                                  python3-pip \
@@ -64,6 +63,13 @@ RUN apt-get -qqy update \
                                                  subversion \
                                                  valgrind \
                                                  vim \
+ && apt-get -qqy clean \
+ && rm -rf /var/lib/apt/lists
+
+RUN wget -qO- https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add - \
+ && echo "deb https://adoptopenjdk.jfrog.io/adoptopenjdk/deb buster main" | tee /etc/apt/sources.list.d/adoptopenjdk.list \
+ && apt-get -qqy update \
+ && apt-get -qqy install --no-install-recommends adoptopenjdk-8-hotspot \
  && apt-get -qqy clean \
  && rm -rf /var/lib/apt/lists
 
@@ -187,16 +193,16 @@ COPY lang/ruby/Gemfile /tmp
 RUN bundle install --gemfile=/tmp/Gemfile
 
 # Note: This "ubertool" container has two JDK versions:
-# - OpenJDK 8 (installed as a package and available at /usr/bin/java)
+# - OpenJDK 8 (installed as an AdoptOpenJDK package)
 # - OpenJDK 11 (installed from the base image, and prioritized in the PATH)
 # - The root build.sh script switches between the versions according to
 #   the JAVA environment variable.
 
-# Since want the JDK8 as a default, we have to re-prepend it to the PATH.
+# Since we want the JDK8 as a default, we have to re-prepend it to the PATH.
 # The /usr/local/openjdk-8 link is created to be consistent with the
 # openjdk:8 image.
 
-RUN ln -s /usr/lib/jvm/java-8-openjdk-amd64 /usr/local/openjdk-8
+RUN ln -s /usr/lib/jvm/adoptopenjdk-8-hotspot-amd64 /usr/local/openjdk-8
 ENV JAVA_HOME /usr/local/openjdk-8
 ENV PATH $JAVA_HOME/bin:$PATH
 


### PR DESCRIPTION
This requires installing the JDK8 from another repository, in this case AdoptOpenJDK.

I checked building a distribution with JDK8 and running all tests in the tool on my local machine.

Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3092
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: The ubertool is no longer used for CI.

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
