### PR TITLE
AVRO-3007: Standardize Building Python Packages

### DIFF
--- a/lang/py/build.sh
+++ b/lang/py/build.sh
@@ -35,12 +35,21 @@ clean() {
                  'userlogs'
 }
 
-dist() {
-  python3 setup.py sdist
-  python3 setup.py bdist_wheel
-  mkdir -p ../../dist/py
-  cp dist/*.{tar.gz,whl} ../../dist/py
-}
+dist() (
+  ##
+  # Use https://pypa-build.readthedocs.io to create the build artifacts.
+  local destination virtualenv
+  destination=$(
+    d=../../dist/py
+    mkdir -p "$d"
+    cd -P "$d"
+    pwd
+  )
+  virtualenv="$(mktemp -d)"
+  python3 -m venv "$virtualenv"
+  "$virtualenv/bin/python3" -m pip install build
+  "$virtualenv/bin/python3" -m build --outdir "$destination"
+)
 
 interop-data-generate() {
   ./setup.py generate_interop_data

--- a/lang/py/pyproject.toml
+++ b/lang/py/pyproject.toml
@@ -13,6 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+##
+# Minimal pip build requirements:
+# https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support
+[build-system]
+requires = ["setuptools>=40.8.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [tool.black]
 line-length = 150
 


### PR DESCRIPTION
- Modernize the Python build system to the PEP 517 standard.
- Build wheel and tar distributions to ship.

### Jira

- [x] PR addresses [AVRO-3007](https://issues.apache.org/jira/browse/AVRO-3007/)
- [x] PR references AVRO-3007 in the PR title.
- [x] PR introduces build-time dependency on [build](https://github.com/pypa/build), which has an MIT license.

### Tests

N/A

### Commits

- [x] Commits all reference AVRO-3007
- [x] Commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)"
  - [x] Subject is separated from body by a blank line
  - [x] Subject is limited to 50 characters (not including Jira issue reference)
  - [x] Subject does not end with a period
  - [x] Subject uses the imperative mood ("add", not "adding")
  - [x] Body wraps at 72 characters
  - [x] Body explains "what" and "why", not "how"

### Documentation

N/A (Still uses ./build.sh dist)
