### PR TITLE
AVRO-3183: Do Not Double Buffer Data in DataFileWriter

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/file/DataFileWriter.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/file/DataFileWriter.java
@@ -238,10 +238,10 @@ public class DataFileWriter<D> implements Closeable, Flushable {
     this.underlyingStream = outs;
     this.out = new BufferedFileOutputStream(outs);
     EncoderFactory efactory = new EncoderFactory();
-    this.vout = efactory.binaryEncoder(out, null);
+    this.vout = efactory.directBinaryEncoder(out, null);
     dout.setSchema(schema);
     buffer = new NonCopyingByteArrayOutputStream(Math.min((int) (syncInterval * 1.25), Integer.MAX_VALUE / 2 - 1));
-    this.bufOut = efactory.binaryEncoder(buffer, null);
+    this.bufOut = efactory.directBinaryEncoder(buffer, null);
     if (this.codec == null) {
       this.codec = CodecFactory.nullCodec().createInstance();
     }


### PR DESCRIPTION
### Jira

- [X] My PR addresses the following [AVRO-3183](https://issues.apache.org/jira/browse/AVRO-3183) issues and references them in the PR title.

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Does not change existing functionality. Uses existing unit tests.

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does