### PR TITLE
Fix c++ windows build. IN and OUT are predefined macros.

### DIFF
--- a/lang/c++/impl/avrogencpp.cc
+++ b/lang/c++/impl/avrogencpp.cc
@@ -804,8 +804,8 @@ static string readGuard(const string &filename) {
 
 int main(int argc, char **argv) {
     const string NS("namespace");
-    const string OUT("output");
-    const string IN("input");
+    const string OUT_FILE("output");
+    const string IN_FILE("input");
     const string INCLUDE_PREFIX("include-prefix");
     const string NO_UNION_TYPEDEF("no-union-typedef");
 
@@ -817,14 +817,14 @@ int main(int argc, char **argv) {
     po::store(po::parse_command_line(argc, argv, desc), vm);
     po::notify(vm);
 
-    if (vm.count("help") || vm.count(IN) == 0 || vm.count(OUT) == 0) {
+    if (vm.count("help") || vm.count(IN_FILE) == 0 || vm.count(OUT_FILE) == 0) {
         std::cout << desc << std::endl;
         return 1;
     }
 
     string ns = vm.count(NS) > 0 ? vm[NS].as<string>() : string();
-    string outf = vm.count(OUT) > 0 ? vm[OUT].as<string>() : string();
-    string inf = vm.count(IN) > 0 ? vm[IN].as<string>() : string();
+    string outf = vm.count(OUT_FILE) > 0 ? vm[OUT_FILE].as<string>() : string();
+    string inf = vm.count(IN_FILE) > 0 ? vm[IN_FILE].as<string>() : string();
     string incPrefix = vm[INCLUDE_PREFIX].as<string>();
     bool noUnion = vm.count(NO_UNION_TYPEDEF) != 0;
     if (incPrefix == "-") {


### PR DESCRIPTION
I have not followed your required steps and have not created a jira issue. This is a drive by fix that I have done while doing microsoft/vcpkg#17335 because it causes the pipeline to fail (see for example [here](https://github.com/microsoft/vcpkg/runs/2714029054)).  
But I think you are maybe interested in this fix and want to integrate it. 