### PR TITLE
AVRO-3167: Simplify Codec Buffer Allocation

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/file/BZip2Codec.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/file/BZip2Codec.java
@@ -18,10 +18,10 @@
 package org.apache.avro.file;
 
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
+import org.apache.avro.util.NonCopyingByteArrayOutputStream;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream;
 
@@ -30,8 +30,6 @@ public class BZip2Codec extends Codec {
 
   public static final int DEFAULT_BUFFER_SIZE = 64 * 1024;
   private final byte[] buffer = new byte[DEFAULT_BUFFER_SIZE];
-
-  private ByteArrayOutputStream outputBuffer;
 
   static class Option extends CodecFactory {
     @Override
@@ -47,28 +45,31 @@ public class BZip2Codec extends Codec {
 
   @Override
   public ByteBuffer compress(ByteBuffer uncompressedData) throws IOException {
-    ByteArrayOutputStream baos = getOutputBuffer(uncompressedData.remaining());
+    NonCopyingByteArrayOutputStream baos = new NonCopyingByteArrayOutputStream(DEFAULT_BUFFER_SIZE);
 
     try (BZip2CompressorOutputStream outputStream = new BZip2CompressorOutputStream(baos)) {
       outputStream.write(uncompressedData.array(), computeOffset(uncompressedData), uncompressedData.remaining());
     }
 
-    return ByteBuffer.wrap(baos.toByteArray());
+    return baos.asByteBuffer();
   }
 
   @Override
   public ByteBuffer decompress(ByteBuffer compressedData) throws IOException {
     ByteArrayInputStream bais = new ByteArrayInputStream(compressedData.array(), computeOffset(compressedData),
         compressedData.remaining());
+
+    @SuppressWarnings("resource")
+    NonCopyingByteArrayOutputStream baos = new NonCopyingByteArrayOutputStream(DEFAULT_BUFFER_SIZE);
+
     try (BZip2CompressorInputStream inputStream = new BZip2CompressorInputStream(bais)) {
-      ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
       int readCount = -1;
       while ((readCount = inputStream.read(buffer, compressedData.position(), buffer.length)) > 0) {
         baos.write(buffer, 0, readCount);
       }
 
-      return ByteBuffer.wrap(baos.toByteArray());
+      return baos.asByteBuffer();
     }
   }
 
@@ -84,12 +85,4 @@ public class BZip2Codec extends Codec {
     return obj != null && obj.getClass() == getClass();
   }
 
-  // get and initialize the output buffer for use.
-  private ByteArrayOutputStream getOutputBuffer(int suggestedLength) {
-    if (null == outputBuffer) {
-      outputBuffer = new ByteArrayOutputStream(suggestedLength);
-    }
-    outputBuffer.reset();
-    return outputBuffer;
-  }
 }

--- a/lang/java/avro/src/main/java/org/apache/avro/file/DataFileWriter.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/file/DataFileWriter.java
@@ -20,7 +20,6 @@ package org.apache.avro.file;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.BufferedOutputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.File;
 import java.io.FilterOutputStream;
@@ -42,6 +41,7 @@ import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.util.NonCopyingByteArrayOutputStream;
 import org.apache.commons.compress.utils.IOUtils;
 
 /**
@@ -401,7 +401,7 @@ public class DataFileWriter<D> implements Closeable, Flushable {
     if (blockCount > 0) {
       try {
         bufOut.flush();
-        ByteBuffer uncompressed = buffer.getByteArrayAsByteBuffer();
+        ByteBuffer uncompressed = buffer.asByteBuffer();
         DataBlock block = new DataBlock(uncompressed, blockCount);
         block.setFlushOnWrite(flushOnEveryBlock);
         block.compressUsing(codec);
@@ -497,16 +497,6 @@ public class DataFileWriter<D> implements Closeable, Flushable {
         // occurred during the write
         count = 0;
       }
-    }
-  }
-
-  private static class NonCopyingByteArrayOutputStream extends ByteArrayOutputStream {
-    NonCopyingByteArrayOutputStream(int initialSize) {
-      super(initialSize);
-    }
-
-    ByteBuffer getByteArrayAsByteBuffer() {
-      return ByteBuffer.wrap(buf, 0, count);
     }
   }
 

--- a/lang/java/avro/src/main/java/org/apache/avro/file/ZstandardCodec.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/file/ZstandardCodec.java
@@ -18,17 +18,18 @@
 package org.apache.avro.file;
 
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 
+import org.apache.avro.util.NonCopyingByteArrayOutputStream;
 import org.apache.commons.compress.utils.IOUtils;
 
 public class ZstandardCodec extends Codec {
   public final static int DEFAULT_COMPRESSION = 3;
   public final static boolean DEFAULT_USE_BUFFERPOOL = false;
+  private static final int DEFAULT_BUFFER_SIZE = 8192;
 
   static class Option extends CodecFactory {
     private final int compressionLevel;
@@ -50,7 +51,6 @@ public class ZstandardCodec extends Codec {
   private final int compressionLevel;
   private final boolean useChecksum;
   private final boolean useBufferPool;
-  private ByteArrayOutputStream outputBuffer;
 
   /**
    * Create a ZstandardCodec instance with the given compressionLevel, checksum,
@@ -69,31 +69,22 @@ public class ZstandardCodec extends Codec {
 
   @Override
   public ByteBuffer compress(ByteBuffer data) throws IOException {
-    ByteArrayOutputStream baos = getOutputBuffer(data.remaining());
+    NonCopyingByteArrayOutputStream baos = new NonCopyingByteArrayOutputStream(DEFAULT_BUFFER_SIZE);
     try (OutputStream outputStream = ZstandardLoader.output(baos, compressionLevel, useChecksum, useBufferPool)) {
       outputStream.write(data.array(), computeOffset(data), data.remaining());
     }
-    return ByteBuffer.wrap(baos.toByteArray());
+    return baos.asByteBuffer();
   }
 
   @Override
   public ByteBuffer decompress(ByteBuffer compressedData) throws IOException {
-    ByteArrayOutputStream baos = getOutputBuffer(compressedData.remaining());
+    NonCopyingByteArrayOutputStream baos = new NonCopyingByteArrayOutputStream(DEFAULT_BUFFER_SIZE);
     InputStream bytesIn = new ByteArrayInputStream(compressedData.array(), computeOffset(compressedData),
         compressedData.remaining());
     try (InputStream ios = ZstandardLoader.input(bytesIn, useBufferPool)) {
       IOUtils.copy(ios, baos);
     }
-    return ByteBuffer.wrap(baos.toByteArray());
-  }
-
-  // get and initialize the output buffer for use.
-  private ByteArrayOutputStream getOutputBuffer(int suggestedLength) {
-    if (outputBuffer == null) {
-      outputBuffer = new ByteArrayOutputStream(suggestedLength);
-    }
-    outputBuffer.reset();
-    return outputBuffer;
+    return baos.asByteBuffer();
   }
 
   @Override

--- a/lang/java/avro/src/main/java/org/apache/avro/util/NonCopyingByteArrayOutputStream.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/util/NonCopyingByteArrayOutputStream.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.avro.util;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+
+/**
+ * Utility to make data written to an {@link ByteArrayOutputStream} directly
+ * available as a {@link ByteBuffer}.
+ */
+public class NonCopyingByteArrayOutputStream extends ByteArrayOutputStream {
+
+  /**
+   * Creates a new byte array output stream, with a buffer capacity of the
+   * specified size, in bytes.
+   *
+   * @param size the initial size
+   * @throws IllegalArgumentException if size is negative
+   */
+  public NonCopyingByteArrayOutputStream(int size) {
+    super(size);
+  }
+
+  /**
+   * Get the contents of this ByteArrayOutputStream wrapped as a ByteBuffer. This
+   * is a shallow copy. Changes to this ByteArrayOutputstream "write through" to
+   * the ByteBuffer.
+   *
+   * @return The contents of this ByteArrayOutputstream wrapped as a ByteBuffer
+   */
+  public ByteBuffer asByteBuffer() {
+    return ByteBuffer.wrap(super.buf, 0, super.count);
+  }
+}


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
No change in behavior, simply performance/simplicity

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
