### PR TITLE
Enhance json parsing exception text to make it easier to locate problem

### DIFF
--- a/lang/c++/impl/parsing/JsonCodec.cc
+++ b/lang/c++/impl/parsing/JsonCodec.cc
@@ -162,7 +162,8 @@ public:
             case Symbol::Kind::Field:
                 expectToken(in_, JsonParser::Token::String);
                 if (s.extra<string>() != in_.stringValue()) {
-                    throw Exception("Incorrect field");
+                    throw Exception(boost::format("Incorrect field: expected \"%1%\" but got \"%2%\".") % 
+                        s.extra<string>() % in_.stringValue());
                 }
                 break;
             default:


### PR DESCRIPTION
Simple change to make it easier to debug json that doesn't conform to a schema.

I'll put in an issue if that's required to accept a PR.