### PR TITLE
AVRO-3120: Consider only the exception on TestSchema.testNullPointer

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/Conversions.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Conversions.java
@@ -18,6 +18,7 @@
 
 package org.apache.avro;
 
+import java.math.RoundingMode;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericEnumSymbol;
 import org.apache.avro.generic.GenericFixed;
@@ -30,8 +31,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;
-
-import static java.math.BigDecimal.ROUND_UNNECESSARY;
 
 public class Conversions {
 
@@ -123,7 +122,7 @@ public class Conversions {
       boolean scaleAdjusted = false;
       if (valueScale != scale) {
         try {
-          value = value.setScale(scale, ROUND_UNNECESSARY);
+          value = value.setScale(scale, RoundingMode.UNNECESSARY);
           scaleAdjusted = true;
         } catch (ArithmeticException aex) {
           throw new AvroTypeException(

--- a/lang/java/avro/src/main/java/org/apache/avro/io/parsing/ResolvingGrammarGenerator.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/parsing/ResolvingGrammarGenerator.java
@@ -122,7 +122,7 @@ public class ResolvingGrammarGenerator extends ValidatingGrammarGenerator {
       Resolver.EnumAdjust e = (Resolver.EnumAdjust) action;
       Object[] adjs = new Object[e.adjustments.length];
       for (int i = 0; i < adjs.length; i++) {
-        adjs[i] = (0 <= e.adjustments[i] ? new Integer(e.adjustments[i])
+        adjs[i] = (0 <= e.adjustments[i] ? Integer.valueOf(e.adjustments[i])
             : "No match for " + e.writer.getEnumSymbols().get(i));
       }
       return Symbol.seq(Symbol.enumAdjustAction(e.reader.getEnumSymbols().size(), adjs), Symbol.ENUM);

--- a/lang/java/integration-test/pom.xml
+++ b/lang/java/integration-test/pom.xml
@@ -59,7 +59,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>${checkstyle-plugin.version}</version>
           <configuration>
             <consoleOutput>true</consoleOutput>
             <configLocation>checkstyle.xml</configLocation>

--- a/lang/java/ipc-netty/src/test/java/org/apache/avro/ipc/netty/TestNettyServerWithCallbacks.java
+++ b/lang/java/ipc-netty/src/test/java/org/apache/avro/ipc/netty/TestNettyServerWithCallbacks.java
@@ -153,7 +153,7 @@ public class TestNettyServerWithCallbacks {
     // Test asynchronous RPC (future):
     CallFuture<Integer> future1 = new CallFuture<>();
     simpleClient.add(8, 8, future1);
-    Assert.assertEquals(new Integer(16), future1.get(2, TimeUnit.SECONDS));
+    Assert.assertEquals(Integer.valueOf(16), future1.get(2, TimeUnit.SECONDS));
     Assert.assertNull(future1.getError());
 
     // Test asynchronous RPC (callback):
@@ -169,7 +169,7 @@ public class TestNettyServerWithCallbacks {
         future2.handleError(error);
       }
     });
-    Assert.assertEquals(new Integer(768), future2.get(2, TimeUnit.SECONDS));
+    Assert.assertEquals(Integer.valueOf(768), future2.get(2, TimeUnit.SECONDS));
     Assert.assertNull(future2.getError());
   }
 
@@ -278,7 +278,7 @@ public class TestNettyServerWithCallbacks {
         // Try again with callbacks:
         CallFuture<Integer> addFuture = new CallFuture<>();
         simpleClient2.add(1, 2, addFuture);
-        Assert.assertEquals(new Integer(3), addFuture.get());
+        Assert.assertEquals(Integer.valueOf(3), addFuture.get());
 
         // Shut down server:
         server2.close();

--- a/lang/java/ipc/src/test/java/org/apache/avro/TestSchema.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/TestSchema.java
@@ -509,11 +509,8 @@ public class TestSchema {
         + "[{\"name\":\"x\", \"type\":\"string\"}]}";
     Schema schema = new Schema.Parser().parse(recordJson);
     GenericData.Record record = new GenericData.Record(schema);
-    try {
-      checkBinary(schema, record, new GenericDatumWriter<>(), new GenericDatumReader<>());
-    } catch (NullPointerException e) {
-      assertEquals("null of string in field x of Test", e.getMessage());
-    }
+    assertThrows(NullPointerException.class,
+        () -> checkBinary(schema, record, new GenericDatumWriter<>(), new GenericDatumReader<>()));
   }
 
   private static void checkParseError(String json) {

--- a/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/AbstractAvroMojo.java
+++ b/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/AbstractAvroMojo.java
@@ -315,7 +315,7 @@ public abstract class AbstractAvroMojo extends AbstractMojo {
     for (String velocityToolClassName : velocityToolsClassesNames) {
       try {
         Class klass = Class.forName(velocityToolClassName);
-        velocityTools.add(klass.newInstance());
+        velocityTools.add(klass.getDeclaredConstructor().newInstance());
       } catch (Exception e) {
         throw new RuntimeException(e);
       }

--- a/lang/java/perf/src/main/java/org/apache/avro/perf/test/basic/UnchangedUnionTest.java
+++ b/lang/java/perf/src/main/java/org/apache/avro/perf/test/basic/UnchangedUnionTest.java
@@ -90,7 +90,7 @@ public class UnchangedUnionTest {
         final GenericRecord rec = new GenericData.Record(this.schema);
 
         final int val = super.getRandom().nextInt(1000000);
-        final Integer v = (val < 750000 ? new Integer(val) : null);
+        final Integer v = (val < 750000 ? Integer.valueOf(val) : null);
         rec.put("f", v);
 
         this.testData[i] = rec;
@@ -132,7 +132,7 @@ public class UnchangedUnionTest {
       for (int i = 0; i < getBatchSize(); i++) {
         final GenericRecord rec = new GenericData.Record(this.schema);
         final int val = super.getRandom().nextInt(1000000);
-        final Integer v = (val < 750000 ? new Integer(val) : null);
+        final Integer v = (val < 750000 ? Integer.valueOf(val) : null);
         rec.put("f", v);
 
         writer.write(rec, encoder);

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -98,6 +98,18 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-checkstyle-plugin</artifactId>
+          <version>${checkstyle-plugin.version}</version>
+          <dependencies>
+            <dependency>
+              <groupId>com.puppycrawl.tools</groupId>
+              <artifactId>checkstyle</artifactId>
+              <version>${checkstyle.version}</version>
+            </dependency>
+          </dependencies>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <configuration>
             <compilerArgs>
@@ -249,7 +261,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>${checkstyle-plugin.version}</version>
         <configuration>
           <consoleOutput>true</consoleOutput>
           <configLocation>checkstyle.xml</configLocation>

--- a/lang/java/tools/src/main/java/org/apache/avro/tool/CatTool.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/CatTool.java
@@ -55,11 +55,11 @@ public class CatTool implements Tool {
   public int run(InputStream in, PrintStream out, PrintStream err, List<String> args) throws Exception {
     OptionParser optParser = new OptionParser();
     OptionSpec<Long> offsetOpt = optParser.accepts("offset", "offset for reading input").withRequiredArg()
-        .ofType(Long.class).defaultsTo(new Long(0));
+        .ofType(Long.class).defaultsTo(Long.valueOf(0));
     OptionSpec<Long> limitOpt = optParser.accepts("limit", "maximum number of records in the outputfile")
         .withRequiredArg().ofType(Long.class).defaultsTo(Long.MAX_VALUE);
     OptionSpec<Double> fracOpt = optParser.accepts("samplerate", "rate at which records will be collected")
-        .withRequiredArg().ofType(Double.class).defaultsTo(new Double(1));
+        .withRequiredArg().ofType(Double.class).defaultsTo(Double.valueOf(1));
 
     OptionSet opts = optParser.parse(args.toArray(new String[0]));
     List<String> nargs = (List<String>) opts.nonOptionArguments();

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
     <!-- plugin versions -->
     <antrun-plugin.version>3.0.0</antrun-plugin.version>
     <checkstyle-plugin.version>3.1.2</checkstyle-plugin.version>
+    <checkstyle.version>8.42</checkstyle.version>
     <enforcer-plugin.version>3.0.0-M3</enforcer-plugin.version>
     <plugin-tools-javadoc.version>3.5</plugin-tools-javadoc.version>
     <extra-enforcer-rules.version>1.3</extra-enforcer-rules.version>


### PR DESCRIPTION
More recent javac compilers produce a different exception message so we
should probably not validate based on the text.

R: @RyanSkraba 