### PR TITLE
AVRO-3204 Rust: Update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,3 +65,10 @@ updates:
       day: "sunday"
     open-pull-requests-limit: 20
 
+  - package-ecosystem: "cargo"
+    directory: "/lang/rust/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    open-pull-requests-limit: 20
+

--- a/lang/rust/Cargo.toml
+++ b/lang/rust/Cargo.toml
@@ -46,27 +46,27 @@ name = "single"
 harness = false
 
 [dependencies]
-byteorder = "1.0.0"
-crc = { version = "1.3.0", optional = true }
+byteorder = "1.4.3"
+crc = { version = "1.8.1", optional = true }
 digest = "0.9"
-libflate = "1"
-num-bigint = "0.2.6"
-rand = "0.7.0"
-regex = "^1.4"
-serde_json = "1.0"
-serde = { version = "1.0", features = ["derive"] }
-snap = { version = "0.2.3", optional = true }
-strum = "0.18.0"
-strum_macros = "0.18.0"
-thiserror = "1.0"
-typed-builder = "0.5.1"
-uuid = { version = "0.8.1", features = ["serde", "v4"] }
+libflate = "1.1.1"
+num-bigint = "0.3.3"
+rand = "0.8.4"
+regex = "1.5.4"
+serde_json = "1.0.67"
+serde = { version = "1.0.130", features = ["derive"] }
+snap = { version = "1.0.5", optional = true }
+strum = "0.21.0"
+strum_macros = "0.21.1"
+thiserror = "1.0.29"
+typed-builder = "0.9.1"
+uuid = { version = "0.8.2", features = ["serde", "v4"] }
 zerocopy = "0.3.0"
-lazy_static = "^1.1"
+lazy_static = "1.1.1"
 
 [dev-dependencies]
-md-5 = "0.9"
-sha2 = "0.9"
-criterion = "0.3.1"
-anyhow = "1.0.31"
-hex-literal = "0.3.1"
+md-5 = "0.9.1"
+sha2 = "0.9.8"
+criterion = "0.3.5"
+anyhow = "1.0.44"
+hex-literal = "0.3.3"

--- a/lang/rust/src/codec.rs
+++ b/lang/rust/src/codec.rs
@@ -62,8 +62,8 @@ impl Codec {
             Codec::Snappy => {
                 use byteorder::ByteOrder;
 
-                let mut encoded: Vec<u8> = vec![0; snap::max_compress_len(stream.len())];
-                let compressed_size = snap::Encoder::new()
+                let mut encoded: Vec<u8> = vec![0; snap::raw::max_compress_len(stream.len())];
+                let compressed_size = snap::raw::Encoder::new()
                     .compress(&stream[..], &mut encoded[..])
                     .map_err(Error::SnappyCompress)?;
 
@@ -94,10 +94,10 @@ impl Codec {
             Codec::Snappy => {
                 use byteorder::ByteOrder;
 
-                let decompressed_size = snap::decompress_len(&stream[..stream.len() - 4])
+                let decompressed_size = snap::raw::decompress_len(&stream[..stream.len() - 4])
                     .map_err(Error::GetSnappyDecompressLen)?;
                 let mut decoded = vec![0; decompressed_size];
-                snap::Decoder::new()
+                snap::raw::Decoder::new()
                     .decompress(&stream[..stream.len() - 4], &mut decoded[..])
                     .map_err(Error::SnappyDecompress)?;
 


### PR DESCRIPTION
Update all prod and dev dependencies to their latest versions.

Add an entry for dependabot for Rust.

### Jira

- [X] My PR addresses the following [AVRO-3204](https://issues.apache.org/jira/browse/AVRO-3204) issue

### Tests

- [X] Only Cargo.toml is updated and all tests still pass

### Commits

- [X] My commits all reference Jira issues in their subject lines!

### Documentation

- [X] No need of documentation!