### PR TITLE
AVRO-3182: support parsing union schema json string with extra type p…

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/Schema.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Schema.java
@@ -1643,6 +1643,10 @@ public abstract class Schema extends JsonProperties implements Serializable {
       return result;
     } else if (schema.isObject()) {
       Schema result;
+      JsonNode typeJsonNode = schema.get("type");
+      if (typeJsonNode != null && typeJsonNode.isArray()) {
+        return parse(typeJsonNode, names);
+      }
       String type = getRequiredText(schema, "type", "No type");
       Name name = null;
       String savedSpace = names.space();

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchema.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchema.java
@@ -360,4 +360,12 @@ public class TestSchema {
   public void testEnumSymbolAsNull() {
     Schema.createEnum("myField", "doc", "namespace", Collections.singletonList(null));
   }
+
+  @Test
+  public void testParseUnionSchemaJsonStringWithExtraTypeProperty() {
+    String union = "{\"type\":[{\"type\":\"record\",\"name\":\"name1\",\"namespace\":\"org.apache.avro.nested\",\"fields\":[{\"name\":\"field1\",\"type\":\"int\"}]},{\"type\":\"record\",\"name\":\"name2\",\"namespace\":\"org.apache.avro.nested\",\"fields\":[{\"name\":\"field2\",\"type\":[\"string\",\"null\"]}]}]}";
+    Schema.Parser parser = new Schema.Parser();
+    Schema unionSchema = parser.parse(union);
+    assertTrue(unionSchema.isUnion());
+  }
 }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3182
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
       - org.apache.avro.TestSchema#testParseUnionSchemaJsonStringWithExtraTypeProperty

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
