### PR TITLE
AVRO-3193: Add Rust Checks to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@
 [![test python][test python img]][test python]
 [![test php][test php img]][test php]
 
+[![rust continuous integration][rust continuous integration img]][rust continuous integration]
+[![rust clippy check][rust clippy check img]][rust clippy check]
+[![rust security audit][rust security audit img]][rust security audit]
+
 [![codeql c#][codeql c# img]][codeql c#]
 [![codeql java][codeql java img]][codeql java]
 [![codeql javascript][codeql javascript img]][codeql javascript]
@@ -39,6 +43,10 @@ To contribute to Avro, please read:
 [test python]:     https://github.com/apache/avro/actions/workflows/test-lang-py.yml
 [test php]:        https://github.com/apache/avro/actions/workflows/test-lang-php.yml
 
+[rust continuous integration]: https://github.com/apache/avro/actions/workflows/test-lang-rust-ci.yml
+[rust clippy check]:           https://github.com/apache/avro/actions/workflows/test-lang-rust-clippy.yml
+[rust security audit]:         https://github.com/apache/avro/actions/workflows/test-lang-rust-audit.yml
+
 [codeql c#]:         https://github.com/apache/avro/actions/workflows/codeql-csharp-analysis.yml
 [codeql java]:       https://github.com/apache/avro/actions/workflows/codeql-java-analysis.yml
 [codeql javascript]: https://github.com/apache/avro/actions/workflows/codeql-js-analysis.yml
@@ -53,6 +61,10 @@ To contribute to Avro, please read:
 [test ruby img]:       https://github.com/apache/avro/actions/workflows/test-lang-ruby.yml/badge.svg
 [test python img]:     https://github.com/apache/avro/actions/workflows/test-lang-py.yml/badge.svg
 [test php img]:        https://github.com/apache/avro/actions/workflows/test-lang-php.yml/badge.svg
+
+[rust continuous integration img]: https://github.com/apache/avro/actions/workflows/test-lang-rust-ci.yml/badge.svg
+[rust clippy check img]:           https://github.com/apache/avro/actions/workflows/test-lang-rust-clippy.yml/badge.svg
+[rust security audit img]:         https://github.com/apache/avro/actions/workflows/test-lang-rust-audit.yml/badge.svg
 
 [codeql c# img]:         https://github.com/apache/avro/actions/workflows/codeql-csharp-analysis.yml/badge.svg
 [codeql java img]:       https://github.com/apache/avro/actions/workflows/codeql-java-analysis.yml/badge.svg


### PR DESCRIPTION
The README has not been updated since the adoption of the Rust component. Even though the rust checks aren't passing, having them present will make it clear to people exploring the repo in GitHub that there is a rust implementation, and provides guidance about what needs to be addressed.

### Jira

- [x] Addresses [AVRO-3193](https://issues.apache.org/jira/browse/AVRO-3193)
- [x] PR title tags the Jira issue
- [x] Adds no new dependency

### Tests

- [x] N/A

### Commits

- [x] Commits all reference the Jira issue in their subject lines.
- [x] Commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
