### PR TITLE
AVRO-1938: Generate Parsing Canonical Forms of Schema

### DIFF
--- a/lang/py/avro/protocol.py
+++ b/lang/py/avro/protocol.py
@@ -209,13 +209,14 @@ class Message:
         return json.dumps(self.to_json())
 
     def to_json(self, names=None):
-        if names is None:
-            names = avro.schema.Names()
+        names = names or avro.schema.Names()
+
         to_dump = {}
         to_dump['request'] = self.request.to_json(names)
         to_dump['response'] = self.response.to_json(names)
         if self.errors:
             to_dump['errors'] = self.errors.to_json(names)
+
         return to_dump
 
     def __eq__(self, that):
@@ -231,6 +232,7 @@ def make_avpr_object(json_data):
         messages = json_data.get('messages')
     except AttributeError:
         raise avro.errors.ProtocolParseException('Not a JSON object: %s' % json_data)
+
     return Protocol(name, namespace, types, messages)
 
 

--- a/lang/py/avro/schema.py
+++ b/lang/py/avro/schema.py
@@ -224,8 +224,11 @@ class Schema(abc.ABC, CanonicalPropertiesMixin):
         in the parameter names.
         """
 
+    @abc.abstractmethod
     def validate(self, datum):
         """Returns the appropriate schema object if datum is valid for that schema, else None.
+
+        To be implemented in subclasses.
 
         Validation concerns only shape and type of data in the top level of the current schema.
         In most cases, the returned schema object will be self. However, for UnionSchema objects,
@@ -234,20 +237,20 @@ class Schema(abc.ABC, CanonicalPropertiesMixin):
         @arg datum: The data to be checked for validity according to this schema
         @return Optional[Schema]
         """
-        raise Exception("Must be implemented by subclasses.")
 
     @abc.abstractmethod
-    def to_canonical_json(self, names):
+    def to_canonical_json(self, names=None):
         """
         Converts the schema object into its Canonical Form
         http://avro.apache.org/docs/current/spec.html#Parsing+Canonical+Form+for+Schemas
+
+        To be implemented in subclasses.
         """
-        raise NotImplementedError("to_canonical_json must be implemented by subclasses")
 
     @property
     def canonical_form(self):
         # The separators eliminate whitespace around commas and colons.
-        return json.dumps(self.to_canonical_json(None), separators=(",", ":"))
+        return json.dumps(self.to_canonical_json(), separators=(",", ":"))
 
 
 class Name:
@@ -258,22 +261,24 @@ class Name:
     def __init__(self, name_attr, space_attr, default_space):
         """The fullname is determined in one of the following ways:
 
-        - A name and namespace are both specified. For example, one might use "name": "X", "namespace": "org.foo" to indicate the fullname org.foo.X.
+        - A name and namespace are both specified. For example, one might use "name": "X",
+            "namespace": "org.foo" to indicate the fullname org.foo.X.
         - A fullname is specified. If the name specified contains a dot,
-          then it is assumed to be a fullname, and any namespace also specified is ignored.
-          For example, use "name": "org.foo.X" to indicate the fullname org.foo.X.
+            then it is assumed to be a fullname, and any namespace also specified is ignored.
+            For example, use "name": "org.foo.X" to indicate the fullname org.foo.X.
         - A name only is specified, i.e., a name that contains no dots.
-          In this case the namespace is taken from the most tightly enclosing schema or protocol.
-          For example, if "name": "X" is specified, and this occurs within a field of
-          the record definition of org.foo.Y, then the fullname is org.foo.X.
-          If there is no enclosing namespace then the null namespace is used.
+            In this case the namespace is taken from the most tightly enclosing schema or protocol.
+            For example, if "name": "X" is specified, and this occurs within a field of
+            the record definition of org.foo.Y, then the fullname is org.foo.X.
+            If there is no enclosing namespace then the null namespace is used.
 
         References to previously defined names are as in the latter two cases above:
         if they contain a dot they are a fullname,
         if they do not contain a dot, the namespace is the namespace of the enclosing definition.
 
         @arg name_attr: name value read in schema or None.
-        @arg space_attr: namespace value read in schema or None. The empty string may be used as a namespace to indicate the null namespace.
+        @arg space_attr: namespace value read in schema or None. The empty string may be used as a namespace
+            to indicate the null namespace.
         @arg default_space: the current default space or None.
         """
         if name_attr is None:
@@ -326,9 +331,8 @@ class Names:
 
     def get_name(self, name_attr, space_attr):
         test = Name(name_attr, space_attr, self.default_namespace).fullname
-        if test not in self.names:
-            return None
-        return self.names[test]
+
+        return None if test not in self.names else self.names[test]
 
     def prune_namespace(self, properties):
         """given a properties, return properties with namespace removed if
@@ -336,12 +340,15 @@ class Names:
         if self.default_namespace is None:
             # I have no default -- no change
             return properties
+
         if 'namespace' not in properties:
             # he has no namespace - no change
             return properties
+
         if properties['namespace'] != self.default_namespace:
             # we're different - leave his stuff alone
             return properties
+
         # we each have a namespace and it's redundant. delete his.
         prunable = properties.copy()
         del(prunable['namespace'])
@@ -351,10 +358,10 @@ class Names:
         """
         Add a new schema object to the name set.
 
-          @arg name_attr: name value read in schema
-          @arg space_attr: namespace value read in schema.
+        @arg name_attr: name value read in schema
+        @arg space_attr: namespace value read in schema.
 
-          @return: the Name that was just added.
+        @return: the Name that was just added.
         """
         to_add = Name(name_attr, space_attr, self.default_namespace)
 
@@ -504,17 +511,19 @@ class Field(CanonicalPropertiesMixin):
         return json.dumps(self.to_json())
 
     def to_json(self, names=None):
-        if names is None:
-            names = Names()
+        names = names or Names()
+
         to_dump = self.props.copy()
         to_dump['type'] = self.type.to_json(names)
+
         return to_dump
 
     def to_canonical_json(self, names=None):
-        if names is None:
-            names = Names()
+        names = names or Names()
+
         to_dump = self.canonical_properties
         to_dump["type"] = self.type.to_canonical_json(names)
+
         return to_dump
 
     def __eq__(self, that):
@@ -638,15 +647,15 @@ class FixedSchema(NamedSchema):
         return self.type == writer.type and self.check_props(writer, ['fullname', 'size'])
 
     def to_json(self, names=None):
-        if names is None:
-            names = Names()
+        names = names or Names()
+
         if self.fullname in names.names:
             return self.name_ref(names)
-        else:
-            names.names[self.fullname] = self
-            return names.prune_namespace(self.props)
 
-    def to_canonical_json(self, names):
+        names.names[self.fullname] = self
+        return names.prune_namespace(self.props)
+
+    def to_canonical_json(self, names=None):
         to_dump = self.canonical_properties
         to_dump["name"] = self.fullname
 
@@ -724,16 +733,17 @@ class EnumSchema(NamedSchema):
         return self.type == writer.type and self.check_props(writer, ['fullname'])
 
     def to_json(self, names=None):
-        if names is None:
-            names = Names()
+        names = names or Names()
+
         if self.fullname in names.names:
             return self.name_ref(names)
-        else:
-            names.names[self.fullname] = self
-            return names.prune_namespace(self.props)
+
+        names.names[self.fullname] = self
+        return names.prune_namespace(self.props)
 
     def to_canonical_json(self, names=None):
         names_as_json = self.to_json(names)
+
         if isinstance(names_as_json, str):
             to_dump = self.fullname
         else:
@@ -783,19 +793,21 @@ class ArraySchema(Schema):
         return self.type == writer.type and self.items.check_props(writer.items, ['type'])
 
     def to_json(self, names=None):
-        if names is None:
-            names = Names()
+        names = names or Names()
+
         to_dump = self.props.copy()
         item_schema = self.get_prop('items')
         to_dump['items'] = item_schema.to_json(names)
+
         return to_dump
 
     def to_canonical_json(self, names=None):
-        if names is None:
-            names = Names()
+        names = names or Names()
+
         to_dump = self.canonical_properties
         item_schema = self.get_prop("items")
         to_dump["items"] = item_schema.to_canonical_json(names)
+
         return to_dump
 
     def validate(self, datum):
@@ -837,17 +849,19 @@ class MapSchema(Schema):
         return writer.type == self.type and self.values.check_props(writer.values, ['type'])
 
     def to_json(self, names=None):
-        if names is None:
-            names = Names()
+        names = names or Names()
+
         to_dump = self.props.copy()
         to_dump['values'] = self.get_prop('values').to_json(names)
+
         return to_dump
 
-    def to_canonical_json(self, names):
-        if names is None:
-            names = Names()
+    def to_canonical_json(self, names=None):
+        names = names or Names()
+
         to_dump = self.canonical_properties
         to_dump["values"] = self.get_prop("values").to_canonical_json(names)
+
         return to_dump
 
     def validate(self, datum):
@@ -905,16 +919,17 @@ class UnionSchema(Schema):
         return writer.type in {'union', 'error_union'} or any(s.match(writer) for s in self.schemas)
 
     def to_json(self, names=None):
-        if names is None:
-            names = Names()
+        names = names or Names()
+
         to_dump = []
         for schema in self.schemas:
             to_dump.append(schema.to_json(names))
+
         return to_dump
 
-    def to_canonical_json(self, names):
-        if names is None:
-            names = Names()
+    def to_canonical_json(self, names=None):
+        names = names or Names()
+
         return [schema.to_canonical_json(names) for schema in self.schemas]
 
     def validate(self, datum):
@@ -934,14 +949,15 @@ class ErrorUnionSchema(UnionSchema):
         UnionSchema.__init__(self, ['string'] + schemas, names)
 
     def to_json(self, names=None):
-        if names is None:
-            names = Names()
+        names = names or Names()
+
         to_dump = []
         for schema in self.schemas:
             # Don't print the system error schema
             if schema.type == 'string':
                 continue
             to_dump.append(schema.to_json(names))
+
         return to_dump
 
 
@@ -1029,8 +1045,8 @@ class RecordSchema(NamedSchema):
         return fields_dict
 
     def to_json(self, names=None):
-        if names is None:
-            names = Names()
+        names = names or Names()
+
         # Request records don't have names
         if self.type == 'request':
             return [f.to_json(names) for f in self.fields]
@@ -1042,11 +1058,11 @@ class RecordSchema(NamedSchema):
 
         to_dump = names.prune_namespace(self.props.copy())
         to_dump['fields'] = [f.to_json(names) for f in self.fields]
+
         return to_dump
 
-    def to_canonical_json(self, names):
-        if names is None:
-            names = Names()
+    def to_canonical_json(self, names=None):
+        names = names or Names()
 
         if self.type == 'request':
             raise NotImplementedError("Canonical form (probably) does not make sense on type request")
@@ -1056,9 +1072,8 @@ class RecordSchema(NamedSchema):
 
         if self.fullname in names.names:
             return self.name_ref(names)
-        else:
-            names.names[self.fullname] = self
 
+        names.names[self.fullname] = self
         to_dump["fields"] = [f.to_canonical_json(names) for f in self.fields]
 
         return to_dump
@@ -1224,18 +1239,19 @@ def make_avsc_object(json_data, names=None, validate_enum_symbols=True):
     @arg names: A Names object (tracks seen names and default space)
     @arg validate_enum_symbols: If False, will allow enum symbols that are not valid Avro names.
     """
-    if names is None:
-        names = Names()
+    names = names or Names()
 
     # JSON object (non-union)
     if callable(getattr(json_data, 'get', None)):
         type = json_data.get('type')
         other_props = get_other_props(json_data, SCHEMA_RESERVED_PROPS)
         logical_type = json_data.get('logicalType')
+
         if logical_type:
             logical_schema = make_logical_schema(logical_type, type, other_props or {})
             if logical_schema is not None:
                 return logical_schema
+
         if type in NAMED_TYPES:
             name = json_data.get('name')
             namespace = json_data.get('namespace', names.default_namespace)
@@ -1259,8 +1275,10 @@ def make_avsc_object(json_data, names=None, validate_enum_symbols=True):
                 return RecordSchema(name, namespace, fields, names, type, doc, other_props)
             else:
                 raise avro.errors.SchemaParseException('Unknown Named Type: %s' % type)
+
         if type in PRIMITIVE_TYPES:
             return PrimitiveSchema(type, other_props)
+
         if type in VALID_TYPES:
             if type == 'array':
                 items = json_data.get('items')

--- a/lang/py/avro/schema.py
+++ b/lang/py/avro/schema.py
@@ -331,8 +331,7 @@ class Names:
 
     def get_name(self, name_attr, space_attr):
         test = Name(name_attr, space_attr, self.default_namespace).fullname
-
-        return None if test not in self.names else self.names[test]
+        return self.names.get(test)
 
     def prune_namespace(self, properties):
         """given a properties, return properties with namespace removed if

--- a/lang/py/avro/test/test_schema.py
+++ b/lang/py/avro/test/test_schema.py
@@ -897,7 +897,7 @@ class CanonicalFormTestCase(unittest.TestCase):
              '{"name":"serverHash","type":{"name":"org.apache.avro.ipc.MD5","type":"fixed","size":16}},'
              '{"name":"meta","type":["null",{"type":"map","values":"bytes"}]}]}'))
 
-    def test_large_record_handshake_request(self):
+    def test_large_record_handshake_response(self):
         s = avro.schema.parse("""
             {
             "type": "record",


### PR DESCRIPTION
This PR adds support for generating Parsing Canonical Forms of Avro Schemas to the main `avro` package.

The bulk of the work was done by @kojiromike and @forsberg. This PR cleans up code where necessary, adds more test cases, and clarifies on transformations wherever not applicable in Python (ex. Transformation of integers with leading zeros)

Closes: https://issues.apache.org/jira/browse/AVRO-1938
Closes: https://github.com/apache/avro/pull/700/

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AVRO-1938

### Tests

- [x] My PR adds the following unit tests:
  Test cases in `test/test_schema.py::CanonicalFormTestCase`

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  Test cases act as stand-ins for the feature for now. Comprehensive documentation needs to be added later.
