### PR TITLE
AVRO-3108: Drop support for Ruby 2.5

### DIFF
--- a/.github/workflows/test-lang-ruby.yml
+++ b/.github/workflows/test-lang-ruby.yml
@@ -34,7 +34,6 @@ jobs:
     strategy:
       matrix:
         ruby:
-        - '2.5'
         - '2.6'
         - '2.7'
         - '3.0'
@@ -74,7 +73,6 @@ jobs:
     strategy:
       matrix:
         ruby:
-        - '2.5'
         - '2.6'
         - '2.7'
         - '3.0'

--- a/BUILD.md
+++ b/BUILD.md
@@ -11,8 +11,7 @@ The following packages must be installed before Avro can be built:
  - C++: cmake 3.7.2 or greater, g++, flex, bison, libboost-dev
  - C#: .NET Core 2.2 SDK
  - JavaScript: Node 6.x+, nodejs, npm
- - Ruby: Ruby 2.3.3 or greater, ruby-dev, gem, rake, echoe, yajl-ruby,
-   snappy, zstd-ruby
+ - Ruby: Ruby 2.6 or greater, ruby-dev, gem, bundler, snappy
  - Perl: Perl 5.24.1 or greater, gmake, Module::Install,
    Module::Install::ReadmeFromPod, Module::Install::Repository,
    Math::BigInt, JSON::XS, Try::Tiny, Regexp::Common, Encode,

--- a/lang/ruby/Gemfile
+++ b/lang/ruby/Gemfile
@@ -20,13 +20,10 @@ gem 'multi_json'
 gem 'snappy'
 gem 'zstd-ruby'
 gem 'test-unit'
-# parallel 1.20.0 requires Ruby 2.5+
-gem 'parallel', '<= 1.19.2'
+gem 'parallel'
 # webrick is no longer included with Ruby 3.0+
 gem 'webrick'
 
-# rubocop 0.82 requires Ruby 2.4+
-gem 'rubocop', '<= 0.81'
-
-# rdoc 6.2.1 requires Ruby 2.4+
-gem 'rdoc', '<= 6.2.0'
+# rubocop v1.0 and later introduces new Lint cops to be addressed
+gem 'rubocop', '< 1.0'
+gem 'rdoc'

--- a/lang/ruby/build.sh
+++ b/lang/ruby/build.sh
@@ -22,10 +22,11 @@ cd "$(dirname "$0")"
 
 # maintain our gems here
 export GEM_HOME="$PWD/.gem/"
-export PATH="$GEM_HOME/bin:$PATH"
+export PATH="/usr/local/rbenv/shims:$GEM_HOME/bin:$PATH"
 
 # bootstrap bundler
 gem install --no-document -v 1.17.3 bundler
+rbenv rehash
 bundle install
 
 for target in "$@"

--- a/lang/ruby/build.sh
+++ b/lang/ruby/build.sh
@@ -26,7 +26,9 @@ export PATH="/usr/local/rbenv/shims:$GEM_HOME/bin:$PATH"
 
 # bootstrap bundler
 gem install --no-document -v 1.17.3 bundler
-rbenv rehash
+
+# rbenv is used by the Dockerfile but not the Github action in CI
+rbenv rehash || echo "Not using rbenv"
 bundle install
 
 for target in "$@"

--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -32,7 +32,6 @@ RUN apt-get -qqy update \
                                                  asciidoc \
                                                  bison \
                                                  bzip2 \
-                                                 bundler \
                                                  cmake \
                                                  cppcheck \
                                                  curl \
@@ -46,8 +45,10 @@ RUN apt-get -qqy update \
                                                  libfreetype6-dev \
                                                  libglib2.0-dev \
                                                  libjansson-dev \
+                                                 libreadline-dev \
                                                  libsnappy-dev \
                                                  libsnappy1v5 \
+                                                 libssl-dev \
                                                  make \
                                                  mypy \
                                                  perl \
@@ -56,9 +57,6 @@ RUN apt-get -qqy update \
                                                  python3-setuptools \
                                                  python3-snappy \
                                                  python3-wheel \
-                                                 rake \
-                                                 ruby \
-                                                 ruby-dev \
                                                  source-highlight \
                                                  subversion \
                                                  valgrind \
@@ -188,9 +186,20 @@ RUN curl -sSLO https://packages.microsoft.com/config/ubuntu/16.04/packages-micro
  && apt-get -qqy clean \
  && rm -rf /var/lib/apt/lists
 
-# Install Ruby modules
+# Install Ruby
+ENV RBENV_ROOT /usr/local/rbenv
+RUN git clone https://github.com/rbenv/rbenv.git /usr/local/rbenv \
+  && git clone https://github.com/rbenv/ruby-build.git /usr/local/rbenv/plugins/ruby-build \
+  && /usr/local/rbenv/plugins/ruby-build/install.sh \
+  && echo 'eval "$(rbenv init -)"' >> /etc/profile.d/rbenv.sh \
+  && echo 'eval "$(rbenv init -)"' >> /etc/bash.bashrc
+ENV PATH /usr/local/rbenv/bin:$PATH
+RUN rbenv install 2.6.7 && rbenv global 2.6.7 \
+  && rbenv exec gem install bundler -v 1.17.3 --no-document
 COPY lang/ruby/Gemfile /tmp
-RUN bundle install --gemfile=/tmp/Gemfile
+RUN rbenv exec bundle install --gemfile=/tmp/Gemfile \
+  && chgrp -R staff /usr/local/rbenv \
+  && chmod -R g+rw /usr/local/rbenv
 
 # Note: This "ubertool" container has two JDK versions:
 # - OpenJDK 8 (installed as an AdoptOpenJDK package)


### PR DESCRIPTION
Ruby 2.5 is EOL as of March 31, 2021.