### PR TITLE
AVRO-3152: Correction: Specify Languages

### DIFF
--- a/.github/workflows/codeql-csharp-analysis.yml
+++ b/.github/workflows/codeql-csharp-analysis.yml
@@ -29,7 +29,7 @@ on:
     branches:
     - master
     paths:
-    - .github/workflows/test-lang-csharp.yml
+    - .github/workflows/codeql-csharp-analysis.yml
     - lang/csharp/**
 
 jobs:

--- a/.github/workflows/codeql-java-analysis.yml
+++ b/.github/workflows/codeql-java-analysis.yml
@@ -28,7 +28,7 @@ on:
     branches:
     - master
     paths:
-    - .github/workflows/test-lang-java.yml
+    - .github/workflows/codeql-java-analysis.yml
     - lang/java/**
     - pom.xml
 
@@ -43,10 +43,7 @@ jobs:
         # Override automatic language detection by changing the below list
         # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
         language:
-        - csharp
         - java
-        - javascript
-        - python
         # Learn more...
         # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
 

--- a/.github/workflows/codeql-js-analysis.yml
+++ b/.github/workflows/codeql-js-analysis.yml
@@ -29,7 +29,7 @@ on:
     branches:
     - master
     paths:
-    - .github/workflows/test-lang-js.yml
+    - .github/workflows/codeql-js-analysis.yml
     - lang/js/**
 
 jobs:
@@ -43,10 +43,7 @@ jobs:
         # Override automatic language detection by changing the below list
         # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
         language:
-        - csharp
-        - java
         - javascript
-        - python
         # Learn more...
         # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
 

--- a/.github/workflows/codeql-py-analysis.yml
+++ b/.github/workflows/codeql-py-analysis.yml
@@ -29,7 +29,7 @@ on:
     branches:
     - master
     paths:
-    - .github/workflows/test-lang-py.yml
+    - .github/workflows/codeql-py-analysis.yml
     - lang/py/**
 
 jobs:
@@ -43,9 +43,6 @@ jobs:
         # Override automatic language detection by changing the below list
         # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
         language:
-        - csharp
-        - java
-        - javascript
         - python
         # Learn more...
         # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection


### PR DESCRIPTION
Pull request #1237 seemed to work when I tested it, but continued to scan changesets even for implementations that had not changed.
This seems to be due to the fact that the matrix language list was not specified correctly in each yml file.

### Jira

- [x] Pull request addresses [AVRO-3152](https://issues.apache.org/jira/browse/AVRO-3152)
- [x] Pull request notes AVRO-3152 in the title.
- [x] Changes no dependencies.

### Tests

N/A

### Commits

- [x] Commits reference AVRO-3152 in the title.
- [x] Commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)"
  - [x] Subject is separated from body by a blank line
  - [x] Subject is limited to 50 characters (not including Jira issue reference)
  - [x] Subject does not end with a period
  - [x] Subject uses the imperative mood ("add", not "adding")
  - [x] Body wraps at 72 characters
  - [x] Body explains "what" and "why", not "how"

### Documentation

N/A
