### PR TITLE
fix error when trying to read 0 bytes at eof

### DIFF
--- a/lang/perl/lib/Avro/DataFileReader.pm
+++ b/lang/perl/lib/Avro/DataFileReader.pm
@@ -133,12 +133,12 @@ sub next {
 
     my @objs;
 
-    $datafile->read_block_header if $datafile->eob;
+    $datafile->read_block_header if $datafile->eob and not $datafile->eof;
     return ()                    if $datafile->eof;
 
     my $block_count = $datafile->{object_count};
 
-    if ($block_count <= $count) {
+    if ($block_count < $count) {
         push @objs, $datafile->read_to_block_end;
         croak "Didn't read as many objects than expected"
             unless scalar @objs == $block_count;


### PR DESCRIPTION
When reading an avro file record for record each time when reading the last record DataFileReader tries to get the next block but (of course) fails. This fixes the issue.

Make sure you have checked _all_ steps below.

### Jira

I have no Jira access.

### Tests

- [X] does not need testing for this extremely good reason:

It's a +/-1 issue and the fix is in use now for 5 months.