### PR TITLE
AVRO-3113: Update enforcer-plugin to version 3.0.0-M3

### DIFF
--- a/.github/workflows/rat.yml
+++ b/.github/workflows/rat.yml
@@ -36,8 +36,9 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'adopt'
           java-version: '11'
 
       - name: Run Rat

--- a/.github/workflows/test-lang-java.yml
+++ b/.github/workflows/test-lang-java.yml
@@ -54,22 +54,6 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
 
-      - name: Override DNS to fix IP address for hostname
-        run: |
-          ip -br addr
-          echo "'hostname -i' shows '$(hostname -i)'"
-          echo "'hostname -I' shows '$(hostname -I)'"
-          hostname_short=$(hostname -s)
-          hostname_long=$(hostname -f)
-          if ! grep -q $hostname_short /etc/hosts; then
-          actual_ip=$(ip -4 addr show dev eth0 | grep -o 'inet [0-9.]*' | cut -f2 -d ' ')
-          echo "Setting $hostname_long / $hostname_short to $actual_ip in /etc/hosts"
-          echo "$actual_ip $hostname_long $hostname_short" | sudo tee -a /etc/hosts
-          ip -br addr
-          echo "'hostname -i' shows '$(hostname -i)'"
-          echo "'hostname -I' shows '$(hostname -I)'"
-          fi
-
       - name: Lint
         run: ./build.sh lint
 
@@ -99,22 +83,6 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
-
-      - name: Override DNS to fix IP address for hostname
-        run: |
-          ip -br addr
-          echo "'hostname -i' shows '$(hostname -i)'"
-          echo "'hostname -I' shows '$(hostname -I)'"
-          hostname_short=$(hostname -s)
-          hostname_long=$(hostname -f)
-          if ! grep -q $hostname_short /etc/hosts; then
-          actual_ip=$(ip -4 addr show dev eth0 | grep -o 'inet [0-9.]*' | cut -f2 -d ' ')
-          echo "Setting $hostname_long / $hostname_short to $actual_ip in /etc/hosts"
-          echo "$actual_ip $hostname_long $hostname_short" | sudo tee -a /etc/hosts
-          ip -br addr
-          echo "'hostname -i' shows '$(hostname -i)'"
-          echo "'hostname -I' shows '$(hostname -I)'"
-          fi
 
       - name: Install Java Avro for Interop Test
         working-directory: .

--- a/.github/workflows/test-lang-java.yml
+++ b/.github/workflows/test-lang-java.yml
@@ -50,8 +50,9 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'adopt'
           java-version: ${{ matrix.java }}
 
       - name: Lint
@@ -80,8 +81,9 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'adopt'
           java-version: ${{ matrix.java }}
 
       - name: Install Java Avro for Interop Test

--- a/pom.xml
+++ b/pom.xml
@@ -47,10 +47,12 @@
     <avro.docDir>build/avro-doc-${project.version}/api</avro.docDir>
     <!-- plugin versions -->
     <antrun-plugin.version>3.0.0</antrun-plugin.version>
-    <checkstyle-plugin.version>3.1.1</checkstyle-plugin.version>
-    <spotless-maven-plugin.version>1.31.1</spotless-maven-plugin.version>
+    <checkstyle-plugin.version>3.1.2</checkstyle-plugin.version>
+    <enforcer-plugin.version>3.0.0-M3</enforcer-plugin.version>
     <plugin-tools-javadoc.version>3.5</plugin-tools-javadoc.version>
     <extra-enforcer-rules.version>1.3</extra-enforcer-rules.version>
+    <spotless-maven-plugin.version>1.31.1</spotless-maven-plugin.version>
+    <surefire.version>3.0.0-M5</surefire.version>
   </properties>
 
   <modules>
@@ -108,6 +110,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
+        <version>${enforcer-plugin.version}</version>
         <executions>
           <execution>
             <id>default-cli</id>


### PR DESCRIPTION
It also update other plugin versions to enable the project to build in more recent JDKs.
And reverts the hack we did for the github actions issue that apparently is not needed anymore https://github.com/actions/virtual-environments/issues/3185#issuecomment-824562686

R: @RyanSkraba 