### PR TITLE
AVRO-3168 Enable custom coders by default

### DIFF
--- a/doc/src/content/xdocs/gettingstartedjava.xml
+++ b/doc/src/content/xdocs/gettingstartedjava.xml
@@ -324,41 +324,29 @@ $ mvn -q exec:java -Dexec.mainClass=example.SpecificMain
         </source>
       </section>
       <section>
-        <title>Beta feature: Generating faster code</title>
+        <title>Generating faster code</title>
         <p>
-          In this release we have introduced a new approach to
+          In avro 1.9 we have introduced a new approach to
           generating code that speeds up decoding of objects by more
           than 10% and encoding by more than 30% (future performance
-          enhancements are underway).  To ensure a smooth introduction
-          of this change into production systems, this feature is
-          controlled by a feature flag, the system
+          enhancements are underway). Previously this feature was turned off
+          by default. In avro 1.11 it is on by default.
           property <code>org.apache.avro.specific.use_custom_coders</code>.
-          In this first release, this feature is off by default.  To
-          turn it on, set the system flag to <code>true</code> at
-          runtime.  In the sample above, for example, you could enable
-          the fater coders as follows:
         </p>
-        <source>
-$ mvn -q exec:java -Dexec.mainClass=example.SpecificMain \
-    -Dorg.apache.avro.specific.use_custom_coders=true
-        </source>
         <p>
           Note that you do <em>not</em> have to recompile your Avro
           schema to have access to this feature.  The feature is
           compiled and built into your code, and you turn it on and
-          off at runtime using the feature flag.  As a result, you can
-          turn it on during testing, for example, and then off in
-          production.  Or you can turn it on in production, and
-          quickly turn it off if something breaks.
+          off at runtime using the feature flag.
         </p>
         <p>
-          We encourage the Avro community to exercise this new feature
-          early to help build confidence.  (For those paying
-          one-demand for compute resources in the cloud, it can lead
-          to meaningful cost savings.)  As confidence builds, we will
-          turn this feature on by default, and eventually eliminate
-          the feature flag (and the old code).
+          To turn it off, set the system flag to <code>false</code> at
+          runtime.
         </p>
+        <source>
+          $ mvn -q exec:java -Dexec.mainClass=example.SpecificMain \
+          -Dorg.apache.avro.specific.use_custom_coders=false
+        </source>
       </section>
     </section>
 

--- a/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificData.java
@@ -184,14 +184,14 @@ public class SpecificData extends GenericData {
   }
 
   private boolean useCustomCoderFlag = Boolean
-      .parseBoolean(System.getProperty("org.apache.avro.specific.use_custom_coders", "false"));
+      .parseBoolean(System.getProperty("org.apache.avro.specific.use_custom_coders", "true"));
 
   /**
    * Retrieve the current value of the custom-coders feature flag. Defaults to
    * <code>true</code>, but this default can be overriden using the system
    * property <code>org.apache.avro.specific.use_custom_coders</code>, and can be
    * set dynamically by {@link SpecificData#useCustomCoders()}. See <a
-   * href="https://avro.apache.org/docs/current/gettingstartedjava.html#Beta+feature:+Generating+faster+code"Getting
+   * href="https://avro.apache.org/docs/current/gettingstartedjava.html#Generating+faster+code"Getting
    * started with Java</a> for more about this feature flag.
    */
   public boolean useCustomCoders() {


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO-3168) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3168
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: No unit tests as this is a feature flag change


### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
