### PR TITLE
AVRO-3173 Rust: fix panic messages in test code

### DIFF
--- a/lang/rust/tests/io.rs
+++ b/lang/rust/tests/io.rs
@@ -102,7 +102,7 @@ fn test_validate() {
         let schema = Schema::parse_str(raw_schema).unwrap();
         assert!(
             value.validate(&schema),
-            format!("value {:?} does not validate schema: {}", value, raw_schema)
+            "value {:?} does not validate schema: {}", value, raw_schema
         );
     }
 }

--- a/lang/rust/tests/schema.rs
+++ b/lang/rust/tests/schema.rs
@@ -1170,7 +1170,7 @@ fn test_root_error_is_not_swallowed_on_parse_error() -> Result<(), String> {
     if let Error::ParseSchemaJson(e) = error {
         assert!(
             e.to_string().contains("expected value at line 1 column 1"),
-            e.to_string()
+            "{}", e
         );
         Ok(())
     } else {


### PR DESCRIPTION
Fix warnings by using the updated assert API


### Jira
 
  https://issues.apache.org/jira/browse/AVRO-3173
 
### Tests

Only test code is updated
