### PR TITLE
AVRO-3112: Freeze string literals for Ruby

### DIFF
--- a/lang/ruby/.rubocop.yml
+++ b/lang/ruby/.rubocop.yml
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 AllCops:
   TargetRubyVersion: 2.6
   NewCops: disable

--- a/lang/ruby/.rubocop.yml
+++ b/lang/ruby/.rubocop.yml
@@ -1,0 +1,33 @@
+AllCops:
+  TargetRubyVersion: 2.6
+  NewCops: disable
+
+Bundler:
+  Enabled: false
+
+Layout:
+  Enabled: false
+
+Lint:
+  Enabled: true
+
+Metrics:
+  Enabled: false
+
+Naming:
+  Enabled: false
+
+Security:
+  Enabled: false
+
+Style:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: true
+
+Style/MutableConstant:
+  Enabled: true
+
+Style/RedundantFreeze:
+  Enabled: true

--- a/lang/ruby/Gemfile
+++ b/lang/ruby/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/lang/ruby/Rakefile
+++ b/lang/ruby/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/lang/ruby/build.sh
+++ b/lang/ruby/build.sh
@@ -28,14 +28,14 @@ export PATH="/usr/local/rbenv/shims:$GEM_HOME/bin:$PATH"
 gem install --no-document -v 1.17.3 bundler
 
 # rbenv is used by the Dockerfile but not the Github action in CI
-rbenv rehash || echo "Not using rbenv"
+rbenv rehash 2>/dev/null || echo "Not using rbenv"
 bundle install
 
 for target in "$@"
 do
   case "$target" in
     lint)
-      bundle exec rubocop --lint
+      bundle exec rubocop
       ;;
 
     test)

--- a/lang/ruby/interop/test_interop.rb
+++ b/lang/ruby/interop/test_interop.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -19,7 +20,7 @@ require 'rubygems'
 require 'test/unit'
 require 'avro'
 
-CODECS_TO_VALIDATE = ['deflate', 'snappy', 'zstandard']  # The 'null' codec is implicitly included
+CODECS_TO_VALIDATE = ['deflate', 'snappy', 'zstandard'].freeze  # The 'null' codec is implicitly included
 
 class TestInterop < Test::Unit::TestCase
   HERE = File.expand_path(File.dirname(__FILE__))

--- a/lang/ruby/lib/avro.rb
+++ b/lang/ruby/lib/avro.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/lang/ruby/lib/avro/data_file.rb
+++ b/lang/ruby/lib/avro/data_file.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -5,9 +6,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 # https://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,7 +26,7 @@ module Avro
     SYNC_SIZE = 16
     SYNC_INTERVAL = 4000 * SYNC_SIZE
     META_SCHEMA = Schema.parse('{"type": "map", "values": "bytes"}')
-    VALID_ENCODINGS = ['binary'] # not used yet
+    VALID_ENCODINGS = ['binary'].freeze # not used yet
 
     class DataFileError < AvroError; end
 
@@ -99,7 +100,7 @@ module Avro
         @encoder = IO::BinaryEncoder.new(@writer)
         @datum_writer = datum_writer
         @meta = meta
-        @buffer_writer = StringIO.new('', 'w')
+        @buffer_writer = StringIO.new(+'', 'w')
         @buffer_writer.set_encoding('BINARY') if @buffer_writer.respond_to?(:set_encoding)
         @buffer_encoder = IO::BinaryEncoder.new(@buffer_writer)
         @block_count = 0

--- a/lang/ruby/lib/avro/io.rb
+++ b/lang/ruby/lib/avro/io.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -76,7 +77,7 @@ module Avro
         # The float is converted into a 32-bit integer using a method
         # equivalent to Java's floatToIntBits and then encoded in
         # little-endian format.
-        read_and_unpack(4, 'e'.freeze)
+        read_and_unpack(4, 'e')
       end
 
       def read_double
@@ -84,7 +85,7 @@ module Avro
         # The double is converted into a 64-bit integer using a method
         # equivalent to Java's doubleToLongBits and then encoded in
         # little-endian format.
-        read_and_unpack(8, 'E'.freeze)
+        read_and_unpack(8, 'E')
       end
 
       def read_bytes
@@ -97,7 +98,7 @@ module Avro
         # A string is encoded as a long followed by that many bytes of
         # UTF-8 encoded character data.
         read_bytes.tap do |string|
-          string.force_encoding('UTF-8'.freeze) if string.respond_to? :force_encoding
+          string.force_encoding('UTF-8') if string.respond_to? :force_encoding
         end
       end
 
@@ -205,7 +206,7 @@ module Avro
       # equivalent to Java's floatToIntBits and then encoded in
       # little-endian format.
       def write_float(datum)
-        @writer.write([datum].pack('e'.freeze))
+        @writer.write([datum].pack('e'))
       end
 
       # A double is written as 8 bytes.
@@ -213,7 +214,7 @@ module Avro
       # equivalent to Java's doubleToLongBits and then encoded in
       # little-endian format.
       def write_double(datum)
-        @writer.write([datum].pack('E'.freeze))
+        @writer.write([datum].pack('E'))
       end
 
       # Bytes are encoded as a long followed by that many bytes of data.
@@ -225,7 +226,7 @@ module Avro
       # A string is encoded as a long followed by that many bytes of
       # UTF-8 encoded character data
       def write_string(datum)
-        datum = datum.encode('utf-8'.freeze) if datum.respond_to? :encode
+        datum = datum.encode('utf-8') if datum.respond_to? :encode
         write_bytes(datum)
       end
 

--- a/lang/ruby/lib/avro/ipc.rb
+++ b/lang/ruby/lib/avro/ipc.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -63,8 +64,11 @@ module Avro::IPC
   SYSTEM_ERROR_SCHEMA = Avro::Schema.parse('["string"]')
 
   # protocol cache
+  # rubocop:disable Style/MutableConstant
   REMOTE_HASHES = {}
   REMOTE_PROTOCOLS = {}
+  # rubocop:enable Style/MutableConstant
+
 
   BUFFER_HEADER_LENGTH = 4
   BUFFER_SIZE = 8192
@@ -394,7 +398,7 @@ module Avro::IPC
     def read_framed_message
       message = []
       loop do
-        buffer = StringIO.new(''.force_encoding('BINARY'))
+        buffer = StringIO.new(String.new('', encoding: 'BINARY'))
         buffer_length = read_buffer_length
         if buffer_length == 0
           return message.join

--- a/lang/ruby/lib/avro/logical_types.rb
+++ b/lang/ruby/lib/avro/logical_types.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/lang/ruby/lib/avro/protocol.rb
+++ b/lang/ruby/lib/avro/protocol.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/lang/ruby/lib/avro/schema.rb
+++ b/lang/ruby/lib/avro/schema.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -29,7 +30,7 @@ module Avro
     NAMED_TYPES_SYM     = Set.new(NAMED_TYPES.map(&:to_sym))
     VALID_TYPES_SYM     = Set.new(VALID_TYPES.map(&:to_sym))
 
-    NAME_REGEX = /^([A-Za-z_][A-Za-z0-9_]*)(\.([A-Za-z_][A-Za-z0-9_]*))*$/
+    NAME_REGEX = /^([A-Za-z_][A-Za-z0-9_]*)(\.([A-Za-z_][A-Za-z0-9_]*))*$/.freeze
 
     INT_MIN_VALUE = -(1 << 31)
     INT_MAX_VALUE = (1 << 31) - 1
@@ -175,7 +176,7 @@ module Avro
       fp
     end
 
-    SINGLE_OBJECT_MAGIC_NUMBER = [0xC3, 0x01]
+    SINGLE_OBJECT_MAGIC_NUMBER = [0xC3, 0x01].freeze
     def single_object_encoding_header
       [SINGLE_OBJECT_MAGIC_NUMBER, single_object_schema_fingerprint].flatten
     end
@@ -413,7 +414,7 @@ module Avro
     end
 
     class EnumSchema < NamedSchema
-      SYMBOL_REGEX = /^[A-Za-z_][A-Za-z0-9_]*$/
+      SYMBOL_REGEX = /^[A-Za-z_][A-Za-z0-9_]*$/.freeze
 
       attr_reader :symbols, :doc, :default
 

--- a/lang/ruby/lib/avro/schema_compatibility.rb
+++ b/lang/ruby/lib/avro/schema_compatibility.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/lang/ruby/lib/avro/schema_normalization.rb
+++ b/lang/ruby/lib/avro/schema_normalization.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/lang/ruby/lib/avro/schema_validator.rb
+++ b/lang/ruby/lib/avro/schema_validator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,19 +17,19 @@
 
 module Avro
   class SchemaValidator
-    ROOT_IDENTIFIER = '.'.freeze
-    PATH_SEPARATOR = '.'.freeze
-    INT_RANGE = Schema::INT_MIN_VALUE..Schema::INT_MAX_VALUE
-    LONG_RANGE = Schema::LONG_MIN_VALUE..Schema::LONG_MAX_VALUE
+    ROOT_IDENTIFIER = '.'
+    PATH_SEPARATOR = '.'
+    INT_RANGE = (Schema::INT_MIN_VALUE..Schema::INT_MAX_VALUE).freeze
+    LONG_RANGE = (Schema::LONG_MIN_VALUE..Schema::LONG_MAX_VALUE).freeze
     COMPLEX_TYPES = [:array, :error, :map, :record, :request].freeze
     BOOLEAN_VALUES = [true, false].freeze
     DEFAULT_VALIDATION_OPTIONS = { recursive: true, encoded: false, fail_on_extra_fields: false }.freeze
     RECURSIVE_SIMPLE_VALIDATION_OPTIONS = { encoded: true }.freeze
     RUBY_CLASS_TO_AVRO_TYPE = {
-      NilClass => 'null'.freeze,
-      String => 'string'.freeze,
-      Float => 'float'.freeze,
-      Hash => 'record'.freeze
+      NilClass => 'null',
+      String => 'string',
+      Float => 'float',
+      Hash => 'record'
     }.freeze
 
     class Result
@@ -217,9 +218,9 @@ module Avro
       end
 
       def deeper_path_for_hash(sub_key, path)
-        deeper_path = "#{path}#{PATH_SEPARATOR}#{sub_key}"
+        deeper_path = +"#{path}#{PATH_SEPARATOR}#{sub_key}"
         deeper_path.squeeze!(PATH_SEPARATOR)
-        deeper_path
+        deeper_path.freeze
       end
 
       def actual_value_message(value)
@@ -240,7 +241,7 @@ module Avro
       end
 
       def ruby_integer_to_avro_type(value)
-        INT_RANGE.cover?(value) ? 'int'.freeze : 'long'.freeze
+        INT_RANGE.cover?(value) ? 'int' : 'long'
       end
     end
   end

--- a/lang/ruby/test/case_finder.rb
+++ b/lang/ruby/test/case_finder.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/lang/ruby/test/random_data.rb
+++ b/lang/ruby/test/random_data.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -5,9 +6,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 # https://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -74,7 +75,7 @@ class RandomData
       return nil if len == 0
       symbols[rand(len)]
     when :fixed
-      f = ""
+      f = +""
       schm.size.times { f << BYTEPOOL[rand(BYTEPOOL.size), 1] }
       f
     end
@@ -95,7 +96,7 @@ class RandomData
   BYTEPOOL = '12345abcd'
 
   def randstr(chars=CHARPOOL, length=20)
-    str = ''
+    str = +''
     rand(length+1).times { str << chars[rand(chars.size)] }
     str
   end

--- a/lang/ruby/test/sample_ipc_client.rb
+++ b/lang/ruby/test/sample_ipc_client.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/lang/ruby/test/sample_ipc_http_client.rb
+++ b/lang/ruby/test/sample_ipc_http_client.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/lang/ruby/test/sample_ipc_http_server.rb
+++ b/lang/ruby/test/sample_ipc_http_server.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/lang/ruby/test/sample_ipc_server.rb
+++ b/lang/ruby/test/sample_ipc_server.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/lang/ruby/test/test_datafile.rb
+++ b/lang/ruby/test/test_datafile.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/lang/ruby/test/test_fingerprints.rb
+++ b/lang/ruby/test/test_fingerprints.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/lang/ruby/test/test_help.rb
+++ b/lang/ruby/test/test_help.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/lang/ruby/test/test_io.rb
+++ b/lang/ruby/test/test_io.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -217,7 +218,7 @@ EOS
     [64, '80 01'],
     [8192, '80 80 01'],
     [-8193, '81 80 01'],
-  ]
+  ].freeze
 
   def avro_hexlify(reader)
     bytes = []
@@ -266,46 +267,46 @@ EOS
 
   def test_utf8_string_encoding
     [
-      "\xC3".force_encoding('ISO-8859-1'),
-      "\xC3\x83".force_encoding('UTF-8')
+      String.new("\xC3", encoding: 'ISO-8859-1'),
+      String.new("\xC3\x83", encoding: 'UTF-8')
     ].each do |value|
-      output = ''.force_encoding('BINARY')
+      output = String.new('', encoding: 'BINARY')
       encoder = Avro::IO::BinaryEncoder.new(StringIO.new(output))
       datum_writer = Avro::IO::DatumWriter.new(Avro::Schema.parse('"string"'))
       datum_writer.write(value, encoder)
 
-      assert_equal "\x04\xc3\x83".force_encoding('BINARY'), output
+      assert_equal String.new("\x04\xc3\x83", encoding: 'BINARY'), output
     end
   end
 
   def test_bytes_encoding
     [
-      "\xC3\x83".force_encoding('BINARY'),
-      "\xC3\x83".force_encoding('ISO-8859-1'),
-      "\xC3\x83".force_encoding('UTF-8')
+      String.new("\xC3\x83", encoding: 'BINARY'),
+      String.new("\xC3\x83", encoding: 'ISO-8859-1'),
+      String.new("\xC3\x83", encoding: 'UTF-8')
     ].each do |value|
-      output = ''.force_encoding('BINARY')
+      output = String.new('', encoding: 'BINARY')
       encoder = Avro::IO::BinaryEncoder.new(StringIO.new(output))
       datum_writer = Avro::IO::DatumWriter.new(Avro::Schema.parse('"bytes"'))
       datum_writer.write(value, encoder)
 
-      assert_equal "\x04\xc3\x83".force_encoding('BINARY'), output
+      assert_equal String.new("\x04\xc3\x83", encoding: 'BINARY'), output
     end
   end
 
   def test_fixed_encoding
     [
-      "\xC3\x83".force_encoding('BINARY'),
-      "\xC3\x83".force_encoding('ISO-8859-1'),
-      "\xC3\x83".force_encoding('UTF-8')
+      String.new("\xC3\x83", encoding: 'BINARY'),
+      String.new("\xC3\x83", encoding: 'ISO-8859-1'),
+      String.new("\xC3\x83", encoding: 'UTF-8')
     ].each do |value|
-      output = ''.force_encoding('BINARY')
+      output = String.new('', encoding: 'BINARY')
       encoder = Avro::IO::BinaryEncoder.new(StringIO.new(output))
       schema = '{"type": "fixed", "name": "TwoBytes", "size": 2}'
       datum_writer = Avro::IO::DatumWriter.new(Avro::Schema.parse(schema))
       datum_writer.write(value, encoder)
 
-      assert_equal "\xc3\x83".force_encoding('BINARY'), output
+      assert_equal String.new("\xC3\x83", encoding: 'BINARY'), output
     end
   end
 
@@ -567,7 +568,7 @@ EOS
     datum = randomdata.next
     assert validate(schm, datum), 'datum is not valid for schema'
     w = Avro::IO::DatumWriter.new(schm)
-    writer = StringIO.new "", "w"
+    writer = StringIO.new(+"", "w")
     w.write(datum, Avro::IO::BinaryEncoder.new(writer))
     r = datum_reader(schm)
     reader = StringIO.new(writer.string)

--- a/lang/ruby/test/test_logical_types.rb
+++ b/lang/ruby/test/test_logical_types.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -99,7 +100,7 @@ class TestLogicalTypes < Test::Unit::TestCase
   end
 
   def encode(datum, schema)
-    buffer = StringIO.new("")
+    buffer = StringIO.new
     encoder = Avro::IO::BinaryEncoder.new(buffer)
 
     datum_writer = Avro::IO::DatumWriter.new(schema)

--- a/lang/ruby/test/test_protocol.rb
+++ b/lang/ruby/test/test_protocol.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -184,7 +185,7 @@ EOS
   }
 }
 EOS
-]
+].freeze
 
   Protocol = Avro::Protocol
   def test_parse

--- a/lang/ruby/test/test_schema.rb
+++ b/lang/ruby/test/test_schema.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/lang/ruby/test/test_schema_compatibility.rb
+++ b/lang/ruby/test/test_schema_compatibility.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/lang/ruby/test/test_schema_normalization.rb
+++ b/lang/ruby/test/test_schema_normalization.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/lang/ruby/test/test_schema_validator.rb
+++ b/lang/ruby/test/test_schema_validator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/lang/ruby/test/test_socket_transport.rb
+++ b/lang/ruby/test/test_socket_transport.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/lang/ruby/test/tool.rb
+++ b/lang/ruby/test/tool.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information


### PR DESCRIPTION
https://issues.apache.org/jira/browse/AVRO-3112

Freeze all string literals in Ruby by default to improve performance and ensure reliability.

This is implemented by adding the `frozen_string_literal: true` pragma to all ruby files. This comment was added using the RuboCop linting and style checking tool already present. To support this, a RuboCop configuration was added to enforce this rule and a couple of related (redundant string freezes and mutable constants) in addition to the lint rules that were checked previously.

Manual code changes were needed in a couple of places where strings needed to be mutable or constants are mutated.
