### PR TITLE
AVRO-3118: Treat "" as Null Namespace

### DIFF
--- a/lang/py/avro/schema.py
+++ b/lang/py/avro/schema.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- mode: python -*-
 # -*- coding: utf-8 -*-
 
 ##
@@ -411,14 +410,16 @@ class NamedSchema(Schema):
     def __init__(self, type, name, namespace=None, names=None, other_props=None):
         # Ensure valid ctor args
         if not name:
-            fail_msg = 'Named Schemas must have a non-empty name.'
+            fail_msg = "Named Schemas must have a non-empty name."
             raise avro.errors.SchemaParseException(fail_msg)
         elif not isinstance(name, str):
-            fail_msg = 'The name property must be a string.'
+            fail_msg = "The name property must be a string."
             raise avro.errors.SchemaParseException(fail_msg)
         elif namespace is not None and not isinstance(namespace, str):
-            fail_msg = 'The namespace property must be a string.'
+            fail_msg = "The namespace property must be a string."
             raise avro.errors.SchemaParseException(fail_msg)
+
+        namespace = namespace or None  # Empty string -> None
 
         # Call parent ctor
         Schema.__init__(self, type, other_props)
@@ -427,9 +428,9 @@ class NamedSchema(Schema):
         new_name = names.add_name(name, namespace, self)
 
         # Store name and namespace as they were read in origin schema
-        self.set_prop('name', name)
+        self.set_prop("name", name)
         if namespace is not None:
-            self.set_prop('namespace', new_name.space)
+            self.set_prop("namespace", new_name.space)
 
         # Store full name as calculated from name, namespace
         self._fullname = new_name.fullname

--- a/lang/py/avro/test/test_schema.py
+++ b/lang/py/avro/test/test_schema.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- mode: python -*-
 # -*- coding: utf-8 -*-
 
 ##
@@ -67,8 +66,20 @@ PRIMITIVE_EXAMPLES.extend([ValidTestSchema({"type": t}) for t in avro.schema.PRI
 
 FIXED_EXAMPLES = [
     ValidTestSchema({"type": "fixed", "name": "Test", "size": 1}),
-    ValidTestSchema({"type": "fixed", "name": "MyFixed", "size": 1,
-                     "namespace": "org.apache.hadoop.avro"}),
+    ValidTestSchema(
+        {
+            "type": "fixed",
+            "name": "MyFixed",
+            "size": 1,
+            "namespace": "org.apache.hadoop.avro",
+        }
+    ),
+    ValidTestSchema(
+        {"type": "fixed", "name": "NullNamespace", "namespace": None, "size": 1}
+    ),
+    ValidTestSchema(
+        {"type": "fixed", "name": "EmptyStringNamespace", "namespace": "", "size": 1}
+    ),
     InvalidTestSchema({"type": "fixed", "name": "Missing size"}),
     InvalidTestSchema({"type": "fixed", "size": 314}),
     InvalidTestSchema({"type": "fixed", "size": 314, "name": "dr. spaceman"}, comment='AVRO-621'),
@@ -538,14 +549,21 @@ class RoundTripParseTestCase(unittest.TestCase):
         ignores this class. The autoloader will ignore this class as long as it has
         no methods starting with `test_`.
         """
-        super().__init__('parse_round_trip')
+        super().__init__("parse_round_trip")
         self.test_schema = test_schema
 
     def parse_round_trip(self):
         """The string of a Schema should be parseable to the same Schema."""
         parsed = self.test_schema.parse()
         round_trip = avro.schema.parse(str(parsed))
-        self.assertEqual(parsed, round_trip)
+        self.assertEqual(
+            parsed,
+            round_trip,
+            {
+                "original schema": parsed.to_json(),
+                "round trip schema": round_trip.to_json(),
+            },
+        )
 
 
 class DocAttributesTestCase(unittest.TestCase):


### PR DESCRIPTION
This changeset brings the python implementation in line with [the specification](https://avro.apache.org/docs/current/spec.html#names) insofar as when a namespace is the empty string, it should be treated as if the namespace were null. 

### Jira

This PR…

- [x] …addresses [AVRO-3118](https://issues.apache.org/jira/browse/AVRO-3118).
- [x] …adds no dependencies.

### Tests

- [x] This PR adds schema test cases to validate the problem and solution.

### Commits

- [x] These commits all reference Jira issues in their subject lines.
- [x] These commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
- [x] Subject is separated from body by a blank line
- [x] Subject is limited to 50 characters (not including Jira issue reference)
- [x] Subject does not end with a period
- [x] Subject uses the imperative mood ("add", not "adding")
- [x] Body wraps at 72 characters
- [x] Body explains "what" and "why", not "how"

### Documentation

- [x] This is a bugfix that puts the behavior of the software more in line with the existing specification and documentation.
