### PR TITLE
AVRO-3113: Enforce Java 8 bytecode compatibility on Java dependencies

### DIFF
--- a/.github/workflows/test-lang-java.yml
+++ b/.github/workflows/test-lang-java.yml
@@ -23,6 +23,7 @@ on:
     paths:
     - .github/workflows/test-lang-java.yml
     - lang/java/**
+    - pom.xml
 
 defaults:
   run:

--- a/pom.xml
+++ b/pom.xml
@@ -110,12 +110,33 @@
         <artifactId>maven-enforcer-plugin</artifactId>
         <executions>
           <execution>
-            <id>enforce-maven-version</id>
+            <id>default-cli</id>
             <goals>
               <goal>enforce</goal>
             </goals>
             <configuration>
               <rules>
+                <enforceBytecodeVersion>
+                  <maxJdkVersion>1.8</maxJdkVersion>
+                  <!--
+                    Multi release jars that are Java 8 compatible should pass,
+                    but the extra-enforcer-plugin does not detect them
+                    correctly so we should ignore them explicitly.
+                    -->
+                  <ignoreClasses>
+                    <ignoreClass>module-info</ignoreClass>
+                  </ignoreClasses>
+                  <excludes>
+                    <!--
+                      Supplied by the user JDK and compiled with matching
+                      version. Is not shaded, so safe to ignore.
+                    -->
+                    <exclude>jdk.tools:jdk.tools</exclude>
+                  </excludes>
+                </enforceBytecodeVersion>
+                <requireJavaVersion>
+                  <version>[1.8,)</version>
+                </requireJavaVersion>
                 <requireMavenVersion>
                   <version>[3.3.9,)</version>
                 </requireMavenVersion>


### PR DESCRIPTION
Some dependencies (jetty) are starting to produce releases with bytecode that targets more recent versions of Java (e.g. Java 11). We should validate that we don't end up accidentally introducing one of those in order to keep supporting the minimum Java version we target (Java 8) correctly.

R: @dkulp or @RyanSkraba 