### PR TITLE
AVRO-3190: Error when trying to read 0 bytes at eof

### DIFF
--- a/lang/perl/lib/Avro/DataFileReader.pm
+++ b/lang/perl/lib/Avro/DataFileReader.pm
@@ -133,12 +133,12 @@ sub next {
 
     my @objs;
 
-    $datafile->read_block_header if $datafile->eob;
+    $datafile->read_block_header if $datafile->eob and not $datafile->eof;
     return ()                    if $datafile->eof;
 
     my $block_count = $datafile->{object_count};
 
-    if ($block_count <= $count) {
+    if ($block_count < $count) {
         push @objs, $datafile->read_to_block_end;
         croak "Didn't read as many objects than expected"
             unless scalar @objs == $block_count;

--- a/lang/perl/lib/Avro/DataFileReader.pm
+++ b/lang/perl/lib/Avro/DataFileReader.pm
@@ -133,8 +133,8 @@ sub next {
 
     my @objs;
 
-    $datafile->read_block_header if $datafile->eob and not $datafile->eof;
     return ()                    if $datafile->eof;
+    $datafile->read_block_header if $datafile->eob;
 
     my $block_count = $datafile->{object_count};
 

--- a/lang/perl/t/04_datafile.t
+++ b/lang/perl/t/04_datafile.t
@@ -175,4 +175,46 @@ is_deeply $all[0], $data, "Our data is intact!";
     is_deeply $all[0], $data, "Our data is intact!";
 }
 
+## Test on a slightly larger file with 100 records
+{
+    my $tmpfh_write100 = File::Temp->new(UNLINK => 1);
+    my $write100_file = Avro::DataFileWriter->new(
+        fh             => $tmpfh_write100,
+        writer_schema  => $schema,
+        block_max_size => 100, # Small block size to force > 1 block
+    );
+    foreach (0..100) {
+        $write100_file->print($data);
+    }
+    $write100_file->flush;
+
+    seek $tmpfh_write100, 0, 0;
+    my $read100_file = Avro::DataFileReader->new(
+        fh => $tmpfh_write100,
+    );
+
+    # Read the first instance.
+    my @next = $read100_file->next(1);
+    is scalar @next, 1, "first object back";
+    is scalar $read100_file->eob, 0, "not end-of-block";
+    is scalar $read100_file->eof, 0, "not end-of-file";
+    is scalar $read100_file->{object_count}, 2, "block count";
+
+    # Scan over the next 98
+    foreach (0..98) {
+        $read100_file->next(1);
+    }
+
+    # Read the last instance.
+    @next = $read100_file->next(1);
+    is scalar @next, 1, "last object back";
+    is scalar $read100_file->eob, 1, "end-of-block";
+    is scalar $read100_file->eof, 1, "end-of-file";
+    is scalar $read100_file->{object_count}, 0, "no blocks remaining";
+
+    # One more instance
+    @next = $read100_file->next(1);
+    is scalar @next, 0, "no more objects back";
+}
+
 done_testing;


### PR DESCRIPTION
(Reopened https://github.com/apache/avro/pull/1313, thanks @Skeeve and @martin-g)

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-AVRO-3190
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
