### PR TITLE
Memory optimization in SchemaName.Fullname

### DIFF
--- a/lang/csharp/src/apache/main/Schema/SchemaName.cs
+++ b/lang/csharp/src/apache/main/Schema/SchemaName.cs
@@ -25,6 +25,9 @@ namespace Avro
     /// </summary>
     public class SchemaName
     {
+        // cache the full name, so it won't allocate new strings on each call
+        private String fullName;
+        
         /// <summary>
         /// Name of the schema
         /// </summary>
@@ -43,7 +46,7 @@ namespace Avro
         /// <summary>
         /// Namespace.Name of the schema
         /// </summary>
-        public String Fullname { get { return string.IsNullOrEmpty(Namespace) ? this.Name : Namespace + "." + this.Name; } }
+        public String Fullname { get { return fullName; } }
 
         /// <summary>
         /// Namespace of the schema
@@ -78,6 +81,8 @@ namespace Avro
                 this.Name = parts[parts.Length - 1];
                 this.EncSpace = encspace;
             }
+            
+            fullName = string.IsNullOrEmpty(Namespace) ? this.Name : Namespace + "." + this.Name;
         }
 
         /// <summary>


### PR DESCRIPTION
FullName property is being called by `ClassCache.GetClass` for each property:
```csharp
public DotnetClass GetClass(RecordSchema schema)
{
	DotnetClass result;
	if (!this._nameClassMap.TryGetValue(schema.Fullname, ref result))
.
.
```

This allocates TONS of strings on a scenario which calls `Avro.Reflect.ReflectDefaultWriter.WriteRecord` on large amount of entities (millions) + large amount of fields (tens).

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
