### PR TITLE
AVRO-3182 fix union schema ToString() has an extra type property

### DIFF
--- a/lang/csharp/src/apache/main/Schema/PrimitiveSchema.cs
+++ b/lang/csharp/src/apache/main/Schema/PrimitiveSchema.cs
@@ -140,17 +140,18 @@ namespace Avro
         /// <returns>The canonical JSON representation of this schema.</returns>
         public override string ToString()
         {
-            System.IO.StringWriter sw = new System.IO.StringWriter();
-            Newtonsoft.Json.JsonTextWriter writer = new Newtonsoft.Json.JsonTextWriter(sw);
+            using (System.IO.StringWriter sw = new System.IO.StringWriter())
+            using (Newtonsoft.Json.JsonTextWriter writer = new Newtonsoft.Json.JsonTextWriter(sw))
+            {
+                writer.WriteStartObject();
+                writer.WritePropertyName("type");
 
-            writer.WriteStartObject();
-            writer.WritePropertyName("type");
+                WriteJson(writer, new SchemaNames(), null); // stand alone schema, so no enclosing name space
 
-            WriteJson(writer, new SchemaNames(), null); // stand alone schema, so no enclosing name space
+                writer.WriteEndObject();
 
-            writer.WriteEndObject();
-
-            return sw.ToString();
+                return sw.ToString();
+            }
         }
     }
 }

--- a/lang/csharp/src/apache/main/Schema/PrimitiveSchema.cs
+++ b/lang/csharp/src/apache/main/Schema/PrimitiveSchema.cs
@@ -133,5 +133,24 @@ namespace Avro
         {
             return 13 * Tag.GetHashCode() + getHashCode(Props);
         }
+
+        /// <summary>
+        /// Returns the canonical JSON representation of this schema.
+        /// </summary>
+        /// <returns>The canonical JSON representation of this schema.</returns>
+        public override string ToString()
+        {
+            System.IO.StringWriter sw = new System.IO.StringWriter();
+            Newtonsoft.Json.JsonTextWriter writer = new Newtonsoft.Json.JsonTextWriter(sw);
+
+            writer.WriteStartObject();
+            writer.WritePropertyName("type");
+
+            WriteJson(writer, new SchemaNames(), null); // stand alone schema, so no enclosing name space
+
+            writer.WriteEndObject();
+
+            return sw.ToString();
+        }
     }
 }

--- a/lang/csharp/src/apache/main/Schema/Schema.cs
+++ b/lang/csharp/src/apache/main/Schema/Schema.cs
@@ -269,16 +269,7 @@ namespace Avro
             System.IO.StringWriter sw = new System.IO.StringWriter();
             Newtonsoft.Json.JsonTextWriter writer = new Newtonsoft.Json.JsonTextWriter(sw);
 
-            if (this is PrimitiveSchema)
-            {
-                writer.WriteStartObject();
-                writer.WritePropertyName("type");
-            }
-
             WriteJson(writer, new SchemaNames(), null); // stand alone schema, so no enclosing name space
-
-            if (this is PrimitiveSchema)
-                writer.WriteEndObject();
 
             return sw.ToString();
         }

--- a/lang/csharp/src/apache/main/Schema/Schema.cs
+++ b/lang/csharp/src/apache/main/Schema/Schema.cs
@@ -266,12 +266,13 @@ namespace Avro
         /// <returns>The canonical JSON representation of this schema.</returns>
         public override string ToString()
         {
-            System.IO.StringWriter sw = new System.IO.StringWriter();
-            Newtonsoft.Json.JsonTextWriter writer = new Newtonsoft.Json.JsonTextWriter(sw);
+            using (System.IO.StringWriter sw = new System.IO.StringWriter())
+            using (Newtonsoft.Json.JsonTextWriter writer = new Newtonsoft.Json.JsonTextWriter(sw))
+            {
+                WriteJson(writer, new SchemaNames(), null); // stand alone schema, so no enclosing name space
 
-            WriteJson(writer, new SchemaNames(), null); // stand alone schema, so no enclosing name space
-
-            return sw.ToString();
+                return sw.ToString();
+            }
         }
 
         /// <summary>

--- a/lang/csharp/src/apache/main/Schema/Schema.cs
+++ b/lang/csharp/src/apache/main/Schema/Schema.cs
@@ -269,7 +269,7 @@ namespace Avro
             System.IO.StringWriter sw = new System.IO.StringWriter();
             Newtonsoft.Json.JsonTextWriter writer = new Newtonsoft.Json.JsonTextWriter(sw);
 
-            if (this is PrimitiveSchema || this is UnionSchema)
+            if (this is PrimitiveSchema)
             {
                 writer.WriteStartObject();
                 writer.WritePropertyName("type");
@@ -277,7 +277,7 @@ namespace Avro
 
             WriteJson(writer, new SchemaNames(), null); // stand alone schema, so no enclosing name space
 
-            if (this is PrimitiveSchema || this is UnionSchema)
+            if (this is PrimitiveSchema)
                 writer.WriteEndObject();
 
             return sw.ToString();

--- a/lang/csharp/src/apache/test/Schema/SchemaTests.cs
+++ b/lang/csharp/src/apache/test/Schema/SchemaTests.cs
@@ -360,5 +360,12 @@ namespace Avro.Test
 
             Assert.AreEqual(expectedName, schema.Name);
         }
+
+        [TestCase("[\"null\",\"string\"]", "[\"null\",\"string\"]")]
+        public void TestUnionSchemaWithoutTypeProperty(string schemaJson, string expectedSchemaJson)
+        {
+            var schema = Schema.Parse(schemaJson);
+            Assert.AreEqual(schema.ToString(), expectedSchemaJson);
+        }
     }
 }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3182
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
