### PR TITLE
AVRO-3156: SpecificRecordBuilder performance degradation

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificData.java
@@ -161,15 +161,10 @@ public class SpecificData extends GenericData {
    */
   public static SpecificData getForSchema(Schema reader) {
     if (reader != null && reader.getType() == Type.RECORD) {
-      final String className = getClassName(reader);
-      if (className != null) {
-        final Class<?> clazz;
-        try {
-          clazz = Class.forName(className);
-          return getForClass(clazz);
-        } catch (ClassNotFoundException e) {
-          return SpecificData.get();
-        }
+      // Rely on classCache of default instance
+      final Class<?> clazz = SpecificData.get().getClass(reader);
+      if (clazz != null) {
+        return getForClass(clazz);
       }
     }
     return SpecificData.get();

--- a/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificRecordBuilderBase.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificRecordBuilderBase.java
@@ -60,6 +60,6 @@ abstract public class SpecificRecordBuilderBase<T extends SpecificRecord> extend
    * @param other the record instance to copy.
    */
   protected SpecificRecordBuilderBase(T other) {
-    super(other.getSchema(), SpecificData.getForSchema(other.getSchema()));
+    super(other.getSchema(), SpecificData.getForClass(other.getClass()));
   }
 }


### PR DESCRIPTION
The change introduced in spark 1.9.0 which changed:

    SpecificData.get()

into:

    SpecificData.getForSchema(schema)

introduced a significant performance degradation in environments where the class belonging to the `schema` is provided by a different classloader then the classloader containing `SpecificData`.

In this patch we use the `classCache` of the default `SpecificData` so the sometimes expensive classloader codepath is cached.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3156

### Tests

- [x] My PR does not need testing for this extremely good reason: performance optimization which is tested

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
