### PR TITLE
AVRO-3100: Fix module typo in avro.tool

### DIFF
--- a/lang/py/avro/tool.py
+++ b/lang/py/avro/tool.py
@@ -73,7 +73,7 @@ class GenericHandler(http.server.BaseHTTPRequestHandler):
 
 
 def run_server(uri, proto, msg, datum):
-    url_obj = urllib.parse(uri)
+    url_obj = urllib.parse.urlparse(uri)
     server_addr = (url_obj.hostname, url_obj.port)
     global responder
     global server_should_shutdown
@@ -88,7 +88,7 @@ def run_server(uri, proto, msg, datum):
 
 
 def send_message(uri, proto, msg, datum):
-    url_obj = urllib.parse(uri)
+    url_obj = urllib.parse.urlparse(uri)
     client = avro.ipc.HTTPTransceiver(url_obj.hostname, url_obj.port)
     proto_json = open(proto, 'rb').read()
     requestor = avro.ipc.Requestor(avro.protocol.parse(proto_json), client)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3100
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

With AVRO-3092, this tool is now being used during testing.

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
