### PR TITLE
AVRO-3104 Allow Comparing Schemas to non-Schemas

### DIFF
--- a/lang/py/avro/test/test_schema.py
+++ b/lang/py/avro/test/test_schema.py
@@ -597,7 +597,12 @@ class OtherAttributesTestCase(unittest.TestCase):
     def check_attributes(self):
         """Other attributes and their types on a schema should be preserved."""
         sch = self.test_schema.parse()
+        try:
+            self.assertNotEqual(sch, object(), "A schema is never equal to a non-schema instance.")
+        except AttributeError:
+            self.fail("Comparing a schema to a non-schema should be False, but not error.")
         round_trip = avro.schema.parse(str(sch))
+        self.assertEqual(sch, round_trip, "A schema should be equal to another schema parsed from the same json.")
         self.assertEqual(sch.other_props, round_trip.other_props,
                          "Properties were not preserved in a round-trip parse.")
         self._check_props(sch.other_props)


### PR DESCRIPTION
If you try to test if an arbitrary object is equal to a schema, as in `some_schema == not_a_schema`, avro would crash with an `AttributeError`. This comparison should not crash.It should simply return `False` when the other object is not a schema.

### Jira

My PR...
- [x] Addresses [AVRO-3104](https://issues.apache.org/jira/browse/AVRO-3104)
- [x] Adds no dependencies

### Tests

- [x] Passes existing tests.
- [x] Passes new tests to compare schemas to `object()`.

### Commits

- [x] My commits all reference Jira issues in their subject lines.
- [x] My commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  - [x] Subject is separated from body by a blank line
  - [x] Subject is limited to 50 characters (not including Jira issue reference)
  - [x] Subject does not end with a period
  - [x] Subject uses the imperative mood ("add", not "adding")
  - [x] Body wraps at 72 characters
  - [x] Body explains "what" and "why", not "how"

### Documentation

N/A
