### PR TITLE
AVRO-2123: Duration logical type Java conversion

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/Conversions.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Conversions.java
@@ -216,7 +216,7 @@ public class Conversions {
       @Override
       public GenericFixed toFixed(Duration value, Schema schema, LogicalType type) {
 
-          if (value.isZero()) {
+          if (value == null || value.isZero()) {
               return new GenericData.Fixed(schema, EMPTY_BYTE_ARRAY);
           }
 

--- a/lang/java/avro/src/main/java/org/apache/avro/Conversions.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Conversions.java
@@ -28,6 +28,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
@@ -156,9 +157,9 @@ public class Conversions {
       private static final String DOC_STR = "For more information on the duration logical type, please refer to " + DOC_URL;
 
       private static final byte[] EMPTY_BYTE_ARRAY = new byte[] {
-          Byte.MIN_VALUE, Byte.MIN_VALUE, Byte.MIN_VALUE, Byte.MIN_VALUE,
-          Byte.MIN_VALUE, Byte.MIN_VALUE, Byte.MIN_VALUE, Byte.MIN_VALUE,
-          Byte.MIN_VALUE, Byte.MIN_VALUE, Byte.MIN_VALUE, Byte.MIN_VALUE
+          0x0, 0x0, 0x0, 0x0,
+          0x0, 0x0, 0x0, 0x0,
+          0x0, 0x0, 0x0, 0x0
       };
 
       private static byte[] toBytes(int value){
@@ -166,7 +167,7 @@ public class Conversions {
       }
 
       private static int toInt(byte[] bytes) {
-          return ByteBuffer.wrap(bytes).getInt();
+          return ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN).getInt();
       }
 
       private static byte[] buildByteArray(int months, int days, int milliSeconds) {
@@ -242,7 +243,7 @@ public class Conversions {
           }
 
           try {
-              milliSeconds = (int) value.toMillis();
+              milliSeconds = (int) value.minus(months * MONTH_DAYS, ChronoUnit.DAYS).minus(days, ChronoUnit.DAYS).toMillis();
           } catch (Throwable e) {
               throw new IllegalArgumentException("The milliseconds part of a duration must fit a 4-byte int, longer duration given. " + DOC_STR, e);
           }

--- a/lang/java/avro/src/main/java/org/apache/avro/Conversions.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Conversions.java
@@ -27,6 +27,7 @@ import org.apache.avro.generic.IndexedRecord;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;

--- a/lang/java/avro/src/main/java/org/apache/avro/LogicalTypes.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/LogicalTypes.java
@@ -421,37 +421,6 @@ public class LogicalTypes {
     }
   }
 
-
-  /** TimeMicros represents a time in microseconds without a date */
-  public static class TimeMicros extends LogicalType {
-    private TimeMicros() {
-      super(TIME_MICROS);
-    }
-
-    @Override
-    public void validate(Schema schema) {
-      super.validate(schema);
-      if (schema.getType() != Schema.Type.LONG) {
-        throw new IllegalArgumentException("Time (micros) can only be used with an underlying long type");
-      }
-    }
-  }
-
-  /** TimestampMillis represents a date and time in milliseconds */
-  public static class TimestampMillis extends LogicalType {
-    private TimestampMillis() {
-      super(TIMESTAMP_MILLIS);
-    }
-
-    @Override
-    public void validate(Schema schema) {
-      super.validate(schema);
-      if (schema.getType() != Schema.Type.LONG) {
-        throw new IllegalArgumentException("Timestamp (millis) can only be used with an underlying long type");
-      }
-    }
-  }
-
   /** Duration represents an amount of time defined by a number of months, days and milliseconds */
   public static class Duration extends LogicalType {
     private Duration() {
@@ -461,7 +430,7 @@ public class LogicalTypes {
     @Override
     public void validate(Schema schema) {
       super.validate(schema);
-      if (schema.getType() != Schema.Type.FIXED || schema.getSize() != 12) {
+      if (schema.getType() != Schema.Type.FIXED || schema.getFixedSize() != 12) {
         throw new IllegalArgumentException("Duration can only be used with an underlying fixed type of size 12");
       }
     }

--- a/lang/java/avro/src/main/java/org/apache/avro/LogicalTypes.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/LogicalTypes.java
@@ -102,6 +102,9 @@ public class LogicalTypes {
       case LOCAL_TIMESTAMP_MILLIS:
         logicalType = LOCAL_TIMESTAMP_MILLIS_TYPE;
         break;
+      case DURATION:
+        logicalType = DURATION_TYPE;
+        break;
       default:
         final LogicalTypeFactory typeFactory = REGISTERED_TYPES.get(typeName);
         logicalType = (typeFactory == null) ? null : typeFactory.fromSchema(schema);
@@ -134,6 +137,7 @@ public class LogicalTypes {
   private static final String TIMESTAMP_MICROS = "timestamp-micros";
   private static final String LOCAL_TIMESTAMP_MILLIS = "local-timestamp-millis";
   private static final String LOCAL_TIMESTAMP_MICROS = "local-timestamp-micros";
+  private static final String DURATION = "duration";
 
   /** Create a Decimal LogicalType with the given precision and scale 0 */
   public static Decimal decimal(int precision) {
@@ -192,6 +196,13 @@ public class LogicalTypes {
   public static LocalTimestampMicros localTimestampMicros() {
     return LOCAL_TIMESTAMP_MICROS_TYPE;
   }
+
+  private static final Duration DURATION_TYPE = new Duration();
+
+  public static Duration duration() {
+    return DURATION_TYPE;
+  }
+
 
   /** Decimal represents arbitrary-precision fixed-scale decimal numbers */
   public static class Decimal extends LogicalType {
@@ -406,6 +417,52 @@ public class LogicalTypes {
       super.validate(schema);
       if (schema.getType() != Schema.Type.LONG) {
         throw new IllegalArgumentException("Local timestamp (micros) can only be used with an underlying long type");
+      }
+    }
+  }
+
+
+  /** TimeMicros represents a time in microseconds without a date */
+  public static class TimeMicros extends LogicalType {
+    private TimeMicros() {
+      super(TIME_MICROS);
+    }
+
+    @Override
+    public void validate(Schema schema) {
+      super.validate(schema);
+      if (schema.getType() != Schema.Type.LONG) {
+        throw new IllegalArgumentException("Time (micros) can only be used with an underlying long type");
+      }
+    }
+  }
+
+  /** TimestampMillis represents a date and time in milliseconds */
+  public static class TimestampMillis extends LogicalType {
+    private TimestampMillis() {
+      super(TIMESTAMP_MILLIS);
+    }
+
+    @Override
+    public void validate(Schema schema) {
+      super.validate(schema);
+      if (schema.getType() != Schema.Type.LONG) {
+        throw new IllegalArgumentException("Timestamp (millis) can only be used with an underlying long type");
+      }
+    }
+  }
+
+  /** Duration represents an amount of time defined by a number of months, days and milliseconds */
+  public static class Duration extends LogicalType {
+    private Duration() {
+      super(DURATION);
+    }
+
+    @Override
+    public void validate(Schema schema) {
+      super.validate(schema);
+      if (schema.getType() != Schema.Type.FIXED || schema.getSize() != 12) {
+        throw new IllegalArgumentException("Duration can only be used with an underlying fixed type of size 12");
       }
     }
   }

--- a/lang/java/avro/src/test/java/org/apache/avro/TestDurationConversion.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestDurationConversion.java
@@ -26,184 +26,142 @@ import org.junit.rules.ExpectedException;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.Arrays;
 
 import static java.math.RoundingMode.HALF_EVEN;
 import static org.junit.Assert.*;
 
 public class TestDurationConversion {
 
-  private static final Conversion<BigDecimal> CONVERSION = new Conversions.DecimalConversion();
+  private static final Conversion<Duration> CONVERSION = new Conversions.DurationConversion();
 
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
 
-  private Schema smallerSchema;
-  private LogicalType smallerLogicalType;
-  private Schema largerSchema;
-  private LogicalType largerLogicalType;
+  private Schema schema;
+  private LogicalType logicalType;
 
   @Before
   public void setup() {
-    smallerSchema = Schema.createFixed("smallFixed", null, null, 3);
-    smallerSchema.addProp("logicalType", "decimal");
-    smallerSchema.addProp("precision", 5);
-    smallerSchema.addProp("scale", 2);
-    smallerLogicalType = LogicalTypes.fromSchema(smallerSchema);
-
-    largerSchema = Schema.createFixed("largeFixed", null, null, 12);
-    largerSchema.addProp("logicalType", "decimal");
-    largerSchema.addProp("precision", 28);
-    largerSchema.addProp("scale", 15);
-    largerLogicalType = LogicalTypes.fromSchema(largerSchema);
-  }
-
-  @Test
-  public void testToFromBytes() {
-    final BigDecimal value = BigDecimal.valueOf(10.99).setScale(15, HALF_EVEN);
-    final ByteBuffer byteBuffer = CONVERSION.toBytes(value, largerSchema, largerLogicalType);
-    final BigDecimal result = CONVERSION.fromBytes(byteBuffer, largerSchema, largerLogicalType);
-    assertEquals(value, result);
-  }
-
-  @Test
-  public void testToFromBytesMaxPrecision() {
-    final BigDecimal value = new BigDecimal("4567335489766.99834").setScale(15, HALF_EVEN);
-    final ByteBuffer byteBuffer = CONVERSION.toBytes(value, largerSchema, largerLogicalType);
-    final BigDecimal result = CONVERSION.fromBytes(byteBuffer, largerSchema, largerLogicalType);
-    assertEquals(value, result);
-  }
-
-  @Test
-  public void testToBytesPrecisionError() {
-    final BigDecimal value = new BigDecimal("1.07046455859736525E+18").setScale(15, HALF_EVEN);
-    expectedException.expect(AvroTypeException.class);
-    expectedException.expectMessage("Cannot encode decimal with precision 34 as max precision 28");
-    CONVERSION.toBytes(value, largerSchema, largerLogicalType);
-  }
-
-  @Test
-  public void testToBytesFixedSmallerScale() {
-    final BigDecimal value = new BigDecimal("99892.1234").setScale(10, HALF_EVEN);
-    final ByteBuffer byteBuffer = CONVERSION.toBytes(value, largerSchema, largerLogicalType);
-    final BigDecimal result = CONVERSION.fromBytes(byteBuffer, largerSchema, largerLogicalType);
-    assertEquals(new BigDecimal("99892.123400000000000"), result);
-  }
-
-  @Test
-  public void testToBytesScaleError() {
-    final BigDecimal value = new BigDecimal("4567335489766.989989998435899453").setScale(16, HALF_EVEN);
-    expectedException.expect(AvroTypeException.class);
-    expectedException.expectMessage("Cannot encode decimal with scale 16 as scale 15 without rounding");
-    CONVERSION.toBytes(value, largerSchema, largerLogicalType);
+    schema = Schema.createFixed("aFixed", null, null, 12);
+    schema.addProp("logicalType", "duration");
+    logicalType = LogicalTypes.fromSchema(schema);
   }
 
   @Test
   public void testToFromFixed() {
-    final BigDecimal value = new BigDecimal("3").setScale(15, HALF_EVEN);
-    final GenericFixed fixed = CONVERSION.toFixed(value, largerSchema, largerLogicalType);
-    final BigDecimal result = CONVERSION.fromFixed(fixed, largerSchema, largerLogicalType);
+    final Duration value = Duration.ofDays(10).plusMillis(100);
+    final GenericFixed fixed = CONVERSION.toFixed(value, schema, logicalType);
+    final Duration result = CONVERSION.fromFixed(fixed, schema, logicalType);
     assertEquals(value, result);
   }
 
   @Test
-  public void testToFromFixedMaxPrecision() {
-    final BigDecimal value = new BigDecimal("4567335489766.99834").setScale(15, HALF_EVEN);
-    final GenericFixed fixed = CONVERSION.toFixed(value, largerSchema, largerLogicalType);
-    final BigDecimal result = CONVERSION.fromFixed(fixed, largerSchema, largerLogicalType);
-    assertEquals(value, result);
+  public void testConvertingMillisecondsFromBytes() {
+    LogicalTypes.Duration duration = (LogicalTypes.Duration) logicalType;
+
+    final Duration durationValue = Duration.ofMillis(200);
+
+    final byte[] bytes = new byte[]{
+      0x0, 0x0, 0x0, 0x0,
+      0x0, 0x0, 0x0, 0x0,
+      -0x38, 0x0, 0x0, 0x0
+    };
+
+    final GenericFixed dd = new GenericData.Fixed(schema, bytes);
+
+    final Duration fromBytes = CONVERSION.fromFixed(dd, schema, duration);
+
+    assertEquals(durationValue, fromBytes);
   }
 
   @Test
-  public void testToFixedPrecisionError() {
-    final BigDecimal value = new BigDecimal("1.07046455859736525E+18").setScale(15, HALF_EVEN);
-    expectedException.expect(AvroTypeException.class);
-    expectedException.expectMessage("Cannot encode decimal with precision 34 as max precision 28");
-    CONVERSION.toFixed(value, largerSchema, largerLogicalType);
+  public void testConvertingDaysFromBytes() {
+    LogicalTypes.Duration duration = (LogicalTypes.Duration) logicalType;
+
+    final Duration durationValue = Duration.ofDays(29);
+
+    final byte[] bytes = new byte[]{
+      0x0, 0x0, 0x0, 0x0,
+      0x1D, 0x0, 0x0, 0x0,
+      0x0, 0x0, 0x0, 0x0
+    };
+
+    final GenericFixed dd = new GenericData.Fixed(schema, bytes);
+
+    final Duration fromBytes = CONVERSION.fromFixed(dd, schema, duration);
+
+    assertEquals(durationValue, fromBytes);
   }
 
   @Test
-  public void testToFromFixedSmallerScale() {
-    final BigDecimal value = new BigDecimal("99892.1234").setScale(10, HALF_EVEN);
-    final GenericFixed fixed = CONVERSION.toFixed(value, largerSchema, largerLogicalType);
-    final BigDecimal result = CONVERSION.fromFixed(fixed, largerSchema, largerLogicalType);
-    assertEquals(new BigDecimal("99892.123400000000000"), result);
+  public void testConvertingMonthsFromBytes() {
+    LogicalTypes.Duration duration = (LogicalTypes.Duration) logicalType;
+
+    final Duration durationValue = Duration.ofDays(60);
+
+    final byte[] bytes = new byte[]{
+      0x02, 0x0, 0x0, 0x0,
+      0x0, 0x0, 0x0, 0x0,
+      0x0, 0x0, 0x0, 0x0
+    };
+
+    final GenericFixed dd = new GenericData.Fixed(schema, bytes);
+
+    final Duration fromBytes = CONVERSION.fromFixed(dd, schema, duration);
+
+    assertEquals(durationValue, fromBytes);
   }
 
   @Test
-  public void testToFixedScaleError() {
-    final BigDecimal value = new BigDecimal("4567335489766.3453453453453453453453").setScale(16, HALF_EVEN);
-    expectedException.expect(AvroTypeException.class);
-    expectedException.expectMessage("Cannot encode decimal with scale 16 as scale 15 without rounding");
-    CONVERSION.toFixed(value, largerSchema, largerLogicalType);
+  public void testConvertingMillisecondsToBytes() {
+    LogicalTypes.Duration duration = (LogicalTypes.Duration) logicalType;
+
+    final Duration durationValue = Duration.ofMillis(200);
+
+    final byte[] bytes = new byte[]{
+      0x0, 0x0, 0x0, 0x0,
+      0x0, 0x0, 0x0, 0x0,
+      -0x38, 0x0, 0x0, 0x0
+    };
+
+    final GenericFixed fixed = CONVERSION.toFixed(durationValue, schema, duration);
+
+    assertArrayEquals(bytes, fixed.bytes());
   }
 
   @Test
-  public void testToFromFixedMatchScaleAndPrecision() {
-    final BigDecimal value = new BigDecimal("123.45");
-    final GenericFixed fixed = CONVERSION.toFixed(value, smallerSchema, smallerLogicalType);
-    final BigDecimal result = CONVERSION.fromFixed(fixed, smallerSchema, smallerLogicalType);
-    assertEquals(value, result);
+  public void testConvertingDaysToBytes() {
+    LogicalTypes.Duration duration = (LogicalTypes.Duration) logicalType;
+
+    final Duration durationValue = Duration.ofDays(29);
+
+    final byte[] bytes = new byte[]{
+      0x0, 0x0, 0x0, 0x0,
+      0x1D, 0x0, 0x0, 0x0,
+      0x0, 0x0, 0x0, 0x0
+    };
+
+    final GenericFixed fixed = CONVERSION.toFixed(durationValue, schema, duration);
+
+    assertArrayEquals(bytes, fixed.bytes());
   }
 
   @Test
-  public void testToFromFixedRepresentedInLogicalTypeAllowRoundUnneccesary() {
-    final BigDecimal value = new BigDecimal("123.4500");
-    final GenericFixed fixed = CONVERSION.toFixed(value, smallerSchema, smallerLogicalType);
-    final BigDecimal result = CONVERSION.fromFixed(fixed, smallerSchema, smallerLogicalType);
-    assertEquals(new BigDecimal("123.45"), result);
-  }
+  public void testConvertingWeeksToBytes() {
+    LogicalTypes.Duration duration = (LogicalTypes.Duration) logicalType;
 
-  @Test
-  public void testToFromFixedPrecisionErrorAfterAdjustingScale() {
-    final BigDecimal value = new BigDecimal("1234.560");
-    expectedException.expect(AvroTypeException.class);
-    expectedException.expectMessage(
-        "Cannot encode decimal with precision 6 as max precision 5. This is after safely adjusting scale from 3 to required 2");
-    CONVERSION.toFixed(value, smallerSchema, smallerLogicalType);
-  }
+    final Duration durationValue = Duration.ofDays(60);
 
-  @Test
-  public void testToFixedRepresentedInLogicalTypeErrorIfRoundingRequired() {
-    final BigDecimal value = new BigDecimal("123.456");
-    expectedException.expect(AvroTypeException.class);
-    expectedException.expectMessage("Cannot encode decimal with scale 3 as scale 2 without rounding");
-    CONVERSION.toFixed(value, smallerSchema, smallerLogicalType);
-  }
+    final byte[] bytes = new byte[]{
+      0x02, 0x0, 0x0, 0x0,
+      0x0, 0x0, 0x0, 0x0,
+      0x0, 0x0, 0x0, 0x0
+    };
 
-  @Test
-  public void testImportanceOfEnsuringCorrectScaleWhenConvertingFixed() {
-    LogicalTypes.Decimal decimal = (LogicalTypes.Decimal) smallerLogicalType;
+    final GenericFixed fixed = CONVERSION.toFixed(durationValue, schema, duration);
 
-    final BigDecimal bigDecimal = new BigDecimal("1234.5");
-    assertEquals(decimal.getPrecision(), bigDecimal.precision());
-    assertTrue(decimal.getScale() >= bigDecimal.scale());
-
-    final byte[] bytes = bigDecimal.unscaledValue().toByteArray();
-
-    final BigDecimal fromFixed = CONVERSION.fromFixed(new GenericData.Fixed(smallerSchema, bytes), smallerSchema,
-        decimal);
-
-    assertNotEquals(0, bigDecimal.compareTo(fromFixed));
-    assertNotEquals(bigDecimal, fromFixed);
-
-    assertEquals(new BigDecimal("123.45"), fromFixed);
-  }
-
-  @Test
-  public void testImportanceOfEnsuringCorrectScaleWhenConvertingBytes() {
-    LogicalTypes.Decimal decimal = (LogicalTypes.Decimal) smallerLogicalType;
-
-    final BigDecimal bigDecimal = new BigDecimal("1234.5");
-    assertEquals(decimal.getPrecision(), bigDecimal.precision());
-    assertTrue(decimal.getScale() >= bigDecimal.scale());
-
-    final byte[] bytes = bigDecimal.unscaledValue().toByteArray();
-
-    final BigDecimal fromBytes = CONVERSION.fromBytes(ByteBuffer.wrap(bytes), smallerSchema, decimal);
-
-    assertNotEquals(0, bigDecimal.compareTo(fromBytes));
-    assertNotEquals(bigDecimal, fromBytes);
-
-    assertEquals(new BigDecimal("123.45"), fromBytes);
+    assertArrayEquals(bytes, fixed.bytes());
   }
 }

--- a/lang/java/avro/src/test/java/org/apache/avro/TestDurationConversion.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestDurationConversion.java
@@ -32,6 +32,10 @@ import java.util.Arrays;
 import static java.math.RoundingMode.HALF_EVEN;
 import static org.junit.Assert.*;
 
+/*
+ *  TODO test for negative duration
+ *  TODO test for empty byte array (0 duration)
+ */
 public class TestDurationConversion {
 
   private static final Conversion<Duration> CONVERSION = new Conversions.DurationConversion();
@@ -124,6 +128,23 @@ public class TestDurationConversion {
       0x0, 0x0, 0x0, 0x0,
       0x0, 0x0, 0x0, 0x0,
       -0x38, 0x0, 0x0, 0x0
+    };
+
+    final GenericFixed fixed = CONVERSION.toFixed(durationValue, schema, duration);
+
+    assertArrayEquals(bytes, fixed.bytes());
+  }
+
+  @Test
+  public void testConvertingMillisecondsWithNanosecondAdjustmentToBytes() {
+    LogicalTypes.Duration duration = (LogicalTypes.Duration) logicalType;
+
+    final Duration durationValue = Duration.ofMillis(200).plusNanos(10);
+
+    final byte[] bytes = new byte[]{
+      0x0, 0x0, 0x0, 0x0,
+      0x0, 0x0, 0x0, 0x0,
+      -0x37, 0x0, 0x0, 0x0
     };
 
     final GenericFixed fixed = CONVERSION.toFixed(durationValue, schema, duration);

--- a/lang/java/avro/src/test/java/org/apache/avro/TestDurationConversion.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestDurationConversion.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.avro;
+
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericFixed;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+
+import static java.math.RoundingMode.HALF_EVEN;
+import static org.junit.Assert.*;
+
+public class TestDurationConversion {
+
+  private static final Conversion<BigDecimal> CONVERSION = new Conversions.DecimalConversion();
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  private Schema smallerSchema;
+  private LogicalType smallerLogicalType;
+  private Schema largerSchema;
+  private LogicalType largerLogicalType;
+
+  @Before
+  public void setup() {
+    smallerSchema = Schema.createFixed("smallFixed", null, null, 3);
+    smallerSchema.addProp("logicalType", "decimal");
+    smallerSchema.addProp("precision", 5);
+    smallerSchema.addProp("scale", 2);
+    smallerLogicalType = LogicalTypes.fromSchema(smallerSchema);
+
+    largerSchema = Schema.createFixed("largeFixed", null, null, 12);
+    largerSchema.addProp("logicalType", "decimal");
+    largerSchema.addProp("precision", 28);
+    largerSchema.addProp("scale", 15);
+    largerLogicalType = LogicalTypes.fromSchema(largerSchema);
+  }
+
+  @Test
+  public void testToFromBytes() {
+    final BigDecimal value = BigDecimal.valueOf(10.99).setScale(15, HALF_EVEN);
+    final ByteBuffer byteBuffer = CONVERSION.toBytes(value, largerSchema, largerLogicalType);
+    final BigDecimal result = CONVERSION.fromBytes(byteBuffer, largerSchema, largerLogicalType);
+    assertEquals(value, result);
+  }
+
+  @Test
+  public void testToFromBytesMaxPrecision() {
+    final BigDecimal value = new BigDecimal("4567335489766.99834").setScale(15, HALF_EVEN);
+    final ByteBuffer byteBuffer = CONVERSION.toBytes(value, largerSchema, largerLogicalType);
+    final BigDecimal result = CONVERSION.fromBytes(byteBuffer, largerSchema, largerLogicalType);
+    assertEquals(value, result);
+  }
+
+  @Test
+  public void testToBytesPrecisionError() {
+    final BigDecimal value = new BigDecimal("1.07046455859736525E+18").setScale(15, HALF_EVEN);
+    expectedException.expect(AvroTypeException.class);
+    expectedException.expectMessage("Cannot encode decimal with precision 34 as max precision 28");
+    CONVERSION.toBytes(value, largerSchema, largerLogicalType);
+  }
+
+  @Test
+  public void testToBytesFixedSmallerScale() {
+    final BigDecimal value = new BigDecimal("99892.1234").setScale(10, HALF_EVEN);
+    final ByteBuffer byteBuffer = CONVERSION.toBytes(value, largerSchema, largerLogicalType);
+    final BigDecimal result = CONVERSION.fromBytes(byteBuffer, largerSchema, largerLogicalType);
+    assertEquals(new BigDecimal("99892.123400000000000"), result);
+  }
+
+  @Test
+  public void testToBytesScaleError() {
+    final BigDecimal value = new BigDecimal("4567335489766.989989998435899453").setScale(16, HALF_EVEN);
+    expectedException.expect(AvroTypeException.class);
+    expectedException.expectMessage("Cannot encode decimal with scale 16 as scale 15 without rounding");
+    CONVERSION.toBytes(value, largerSchema, largerLogicalType);
+  }
+
+  @Test
+  public void testToFromFixed() {
+    final BigDecimal value = new BigDecimal("3").setScale(15, HALF_EVEN);
+    final GenericFixed fixed = CONVERSION.toFixed(value, largerSchema, largerLogicalType);
+    final BigDecimal result = CONVERSION.fromFixed(fixed, largerSchema, largerLogicalType);
+    assertEquals(value, result);
+  }
+
+  @Test
+  public void testToFromFixedMaxPrecision() {
+    final BigDecimal value = new BigDecimal("4567335489766.99834").setScale(15, HALF_EVEN);
+    final GenericFixed fixed = CONVERSION.toFixed(value, largerSchema, largerLogicalType);
+    final BigDecimal result = CONVERSION.fromFixed(fixed, largerSchema, largerLogicalType);
+    assertEquals(value, result);
+  }
+
+  @Test
+  public void testToFixedPrecisionError() {
+    final BigDecimal value = new BigDecimal("1.07046455859736525E+18").setScale(15, HALF_EVEN);
+    expectedException.expect(AvroTypeException.class);
+    expectedException.expectMessage("Cannot encode decimal with precision 34 as max precision 28");
+    CONVERSION.toFixed(value, largerSchema, largerLogicalType);
+  }
+
+  @Test
+  public void testToFromFixedSmallerScale() {
+    final BigDecimal value = new BigDecimal("99892.1234").setScale(10, HALF_EVEN);
+    final GenericFixed fixed = CONVERSION.toFixed(value, largerSchema, largerLogicalType);
+    final BigDecimal result = CONVERSION.fromFixed(fixed, largerSchema, largerLogicalType);
+    assertEquals(new BigDecimal("99892.123400000000000"), result);
+  }
+
+  @Test
+  public void testToFixedScaleError() {
+    final BigDecimal value = new BigDecimal("4567335489766.3453453453453453453453").setScale(16, HALF_EVEN);
+    expectedException.expect(AvroTypeException.class);
+    expectedException.expectMessage("Cannot encode decimal with scale 16 as scale 15 without rounding");
+    CONVERSION.toFixed(value, largerSchema, largerLogicalType);
+  }
+
+  @Test
+  public void testToFromFixedMatchScaleAndPrecision() {
+    final BigDecimal value = new BigDecimal("123.45");
+    final GenericFixed fixed = CONVERSION.toFixed(value, smallerSchema, smallerLogicalType);
+    final BigDecimal result = CONVERSION.fromFixed(fixed, smallerSchema, smallerLogicalType);
+    assertEquals(value, result);
+  }
+
+  @Test
+  public void testToFromFixedRepresentedInLogicalTypeAllowRoundUnneccesary() {
+    final BigDecimal value = new BigDecimal("123.4500");
+    final GenericFixed fixed = CONVERSION.toFixed(value, smallerSchema, smallerLogicalType);
+    final BigDecimal result = CONVERSION.fromFixed(fixed, smallerSchema, smallerLogicalType);
+    assertEquals(new BigDecimal("123.45"), result);
+  }
+
+  @Test
+  public void testToFromFixedPrecisionErrorAfterAdjustingScale() {
+    final BigDecimal value = new BigDecimal("1234.560");
+    expectedException.expect(AvroTypeException.class);
+    expectedException.expectMessage(
+        "Cannot encode decimal with precision 6 as max precision 5. This is after safely adjusting scale from 3 to required 2");
+    CONVERSION.toFixed(value, smallerSchema, smallerLogicalType);
+  }
+
+  @Test
+  public void testToFixedRepresentedInLogicalTypeErrorIfRoundingRequired() {
+    final BigDecimal value = new BigDecimal("123.456");
+    expectedException.expect(AvroTypeException.class);
+    expectedException.expectMessage("Cannot encode decimal with scale 3 as scale 2 without rounding");
+    CONVERSION.toFixed(value, smallerSchema, smallerLogicalType);
+  }
+
+  @Test
+  public void testImportanceOfEnsuringCorrectScaleWhenConvertingFixed() {
+    LogicalTypes.Decimal decimal = (LogicalTypes.Decimal) smallerLogicalType;
+
+    final BigDecimal bigDecimal = new BigDecimal("1234.5");
+    assertEquals(decimal.getPrecision(), bigDecimal.precision());
+    assertTrue(decimal.getScale() >= bigDecimal.scale());
+
+    final byte[] bytes = bigDecimal.unscaledValue().toByteArray();
+
+    final BigDecimal fromFixed = CONVERSION.fromFixed(new GenericData.Fixed(smallerSchema, bytes), smallerSchema,
+        decimal);
+
+    assertNotEquals(0, bigDecimal.compareTo(fromFixed));
+    assertNotEquals(bigDecimal, fromFixed);
+
+    assertEquals(new BigDecimal("123.45"), fromFixed);
+  }
+
+  @Test
+  public void testImportanceOfEnsuringCorrectScaleWhenConvertingBytes() {
+    LogicalTypes.Decimal decimal = (LogicalTypes.Decimal) smallerLogicalType;
+
+    final BigDecimal bigDecimal = new BigDecimal("1234.5");
+    assertEquals(decimal.getPrecision(), bigDecimal.precision());
+    assertTrue(decimal.getScale() >= bigDecimal.scale());
+
+    final byte[] bytes = bigDecimal.unscaledValue().toByteArray();
+
+    final BigDecimal fromBytes = CONVERSION.fromBytes(ByteBuffer.wrap(bytes), smallerSchema, decimal);
+
+    assertNotEquals(0, bigDecimal.compareTo(fromBytes));
+    assertNotEquals(bigDecimal, fromBytes);
+
+    assertEquals(new BigDecimal("123.45"), fromBytes);
+  }
+}

--- a/lang/java/avro/src/test/java/org/apache/avro/TestLogicalType.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestLogicalType.java
@@ -226,6 +226,34 @@ public class TestLogicalType {
     assertEqualsFalse("Different logical type", schema1, schema3);
   }
 
+  @Test
+  public void testDurationFromSchema() {
+    Schema schema = Schema.createFixed("aFixed", null, null, 12);
+    schema.addProp("logicalType", "duration");
+    LogicalType logicalType = LogicalTypes.fromSchemaIgnoreInvalid(schema);
+
+    Assert.assertTrue("Should be a Duration", logicalType instanceof LogicalTypes.Duration);
+  }
+
+  @Test
+  public void testDurationValidation() {
+    assertThrows("Should reject too short type", IllegalArgumentException.class,
+    "Duration can only be used with an underlying fixed type of size 12", () -> {
+        LogicalTypes.duration().addToSchema(
+          Schema.createFixed("aFixed", null, null, 11)
+        );
+      return null;
+    });
+
+    assertThrows("Should reject too long type", IllegalArgumentException.class,
+      "Duration can only be used with an underlying fixed type of size 12", () -> {
+        LogicalTypes.duration().addToSchema(
+          Schema.createFixed("anotherFixed", null, null, 13)
+        );
+        return null;
+      });
+  }
+
   public static void assertEqualsTrue(String message, Object o1, Object o2) {
     Assert.assertTrue("Should be equal (forward): " + message, o1.equals(o2));
     Assert.assertTrue("Should be equal (reverse): " + message, o2.equals(o1));


### PR DESCRIPTION
Implementation of http://avro.apache.org/docs/current/spec.html#Duration

Can be used to serialize/deserialize to/from Java POJOs and Generic Fixed type.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2123

### Tests

- [x] My PR adds the following unit tests:
- `lang/java/avro/src/test/java/org/apache/avro/TestDurationConversion.java`

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does: existing conversaion don't have Javadoc so I didn't add one. This is considered an internal API IMHO.
