### PR TITLE
AVRO-2921: Type Hints for avro.schema and avro.protocol

### DIFF
--- a/lang/py/avro/name.py
+++ b/lang/py/avro/name.py
@@ -143,7 +143,7 @@ class Names:
         del prunable["namespace"]
         return prunable
 
-    def add_name(self, name_attr: str, space_attr: str, new_schema: "NamedSchema") -> Name:
+    def add_name(self, name_attr: str, space_attr: Optional[str], new_schema: "NamedSchema") -> Name:
         """
         Add a new schema object to the name set.
 

--- a/lang/py/avro/protocol.py
+++ b/lang/py/avro/protocol.py
@@ -17,199 +17,208 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Protocol implementation."""
+"""
+Protocol implementation.
+
+https://avro.apache.org/docs/current/spec.html#Protocol+Declaration
+"""
 
 import hashlib
 import json
+import sys
+from typing import Mapping, Optional, Sequence, Union, cast
 
 import avro.errors
+import avro.name
 import avro.schema
-
-#
-# Constants
-#
 
 # TODO(hammer): confirmed 'fixed' with Doug
 VALID_TYPE_SCHEMA_TYPES = ("enum", "record", "error", "fixed")
 
-#
-# Base Classes
-#
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
+
+
+class MessageObject(TypedDict, total=False):
+    request: Sequence[Mapping[str, object]]
+    response: Union[str, object]
+    errors: Optional[Sequence[str]]
+
+
+class ProtocolObject(TypedDict, total=False):
+    protocol: str
+    namespace: str
+    types: Sequence[str]
+    messages: Mapping[str, MessageObject]
 
 
 class Protocol:
-    """An application protocol."""
+    """
+    Avro protocols describe RPC interfaces. Like schemas, they are defined with JSON text.
 
-    def _parse_types(self, types, type_names):
-        type_objects = []
-        for type in types:
-            type_object = avro.schema.make_avsc_object(type, type_names)
-            if type_object.type not in VALID_TYPE_SCHEMA_TYPES:
-                fail_msg = f"Type {type} not an enum, fixed, record, or error."
-                raise avro.errors.ProtocolParseException(fail_msg)
-            type_objects.append(type_object)
-        return type_objects
+    A protocol is a JSON object with the following attributes:
 
-    def _parse_messages(self, messages, names):
-        message_objects = {}
-        for name, body in messages.items():
-            if name in message_objects:
-                fail_msg = f'Message name "{name}" repeated.'
-                raise avro.errors.ProtocolParseException(fail_msg)
-            try:
-                request = body.get("request")
-                response = body.get("response")
-                errors = body.get("errors")
-            except AttributeError:
-                fail_msg = f'Message name "{name}" has non-object body {body}.'
-                raise avro.errors.ProtocolParseException(fail_msg)
-            message_objects[name] = Message(name, request, response, errors, names)
-        return message_objects
+    - protocol, a string, the name of the protocol (required);
+    - namespace, an optional string that qualifies the name;
+    - doc, an optional string describing this protocol;
+    - types, an optional list of definitions of named types (records, enums, fixed and errors). An error definition is just like a record definition except it uses "error" instead of "record". Note that forward references to named types are not permitted.
+    - messages, an optional JSON object whose keys are message names and whose values are objects whose attributes are described below. No two messages may have the same name.
 
-    def __init__(self, name, namespace=None, types=None, messages=None):
-        # Ensure valid ctor args
+    The name and namespace qualification rules defined for schema objects apply to protocols as well.
+    """
+
+    __slots__ = [
+        "_md5",
+        "_messages",
+        "_name",
+        "_namespace",
+        "_types",
+    ]
+
+    _md5: bytes
+    _messages: Optional[Mapping[str, "Message"]]
+    _name: str
+    _namespace: Optional[str]
+    _types: Optional[Sequence[avro.schema.NamedSchema]]
+
+    def __init__(
+        self,
+        name: str,
+        namespace: Optional[str] = None,
+        types: Optional[Sequence[str]] = None,
+        messages: Optional[Mapping[str, "MessageObject"]] = None,
+    ) -> None:
         if not name:
-            fail_msg = "Protocols must have a non-empty name."
-            raise avro.errors.ProtocolParseException(fail_msg)
-        elif not isinstance(name, str):
-            fail_msg = "The name property must be a string."
-            raise avro.errors.ProtocolParseException(fail_msg)
-        elif not (namespace is None or isinstance(namespace, str)):
-            fail_msg = "The namespace property must be a string."
-            raise avro.errors.ProtocolParseException(fail_msg)
-        elif not (types is None or isinstance(types, list)):
-            fail_msg = "The types property must be a list."
-            raise avro.errors.ProtocolParseException(fail_msg)
-        elif not (messages is None or callable(getattr(messages, "get", None))):
-            fail_msg = "The messages property must be a JSON object."
-            raise avro.errors.ProtocolParseException(fail_msg)
+            raise avro.errors.ProtocolParseException("Protocols must have a non-empty name.")
+        if not isinstance(name, str):
+            raise avro.errors.ProtocolParseException("The name property must be a string.")
+        if not (namespace is None or isinstance(namespace, str)):
+            raise avro.errors.ProtocolParseException("The namespace property must be a string.")
+        if not (types is None or isinstance(types, list)):
+            raise avro.errors.ProtocolParseException("The types property must be a list.")
+        if not (messages is None or callable(getattr(messages, "get", None))):
+            raise avro.errors.ProtocolParseException("The messages property must be a JSON object.")
+        type_names = avro.name.Names()
 
-        self._props = {}
-        self.set_prop("name", name)
-        type_names = avro.schema.Names()
-        if namespace is not None:
-            self.set_prop("namespace", namespace)
-            type_names.default_namespace = namespace
-        if types is not None:
-            self.set_prop("types", self._parse_types(types, type_names))
-        if messages is not None:
-            self.set_prop("messages", self._parse_messages(messages, type_names))
+        self._name = name
+        self._namespace = type_names.default_namespace = namespace
+        self._types = _parse_types(types, type_names) if types else None
+        self._messages = _parse_messages(messages, type_names) if messages else None
         self._md5 = hashlib.md5(str(self).encode()).digest()
 
-    # read-only properties
     @property
-    def name(self):
-        return self.get_prop("name")
+    def name(self) -> str:
+        return self._name
 
     @property
-    def namespace(self):
-        return self.get_prop("namespace")
+    def namespace(self) -> Optional[str]:
+        return self._namespace
 
     @property
-    def fullname(self):
-        return avro.schema.Name(self.name, self.namespace, None).fullname
+    def fullname(self) -> Optional[str]:
+        return avro.name.Name(self.name, self.namespace, None).fullname
 
     @property
-    def types(self):
-        return self.get_prop("types")
+    def types(self) -> Optional[Sequence[avro.schema.NamedSchema]]:
+        return self._types
 
     @property
-    def types_dict(self):
-        return {type.name: type for type in self.types}
+    def types_dict(self) -> Optional[Mapping[str, avro.schema.NamedSchema]]:
+        return None if self.types is None else {type_.name: type_ for type_ in self.types}
 
     @property
-    def messages(self):
-        return self.get_prop("messages")
+    def messages(self) -> Optional[Mapping[str, "Message"]]:
+        return self._messages
 
     @property
-    def md5(self):
+    def md5(self) -> bytes:
         return self._md5
 
-    @property
-    def props(self):
-        return self._props
+    def to_json(self) -> Mapping[str, Union[str, Sequence[object], Mapping[str, "MessageObject"]]]:
+        names = avro.name.Names(default_namespace=self.namespace)
+        return {
+            "protocol": self.name,
+            **({"namespace": self.namespace} if self.namespace else {}),
+            **({"types": [t.to_json(names) for t in self.types]} if self.types else {}),
+            **({"messages": {name: body.to_json(names) for name, body in self.messages.items()}} if self.messages else {}),
+        }
 
-    # utility functions to manipulate properties dict
-    def get_prop(self, key):
-        return self.props.get(key)
-
-    def set_prop(self, key, value):
-        self.props[key] = value
-
-    def to_json(self):
-        to_dump = {}
-        to_dump["protocol"] = self.name
-        names = avro.schema.Names(default_namespace=self.namespace)
-        if self.namespace:
-            to_dump["namespace"] = self.namespace
-        if self.types:
-            to_dump["types"] = [t.to_json(names) for t in self.types]
-        if self.messages:
-            messages_dict = {}
-            for name, body in self.messages.items():
-                messages_dict[name] = body.to_json(names)
-            to_dump["messages"] = messages_dict
-        return to_dump
-
-    def __str__(self):
+    def __str__(self) -> str:
         return json.dumps(self.to_json())
 
-    def __eq__(self, that):
-        to_cmp = json.loads(str(self))
-        return to_cmp == json.loads(str(that))
+    def __eq__(self, that: object) -> bool:
+        this_ = json.loads(str(self))
+        try:
+            that_ = json.loads(str(that))
+        except json.decoder.JSONDecodeError:
+            return False
+        return cast(bool, this_ == that_)
 
 
 class Message:
-    """A Protocol message."""
+    """
+    A message has attributes:
 
-    def _parse_request(self, request, names):
-        if not isinstance(request, list):
-            fail_msg = f"Request property not a list: {request}"
-            raise avro.errors.ProtocolParseException(fail_msg)
-        return avro.schema.RecordSchema(None, None, request, names, "request")
+    - a doc, an optional description of the message,
+    - a request, a list of named, typed parameter schemas (this has the same form as the fields of a record declaration);
+    - a response schema;
+    - an optional union of declared error schemas. The effective union has "string" prepended to the declared union, to permit transmission of undeclared "system" errors. For example, if the declared error union is ["AccessError"], then the effective union is ["string", "AccessError"]. When no errors are declared, the effective error union is ["string"]. Errors are serialized using the effective union; however, a protocol's JSON declaration contains only the declared union.
+    - an optional one-way boolean parameter.
 
-    def _parse_response(self, response, names):
-        if isinstance(response, str) and names.has_name(response, None):
-            return names.get_name(response, None)
-        else:
-            return avro.schema.make_avsc_object(response, names)
+    A request parameter list is processed equivalently to an anonymous record. Since record field lists may vary between reader and writer, request parameters may also differ between the caller and responder, and such differences are resolved in the same manner as record field differences.
 
-    def _parse_errors(self, errors, names):
-        if not isinstance(errors, list):
-            fail_msg = f"Errors property not a list: {errors}"
-            raise avro.errors.ProtocolParseException(fail_msg)
-        errors_for_parsing = {"type": "error_union", "declared_errors": errors}
-        return avro.schema.make_avsc_object(errors_for_parsing, names)
+    The one-way parameter may only be true when the response type is "null" and no errors are listed.
+    """
 
-    def __init__(self, name, request, response, errors=None, names=None):
+    __slots__ = [
+        "_errors",
+        "_name",
+        "_request",
+        "_response",
+    ]
+
+    def __init__(
+        self,
+        name: str,
+        request: Sequence[Mapping[str, object]],
+        response: Union[str, object],
+        errors: Optional[Sequence[str]] = None,
+        names: Optional[avro.name.Names] = None,
+    ) -> None:
         self._name = name
+        names = names or avro.name.Names()
+        self._request = _parse_request(request, names)
+        self._response = _parse_response(response, names)
+        self._errors = _parse_errors(errors or [], names)
 
-        self._props = {}
-        self.set_prop("request", self._parse_request(request, names))
-        self.set_prop("response", self._parse_response(response, names))
-        self.set_prop("errors", self._parse_errors(errors or [], names))
+    @property
+    def name(self) -> str:
+        return self._name
 
-    # read-only properties
-    name = property(lambda self: self._name)
-    request = property(lambda self: self.get_prop("request"))
-    response = property(lambda self: self.get_prop("response"))
-    errors = property(lambda self: self.get_prop("errors"))
-    props = property(lambda self: self._props)
+    @property
+    def request(self) -> avro.schema.RecordSchema:
+        return self._request
 
-    # utility functions to manipulate properties dict
-    def get_prop(self, key):
-        return self.props.get(key)
+    @property
+    def response(self) -> avro.schema.Schema:
+        return self._response
 
-    def set_prop(self, key, value):
-        self.props[key] = value
+    @property
+    def errors(self) -> avro.schema.ErrorUnionSchema:
+        return self._errors
 
-    def __str__(self):
+    def __str__(self) -> str:
         return json.dumps(self.to_json())
 
-    def to_json(self, names=None):
-        names = names or avro.schema.Names()
+    def to_json(self, names: Optional[avro.name.Names] = None) -> "MessageObject":
+        names = names or avro.name.Names()
 
-        to_dump = {}
+        try:
+            to_dump = MessageObject()
+        except NameError:
+            to_dump = {}
         to_dump["request"] = self.request.to_json(names)
         to_dump["response"] = self.response.to_json(names)
         if self.errors:
@@ -217,29 +226,66 @@ class Message:
 
         return to_dump
 
-    def __eq__(self, that):
-        return self.name == that.name and self.props == that.props
+    def __eq__(self, that: object) -> bool:
+        return all(hasattr(that, prop) and getattr(self, prop) == getattr(that, prop) for prop in self.__class__.__slots__)
 
 
-def make_avpr_object(json_data):
+def _parse_request(request: Sequence[Mapping[str, object]], names: avro.name.Names) -> avro.schema.RecordSchema:
+    if not isinstance(request, Sequence):
+        raise avro.errors.ProtocolParseException(f"Request property not a list: {request}")
+    return avro.schema.RecordSchema(None, None, request, names, "request")
+
+
+def _parse_response(response: Union[str, object], names: avro.name.Names) -> avro.schema.Schema:
+    return (isinstance(response, str) and names.get_name(response)) or avro.schema.make_avsc_object(response, names)
+
+
+def _parse_errors(errors: Sequence[str], names: avro.name.Names) -> avro.schema.ErrorUnionSchema:
+    """Even if errors is empty, we still want an ErrorUnionSchema with "string" in it."""
+    if not isinstance(errors, Sequence):
+        raise avro.errors.ProtocolParseException(f"Errors property not a list: {errors}")
+    errors_for_parsing = {"type": "error_union", "declared_errors": errors}
+    return cast(avro.schema.ErrorUnionSchema, avro.schema.make_avsc_object(errors_for_parsing, names))
+
+
+def make_avpr_object(json_data: "ProtocolObject") -> Protocol:
     """Build Avro Protocol from data parsed out of JSON string."""
-    try:
-        name = json_data.get("protocol")
-        namespace = json_data.get("namespace")
-        types = json_data.get("types")
-        messages = json_data.get("messages")
-    except AttributeError:
+    if not hasattr(json_data, "get"):
         raise avro.errors.ProtocolParseException(f"Not a JSON object: {json_data}")
-
+    name = json_data["protocol"]
+    namespace = json_data.get("namespace")
+    types = json_data.get("types")
+    messages = json_data.get("messages")
     return Protocol(name, namespace, types, messages)
 
 
-def parse(json_string):
+def parse(json_string: str) -> Protocol:
     """Constructs the Protocol from the JSON text."""
     try:
-        json_data = json.loads(json_string)
+        protocol_object = json.loads(json_string)
     except ValueError:
         raise avro.errors.ProtocolParseException(f"Error parsing JSON: {json_string}")
+    return make_avpr_object(protocol_object)
 
-    # construct the Avro Protocol object
-    return make_avpr_object(json_data)
+
+def _parse_types(types: Sequence[str], type_names: avro.name.Names) -> Sequence[avro.schema.NamedSchema]:
+    schemas = []
+    for type_ in types:
+        schema = avro.schema.make_avsc_object(type_, type_names)
+        if isinstance(schema, avro.schema.NamedSchema):
+            schemas.append(schema)
+            continue
+        raise avro.errors.ProtocolParseException(f"Type {type_} not an enum, fixed, record, or error.")
+    return schemas
+
+
+def _parse_messages(message_objects: Mapping[str, "MessageObject"], names: avro.name.Names) -> Mapping[str, Message]:
+    messages = {}
+    for name, body in message_objects.items():
+        if not hasattr(body, "get"):
+            raise avro.errors.ProtocolParseException(f'Message name "{name}" has non-object body {body}.')
+        request = body["request"]
+        response = body["response"]
+        errors = body.get("errors")
+        messages[name] = Message(name, request, response, errors, names)
+    return messages

--- a/lang/py/avro/schema.py
+++ b/lang/py/avro/schema.py
@@ -47,7 +47,7 @@ import math
 import sys
 import uuid
 import warnings
-from typing import Callable, Mapping, MutableMapping, Optional, Sequence, Union, cast
+from typing import Mapping, MutableMapping, Optional, Sequence, cast
 
 import avro.constants
 import avro.errors
@@ -137,7 +137,7 @@ class PropertiesMixin:
         return all(getattr(self, prop) == getattr(other, prop) for prop in props)
 
     @property
-    def other_props(self) -> MutableMapping[str, object]:
+    def other_props(self) -> Mapping[str, object]:
         """Dictionary of non-reserved properties"""
         return get_other_props(self.props, self._reserved_properties)
 
@@ -164,7 +164,7 @@ class CanonicalPropertiesMixin(PropertiesMixin):
     """A Mixin that provides canonical properties to Schema and Field types."""
 
     @property
-    def canonical_properties(self) -> MutableMapping[str, object]:
+    def canonical_properties(self) -> Mapping[str, object]:
         props = self.props
         return collections.OrderedDict((key, props[key]) for key in CANONICAL_FIELD_ORDER if key in props)
 
@@ -174,7 +174,7 @@ class Schema(abc.ABC, CanonicalPropertiesMixin):
 
     _reserved_properties = SCHEMA_RESERVED_PROPS
 
-    def __init__(self, type_: str, other_props: Optional[MutableMapping[str, object]] = None) -> None:
+    def __init__(self, type_: str, other_props: Optional[Mapping[str, object]] = None) -> None:
         if not isinstance(type_, str):
             raise avro.errors.SchemaParseException("Schema type must be a string.")
         if type_ not in VALID_TYPES:
@@ -249,7 +249,7 @@ class NamedSchema(Schema):
         name: str,
         namespace: Optional[str] = None,
         names: Optional[Names] = None,
-        other_props: Optional[MutableMapping[str, object]] = None,
+        other_props: Optional[Mapping[str, object]] = None,
     ) -> None:
         super().__init__(type_, other_props)
         if not name:
@@ -816,33 +816,28 @@ class ErrorUnionSchema(UnionSchema):
 
 class RecordSchema(EqualByJsonMixin, NamedSchema):
     @staticmethod
-    def make_field_objects(field_data, names):
+    def make_field_objects(field_data: Sequence[Mapping[str, object]], names: avro.name.Names) -> Sequence[Field]:
         """We're going to need to make message parameters too."""
         field_objects = []
         field_names = []
-        for i, field in enumerate(field_data):
-            if callable(getattr(field, "get", None)):
-                type = field.get("type")
-                name = field.get("name")
-
-                # null values can have a default value of None
-                has_default = False
-                default = None
-                if "default" in field:
-                    has_default = True
-                    default = field.get("default")
-
-                order = field.get("order")
-                doc = field.get("doc")
-                other_props = get_other_props(field, FIELD_RESERVED_PROPS)
-                new_field = Field(type, name, has_default, default, order, names, doc, other_props)
-                # make sure field name has not been used yet
-                if new_field.name in field_names:
-                    fail_msg = f"Field name {new_field.name} already in use."
-                    raise avro.errors.SchemaParseException(fail_msg)
-                field_names.append(new_field.name)
-            else:
+        for field in field_data:
+            if not callable(getattr(field, "get", None)):
                 raise avro.errors.SchemaParseException(f"Not a valid field: {field}")
+            type = field.get("type")
+            name = field.get("name")
+
+            # null values can have a default value of None
+            has_default = "default" in field
+            default = field.get("default")
+            order = field.get("order")
+            doc = field.get("doc")
+            other_props = get_other_props(field, FIELD_RESERVED_PROPS)
+            new_field = Field(type, name, has_default, default, order, names, doc, other_props)
+            # make sure field name has not been used yet
+            if new_field.name in field_names:
+                fail_msg = f"Field name {new_field.name} already in use."
+                raise avro.errors.SchemaParseException(fail_msg)
+            field_names.append(new_field.name)
             field_objects.append(new_field)
         return field_objects
 
@@ -1058,7 +1053,7 @@ class UUIDSchema(LogicalSchema, PrimitiveSchema):
 #
 
 
-def get_other_props(all_props: MutableMapping[str, object], reserved_props: Sequence[str]) -> MutableMapping[str, object]:
+def get_other_props(all_props: Mapping[str, object], reserved_props: Sequence[str]) -> Mapping[str, object]:
     """
     Retrieve the non-reserved properties from a dictionary of properties
     @args reserved_props: The set of reserved properties to exclude
@@ -1101,7 +1096,7 @@ def make_logical_schema(logical_type, type_, other_props):
     return None
 
 
-def make_avsc_object(json_data, names=None, validate_enum_symbols=True):
+def make_avsc_object(json_data: object, names: Optional[avro.name.Names] = None, validate_enum_symbols: bool = True) -> Schema:
     """
     Build Avro Schema from data parsed out of JSON string.
 
@@ -1112,6 +1107,7 @@ def make_avsc_object(json_data, names=None, validate_enum_symbols=True):
 
     # JSON object (non-union)
     if callable(getattr(json_data, "get", None)):
+        json_data = cast(Mapping, json_data)
         type = json_data.get("type")
         other_props = get_other_props(json_data, SCHEMA_RESERVED_PROPS)
         logical_type = json_data.get("logicalType")
@@ -1119,7 +1115,7 @@ def make_avsc_object(json_data, names=None, validate_enum_symbols=True):
         if logical_type:
             logical_schema = make_logical_schema(logical_type, type, other_props or {})
             if logical_schema is not None:
-                return logical_schema
+                return cast(Schema, logical_schema)
 
         if type in NAMED_TYPES:
             name = json_data.get("name")
@@ -1179,9 +1175,8 @@ def make_avsc_object(json_data, names=None, validate_enum_symbols=True):
     elif json_data in PRIMITIVE_TYPES:
         return PrimitiveSchema(json_data)
     # not for us!
-    else:
-        fail_msg = f"Could not make an Avro Schema object from {json_data}"
-        raise avro.errors.SchemaParseException(fail_msg)
+    fail_msg = f"Could not make an Avro Schema object from {json_data}"
+    raise avro.errors.SchemaParseException(fail_msg)
 
 
 # TODO(hammer): make method for reading from a file?

--- a/lang/py/avro/test/test_protocol.py
+++ b/lang/py/avro/test/test_protocol.py
@@ -415,7 +415,7 @@ class ProtocolParseTestCase(unittest.TestCase):
             self.fail(f"Valid protocol failed to parse: {self.test_proto!s}")
 
     def parse_invalid(self):
-        """Parsing an invalid schema should error."""
+        """Parsing an invalid protocol should error."""
         try:
             self.test_proto.parse()
         except (avro.errors.ProtocolParseException, avro.errors.SchemaParseException):
@@ -424,8 +424,8 @@ class ProtocolParseTestCase(unittest.TestCase):
             self.fail(f"Invalid protocol should not have parsed: {self.test_proto!s}")
 
 
-class ErrorSchemaTestCase(unittest.TestCase):
-    """Enable generating error schema test cases across all the valid test protocols."""
+class ErrorProtocolTestCase(unittest.TestCase):
+    """Enable generating error protocol test cases across all the valid test protocols."""
 
     def __init__(self, test_proto):
         """Ignore the normal signature for unittest.TestCase because we are generating
@@ -433,14 +433,14 @@ class ErrorSchemaTestCase(unittest.TestCase):
         ignores this class. The autoloader will ignore this class as long as it has
         no methods starting with `test_`.
         """
-        super().__init__("check_error_schema_exists")
+        super().__init__("check_error_protocol_exists")
         self.test_proto = test_proto
 
-    def check_error_schema_exists(self):
-        """Protocol messages should always have at least a string error schema."""
+    def check_error_protocol_exists(self):
+        """Protocol messages should always have at least a string error protocol."""
         p = self.test_proto.parse()
         for k, m in p.messages.items():
-            self.assertIsNotNone(m.errors, f"Message {k} did not have the expected implicit string error schema.")
+            self.assertIsNotNone(m.errors, f"Message {k} did not have the expected implicit string error protocol.")
 
 
 class RoundTripParseTestCase(unittest.TestCase):
@@ -456,14 +456,14 @@ class RoundTripParseTestCase(unittest.TestCase):
         self.test_proto = test_proto
 
     def parse_round_trip(self):
-        """The string of a Schema should be parseable to the same Schema."""
+        """The string of a Protocol should be parseable to the same Protocol."""
         parsed = self.test_proto.parse()
         round_trip = avro.protocol.parse(str(parsed))
         self.assertEqual(parsed, round_trip)
 
 
 def load_tests(loader, default_tests, pattern):
-    """Generate test cases across many test schema."""
+    """Generate test cases across many test protocol."""
     suite = unittest.TestSuite()
     suite.addTests(loader.loadTestsFromTestCase(TestMisc))
     suite.addTests(ProtocolParseTestCase(ex) for ex in EXAMPLES)

--- a/lang/py/avro/tether/tether_task.py
+++ b/lang/py/avro/tether/tether_task.py
@@ -22,9 +22,9 @@ import collections
 import io
 import logging
 import os
-import sys
 import threading
 import traceback
+from typing import cast
 
 import avro.errors
 import avro.io
@@ -46,7 +46,8 @@ with open(pfile) as hf:
 inputProtocol = avro.protocol.parse(prototxt)
 
 # use a named tuple to represent the tasktype enumeration
-taskschema = inputProtocol.types_dict["TaskType"]
+assert inputProtocol.types_dict is not None
+taskschema = cast(avro.schema.EnumSchema, inputProtocol.types_dict["TaskType"])
 # Mypy cannot statically type check a dynamically constructed named tuple.
 # Since InputProtocol.avpr is hard-coded here, we can hard-code the symbols.
 _ttype = collections.namedtuple("_ttype", ("MAP", "REDUCE"))

--- a/lang/py/setup.cfg
+++ b/lang/py/setup.cfg
@@ -53,6 +53,7 @@ package_dir =
     avro.tether = avro/tether
 include_package_data = true
 install_requires =
+    typing-extensions;python_version<"3.8"
 zip_safe = true
 scripts =
     scripts/avro


### PR DESCRIPTION
Type Hints for avro.protocol, and avro.schema

### Jira

- [x] PR addresses [AVRO-2921](https://issues.apache.org/jira/browse/AVRO-2921)
- [x] PR references jira issue.
- [x] PR adds a dependency to [typing-extensions](https://github.com/python/typing/blob/master/typing_extensions/README.rst), which has an [Apache Compatible 3rd Party License](https://www.apache.org/legal/resolved.html).
  - The dependency only applies to installations with Python versions earlier than 3.8.
  - It is licensed under the [Python Software Foundation License](https://github.com/python/typing/blob/master/LICENSE).

### Tests

- [x] PR enhances quality checks by adding type hints.

### Commits

- [x] Commits all reference Jira issues in their subject lines.
- [x] Commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  - [x] Subject is separated from body by a blank line
  - [x] Subject is limited to 50 characters (not including Jira issue reference)
  - [x] Subject does not end with a period
  - [x] Subject uses the imperative mood ("add", not "adding")
  - [x] Body wraps at 72 characters
  - [x] Body explains "what" and "why", not "how"

### Documentation

N/A