### PR TITLE
AVRO-3129: Throw SchemaParseException when enum symbol is null

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/Schema.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Schema.java
@@ -1556,6 +1556,8 @@ public abstract class Schema extends JsonProperties implements Serializable {
   private static String validateName(String name) {
     if (!validateNames.get())
       return name; // not validating names
+    if (name == null)
+      throw new SchemaParseException("Null name");
     int length = name.length();
     if (length == 0)
       throw new SchemaParseException("Empty name");

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchema.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchema.java
@@ -355,4 +355,9 @@ public class TestSchema {
     assertEquals(1.0f, field.defaultVal());
     assertEquals(1.0f, GenericData.get().getDefaultValue(field));
   }
+
+  @Test(expected = SchemaParseException.class)
+  public void testEnumSymbolAsNull() {
+    Schema.createEnum("myField", "doc", "namespace", Collections.singletonList(null));
+  }
 }


### PR DESCRIPTION
Avro Schema parser fails with NullPointerException when a schema with null Enum symbols are encountered. This behavior is inconsistent with using an empty symbol where a SchemaParseException is thrown. JIRA: https://issues.apache.org/jira/browse/AVRO-3129

Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO-3129) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3129
  - [x] In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

`testEnumSymbolAsNull`

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

Not applicable.