### PR TITLE
AVRO-3147: Upgrade to rubocop v1.x

### DIFF
--- a/lang/ruby/.rubocop.yml
+++ b/lang/ruby/.rubocop.yml
@@ -17,6 +17,7 @@
 AllCops:
   TargetRubyVersion: 2.6
   NewCops: disable
+  SuggestExtensions: false
 
 Bundler:
   Enabled: false

--- a/lang/ruby/.rubocop.yml
+++ b/lang/ruby/.rubocop.yml
@@ -35,7 +35,7 @@ Naming:
   Enabled: false
 
 Security:
-  Enabled: false
+  Enabled: true
 
 Style:
   Enabled: false

--- a/lang/ruby/.rubocop.yml
+++ b/lang/ruby/.rubocop.yml
@@ -48,3 +48,40 @@ Style/MutableConstant:
 
 Style/RedundantFreeze:
   Enabled: true
+
+# New cops from 1.x. Lines below can be removed after upgrading to rubocop > 2.0.
+
+Gemspec/DateAssignment: # (new in 1.10)
+  Enabled: true
+Lint/AmbiguousAssignment: # (new in 1.7)
+  Enabled: true
+Lint/DeprecatedConstants: # (new in 1.8)
+  Enabled: true
+Lint/DuplicateBranch: # (new in 1.3)
+  Enabled: true
+Lint/DuplicateRegexpCharacterClassElement: # (new in 1.1)
+  Enabled: true
+Lint/EmptyBlock: # (new in 1.1)
+  Enabled: true
+Lint/EmptyClass: # (new in 1.3)
+  Enabled: true
+Lint/LambdaWithoutLiteralBlock: # (new in 1.8)
+  Enabled: true
+Lint/NoReturnInBeginEndBlocks: # (new in 1.2)
+  Enabled: true
+Lint/NumberedParameterAssignment: # (new in 1.9)
+  Enabled: true
+Lint/OrAssignmentToConstant: # (new in 1.9)
+  Enabled: true
+Lint/RedundantDirGlobSort: # (new in 1.8)
+  Enabled: true
+Lint/SymbolConversion: # (new in 1.9)
+  Enabled: true
+Lint/ToEnumArguments: # (new in 1.1)
+  Enabled: true
+Lint/TripleQuotes: # (new in 1.9)
+  Enabled: true
+Lint/UnexpectedBlockArity: # (new in 1.5)
+  Enabled: true
+Lint/UnmodifiedReduceAccumulator: # (new in 1.1)
+  Enabled: true

--- a/lang/ruby/Gemfile
+++ b/lang/ruby/Gemfile
@@ -27,6 +27,6 @@ gem 'webrick'
 
 gem 'memory_profiler'
 
-# rubocop v1.0 and later introduces new Lint cops to be addressed
-gem 'rubocop', '< 1.0'
+# next major version will enable new cops
+gem 'rubocop', '~> 1.15'
 gem 'rdoc'

--- a/lang/ruby/lib/avro/io.rb
+++ b/lang/ruby/lib/avro/io.rb
@@ -393,13 +393,11 @@ module Avro
         case field_schema.type_sym
         when :null
           return nil
-        when :boolean
-          return default_value
         when :int, :long
           return Integer(default_value)
         when :float, :double
           return Float(default_value)
-        when :enum, :fixed, :string, :bytes
+        when :boolean, :enum, :fixed, :string, :bytes
           return default_value
         when :array
           read_array = []

--- a/lang/ruby/lib/avro/schema.rb
+++ b/lang/ruby/lib/avro/schema.rb
@@ -564,7 +564,7 @@ module Avro
     class Field < Schema
       attr_reader :type, :name, :default, :order, :doc, :aliases
 
-      def initialize(type, name, default=:no_default, order=nil, names=nil, namespace=nil, doc=nil, aliases=nil)
+      def initialize(type, name, default=:no_default, order=nil, names=nil, namespace=nil, doc=nil, aliases=nil) # rubocop:disable Lint/MissingSuper
         @type = subparse(type, names, namespace)
         @name = name
         @default = default

--- a/lang/ruby/lib/avro/schema_compatibility.rb
+++ b/lang/ruby/lib/avro/schema_compatibility.rb
@@ -62,6 +62,7 @@ module Avro
       end
 
       # Handle schema promotion
+      # rubocop:disable Lint/DuplicateBranch
       if w_type == :int && INT_COERCIBLE_TYPES_SYM.include?(r_type)
         return true
       elsif w_type == :long && LONG_COERCIBLE_TYPES_SYM.include?(r_type)
@@ -73,6 +74,7 @@ module Avro
       elsif w_type == :bytes && r_type == :string
         return true
       end
+      # rubocop:enable Lint/DuplicateBranch
 
       if readers_schema.respond_to?(:match_schema?)
         readers_schema.match_schema?(writers_schema)

--- a/lang/ruby/test/tool.rb
+++ b/lang/ruby/test/tool.rb
@@ -22,7 +22,7 @@ require 'logger'
 
 class GenericResponder < Avro::IPC::Responder
   def initialize(proto, msg, datum)
-    proto_json = open(proto).read
+    proto_json = File.open(proto).read
     super(Avro::Protocol.parse(proto_json))
     @msg = msg
     @datum = datum
@@ -63,14 +63,14 @@ end
 def send_message(uri, proto, msg, datum)
   uri = URI.parse(uri)
   trans = Avro::IPC::HTTPTransceiver.new(uri.host, uri.port)
-  proto_json = open(proto).read
+  proto_json = File.open(proto).read
   requestor = Avro::IPC::Requestor.new(Avro::Protocol.parse(proto_json),
                                        trans)
   p requestor.request(msg, datum)
 end
 
 def file_or_stdin(f)
-  f == "-" ? STDIN : open(f)
+  f == "-" ? STDIN : File.open(f)
 end
 
 def main

--- a/lang/ruby/test/tool.rb
+++ b/lang/ruby/test/tool.rb
@@ -101,9 +101,9 @@ def main
     if ARGV.size > 4
       case ARGV[4]
       when "-file"
-        Avro::DataFile.open(ARGV[5]) {|f|
-          f.each{|e| datum = e; break }
-        }
+        Avro::DataFile.open(ARGV[5]) do |f|
+          datum = f.first
+        end
       when "-data"
         puts "JSON Decoder not yet implemented."
         return 1
@@ -125,7 +125,7 @@ def main
     if ARGV.size > 4
       case ARGV[4]
       when "-file"
-        Avro::DataFile.open(ARGV[5]){|f| f.each{|e| datum = e; break } }
+        Avro::DataFile.open(ARGV[5]){ |f| datum = f.first }
       when "-data"
         puts "JSON Decoder not yet implemented"
         return 1


### PR DESCRIPTION
https://issues.apache.org/jira/browse/AVRO-3147

Rubocop version is set to >= 1.15 but < 2.0.

In addition to using the newer Rubocop version, new Lint cops are enabled, and any offenses corrected or disabled.

The Security group of cops is also enabled.

