### PR TITLE
AVRO-2921: Type Fixes for avro.datafile

### DIFF
--- a/lang/py/avro/datafile.py
+++ b/lang/py/avro/datafile.py
@@ -129,7 +129,9 @@ class _DataFile(AbstractContextManager):
 class DataFileWriter(_DataFile):
 
     # TODO(hammer): make 'encoder' a metadata property
-    def __init__(self, writer, datum_writer, writers_schema=None, codec=NULL_CODEC):
+    def __init__(
+        self, writer, datum_writer: avro.io.DatumWriter, writers_schema: Optional[avro.schema.Schema] = None, codec: str = NULL_CODEC
+    ) -> None:
         """
         If the schema is not present, presume we're appending.
 
@@ -165,12 +167,25 @@ class DataFileWriter(_DataFile):
             writer.seek(0, 2)
             self._header_written = True
 
-    # read-only properties
-    writer = property(lambda self: self._writer)
-    encoder = property(lambda self: self._encoder)
-    datum_writer = property(lambda self: self._datum_writer)
-    buffer_writer = property(lambda self: self._buffer_writer)
-    buffer_encoder = property(lambda self: self._buffer_encoder)
+    @property
+    def writer(self):
+        return self._writer
+
+    @property
+    def encoder(self):
+        return self._encoder
+
+    @property
+    def datum_writer(self):
+        return self._datum_writer
+
+    @property
+    def buffer_writer(self):
+        return self._buffer_writer
+
+    @property
+    def buffer_encoder(self):
+        return self._buffer_encoder
 
     def _write_header(self):
         header = {"magic": MAGIC, "meta": self.meta, "sync": self.sync_marker}
@@ -271,12 +286,25 @@ class DataFileReader(_DataFile):
     def __iter__(self):
         return self
 
-    # read-only properties
-    reader = property(lambda self: self._reader)
-    raw_decoder = property(lambda self: self._raw_decoder)
-    datum_decoder = property(lambda self: self._datum_decoder)
-    datum_reader = property(lambda self: self._datum_reader)
-    file_length = property(lambda self: self._file_length)
+    @property
+    def reader(self):
+        return self._reader
+
+    @property
+    def raw_decoder(self):
+        return self._raw_decoder
+
+    @property
+    def datum_decoder(self):
+        return self._datum_decoder
+
+    @property
+    def datum_reader(self):
+        return self._datum_reader
+
+    @property
+    def file_length(self):
+        return self._file_length
 
     def determine_file_length(self):
         """

--- a/lang/py/avro/datafile.py
+++ b/lang/py/avro/datafile.py
@@ -22,12 +22,8 @@ Read/Write Avro File Object Containers.
 
 https://avro.apache.org/docs/current/spec.html#Object+Container+Files
 """
-import abc
 import io
 import json
-import os
-import random
-import zlib
 from types import TracebackType
 from typing import BinaryIO, MutableMapping, Optional, Type
 

--- a/lang/py/avro/datafile.py
+++ b/lang/py/avro/datafile.py
@@ -63,24 +63,6 @@ CODEC_KEY = "avro.codec"
 SCHEMA_KEY = "avro.schema"
 
 
-class _DataFileContextManager:
-    """Mixin for making datafiles context managers."""
-
-    __slots__ = ()
-
-    @abc.abstractmethod
-    def close(self) -> None:
-        pass
-
-    def __enter__(self) -> "_DataFileContextManager":
-        return self
-
-    def __exit__(self, type_: Optional[Type[BaseException]], value: Optional[BaseException], traceback: Optional[TracebackType]) -> None:
-        """Perform a close if there's no exception."""
-        if type_ is None:
-            self.close()
-
-
 class _DataFileMetaProperties:
     """Mixin for meta properties."""
 
@@ -102,7 +84,7 @@ class _DataFileMetaProperties:
         return self._meta
 
 
-class _DataFile(_DataFileContextManager, _DataFileMetaProperties):
+class _DataFile(_DataFileMetaProperties):
     """Mixin for methods common to both reading and writing."""
 
     __slots__ = ("block_count", "_sync_marker")
@@ -271,6 +253,14 @@ class DataFileWriter(_DataFile):
         self.flush()
         self.writer.close()
 
+    def __enter__(self) -> "DataFileWriter":
+        return self
+
+    def __exit__(self, type_: Optional[Type[BaseException]], value: Optional[BaseException], traceback: Optional[TracebackType]) -> None:
+        """Perform a close if there's no exception."""
+        if type_ is None:
+            self.close()
+
 
 class DataFileReader(_DataFile):
     """Read files written by DataFileWriter."""
@@ -390,6 +380,14 @@ class DataFileReader(_DataFile):
     def close(self) -> None:
         """Close this reader."""
         self.reader.close()
+
+    def __enter__(self) -> "DataFileReader":
+        return self
+
+    def __exit__(self, type_: Optional[Type[BaseException]], value: Optional[BaseException], traceback: Optional[TracebackType]) -> None:
+        """Perform a close if there's no exception."""
+        if type_ is None:
+            self.close()
 
 
 def generate_sixteen_random_bytes() -> bytes:

--- a/lang/py/avro/test/mock_tether_parent.py
+++ b/lang/py/avro/test/mock_tether_parent.py
@@ -18,7 +18,6 @@
 # limitations under the License.
 
 import http.server
-import socket
 import sys
 from typing import Mapping
 
@@ -67,24 +66,23 @@ class MockParentHandler(http.server.BaseHTTPRequestHandler):
 
 def main() -> None:
     global SERVER_ADDRESS
-    if len(sys.argv) <= 1:
-        raise avro.errors.UsageError("Usage: mock_tether_parent command")
 
-    cmd = sys.argv[1].lower()
-    if sys.argv[1] == "start_server":
-        if len(sys.argv) == 3:
-            port = int(sys.argv[2])
-        else:
-            raise avro.errors.UsageError("Usage: mock_tether_parent start_server port")
+    if len(sys.argv) != 3 or sys.argv[1].lower() != "start_server":
+        raise avro.errors.UsageError("Usage: mock_tether_parent start_server port")
 
-        SERVER_ADDRESS = (SERVER_ADDRESS[0], port)
-        print(f"mock_tether_parent: Launching Server on Port: {SERVER_ADDRESS[1]}")
+    try:
+        port = int(sys.argv[2])
+    except ValueError as e:
+        raise avro.errors.UsageError("Usage: mock_tether_parent start_server port") from e
 
-        # flush the output so it shows up in the parent process
-        sys.stdout.flush()
-        parent_server = http.server.HTTPServer(SERVER_ADDRESS, MockParentHandler)
-        parent_server.allow_reuse_address = True
-        parent_server.serve_forever()
+    SERVER_ADDRESS = (SERVER_ADDRESS[0], port)
+    print(f"mock_tether_parent: Launching Server on Port: {SERVER_ADDRESS[1]}")
+
+    # flush the output so it shows up in the parent process
+    sys.stdout.flush()
+    parent_server = http.server.HTTPServer(SERVER_ADDRESS, MockParentHandler)
+    parent_server.allow_reuse_address = True
+    parent_server.serve_forever()
 
 
 if __name__ == "__main__":

--- a/lang/py/avro/test/test_bench.py
+++ b/lang/py/avro/test/test_bench.py
@@ -26,13 +26,15 @@ import tempfile
 import timeit
 import unittest
 import unittest.mock
+from pathlib import Path
+from typing import List, Mapping, Sequence
 
 import avro.datafile
 import avro.io
 import avro.schema
 
 TYPES = ("A", "CNAME")
-SCHEMA = avro.schema.parse(
+SCHEMA: avro.schema.RecordSchema = avro.schema.parse(
     json.dumps(
         {
             "type": "record",
@@ -56,73 +58,76 @@ try:  # pragma: no cover
     randbytes = random.randbytes  # type: ignore
 except AttributeError:  # pragma: no cover
 
-    def randbytes(n):
+    def randbytes(n: int) -> bytes:
         """Polyfill for random.randbytes in Python < 3.9"""
-        return random.choices(range(256), k=n)
+        return bytes(random.choices(range(256), k=n))
 
 
 class TestBench(unittest.TestCase):
-    def test_minimum_speed(self):
-        with tempfile.NamedTemporaryFile(suffix="avr") as temp:
+    def test_minimum_speed(self) -> None:
+        with tempfile.NamedTemporaryFile(suffix="avr") as temp_:
             pass
+        temp = Path(temp_.name)
         self.assertLess(
-            time_writes(temp.name, NUMBER_OF_TESTS),
+            time_writes(temp, NUMBER_OF_TESTS),
             MAX_WRITE_SECONDS,
             f"Took longer than {MAX_WRITE_SECONDS} second(s) to write the test file with {NUMBER_OF_TESTS} values.",
         )
         self.assertLess(
-            time_read(temp.name),
+            time_read(temp),
             MAX_READ_SECONDS,
             f"Took longer than {MAX_READ_SECONDS} second(s) to read the test file with {NUMBER_OF_TESTS} values.",
         )
 
 
-def rand_name():
+def rand_name() -> str:
     return "".join(random.sample(string.ascii_lowercase, 15))
 
 
-def rand_ip():
+def rand_ip() -> str:
     return ".".join(map(str, randbytes(4)))
 
 
-def picks(n):
+def picks(n) -> Sequence[Mapping[str, str]]:
     return [{"query": rand_name(), "response": rand_ip(), "type": random.choice(TYPES)} for _ in range(n)]
 
 
-def time_writes(path, number):
-    with avro.datafile.DataFileWriter(open(path, "wb"), WRITER, SCHEMA) as dw:
+def time_writes(path: Path, number: int) -> float:
+    with avro.datafile.DataFileWriter(path.open("wb"), WRITER, SCHEMA) as dw:
         globals_ = {"dw": dw, "picks": picks(number)}
         return timeit.timeit("dw.append(next(p))", number=number, setup="p=iter(picks)", globals=globals_)
 
 
-def time_read(path):
+def time_read(path: Path) -> float:
     """
     Time how long it takes to read the file written in the `write` function.
     We only do this once, because the size of the file is defined by the number sent to `write`.
     """
-    with avro.datafile.DataFileReader(open(path, "rb"), READER) as dr:
+    with avro.datafile.DataFileReader(path.open("rb"), READER) as dr:
         return timeit.timeit("tuple(dr)", number=1, globals={"dr": dr})
 
 
-def parse_args():  # pragma: no cover
+def parse_args() -> argparse.Namespace:  # pragma: no cover
     parser = argparse.ArgumentParser(description="Benchmark writing some random avro.")
     parser.add_argument(
         "--number",
         "-n",
         type=int,
-        default=timeit.default_number,
+        default=getattr(timeit, "default_number", 1000000),
         help="how many times to run",
     )
     return parser.parse_args()
 
 
-def main():  # pragma: no cover
+def main() -> None:  # pragma: no cover
     args = parse_args()
-    with tempfile.NamedTemporaryFile(suffix=".avr") as temp:
+    with tempfile.NamedTemporaryFile(suffix=".avr") as temp_:
         pass
+    temp = Path(temp_.name)
+
     print(f"Using file {temp.name}")
-    print(f"Writing: {time_writes(temp.name, args.number)}")
-    print(f"Reading: {time_read(temp.name)}")
+    print(f"Writing: {time_writes(temp, args.number)}")
+    print(f"Reading: {time_read(temp)}")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/lang/py/avro/test/test_bench.py
+++ b/lang/py/avro/test/test_bench.py
@@ -32,6 +32,7 @@ from typing import List, Mapping, Sequence
 import avro.datafile
 import avro.io
 import avro.schema
+import avro.utils
 
 TYPES = ("A", "CNAME")
 SCHEMA: avro.schema.RecordSchema = avro.schema.parse(
@@ -52,15 +53,6 @@ WRITER = avro.io.DatumWriter(SCHEMA)
 NUMBER_OF_TESTS = 10000
 MAX_WRITE_SECONDS = 3 if platform.python_implementation() == "PyPy" else 1
 MAX_READ_SECONDS = 3 if platform.python_implementation() == "PyPy" else 1
-
-
-try:  # pragma: no cover
-    randbytes = random.randbytes  # type: ignore
-except AttributeError:  # pragma: no cover
-
-    def randbytes(n: int) -> bytes:
-        """Polyfill for random.randbytes in Python < 3.9"""
-        return bytes(random.choices(range(256), k=n))
 
 
 class TestBench(unittest.TestCase):
@@ -85,7 +77,7 @@ def rand_name() -> str:
 
 
 def rand_ip() -> str:
-    return ".".join(map(str, randbytes(4)))
+    return ".".join(map(str, avro.utils.randbytes(4)))
 
 
 def picks(n) -> Sequence[Mapping[str, str]]:

--- a/lang/py/avro/test/test_tether_task.py
+++ b/lang/py/avro/test/test_tether_task.py
@@ -36,7 +36,7 @@ class TestTetherTask(unittest.TestCase):
     TODO: We should validate the the server response by looking at stdout
     """
 
-    def test_tether_task(self):
+    def test_tether_task(self) -> None:
         """
         Test that the tether_task is working. We run the mock_tether_parent in a separate
         subprocess
@@ -62,6 +62,8 @@ class TestTetherTask(unittest.TestCase):
 
             # ***************************************************************
             # Test the mapper
+            if avro.tether.tether_task.TaskType is None:
+                self.fail()
             task.configure(
                 avro.tether.tether_task.TaskType.MAP,
                 str(task.inschema),
@@ -89,11 +91,10 @@ class TestTetherTask(unittest.TestCase):
             )
 
             # Serialize some data so we can send it to the input function
-            datum = {"key": "word", "value": 2}
             writer = io.BytesIO()
             encoder = avro.io.BinaryEncoder(writer)
             datum_writer = avro.io.DatumWriter(task.midschema)
-            datum_writer.write(datum, encoder)
+            datum_writer.write({"key": "word", "value": 2}, encoder)
 
             writer.seek(0)
             data = writer.read()

--- a/lang/py/avro/timezones.py
+++ b/lang/py/avro/timezones.py
@@ -18,16 +18,17 @@
 # limitations under the License.
 
 import datetime
+from typing import Optional
 
 
 class UTCTzinfo(datetime.tzinfo):
-    def utcoffset(self, dt):
+    def utcoffset(self, dt: Optional[datetime.datetime] = None) -> datetime.timedelta:
         return datetime.timedelta(0)
 
-    def tzname(self, dt):
+    def tzname(self, dt: Optional[datetime.datetime] = None) -> str:
         return "UTC"
 
-    def dst(self, dt):
+    def dst(self, dt: Optional[datetime.datetime] = None) -> datetime.timedelta:
         return datetime.timedelta(0)
 
 
@@ -36,13 +37,13 @@ utc = UTCTzinfo()
 
 # Test Time Zone with fixed offset and no DST
 class TSTTzinfo(datetime.tzinfo):
-    def utcoffset(self, dt):
+    def utcoffset(self, dt: Optional[datetime.datetime] = None) -> datetime.timedelta:
         return datetime.timedelta(hours=10)
 
-    def tzname(self, dt):
+    def tzname(self, dt: Optional[datetime.datetime] = None) -> str:
         return "TST"
 
-    def dst(self, dt):
+    def dst(self, dt: Optional[datetime.datetime] = None) -> datetime.timedelta:
         return datetime.timedelta(0)
 
 

--- a/lang/py/avro/utils.py
+++ b/lang/py/avro/utils.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+##
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Arbitrary utilities and polyfills.
+"""
+
+import random
+
+
+def _randbytes(n: int) -> bytes:
+    """Polyfill for random.randbytes in Python < 3.9"""
+    return bytes(random.choices(range(256), k=n))
+
+
+randbytes = getattr(random, "randbytes", _randbytes)


### PR DESCRIPTION
...and other small modules

- Type hint and refactor `avro.datafile`
- Type hint `avro.test.mock_tether_parent`
- Type hint `avro.timezones`

### Jira

- [x] PR addresses and references [AVRO-2921][ticket]

### Tests

- [x] PR adds type checks

### Commits

- [x] Commits reference [AVRO-2921][ticket]
- [x] Commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  - [x] Subject is separated from body by a blank line
  - [x] Subject is limited to 50 characters (not including Jira issue reference)
  - [x] Subject does not end with a period
  - [x] Subject uses the imperative mood ("add", not "adding")
  - [x] Body wraps at 72 characters
  - [x] Body explains "what" and "why", not "how"

### Documentation

N/A


[ticket]: https://issues.apache.org/jira/browse/AVRO-2921
