### PR TITLE
AVRO-3093: Stop releasing avro-python3 package

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -26,8 +26,6 @@ Js: ["lang/js/**/*"]
 Perl: ["lang/perl/**/*"]
 Php: ["lang/php/**/*"]
 Python: ["lang/py/**/*"]
-Python3: ["lang/py3/**/*"]
 Ruby: ["lang/ruby/**/*"]
 build: ["**/*Dockerfile*", "**/*.sh", "**/*pom.xml", ".github/**/*"]
 website: ["doc/**/*"]
-

--- a/DIST_README.txt
+++ b/DIST_README.txt
@@ -9,7 +9,6 @@ This distribution contains the following files:
 
   - avro-doc-x.y.z.tar.gz contains Avro's pre-built documentation.
 
-  - the c/, cpp/, csharp/, java/, js/, perl/, php/, py/, py3/ and ruby/
+  - the c/, cpp/, csharp/, java/, js/, perl/, php/, py/, and ruby/
     subdirectories contain pre-built, language-specific binaries,
     bundles, etc. as conveniences.
-

--- a/build.sh
+++ b/build.sh
@@ -94,7 +94,6 @@ do
       # install java artifacts required by other builds and interop tests
       mvn -B install -DskipTests
       (cd lang/py && ./build.sh lint test)
-      (cd lang/py3 && ./build.sh lint test)
       (cd lang/c; ./build.sh test)
       (cd lang/c++; ./build.sh lint test)
       (cd lang/csharp; ./build.sh test)
@@ -104,8 +103,6 @@ do
       (cd lang/perl; ./build.sh lint test)
 
       (cd lang/py; ./build.sh interop-data-generate)
-      (cd lang/py3; python3 setup.py generate_interop_data \
-        --schema-file=../../share/test/schemas/interop.avsc --output-path=../../build/interop/data)
       (cd lang/c; ./build.sh interop-data-generate)
       #(cd lang/c++; make interop-data-generate)
       (cd lang/csharp; ./build.sh interop-data-generate)
@@ -117,7 +114,6 @@ do
       # run interop data tests
       (cd lang/java/ipc; mvn -B test -P interop-data-test)
       (cd lang/py; ./build.sh interop-data-test)
-      (cd lang/py3; python3 setup.py test --test-suite avro.tests.test_datafile_interop.TestDataFileInterop)
       (cd lang/c; ./build.sh interop-data-test)
       #(cd lang/c++; make interop-data-test)
       (cd lang/csharp; ./build.sh interop-data-test)
@@ -164,7 +160,6 @@ do
       (mvn -N -P copy-artifacts antrun:run)
 
       (cd lang/py; ./build.sh dist)
-      (cd lang/py3; ./build.sh dist)
       (cd lang/c; ./build.sh dist)
       (cd lang/c++; ./build.sh dist)
       (cd lang/csharp; ./build.sh dist)
@@ -218,15 +213,6 @@ do
       (cd lang/py; ./build.sh clean)
       rm -rf lang/py/userlogs/
 
-      (cd lang/py3; python3 setup.py clean)
-      rm -rf lang/py3/dist
-      rm -rf lang/py3/avro_python3.egg-info
-      rm -f  lang/py3/avro/*.avsc
-      rm -f  lang/py3/avro/VERSION.txt
-      rm -rf lang/py3/avro/__pycache__/
-      rm -f  lang/py3/avro/tests/interop.avsc
-      rm -rf lang/py3/avro/tests/__pycache__/
-
       (cd lang/c; ./build.sh clean)
 
       (cd lang/c++; ./build.sh clean)
@@ -252,15 +238,6 @@ do
 
       (cd lang/py; ./build.sh clean)
       rm -rf lang/py/userlogs/
-
-      (cd lang/py3; python3 setup.py clean)
-      rm -rf lang/py3/dist
-      rm -rf lang/py3/avro_python3.egg-info
-      rm -f  lang/py3/avro/*.avsc
-      rm -f  lang/py3/avro/VERSION.txt
-      rm -rf lang/py3/avro/__pycache__/
-      rm -f  lang/py3/avro/tests/interop.avsc
-      rm -rf lang/py3/avro/tests/__pycache__/
 
       (cd lang/c; ./build.sh clean)
 

--- a/lang/py/scripts/avro
+++ b/lang/py/scripts/avro
@@ -253,7 +253,7 @@ def main(argv):
 
     # write options
     write_options = optparse.OptionGroup(parser, "write options")
-    write_options.add_option("--schema", help="schema file (required)")
+    write_options.add_option("--schema", help="schema JSON file (required)")
     write_options.add_option("--input-type",
                              help="input file(s) type (json or csv)",
                              choices=["json", "csv"], default=None)
@@ -262,7 +262,7 @@ def main(argv):
 
     opts, args = parser.parse_args(argv[1:])
     if len(args) < 1:
-        parser.error("You much specify `cat` or `write`")  # Will exit
+        parser.error("You must specify `cat` or `write`")  # Will exit
 
     command_name = args.pop(0)
     try:

--- a/pom.xml
+++ b/pom.xml
@@ -382,9 +382,6 @@
                 <exclude>lang/py/build/**</exclude>
                 <exclude>lang/py/dist/**</exclude>
                 <exclude>lang/py/userlogs/**</exclude>
-                <exclude>lang/py3/.eggs/**</exclude>
-                <exclude>lang/py3/build/**</exclude>
-                <exclude>lang/py3/dist/**</exclude>
                 <exclude>lang/ruby/Manifest</exclude>
                 <!-- text documentation files -->
                 <exclude>CHANGES.txt</exclude>

--- a/share/test/interop/bin/test_rpc_interop.sh
+++ b/share/test/interop/bin/test_rpc_interop.sh
@@ -25,15 +25,15 @@ java_tool() {
   java -jar "lang/java/tools/target/avro-tools-$VERSION.jar" "$@"
 }
 
-py3_tool() {
-  PYTHONPATH=lang/py3 python3 -m avro.tool "$@"
+py_tool() {
+  PYTHONPATH=lang/py python3 -m avro.tool "$@"
 }
 
 ruby_tool() {
   ruby -Ilang/ruby/lib lang/ruby/test/tool.rb "$@"
 }
 
-tools=( {java,py3,ruby}_tool )
+tools=( {java,py,ruby}_tool )
 
 proto=share/test/schemas/simple.avpr
 


### PR DESCRIPTION
With the deprecation notice in place for some time, we can stop maintaining and releasing `avro-python3` package along with other SDKs

Closes: https://issues.apache.org/jira/browse/AVRO-3093

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AVRO-3093

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  **NA**

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  **NA**
