### PR TITLE
AVRO-2720: Enhance AvroTypeException message to include field name

### DIFF
--- a/lang/py/avro/errors.py
+++ b/lang/py/avro/errors.py
@@ -53,10 +53,11 @@ class AvroTypeException(AvroException):
 
     def __init__(self, *args):
         try:
-            expected_schema, datum = args[:2]
+            expected_schema, name, datum = args[:3]
         except (IndexError, ValueError):
             return super().__init__(*args)
-        return super().__init__(f"The datum {datum} of the type {type(datum)} is not an example of the schema {_safe_pretty(expected_schema)}")
+        pretty_expected = json.dumps(json.loads(str(expected_schema)), indent=2)
+        return super().__init__(f'The datum "{datum}" provided for "{name}" is not an example of the schema {pretty_expected}')
 
 
 class InvalidDefaultException(AvroTypeException):

--- a/lang/py/avro/io.py
+++ b/lang/py/avro/io.py
@@ -144,7 +144,7 @@ def validate(expected_schema: avro.schema.Schema, datum: object, raise_on_error:
 
         if valid_node is None:
             if raise_on_error:
-                raise avro.errors.AvroTypeException(current_node.schema, current_node.datum)
+                raise avro.errors.AvroTypeException(current_node.schema, current_node.name, current_node.datum)
             return False  # preserve the prior validation behavior of returning false when there are problems.
         # if there are children of this node to append, do so.
         for child_node in _iterate_node(valid_node):

--- a/lang/py/avro/test/test_bench.py
+++ b/lang/py/avro/test/test_bench.py
@@ -22,6 +22,7 @@ import json
 import platform
 import random
 import string
+import sys
 import tempfile
 import timeit
 import unittest
@@ -51,7 +52,15 @@ SCHEMA: avro.schema.RecordSchema = avro.schema.parse(
 READER = avro.io.DatumReader(SCHEMA)
 WRITER = avro.io.DatumWriter(SCHEMA)
 NUMBER_OF_TESTS = 10000
-MAX_WRITE_SECONDS = 3 if platform.python_implementation() == "PyPy" else 1
+
+if platform.python_implementation() == "PyPy":
+    if sys.version_info <= (3, 6):
+        MAX_WRITE_SECONDS = 5
+    else:
+        MAX_WRITE_SECONDS = 3
+else:
+    MAX_WRITE_SECONDS = 1
+
 MAX_READ_SECONDS = 3 if platform.python_implementation() == "PyPy" else 1
 
 

--- a/lang/py/avro/test/test_bench.py
+++ b/lang/py/avro/test/test_bench.py
@@ -52,15 +52,7 @@ SCHEMA: avro.schema.RecordSchema = avro.schema.parse(
 READER = avro.io.DatumReader(SCHEMA)
 WRITER = avro.io.DatumWriter(SCHEMA)
 NUMBER_OF_TESTS = 10000
-
-if platform.python_implementation() == "PyPy":
-    if sys.version_info <= (3, 6):
-        MAX_WRITE_SECONDS = 5
-    else:
-        MAX_WRITE_SECONDS = 3
-else:
-    MAX_WRITE_SECONDS = 1
-
+MAX_WRITE_SECONDS = 5 if platform.python_implementation() == "PyPy" else 1
 MAX_READ_SECONDS = 3 if platform.python_implementation() == "PyPy" else 1
 
 

--- a/lang/py/avro/test/test_bench.py
+++ b/lang/py/avro/test/test_bench.py
@@ -52,8 +52,8 @@ SCHEMA: avro.schema.RecordSchema = avro.schema.parse(
 READER = avro.io.DatumReader(SCHEMA)
 WRITER = avro.io.DatumWriter(SCHEMA)
 NUMBER_OF_TESTS = 10000
-MAX_WRITE_SECONDS = 5 if platform.python_implementation() == "PyPy" else 1
-MAX_READ_SECONDS = 3 if platform.python_implementation() == "PyPy" else 1
+MAX_WRITE_SECONDS = 5 if platform.python_implementation() == "PyPy" else 3
+MAX_READ_SECONDS = 5 if platform.python_implementation() == "PyPy" else 3
 
 
 class TestBench(unittest.TestCase):

--- a/lang/py/avro/test/test_bench.py
+++ b/lang/py/avro/test/test_bench.py
@@ -22,7 +22,6 @@ import json
 import platform
 import random
 import string
-import sys
 import tempfile
 import timeit
 import unittest


### PR DESCRIPTION
The exception message now includes the field name on which the type exception
was raised.

Closes: AVRO-2720

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AVRO-2720

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from the body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  NA
