### PR TITLE
AVRO-3145: Add the CodeQL Badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![Test Ruby](https://github.com/apache/avro/workflows/Test%20Ruby/badge.svg)][Test Ruby]
 [![Test Python](https://github.com/apache/avro/workflows/Test%20Python/badge.svg)][Test Python]
 [![Test PHP](https://github.com/apache/avro/workflows/Test%20PHP/badge.svg)][Test PHP]
+[![CodeQL](https://github.com/apache/avro/workflows/CodeQL/badge.svg)][CodeQL]
 
 -----
 
@@ -32,3 +33,4 @@ To contribute to Avro, please read:
 [Test Ruby]: https://github.com/apache/avro/actions?query=workflow%3A%22Test+Ruby%22
 [Test Python]: https://github.com/apache/avro/actions?query=workflow%3A%22Test+Python%22
 [Test PHP]: https://github.com/apache/avro/actions?query=workflow%3A%22Test+PHP%22
+[CodeQL]: https://github.com/apache/avro/actions?query=workflow%3A%22CodeQL


### PR DESCRIPTION
Indicate the status of the CodeQL scan in the Readme. It's easier to
determine which checks/tests are passing and failing in the Readme than
it is to click around to figure it out.

### Jira

- [x] Addresses [AVRO-3145](https://issues.apache.org/jira/browse/AVRO-3145)
- [x] References the ticket in the PR title
- [x] No dependencies

### Tests

N/A

### Commits

- [x] Commits reference the ticket.

### Documentation

- [x] Improves documentation
