### PR TITLE
AVRO-3134: Fix ArgumentOutOfRangeException in method ToString of AvroDecimal

### DIFF
--- a/lang/csharp/src/apache/main/AvroDecimal.cs
+++ b/lang/csharp/src/apache/main/AvroDecimal.cs
@@ -132,7 +132,7 @@ namespace Avro
         /// <returns>A string representation of the numeric value.</returns>
         public override string ToString()
         {
-            var number = UnscaledValue.ToString(CultureInfo.CurrentCulture);
+            var number = UnscaledValue.ToString($"D{Scale + 1}", CultureInfo.CurrentCulture);
 
             if (Scale > 0)
                 return number.Insert(number.Length - Scale, CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator);

--- a/lang/csharp/src/apache/test/AvroDecimalTest.cs
+++ b/lang/csharp/src/apache/test/AvroDecimalTest.cs
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using NUnit.Framework;
+
+namespace Avro.test
+{
+    [TestFixture]
+    class AvroDecimalTest
+    {
+        [TestCase(1)]
+        [TestCase(1000)]
+        [TestCase(10.10)]
+        [TestCase(0)]
+        [TestCase(0.1)]
+        [TestCase(0.01)]
+        [TestCase(-1)]
+        [TestCase(-1000)]
+        [TestCase(-10.10)]
+        [TestCase(-0.1)]
+        [TestCase(-0.01)]
+        public void TestAvroDecimalToString(decimal value)
+        {
+            var valueString = value.ToString();
+
+            var avroDecimal = new AvroDecimal(value);            
+            var avroDecimalString = avroDecimal.ToString();
+
+            Assert.AreEqual(valueString, avroDecimalString);
+        }
+    }
+}


### PR DESCRIPTION
The method ToString of class AvroDecimal causes ArgumentOutOfRangeException
when Scale is greater than Unscaled number size.
The method ToString of class AvroDecimal returns a wrong result when Scale
is equal to the Unscaled number size because is missing a "0"

Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AVRO-3134

### Tests

- [X] My PR adds the following unit tests:
  - AvroDecimalTest.cs

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"