### PR TITLE
AVRO-3094: improve performance of SpecificData.getForClass(), especially around old generated specific record classes

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificData.java
@@ -69,6 +69,22 @@ public class SpecificData extends GenericData {
     }
 
   };
+  private static final ClassValue<SpecificData> MODEL_CACHE = new ClassValue<SpecificData>() {
+    @Override
+    protected SpecificData computeValue(Class<?> type) {
+      Field specificDataField;
+      try {
+        specificDataField = type.getDeclaredField("MODEL$");
+        specificDataField.setAccessible(true);
+        return (SpecificData) specificDataField.get(null);
+      } catch (NoSuchFieldException e) {
+        // Return default instance
+        return SpecificData.get();
+      } catch (IllegalAccessException e) {
+        throw new AvroRuntimeException("while trying to access field MODEL$ on " + type.getCanonicalName(), e);
+      }
+    }
+  };
 
   public static final String CLASS_PROP = "java-class";
   public static final String KEY_CLASS_PROP = "java-key-class";
@@ -168,17 +184,7 @@ public class SpecificData extends GenericData {
    */
   public static <T> SpecificData getForClass(Class<T> c) {
     if (SpecificRecordBase.class.isAssignableFrom(c)) {
-      final Field specificDataField;
-      try {
-        specificDataField = c.getDeclaredField("MODEL$");
-        specificDataField.setAccessible(true);
-        return (SpecificData) specificDataField.get(null);
-      } catch (NoSuchFieldException e) {
-        // Return default instance
-        return SpecificData.get();
-      } catch (IllegalAccessException e) {
-        throw new AvroRuntimeException(e);
-      }
+      return MODEL_CACHE.get(c);
     }
     return SpecificData.get();
   }


### PR DESCRIPTION
Avro 1.9+ attempts to access static field MODEL$ on avo-generated classes.
Record classes generated by older Avro (for example 1.7) do not have this field.
This causes modern avro to catch an exception on every record being deserialized
for such classes, which can cause a x3 slow down
(see profiler results in the Jira ticket).

This fix uses ClassValue to cache the SpecificData instance to use per class.
This results in s ~x5 speedup for the happy path (classes that have MODEL$) and
~x50 speedup for classes that do not have MODEL$.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3094
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
this PR is a performance improvement to existing (and tested) functionality. the performance improvement has been demonstrated elsewhere: [https://github.com/radai-rosenblatt/avro-3094-benchmarks](https://github.com/radai-rosenblatt/avro-3094-benchmarks)

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
