### PR TITLE
AVRO-3139: Only Run Spotless on Java Changesets

### DIFF
--- a/.github/workflows/spotless.yml
+++ b/.github/workflows/spotless.yml
@@ -20,6 +20,9 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+    paths:
+    - .github/workflows/spotless.yml
+    - lang/java/**
 
 jobs:
   spotless:


### PR DESCRIPTION
Spotless is only configured to run on java right now, so it seems a waste of github actions to run it on anything else. Later, we should discuss running spotless checks for other languages.

### Jira

This PR…

- [x] …addresses [AVRO-3139]().
- [x] …adds no dependencies.

### Tests

N/A

### Commits

My commits…

- [x] …all reference Jira issues in their subject lines.
- [x] …follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  - [x] Subject is separated from body by a blank line
  - [x] Subject is limited to 50 characters (not including Jira issue reference)
  - [x] Subject does not end with a period
  - [x] Subject uses the imperative mood ("add", not "adding")
  - [x] Body wraps at 72 characters
  - [x] Body explains "what" and "why", not "how"

### Documentation

N/A
