### PR TITLE
AVRO-3198: Include venv module in ubertool

### DIFF
--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get -qqy update \
                                                  python3-pip \
                                                  python3-setuptools \
                                                  python3-snappy \
+                                                 python3-venv \
                                                  python3-wheel \
                                                  source-highlight \
                                                  subversion \


### PR DESCRIPTION
This only affects manual builds using the ubertool jar.

This should succeed:

```
./build.sh docker
# in the container
cd lang/python/
./build.sh dist
```

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3198
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR does not need testing for this extremely good reason:  The ubertool docker is run manually.

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
