### PR TITLE
AVRO-3174 JavaScript: Do not use deprecated constructors of Buffer

### DIFF
--- a/lang/js/lib/files.js
+++ b/lang/js/lib/files.js
@@ -56,7 +56,7 @@ var BLOCK_TYPE = schemas.createType({
 var LONG_TYPE = schemas.createType('long');
 
 // First 4 bytes of an Avro object container file.
-var MAGIC_BYTES = new Buffer('Obj\x01');
+var MAGIC_BYTES = Buffer.from('Obj\x01');
 
 // Convenience.
 var f = util.format;
@@ -91,7 +91,7 @@ function RawDecoder(schema, opts) {
   // readable side ends, while we need the other way. So we do it manually.
 
   this._type = parse(schema);
-  this._tap = new Tap(new Buffer(0));
+  this._tap = new Tap(Buffer.alloc(0));
   this._needPush = false;
   this._readValue = createReader(decode, this._type);
   this._finished = false;
@@ -145,8 +145,8 @@ function BlockDecoder(opts) {
   this._type = null;
   this._codecs = opts.codecs;
   this._parseOpts = opts.parseOpts || {};
-  this._tap = new Tap(new Buffer(0));
-  this._blockTap = new Tap(new Buffer(0));
+  this._tap = new Tap(Buffer.alloc(0));
+  this._blockTap = new Tap(Buffer.alloc(0));
   this._syncMarker = null;
   this._readValue = null;
   this._decode = decode;
@@ -221,7 +221,7 @@ BlockDecoder.prototype._write = function (chunk, encoding, cb) {
   // in case we already have all the data (in which case `_write` wouldn't get
   // called anymore).
   this._write = this._writeChunk;
-  this._write(new Buffer(0), encoding, cb);
+  this._write(Buffer.alloc(0), encoding, cb);
 };
 
 BlockDecoder.prototype._writeChunk = function (chunk, encoding, cb) {
@@ -300,7 +300,7 @@ function RawEncoder(schema, opts) {
       this.emit('error', err);
     }
   };
-  this._tap = new Tap(new Buffer(opts.batchSize || 65536));
+  this._tap = new Tap(Buffer.alloc(opts.batchSize || 65536));
 }
 util.inherits(RawEncoder, stream.Transform);
 
@@ -318,7 +318,7 @@ RawEncoder.prototype._transform = function (val, encoding, cb) {
     var len = tap.pos - pos;
     if (len > buf.length) {
       // Not enough space for last written object, need to resize.
-      tap.buf = new Buffer(2 * len);
+      tap.buf = Buffer.alloc(2 * len);
     }
     tap.pos = 0;
     this._writeValue(tap, val); // Rewrite last failed write.
@@ -380,7 +380,7 @@ function BlockEncoder(schema, opts) {
     }
   };
   this._blockSize = opts.blockSize || 65536;
-  this._tap = new Tap(new Buffer(this._blockSize));
+  this._tap = new Tap(Buffer.alloc(this._blockSize));
   this._codecs = opts.codecs;
   this._codec = opts.codec || 'null';
   this._compress = null;
@@ -423,8 +423,8 @@ BlockEncoder.prototype._write = function (val, encoding, cb) {
 
   if (!this._omitHeader) {
     var meta = {
-      'avro.schema': new Buffer(this._schema || this._type.getSchema()),
-      'avro.codec': new Buffer(this._codec)
+      'avro.schema': Buffer.from(this._schema || this._type.getSchema()),
+      'avro.codec': Buffer.from(this._codec)
     };
     var Header = HEADER_TYPE.getRecordConstructor();
     var header = new Header(MAGIC_BYTES, meta, this._syncMarker);
@@ -449,7 +449,7 @@ BlockEncoder.prototype._writeChunk = function (val, encoding, cb) {
       // Not enough space for last written object, need to resize.
       this._blockSize = len * 2;
     }
-    tap.buf = new Buffer(this._blockSize);
+    tap.buf = Buffer.alloc(this._blockSize);
     tap.pos = 0;
     this._writeValue(tap, val); // Rewrite last failed write.
   }
@@ -514,7 +514,7 @@ function extractFileHeader(path, opts) {
   var decode = opts.decode === undefined ? true : !!opts.decode;
   var size = Math.max(opts.size || 4096, 4);
   var fd = fs.openSync(path, 'r');
-  var buf = new Buffer(size);
+  var buf = Buffer.alloc(size);
   var pos = 0;
   var tap = new Tap(buf);
   var header = null;
@@ -543,7 +543,7 @@ function extractFileHeader(path, opts) {
       return true;
     }
     var len = 2 * tap.buf.length;
-    var buf = new Buffer(len);
+    var buf = Buffer.alloc(len);
     len = fs.readSync(fd, buf, 0, len);
     tap.buf = Buffer.concat([tap.buf, buf]);
     tap.pos = 0;
@@ -627,7 +627,7 @@ function createReader(decode, type) {
  *
  */
 function copyBuffer(buf, pos, len) {
-  var copy = new Buffer(len);
+  var copy = Buffer.alloc(len);
   buf.copy(copy, 0, pos, pos + len);
   return copy;
 }

--- a/lang/js/lib/protocols.js
+++ b/lang/js/lib/protocols.js
@@ -310,7 +310,7 @@ MessageEmitter.prototype._createHandshakeRequest = function (
   return new HandshakeRequest(
     getHash(this._ptcl),
     noPtcl ? null : {string: this._ptcl.toString()},
-    new Buffer(hashString, 'binary')
+    Buffer.from(hashString, 'binary')
   );
 };
 
@@ -413,7 +413,7 @@ StatelessEmitter.prototype._emit = function (message, req, cb) {
   emit(false);
 
   function emit(retry) {
-    var tap = new Tap(new Buffer(self._bufferSize));
+    var tap = new Tap(Buffer.alloc(self._bufferSize));
 
     var handshakeReq = self._createHandshakeRequest(serverHashString, !retry);
     safeWrite(tap, HANDSHAKE_REQUEST_TYPE, handshakeReq);
@@ -619,7 +619,7 @@ StatefulEmitter.prototype._emit = function (message, req, cb) {
     return;
   }
 
-  var tap = new Tap(new Buffer(this._bufferSize));
+  var tap = new Tap(Buffer.alloc(this._bufferSize));
   var id = this._id++;
   try {
     safeWrite(tap, this._idType, -id);
@@ -740,7 +740,7 @@ MessageListener.prototype._validateHandshake = function (reqTap, resTap) {
     validationErr ? 'NONE' : serverMatch ? 'BOTH' : 'CLIENT',
     serverMatch ? null : {string: this._ptcl.toString()},
     serverMatch ? null : {'org.apache.avro.ipc.MD5': getHash(this._ptcl)},
-    validationErr ? {map: {error: new Buffer(validationErr.message)}} : null
+    validationErr ? {map: {error: Buffer.from(validationErr.message)}} : null
   );
 
   this.emit('handshake', handshakeReq, handshakeRes);
@@ -807,7 +807,7 @@ MessageListener.prototype.destroy = function (noWait) {
 function StatelessListener(ptcl, readableFactory, opts) {
   MessageListener.call(this, ptcl, opts);
 
-  this._tap = new Tap(new Buffer(this._bufferSize));
+  this._tap = new Tap(Buffer.alloc(this._bufferSize));
   this._message = undefined;
 
   var self = this;
@@ -892,7 +892,7 @@ function StatefulListener(ptcl, readable, writable, opts) {
 
   function onHandshakeData(buf) {
     var reqTap = new Tap(buf);
-    var resTap = new Tap(new Buffer(self._bufferSize));
+    var resTap = new Tap(Buffer.alloc(self._bufferSize));
     if (self._validateHandshake(reqTap, resTap)) {
       self._decoder
         .removeListener('data', onHandshakeData)
@@ -903,7 +903,7 @@ function StatefulListener(ptcl, readable, writable, opts) {
 
   function onRequestData(buf) {
     var reqTap = new Tap(buf);
-    var resTap = new Tap(new Buffer(self._bufferSize));
+    var resTap = new Tap(Buffer.alloc(self._bufferSize));
     var id = 0;
     try {
       id = -self._idType._read(reqTap) | 0;
@@ -1049,7 +1049,7 @@ MessageEncoder.prototype._transform = function (buf, encoding, cb) {
  */
 function MessageDecoder(noEmpty) {
   stream.Transform.call(this);
-  this._buf = new Buffer(0);
+  this._buf = Buffer.alloc(0);
   this._bufs = [];
   this._length = 0;
   this._empty = !!noEmpty;
@@ -1136,7 +1136,7 @@ IdType.createMetadataType = function (Type) {
  *
  */
 function intBuffer(n) {
-  var buf = new Buffer(4);
+  var buf = Buffer.alloc(4);
   buf.writeInt32BE(n);
   return buf;
 }
@@ -1154,7 +1154,7 @@ function safeWrite(tap, type, val) {
   type._write(tap, val);
 
   if (!tap.isValid()) {
-    var buf = new Buffer(tap.pos);
+    var buf = Buffer.alloc(tap.pos);
     tap.buf.copy(buf, 0, 0, pos);
     tap.buf = buf;
     tap.pos = pos;
@@ -1213,7 +1213,7 @@ function asyncAvroCb(ctx, cb, err, res) {
  *
  */
 function getHash(ptcl) {
-  return new Buffer(ptcl._hashString, 'binary');
+  return Buffer.from(ptcl._hashString, 'binary');
 }
 
 /**

--- a/lang/js/lib/schemas.js
+++ b/lang/js/lib/schemas.js
@@ -56,7 +56,7 @@ var NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 var RANDOM = new utils.Lcg();
 
 // Encoding tap (shared for performance).
-var TAP = new Tap(new buffer.SlowBuffer(1024));
+var TAP = new Tap(Buffer.allocUnsafeSlow(1024));
 
 // Path prefix for validity checks (shared for performance).
 var PATH = [];
@@ -166,7 +166,7 @@ function Type(registry) {
   registry[name] = type;
 }
 
-Type.__reset = function (size) { TAP.buf = new buffer.SlowBuffer(size); };
+Type.__reset = function (size) { TAP.buf = Buffer.allocUnsafeSlow(size); };
 
 Type.prototype.createResolver = function (type, opts) {
   if (!(type instanceof Type)) {
@@ -261,7 +261,7 @@ Type.prototype.toBuffer = function (val) {
     TAP.pos = 0;
     this._write(TAP, val);
   }
-  var buf = new Buffer(TAP.pos);
+  var buf = Buffer.alloc(TAP.pos);
   TAP.buf.copy(buf, 0, 0, TAP.pos);
   return buf;
 };
@@ -652,19 +652,19 @@ BytesType.prototype._copy = function (obj, opts) {
       if (typeof obj != 'string') {
         throw new Error(f('cannot coerce to buffer: %j', obj));
       }
-      buf = new Buffer(obj, 'binary');
+      buf = Buffer.from(obj, 'binary');
       this._check(buf, throwInvalidError);
       return buf;
     case 1: // Coerce buffer JSON representation to buffers.
       if (!obj || obj.type !== 'Buffer' || !(obj.data instanceof Array)) {
         throw new Error(f('cannot coerce to buffer: %j', obj));
       }
-      buf = new Buffer(obj.data);
+      buf = Buffer.from(obj.data);
       this._check(buf, throwInvalidError);
       return buf;
     default: // Copy buffer.
       this._check(obj, throwInvalidError);
-      return new Buffer(obj);
+      return Buffer.from(obj);
   }
 };
 BytesType.prototype.compare = Buffer.compare;

--- a/lang/js/lib/utils.js
+++ b/lang/js/lib/utils.js
@@ -198,7 +198,7 @@ Lcg.prototype.nextBuffer = function (len) {
   for (i = 0; i < len; i++) {
     arr.push(this.nextInt(256));
   }
-  return new Buffer(arr);
+  return Buffer.from(arr);
 };
 
 Lcg.prototype.choice = function (arr) {
@@ -423,7 +423,7 @@ Tap.prototype.readFixed = function (len) {
   if (this.pos > this.buf.length) {
     return;
   }
-  var fixed = new Buffer(len);
+  var fixed = Buffer.alloc(len);
   this.buf.copy(fixed, 0, pos, pos + len);
   return fixed;
 };
@@ -546,7 +546,7 @@ Tap.prototype.matchBytes = Tap.prototype.matchString = function (tap) {
 // worry about Avro's zigzag encoding, we directly expose longs as unpacked.
 
 Tap.prototype.unpackLongBytes = function () {
-  var res = new Buffer(8);
+  var res = Buffer.alloc(8);
   var n = 0;
   var i = 0; // Byte index in target buffer.
   var j = 6; // Bit offset in current target buffer byte.

--- a/lang/js/test/test_files.js
+++ b/lang/js/test/test_files.js
@@ -32,7 +32,7 @@ var files = require('../lib/files'),
 var DPATH = path.join(__dirname, 'dat');
 var Header = files.HEADER_TYPE.getRecordConstructor();
 var MAGIC_BYTES = files.MAGIC_BYTES;
-var SYNC = new Buffer('atokensyncheader');
+var SYNC = Buffer.from('atokensyncheader');
 var createType = schemas.createType;
 var streams = files.streams;
 var types = schemas.types;
@@ -96,7 +96,7 @@ suite('files', function () {
           buf = chunk;
         })
         .on('end', function () {
-          assert.deepEqual(buf, new Buffer([2, 0, 3]));
+          assert.deepEqual(buf, Buffer.from([2, 0, 3]));
           cb();
         });
       encoder.write(1);
@@ -112,7 +112,7 @@ suite('files', function () {
           bufs.push(chunk);
         })
         .on('end', function () {
-          assert.deepEqual(bufs, [new Buffer([1]), new Buffer([2])]);
+          assert.deepEqual(bufs, [Buffer.from([1]), Buffer.from([2])]);
           cb();
         });
       encoder.write(-1);
@@ -121,7 +121,7 @@ suite('files', function () {
 
     test('resize', function (cb) {
       var t = createType({type: 'fixed', name: 'A', size: 2});
-      var data = new Buffer([48, 18]);
+      var data = Buffer.from([48, 18]);
       var buf;
       var encoder = new RawEncoder(t, {batchSize: 1})
         .on('data', function (chunk) {
@@ -138,7 +138,7 @@ suite('files', function () {
 
     test('flush when full', function (cb) {
       var t = createType({type: 'fixed', name: 'A', size: 2});
-      var data = new Buffer([48, 18]);
+      var data = Buffer.from([48, 18]);
       var chunks = [];
       var encoder = new RawEncoder(t, {batchSize: 2})
         .on('data', function (chunk) { chunks.push(chunk); })
@@ -194,7 +194,7 @@ suite('files', function () {
           assert.deepEqual(objs, [0]);
           cb();
         });
-      decoder.end(new Buffer([0]));
+      decoder.end(Buffer.from([0]));
     });
 
     test('no writer type', function () {
@@ -210,13 +210,13 @@ suite('files', function () {
           assert.deepEqual(objs, [1, 2]);
           cb();
         });
-      decoder.write(new Buffer([2]));
-      decoder.end(new Buffer([4]));
+      decoder.write(Buffer.from([2]));
+      decoder.end(Buffer.from([4]));
     });
 
     test('no decoding', function (cb) {
       var t = createType('int');
-      var bufs = [new Buffer([3]), new Buffer([124])];
+      var bufs = [Buffer.from([3]), Buffer.from([124])];
       var objs = [];
       var decoder = new RawDecoder(t, {decode: false})
         .on('data', function (obj) { objs.push(obj); })
@@ -234,12 +234,12 @@ suite('files', function () {
       var decoder = new RawDecoder(t)
         .on('data', function (obj) { objs.push(obj); })
         .on('end', function () {
-          assert.deepEqual(objs, [new Buffer([6])]);
+          assert.deepEqual(objs, [Buffer.from([6])]);
           cb();
         });
-      decoder.write(new Buffer([2]));
+      decoder.write(Buffer.from([2]));
       // Let the first read go through (and return null).
-      process.nextTick(function () { decoder.end(new Buffer([6])); });
+      process.nextTick(function () { decoder.end(Buffer.from([6])); });
     });
 
   });
@@ -287,9 +287,9 @@ suite('files', function () {
       }).on('data', function (chunk) { chunks.push(chunk); })
         .on('end', function () {
           assert.deepEqual(chunks, [
-            new Buffer([6]),
-            new Buffer([6]),
-            new Buffer([24, 0, 8]),
+            Buffer.from([6]),
+            Buffer.from([6]),
+            Buffer.from([24, 0, 8]),
             SYNC
           ]);
           cb();
@@ -310,8 +310,8 @@ suite('files', function () {
           assert.deepEqual(
             chunks,
             [
-              new Buffer([2]), new Buffer([2]), new Buffer([2]), SYNC,
-              new Buffer([2]), new Buffer([4]), new Buffer([128, 1]), SYNC
+              Buffer.from([2]), Buffer.from([2]), Buffer.from([2]), SYNC,
+              Buffer.from([2]), Buffer.from([4]), Buffer.from([128, 1]), SYNC
             ]
           );
           cb();
@@ -322,7 +322,7 @@ suite('files', function () {
 
     test('resize', function (cb) {
       var t = createType({type: 'fixed', size: 8, name: 'Eight'});
-      var buf = new Buffer('abcdefgh');
+      var buf = Buffer.from('abcdefgh');
       var chunks = [];
       var encoder = new BlockEncoder(t, {
         omitHeader: true,
@@ -330,8 +330,8 @@ suite('files', function () {
         blockSize: 4
       }).on('data', function (chunk) { chunks.push(chunk); })
         .on('end', function () {
-          var b1 = new Buffer([4]);
-          var b2 = new Buffer([32]);
+          var b1 = Buffer.from([4]);
+          var b2 = Buffer.from([32]);
           assert.deepEqual(chunks, [b1, b2, Buffer.concat([buf, buf]), SYNC]);
           cb();
         });
@@ -351,7 +351,7 @@ suite('files', function () {
 
     test('write non-canonical schema', function (cb) {
       var obj = {type: 'fixed', size: 2, name: 'Id', doc: 'An id.'};
-      var id = new Buffer([1, 2]);
+      var id = Buffer.from([1, 2]);
       var ids = [];
       var encoder = new BlockEncoder(obj);
       var decoder = new streams.BlockDecoder()
@@ -378,8 +378,8 @@ suite('files', function () {
       var decoder = new BlockDecoder()
         .on('data', function () {})
         .on('error', function () { cb(); });
-      decoder.write(new Buffer([0, 3, 2, 1])); // !== MAGIC_BYTES
-      decoder.write(new Buffer([0]));
+      decoder.write(Buffer.from([0, 3, 2, 1])); // !== MAGIC_BYTES
+      decoder.write(Buffer.from([0]));
       decoder.end(SYNC);
     });
 
@@ -390,14 +390,14 @@ suite('files', function () {
       var header = new Header(
         MAGIC_BYTES,
         {
-          'avro.schema': new Buffer('"int"'),
-          'avro.codec': new Buffer('null')
+          'avro.schema': Buffer.from('"int"'),
+          'avro.codec': Buffer.from('null')
         },
         SYNC
       );
       decoder.write(header.$toBuffer());
-      decoder.write(new Buffer([0, 0])); // Empty block.
-      decoder.end(new Buffer('alongerstringthansixteenbytes'));
+      decoder.write(Buffer.from([0, 0])); // Empty block.
+      decoder.end(Buffer.from('alongerstringthansixteenbytes'));
     });
 
     test('missing codec', function (cb) {
@@ -406,7 +406,7 @@ suite('files', function () {
         .on('end', function () { cb(); });
       var header = new Header(
         MAGIC_BYTES,
-        {'avro.schema': new Buffer('"int"')},
+        {'avro.schema': Buffer.from('"int"')},
         SYNC
       );
       decoder.end(header.$toBuffer());
@@ -419,8 +419,8 @@ suite('files', function () {
       var header = new Header(
         MAGIC_BYTES,
         {
-          'avro.schema': new Buffer('"int"'),
-          'avro.codec': new Buffer('"foo"')
+          'avro.schema': Buffer.from('"int"'),
+          'avro.codec': Buffer.from('"foo"')
         },
         SYNC
       );
@@ -434,8 +434,8 @@ suite('files', function () {
       var header = new Header(
         MAGIC_BYTES,
         {
-          'avro.schema': new Buffer('"int2"'),
-          'avro.codec': new Buffer('null')
+          'avro.schema': Buffer.from('"int2"'),
+          'avro.codec': Buffer.from('null')
         },
         SYNC
       );
@@ -469,7 +469,7 @@ suite('files', function () {
       var decoder = new streams.BlockDecoder({decode: false})
         .on('data', function (obj) { objs.push(obj); })
         .on('end', function () {
-          assert.deepEqual(objs, [new Buffer([96])]);
+          assert.deepEqual(objs, [Buffer.from([96])]);
           cb();
         });
       encoder.pipe(decoder);

--- a/lang/js/test/test_protocols.js
+++ b/lang/js/test/test_protocols.js
@@ -199,11 +199,11 @@ suite('protocols', function () {
 
     test('ok', function (done) {
       var parts = [
-        new Buffer([0, 1]),
-        new Buffer([2]),
-        new Buffer([]),
-        new Buffer([3, 4, 5]),
-        new Buffer([])
+        Buffer.from([0, 1]),
+        Buffer.from([2]),
+        Buffer.from([]),
+        Buffer.from([3, 4, 5]),
+        Buffer.from([])
       ];
       var messages = [];
       var readable = createReadableStream(parts.map(frame), true);
@@ -211,7 +211,7 @@ suite('protocols', function () {
         .on('finish', function () {
           assert.deepEqual(
             messages,
-            [new Buffer([0, 1, 2]), new Buffer([3, 4, 5])]
+            [Buffer.from([0, 1, 2]), Buffer.from([3, 4, 5])]
           );
           done();
         });
@@ -220,10 +220,10 @@ suite('protocols', function () {
 
     test('trailing data', function (done) {
       var parts = [
-        new Buffer([0, 1]),
-        new Buffer([2]),
-        new Buffer([]),
-        new Buffer([3])
+        Buffer.from([0, 1]),
+        Buffer.from([2]),
+        Buffer.from([]),
+        Buffer.from([3])
       ];
       var messages = [];
       var readable = createReadableStream(parts.map(frame), true);
@@ -231,7 +231,7 @@ suite('protocols', function () {
       readable
         .pipe(new MessageDecoder())
         .on('error', function () {
-          assert.deepEqual(messages, [new Buffer([0, 1, 2])]);
+          assert.deepEqual(messages, [Buffer.from([0, 1, 2])]);
           done();
         })
         .pipe(writable);
@@ -256,8 +256,8 @@ suite('protocols', function () {
 
     test('ok', function (done) {
       var messages = [
-        new Buffer([0, 1]),
-        new Buffer([2])
+        Buffer.from([0, 1]),
+        Buffer.from([2])
       ];
       var frames = [];
       var readable = createReadableStream(messages, true);
@@ -269,8 +269,8 @@ suite('protocols', function () {
           assert.deepEqual(
             frames,
             [
-              new Buffer([0, 0, 0, 2, 0, 1, 0, 0, 0, 0]),
-              new Buffer([0, 0, 0, 1, 2, 0, 0, 0, 0])
+              Buffer.from([0, 0, 0, 2, 0, 1, 0, 0, 0, 0]),
+              Buffer.from([0, 0, 0, 1, 2, 0, 0, 0, 0])
             ]
           );
           done();
@@ -278,7 +278,7 @@ suite('protocols', function () {
     });
 
     test('all zeros', function (done) {
-      var messages = [new Buffer([0, 0, 0, 0])];
+      var messages = [Buffer.from([0, 0, 0, 0])];
       var frames = [];
       var readable = createReadableStream(messages, true);
       var writable = createWritableStream(frames, true);
@@ -288,7 +288,7 @@ suite('protocols', function () {
         .on('finish', function () {
           assert.deepEqual(
             frames,
-            [new Buffer([0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0])]
+            [Buffer.from([0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0])]
           );
           done();
         });
@@ -296,8 +296,8 @@ suite('protocols', function () {
 
     test('short frame size', function (done) {
       var messages = [
-        new Buffer([0, 1, 2]),
-        new Buffer([2])
+        Buffer.from([0, 1, 2]),
+        Buffer.from([2])
       ];
       var frames = [];
       var readable = createReadableStream(messages, true);
@@ -309,8 +309,8 @@ suite('protocols', function () {
           assert.deepEqual(
             frames,
             [
-              new Buffer([0, 0, 0, 2, 0, 1, 0, 0, 0, 1, 2, 0, 0, 0, 0]),
-              new Buffer([0, 0, 0, 1, 2, 0, 0, 0, 0])
+              Buffer.from([0, 0, 0, 2, 0, 1, 0, 0, 0, 1, 2, 0, 0, 0, 0]),
+              Buffer.from([0, 0, 0, 1, 2, 0, 0, 0, 0])
             ]
           );
           done();
@@ -333,8 +333,8 @@ suite('protocols', function () {
             assert.deepEqual(
               Buffer.concat(bufs),
               HANDSHAKE_REQUEST_TYPE.toBuffer({
-                clientHash: new Buffer(ptcl._hashString, 'binary'),
-                serverHash: new Buffer(ptcl._hashString, 'binary')
+                clientHash: Buffer.from(ptcl._hashString, 'binary'),
+                serverHash: Buffer.from(ptcl._hashString, 'binary')
               })
             );
             this.destroy();
@@ -350,7 +350,7 @@ suite('protocols', function () {
       var resBufs = [
         {
           match: 'NONE',
-          serverHash: {'org.apache.avro.ipc.MD5': new Buffer(16)},
+          serverHash: {'org.apache.avro.ipc.MD5': Buffer.alloc(16)},
           serverProtocol: {string: ptcl.toString()},
         },
         {match: 'BOTH'}
@@ -374,7 +374,7 @@ suite('protocols', function () {
 
     test('incompatible protocol', function (done) {
       var ptcl = createProtocol({protocol: 'Empty'});
-      var hash = new Buffer(16); // Pretend the hash was different.
+      var hash = Buffer.alloc(16); // Pretend the hash was different.
       var resBufs = [
         {
           match: 'NONE',
@@ -385,7 +385,7 @@ suite('protocols', function () {
           match: 'NONE',
           serverHash: {'org.apache.avro.ipc.MD5': hash},
           serverProtocol: {string: ptcl.toString()},
-          meta: {map: {error: new Buffer('abcd')}}
+          meta: {map: {error: Buffer.from('abcd')}}
         }
       ].map(function (val) { return HANDSHAKE_RESPONSE_TYPE.toBuffer(val); });
       var error = false;
@@ -402,8 +402,8 @@ suite('protocols', function () {
 
     test('handshake error', function (done) {
       var resBufs = [
-        new Buffer([4, 0, 0]), // Invalid handshakes.
-        new Buffer([4, 0, 0])
+        Buffer.from([4, 0, 0]), // Invalid handshakes.
+        Buffer.from([4, 0, 0])
       ];
       var ptcl = createProtocol({protocol: 'Empty'});
       var error = false;
@@ -422,7 +422,7 @@ suite('protocols', function () {
       var ptcl = createProtocol({protocol: 'Empty'});
       var idType = protocols.IdType.createMetadataType();
       var resBufs = [
-        new Buffer([0, 0, 0]), // OK handshake.
+        Buffer.from([0, 0, 0]), // OK handshake.
         idType.toBuffer(23)
       ];
       var error = false;
@@ -455,7 +455,7 @@ suite('protocols', function () {
         }
       });
       var resBufs = [
-        new Buffer([0, 0, 0]), // OK handshake.
+        Buffer.from([0, 0, 0]), // OK handshake.
       ];
       var interrupted = 0;
       var transport = createTransport(resBufs, []);
@@ -526,7 +526,7 @@ suite('protocols', function () {
           assert(/trailing data/.test(err.message));
           done();
         });
-      transports[0].readable.end(new Buffer([2, 3]));
+      transports[0].readable.end(Buffer.from([2, 3]));
     });
 
     test('invalid metadata', function (done) {
@@ -544,8 +544,8 @@ suite('protocols', function () {
           done();
         })
         .on('handshake', function () {
-          transports[0].readable.write(frame(new Buffer([2, 3])));
-          transports[0].readable.write(frame(new Buffer(0)));
+          transports[0].readable.write(frame(Buffer.from([2, 3])));
+          transports[0].readable.write(frame(Buffer.alloc(0)));
         });
     });
 
@@ -570,10 +570,10 @@ suite('protocols', function () {
           var idType = protocols.IdType.createMetadataType();
           var bufs = [
               idType.toBuffer(1), // Metadata.
-              new Buffer([3]) // Invalid response.
+              Buffer.from([3]) // Invalid response.
           ];
           transports[0].readable.write(frame(Buffer.concat(bufs)));
-          transports[0].readable.write(frame(new Buffer(0)));
+          transports[0].readable.write(frame(Buffer.alloc(0)));
         });
     });
 
@@ -615,8 +615,8 @@ suite('protocols', function () {
       });
       ptcl.emit('ping', {}, ee, function (err) {
         assert(/interrupted/.test(err.string));
-        readable.write(frame(new Buffer(2)));
-        readable.end(frame(new Buffer(0)));
+        readable.write(frame(Buffer.alloc(2)));
+        readable.end(frame(Buffer.alloc(0)));
       });
       ee.destroy(true);
     });
@@ -650,7 +650,7 @@ suite('protocols', function () {
     test('invalid handshake', function (done) {
       var ptcl = createProtocol({protocol: 'Empty'});
       var transport = createTransport(
-        [new Buffer([4])], // Invalid handshake.
+        [Buffer.from([4])], // Invalid handshake.
         []
       );
       ptcl.createListener(transport)
@@ -667,7 +667,7 @@ suite('protocols', function () {
         protocol: 'Heartbeat',
         messages: {beat: {request: [], response: 'boolean'}}
       });
-      var hash = new Buffer(ptcl2._hashString, 'binary');
+      var hash = Buffer.from(ptcl2._hashString, 'binary');
       var req = {
         clientHash: hash,
         clientProtocol: {string: ptcl2.toString()},
@@ -702,8 +702,8 @@ suite('protocols', function () {
         .on('handshake', function () {
           // Handshake is complete now.
           var writable = transports[0].writable;
-          writable.write(frame(new Buffer([0]))); // Empty metadata.
-          writable.write(frame(new Buffer(0)));
+          writable.write(frame(Buffer.from([0]))); // Empty metadata.
+          writable.write(frame(Buffer.alloc(0)));
         });
     });
 
@@ -737,8 +737,8 @@ suite('protocols', function () {
             });
           [
             idType.toBuffer(-1),
-            new Buffer([4, 104, 105]), // `hi` message.
-            new Buffer(0) // End of frame.
+            Buffer.from([4, 104, 105]), // `hi` message.
+            Buffer.alloc(0) // End of frame.
           ].forEach(function (buf) {
             transports[0].writable.write(frame(buf));
           });
@@ -777,9 +777,9 @@ suite('protocols', function () {
             });
           [
             idType.toBuffer(-1),
-            new Buffer([8, 98, 101, 97, 116]), // `beat` message.
-            new Buffer([8]), // Invalid Avro string encoding.
-            new Buffer(0) // End of frame.
+            Buffer.from([8, 98, 101, 97, 116]), // `beat` message.
+            Buffer.from([8]), // Invalid Avro string encoding.
+            Buffer.alloc(0) // End of frame.
           ].forEach(function (buf) {
             transports[0].writable.write(frame(buf));
           });
@@ -835,7 +835,7 @@ suite('protocols', function () {
           assert(/unknown message/.test(tap.readString()));
           done();
         });
-      var hash = new Buffer(ptcl._hashString, 'binary');
+      var hash = Buffer.from(ptcl._hashString, 'binary');
       var req = {
         clientHash: hash,
         clientProtocol: null,
@@ -845,8 +845,8 @@ suite('protocols', function () {
       encoder.pipe(readable);
       encoder.end(Buffer.concat([
         HANDSHAKE_REQUEST_TYPE.toBuffer(req),
-        new Buffer([0]), // Empty metadata.
-        new Buffer([4, 104, 105]) // `id` message.
+        Buffer.from([0]), // Empty metadata.
+        Buffer.from([4, 104, 105]) // `id` message.
       ]));
     });
 
@@ -1319,7 +1319,7 @@ suite('protocols', function () {
 
 // Message framing.
 function frame(buf) {
-  var framed = new Buffer(buf.length + 4);
+  var framed = Buffer.alloc(buf.length + 4);
   framed.writeInt32BE(buf.length);
   buf.copy(framed, 4);
   return framed;

--- a/lang/js/test/test_schemas.js
+++ b/lang/js/test/test_schemas.js
@@ -80,8 +80,8 @@ suite('types', function () {
     test('toBuffer int', function () {
 
       var type = createType('int');
-      assert.equal(type.fromBuffer(new Buffer([0x80, 0x01])), 64);
-      assert(new Buffer([0]).equals(type.toBuffer(0)));
+      assert.equal(type.fromBuffer(Buffer.from([0x80, 0x01])), 64);
+      assert(Buffer.from([0]).equals(type.toBuffer(0)));
 
     });
 
@@ -163,7 +163,7 @@ suite('types', function () {
 
     test('precision loss', function () {
       var type = createType('long');
-      var buf = new Buffer([0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x20]);
+      var buf = Buffer.from([0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x20]);
       assert.throws(function () { type.fromBuffer(buf); });
     });
 
@@ -186,7 +186,7 @@ suite('types', function () {
 
     test('fromBuffer string', function () {
       var type = createType('string');
-      var buf = new Buffer([0x06, 0x68, 0x69, 0x21]);
+      var buf = Buffer.from([0x06, 0x68, 0x69, 0x21]);
       var s = 'hi!';
       assert.equal(type.fromBuffer(buf), s);
       assert(buf.equals(type.toBuffer(s)));
@@ -194,7 +194,7 @@ suite('types', function () {
 
     test('toBuffer string', function () {
       var type = createType('string');
-      var buf = new Buffer([0x06, 0x68, 0x69, 0x21]);
+      var buf = Buffer.from([0x06, 0x68, 0x69, 0x21]);
       assert(buf.equals(type.toBuffer('hi!', 1)));
     });
 
@@ -204,7 +204,7 @@ suite('types', function () {
       var buf = stringT.toBuffer('\x00\x01');
       assert.deepEqual(
         bytesT.fromBuffer(buf, bytesT.createResolver(stringT)),
-        new Buffer([0, 1])
+        Buffer.from([0, 1])
       );
     });
 
@@ -212,10 +212,10 @@ suite('types', function () {
       var t = createType('string');
       var s = 'hello';
       var b, pos;
-      b = new Buffer(2);
+      b = Buffer.alloc(2);
       pos = t.encode(s, b);
       assert(pos < 0);
-      b = new Buffer(2 - pos);
+      b = Buffer.alloc(2 - pos);
       pos = t.encode(s, b);
       assert(pos >= 0);
       assert.equal(s, t.fromBuffer(b)); // Also checks exact length match.
@@ -311,7 +311,7 @@ suite('types', function () {
 
     var data = [
       {
-        valid: [new Buffer(1), new Buffer('abc')],
+        valid: [Buffer.alloc(1), Buffer.from('abc')],
         invalid: [null, 'hi', undefined, 1, 0, -3.5]
       }
     ];
@@ -321,7 +321,7 @@ suite('types', function () {
     test('clone', function () {
       var t = createType('bytes');
       var s = '\x01\x02';
-      var buf = new Buffer(s);
+      var buf = Buffer.from(s);
       var clone;
       clone = t.clone(buf);
       assert.deepEqual(clone, buf);
@@ -336,18 +336,18 @@ suite('types', function () {
     test('fromString', function () {
       var t = createType('bytes');
       var s = '\x01\x02';
-      var buf = new Buffer(s);
+      var buf = Buffer.from(s);
       var clone = t.fromString(JSON.stringify(s));
       assert.deepEqual(clone, buf);
     });
 
     test('compare', function () {
       var t = createType('bytes');
-      var b1 = t.toBuffer(new Buffer([0, 2]));
+      var b1 = t.toBuffer(Buffer.from([0, 2]));
       assert.equal(t.compareBuffers(b1, b1), 0);
-      var b2 = t.toBuffer(new Buffer([0, 2, 3]));
+      var b2 = t.toBuffer(Buffer.from([0, 2, 3]));
       assert.equal(t.compareBuffers(b1, b2), -1);
-      var b3 = t.toBuffer(new Buffer([1]));
+      var b3 = t.toBuffer(Buffer.from([1]));
       assert.equal(t.compareBuffers(b3, b1), 1);
     });
 
@@ -366,8 +366,8 @@ suite('types', function () {
       {
         name: 'qualified name',
         schema: ['null', {type: 'fixed', name: 'a.B', size: 2}],
-        valid: [null, {'a.B': new Buffer(2)}],
-        invalid: [new Buffer(2)],
+        valid: [null, {'a.B': Buffer.alloc(2)}],
+        invalid: [Buffer.alloc(2)],
         check: assert.deepEqual
       },
       {
@@ -415,7 +415,7 @@ suite('types', function () {
 
     test('read invalid index', function () {
       var type = new types.UnionType(['null', 'int']);
-      var buf = new Buffer([1, 0]);
+      var buf = Buffer.from([1, 0]);
       assert.throws(function () { type.fromBuffer(buf); });
     });
 
@@ -443,7 +443,7 @@ suite('types', function () {
       var t1 = createType('null');
       var t2 = createType(['null', 'int']);
       var a = t2.createResolver(t1);
-      assert.deepEqual(t2.fromBuffer(new Buffer(0), a), null);
+      assert.deepEqual(t2.fromBuffer(Buffer.alloc(0), a), null);
     });
 
     test('resolve [string, int] to [long, string]', function () {
@@ -452,7 +452,7 @@ suite('types', function () {
       var a = t2.createResolver(t1);
       var buf;
       buf = t1.toBuffer({string: 'hi'});
-      assert.deepEqual(t2.fromBuffer(buf, a), {'bytes': new Buffer('hi')});
+      assert.deepEqual(t2.fromBuffer(buf, a), {'bytes': Buffer.from('hi')});
       buf = t1.toBuffer({'int': 1});
       assert.deepEqual(t2.fromBuffer(buf, a), {'int': 1});
     });
@@ -502,7 +502,7 @@ suite('types', function () {
           {name: 'id2', type: ['null', 'an.Id']}
         ]
       });
-      var b = new Buffer([0]);
+      var b = Buffer.from([0]);
       var o = {id1: b, id2: {Id: b}};
       assert.deepEqual(t.clone(o), {id1: b, id2: {'an.Id': b}});
     });
@@ -516,7 +516,7 @@ suite('types', function () {
           {name: 'id2', type: ['null', 'Id']}
         ]
       });
-      var b = new Buffer([0]);
+      var b = Buffer.from([0]);
       var o = {id1: b, id2: {'an.Id': b}};
       assert.throws(function () { t.clone(o); });
     });
@@ -617,7 +617,7 @@ suite('types', function () {
 
     test('read invalid index', function () {
       var type = new types.EnumType({type: 'enum', symbols: ['A'], name: 'a'});
-      var buf = new Buffer([2]);
+      var buf = Buffer.from([2]);
       assert.throws(function () { type.fromBuffer(buf); });
     });
 
@@ -682,8 +682,8 @@ suite('types', function () {
       {
         name: 'size 1',
         schema: {name: 'Foo', size: 2},
-        valid: [new Buffer([1, 2]), new Buffer([2, 3])],
-        invalid: ['HEY', null, undefined, 0, new Buffer(1), new Buffer(3)],
+        valid: [Buffer.from([1, 2]), Buffer.from([2, 3])],
+        invalid: ['HEY', null, undefined, 0, Buffer.alloc(1), Buffer.alloc(3)],
         check: function (a, b) { assert(a.equals(b)); }
       }
     ];
@@ -740,7 +740,7 @@ suite('types', function () {
     test('clone', function () {
       var t = new types.FixedType({name: 'Id', size: 2});
       var s = '\x01\x02';
-      var buf = new Buffer(s);
+      var buf = Buffer.from(s);
       var clone;
       clone = t.clone(buf);
       assert.deepEqual(clone, buf);
@@ -750,7 +750,7 @@ suite('types', function () {
       clone = t.clone(buf.toJSON(), {coerceBuffers: true});
       assert.deepEqual(clone, buf);
       assert.throws(function () { t.clone(1, {coerceBuffers: true}); });
-      assert.throws(function () { t.clone(new Buffer([2])); });
+      assert.throws(function () { t.clone(Buffer.from([2])); });
     });
 
     test('getSchema with extra fields', function () {
@@ -763,16 +763,16 @@ suite('types', function () {
     test('fromString', function () {
       var t = new types.FixedType({name: 'Id', size: 2});
       var s = '\x01\x02';
-      var buf = new Buffer(s);
+      var buf = Buffer.from(s);
       var clone = t.fromString(JSON.stringify(s));
       assert.deepEqual(clone, buf);
     });
 
     test('compare buffers', function () {
       var t = createType({type: 'fixed', name: 'Id', size: 2});
-      var b1 = new Buffer([1, 2]);
+      var b1 = Buffer.from([1, 2]);
       assert.equal(t.compareBuffers(b1, b1), 0);
-      var b2 = new Buffer([2, 2]);
+      var b2 = Buffer.from([2, 2]);
       assert.equal(t.compareBuffers(b1, b2), -1);
     });
 
@@ -820,18 +820,18 @@ suite('types', function () {
     test('write int', function () {
       var t = new types.MapType({type: 'map', values: 'int'});
       var buf = t.toBuffer({'\x01': 3, '\x02': 4});
-      assert.deepEqual(buf, new Buffer([4, 2, 1, 6, 2, 2, 8, 0]));
+      assert.deepEqual(buf, Buffer.from([4, 2, 1, 6, 2, 2, 8, 0]));
     });
 
     test('read long', function () {
       var t = new types.MapType({type: 'map', values: 'long'});
-      var buf = new Buffer([4, 2, 1, 6, 2, 2, 8, 0]);
+      var buf = Buffer.from([4, 2, 1, 6, 2, 2, 8, 0]);
       assert.deepEqual(t.fromBuffer(buf), {'\x01': 3, '\x02': 4});
     });
 
     test('read with sizes', function () {
       var t = new types.MapType({type: 'map', values: 'int'});
-      var buf = new Buffer([1,6,2,97,2,0]);
+      var buf = Buffer.from([1,6,2,97,2,0]);
       assert.deepEqual(t.fromBuffer(buf), {a: 1});
     });
 
@@ -849,8 +849,8 @@ suite('types', function () {
         type: 'record',
         fields: [{name: 'val', type: 'int'}]
       });
-      var b1 = new Buffer([2,2,97,2,0,6]); // Without sizes.
-      var b2 = new Buffer([1,6,2,97,2,0,6]); // With sizes.
+      var b1 = Buffer.from([2,2,97,2,0,6]); // Without sizes.
+      var b2 = Buffer.from([1,6,2,97,2,0,6]); // With sizes.
       var resolver = v2.createResolver(v1);
       assert.deepEqual(v2.fromBuffer(b1, resolver), {val: 3});
       assert.deepEqual(v2.fromBuffer(b2, resolver), {val: 3});
@@ -891,7 +891,7 @@ suite('types', function () {
         }
       });
       var resolver = t2.createResolver(t1);
-      var obj = {one: new Buffer([1, 2])};
+      var obj = {one: Buffer.from([1, 2])};
       var buf = t1.toBuffer(obj);
       assert.deepEqual(t2.fromBuffer(buf, resolver), obj);
     });
@@ -911,7 +911,7 @@ suite('types', function () {
       var o = {one: {type: 'Buffer', data: [1]}};
       assert.throws(function () { t.clone(o); });
       var c = t.clone(o, {coerceBuffers: true});
-      assert.deepEqual(c, {one: new Buffer([1])});
+      assert.deepEqual(c, {one: Buffer.from([1])});
     });
 
     test('compare buffers', function () {
@@ -967,7 +967,7 @@ suite('types', function () {
 
     test('read with sizes', function () {
       var t = new types.ArrayType({type: 'array', items: 'int'});
-      var buf = new Buffer([1,2,2,0]);
+      var buf = Buffer.from([1,2,2,0]);
       assert.deepEqual(t.fromBuffer(buf), [1]);
     });
 
@@ -985,8 +985,8 @@ suite('types', function () {
         type: 'record',
         fields: [{name: 'val', type: 'int'}]
       });
-      var b1 = new Buffer([2,2,0,6]); // Without sizes.
-      var b2 = new Buffer([1,2,2,0,6]); // With sizes.
+      var b1 = Buffer.from([2,2,0,6]); // Without sizes.
+      var b2 = Buffer.from([1,2,2,0,6]); // With sizes.
       var resolver = v2.createResolver(v1);
       assert.deepEqual(v2.fromBuffer(b1, resolver), {val: 3});
       assert.deepEqual(v2.fromBuffer(b2, resolver), {val: 3});
@@ -998,7 +998,7 @@ suite('types', function () {
       var resolver = t2.createResolver(t1);
       var obj = ['\x01\x02'];
       var buf = t1.toBuffer(obj);
-      assert.deepEqual(t2.fromBuffer(buf, resolver), [new Buffer([1, 2])]);
+      assert.deepEqual(t2.fromBuffer(buf, resolver), [Buffer.from([1, 2])]);
     });
 
     test('resolve invalid', function () {
@@ -1027,7 +1027,7 @@ suite('types', function () {
       var o = [{type: 'Buffer', data: [1, 2]}];
       assert.throws(function () { t.clone(o); });
       var c = t.clone(o, {coerceBuffers: true});
-      assert.deepEqual(c, [new Buffer([1, 2])]);
+      assert.deepEqual(c, [Buffer.from([1, 2])]);
     });
 
     test('compare buffers', function () {
@@ -1135,12 +1135,12 @@ suite('types', function () {
           {name: 'name', type: 'string', 'default': '\x01'}
         ]
       });
-      assert.deepEqual(type.toBuffer({}), new Buffer([50, 2, 1]));
+      assert.deepEqual(type.toBuffer({}), Buffer.from([50, 2, 1]));
     });
 
     test('fixed string default', function () {
       var s = '\x01\x04';
-      var b = new Buffer(s);
+      var b = Buffer.from(s);
       var type = createType({
         type: 'record',
         name: 'Object',
@@ -1153,7 +1153,7 @@ suite('types', function () {
         ]
       });
       var obj = new (type.getRecordConstructor())();
-      assert.deepEqual(obj.id, new Buffer([1, 4]));
+      assert.deepEqual(obj.id, Buffer.from([1, 4]));
       assert.deepEqual(type.toBuffer({}), b);
     });
 
@@ -1166,7 +1166,7 @@ suite('types', function () {
             {
               name: 'id',
               type: {type: 'fixed', size: 2, name: 'Id'},
-              'default': new Buffer([0])
+              'default': Buffer.from([0])
             }
           ]
         });
@@ -1236,7 +1236,7 @@ suite('types', function () {
         fields: [{name: 'age', type: 'int'}]
       });
       var Person = type.getRecordConstructor();
-      assert.deepEqual((new Person(48)).$toBuffer(), new Buffer([96]));
+      assert.deepEqual((new Person(48)).$toBuffer(), Buffer.from([96]));
       assert.throws(function () { (new Person()).$toBuffer(); });
     });
 
@@ -1523,7 +1523,7 @@ suite('types', function () {
         name: 'Person',
         fields: [{name: 'pwd', type: 'bytes'}]
       }).getRecordConstructor();
-      var r = new T(new Buffer([1, 2]));
+      var r = new T(Buffer.from([1, 2]));
       assert.equal(r.$toString(), T.getType().toString(r));
     });
 
@@ -1711,7 +1711,7 @@ suite('types', function () {
           return n;
         },
         toBuffer: function (n) {
-          var buf = new Buffer(8);
+          var buf = Buffer.alloc(8);
           var neg = n < 0;
           if (neg) {
             invert(buf);
@@ -1782,7 +1782,7 @@ suite('types', function () {
           return tap.readLong();
         },
         toBuffer: function (n) {
-          var buf = new Buffer(10);
+          var buf = Buffer.alloc(10);
           var tap = new Tap(buf);
           tap.writeLong(n);
           return buf.slice(0, tap.pos);
@@ -2137,13 +2137,13 @@ suite('types', function () {
       assert(t.isValid(2));
       assert(!t.isValid(3));
       assert(!t.isValid('abc'));
-      assert.equal(t.fromBuffer(new Buffer([4])), 2);
+      assert.equal(t.fromBuffer(Buffer.from([4])), 2);
       assert.equal(t.clone(4), 4);
       assert.equal(t.fromString('6'), 6);
       assert.throws(function () { t.clone(3); });
       assert.throws(function () { t.fromString('5'); });
       assert.throws(function () { t.toBuffer(3); });
-      assert.throws(function () { t.fromBuffer(new Buffer([2])); });
+      assert.throws(function () { t.fromBuffer(Buffer.from([2])); });
     });
 
   });
@@ -2200,28 +2200,28 @@ suite('types', function () {
     test('fromBuffer truncated', function () {
       var type = createType('int');
       assert.throws(function () {
-        type.fromBuffer(new Buffer([128]));
+        type.fromBuffer(Buffer.from([128]));
       });
     });
 
     test('fromBuffer bad resolver', function () {
       var type = createType('int');
       assert.throws(function () {
-        type.fromBuffer(new Buffer([0]), 123, {});
+        type.fromBuffer(Buffer.from([0]), 123, {});
       });
     });
 
     test('fromBuffer trailing', function () {
       var type = createType('int');
       assert.throws(function () {
-        type.fromBuffer(new Buffer([0, 2]));
+        type.fromBuffer(Buffer.from([0, 2]));
       });
     });
 
     test('fromBuffer trailing with resolver', function () {
       var type = createType('int');
       var resolver = type.createResolver(createType(['int']));
-      assert.equal(type.fromBuffer(new Buffer([0, 2]), resolver), 1);
+      assert.equal(type.fromBuffer(Buffer.from([0, 2]), resolver), 1);
     });
 
     test('toBuffer', function () {
@@ -2232,7 +2232,7 @@ suite('types', function () {
 
     test('toBuffer and resize', function () {
       var type = createType('string');
-      assert.deepEqual(type.toBuffer('\x01', 1), new Buffer([2, 1]));
+      assert.deepEqual(type.toBuffer('\x01', 1), Buffer.from([2, 1]));
     });
 
     test('type hook', function () {
@@ -2275,7 +2275,7 @@ suite('types', function () {
 
     test('fingerprint', function () {
       var t = createType('int');
-      var buf = new Buffer('ef524ea1b91e73173d938ade36c1db32', 'hex');
+      var buf = Buffer.from('ef524ea1b91e73173d938ade36c1db32', 'hex');
       assert.deepEqual(t.getFingerprint('md5'), buf);
       assert.deepEqual(t.getFingerprint(), buf);
     });
@@ -2324,7 +2324,7 @@ suite('types', function () {
         type: 'record',
         fields: [{name: 'id1', type: {name: 'Id1', type: 'fixed', size: 2}}]
       });
-      var o = {id1: new Buffer([0, 1])};
+      var o = {id1: Buffer.from([0, 1])};
       var s = '{"id1": "\\u0000\\u0001"}';
       var c = t.fromString(s);
       assert.deepEqual(c, o);
@@ -2371,7 +2371,7 @@ suite('types', function () {
       var resolver = t2.createResolver(t1);
       var buf = t1.toBuffer({'int': 12});
       assert.equal(t2.fromBuffer(buf, resolver), 12);
-      buf = new Buffer([4, 0]);
+      buf = Buffer.from([4, 0]);
       assert.throws(function () { t2.fromBuffer(buf, resolver); });
     });
 
@@ -2486,14 +2486,14 @@ suite('types', function () {
 
     test('long valid', function () {
       var t = createType('long');
-      var buf = new Buffer([0, 128, 2, 0]);
+      var buf = Buffer.from([0, 128, 2, 0]);
       var res = t.decode(buf, 1);
       assert.deepEqual(res, {value: 128, offset: 3});
     });
 
     test('bytes invalid', function () {
       var t = createType('bytes');
-      var buf = new Buffer([4, 1]);
+      var buf = Buffer.from([4, 1]);
       var res = t.decode(buf, 0);
       assert.deepEqual(res, {value: undefined, offset: -1});
     });
@@ -2504,23 +2504,23 @@ suite('types', function () {
 
     test('int valid', function () {
       var t = createType('int');
-      var buf = new Buffer(2);
+      var buf = Buffer.alloc(2);
       buf.fill(0);
       var n = t.encode(5, buf, 1);
       assert.equal(n, 2);
-      assert.deepEqual(buf, new Buffer([0, 10]));
+      assert.deepEqual(buf, Buffer.from([0, 10]));
     });
 
     test('string invalid', function () {
       var t = createType('string');
-      var buf = new Buffer(1);
+      var buf = Buffer.alloc(1);
       var n = t.encode('\x01\x02', buf, 0);
       assert.equal(n, -2);
     });
 
     test('invalid', function () {
       var t = createType('float');
-      var buf = new Buffer(2);
+      var buf = Buffer.alloc(2);
       assert.throws(function () { t.encode('hi', buf, 0); });
     });
 
@@ -2563,7 +2563,7 @@ suite('types', function () {
     types.Type.__reset(0);
     var t = createType('string');
     var buf = t.toBuffer('\x01');
-    assert.deepEqual(buf, new Buffer([2, 1]));
+    assert.deepEqual(buf, Buffer.from([2, 1]));
   });
 
 });
@@ -2600,7 +2600,7 @@ function testType(Type, data, invalidSchemas) {
       var items = elem.valid;
       if (items.length > 1) {
         var type = new Type(elem.schema);
-        var buf = new Buffer(1024);
+        var buf = Buffer.alloc(1024);
         var tap = new Tap(buf);
         type._write(tap, items[0]);
         type._write(tap, items[1]);

--- a/lang/js/test/test_utils.js
+++ b/lang/js/test/test_utils.js
@@ -153,7 +153,7 @@ suite('utils', function () {
 
         var tap = newTap(6);
         tap.writeLong(1440756011948);
-        var buf = new Buffer(['0xd8', '0xce', '0x80', '0xbc', '0xee', '0x53']);
+        var buf = Buffer.from(['0xd8', '0xce', '0x80', '0xbc', '0xee', '0x53']);
         assert(tap.isValid());
         assert(buf.equals(tap.buf));
 
@@ -161,7 +161,7 @@ suite('utils', function () {
 
       test('read', function () {
 
-        var buf = new Buffer(['0xd8', '0xce', '0x80', '0xbc', '0xee', '0x53']);
+        var buf = Buffer.from(['0xd8', '0xce', '0x80', '0xbc', '0xee', '0x53']);
         assert.equal((new Tap(buf)).readLong(), 1440756011948);
 
       });
@@ -215,7 +215,7 @@ suite('utils', function () {
     suite('bytes', function () {
 
       testWriterReader({
-        elems: [new Buffer('abc'), new Buffer(0), new Buffer([1, 5, 255])],
+        elems: [Buffer.from('abc'), Buffer.alloc(0), Buffer.from([1, 5, 255])],
         reader: function () { return this.readBytes(); },
         skipper: function () { this.skipBytes(); },
         writer: function (b) { this.writeBytes(b); }
@@ -226,7 +226,7 @@ suite('utils', function () {
     suite('fixed', function () {
 
       testWriterReader({
-        elems: [new Buffer([1, 5, 255])],
+        elems: [Buffer.from([1, 5, 255])],
         reader: function () { return this.readFixed(3); },
         skipper: function () { this.skipFixed(3); },
         writer: function (b) { this.writeFixed(b, 3); }
@@ -240,14 +240,14 @@ suite('utils', function () {
         var tap = newTap(3);
         var s = '\x01\x02';
         tap.writeBinary(s, 2);
-        assert.deepEqual(tap.buf, new Buffer([1,2,0]));
+        assert.deepEqual(tap.buf, Buffer.from([1,2,0]));
       });
 
       test('write invalid', function () {
         var tap = newTap(1);
         var s = '\x01\x02';
         tap.writeBinary(s, 2);
-        assert.deepEqual(tap.buf, new Buffer([0]));
+        assert.deepEqual(tap.buf, Buffer.from([0]));
       });
 
     });
@@ -260,14 +260,14 @@ suite('utils', function () {
         t.pos = 0;
         assert.deepEqual(
           t.unpackLongBytes(),
-          new Buffer([5, 0, 0, 0, 0, 0, 0, 0])
+          Buffer.from([5, 0, 0, 0, 0, 0, 0, 0])
         );
         t.pos = 0;
         t.writeLong(-5);
         t.pos = 0;
         assert.deepEqual(
           t.unpackLongBytes(),
-          new Buffer([-5, -1, -1, -1, -1, -1, -1, -1])
+          Buffer.from([-5, -1, -1, -1, -1, -1, -1, -1])
         );
         t.pos = 0;
       });
@@ -288,7 +288,7 @@ suite('utils', function () {
 
       test('pack single byte', function () {
         var t = newTap(10);
-        var b = new Buffer(8);
+        var b = Buffer.alloc(8);
         b.fill(0);
         b.writeInt32LE(12);
         t.packLongBytes(b);
@@ -306,7 +306,7 @@ suite('utils', function () {
         b.writeInt32LE(-1);
         b.writeInt32LE(-1, 4);
         t.packLongBytes(b);
-        assert.deepEqual(t.buf.slice(0, t.pos), new Buffer([1]));
+        assert.deepEqual(t.buf.slice(0, t.pos), Buffer.from([1]));
         t.pos = 0;
         assert.deepEqual(t.readLong(), -1);
       });
@@ -335,7 +335,7 @@ suite('utils', function () {
 
     function newTap(n) {
 
-      var buf = new Buffer(n);
+      var buf = Buffer.alloc(n);
       buf.fill(0);
       return new Tap(buf);
 
@@ -364,13 +364,13 @@ suite('utils', function () {
       });
 
       test('read over ' + name, function () {
-        var tap = new Tap(new Buffer(0));
+        var tap = new Tap(Buffer.alloc(0));
         readFn.call(tap); // Shouldn't throw.
         assert(!tap.isValid());
       });
 
       test('write over ' + name, function () {
-        var tap = new Tap(new Buffer(0));
+        var tap = new Tap(Buffer.alloc(0));
         writeFn.call(tap, elems[0]); // Shouldn't throw.
         assert(!tap.isValid());
       });


### PR DESCRIPTION
Use Buffer.alloc(), allocUnsafeSlow() and from() factory methods instead


### Jira

  https://issues.apache.org/jira/browse/AVRO-3174

### Tests

Several test files are also updated.
Now running `npm run test` no more produces this warning: 

```
(node:1205780) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

### Documentation

No public facing API has been changed. No need of documentation updates.