### PR TITLE
AVRO-3208: Utf8 datum are Serializable

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/util/Utf8.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/util/Utf8.java
@@ -17,6 +17,10 @@
  */
 package org.apache.avro.util;
 
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
@@ -29,7 +33,7 @@ import org.slf4j.LoggerFactory;
  * efficient than {@link String} when reading or writing a sequence of values,
  * as a single instance may be reused.
  */
-public class Utf8 implements Comparable<Utf8>, CharSequence {
+public class Utf8 implements Comparable<Utf8>, CharSequence, Externalizable {
   private static final String MAX_LENGTH_PROPERTY = "org.apache.avro.limits.string.maxLength";
   private static final int MAX_LENGTH;
   private static final byte[] EMPTY = new byte[0];
@@ -220,5 +224,17 @@ public class Utf8 implements Comparable<Utf8>, CharSequence {
   /** Gets the UTF-8 bytes for a String */
   public static byte[] getBytesFor(String str) {
     return str.getBytes(StandardCharsets.UTF_8);
+  }
+
+  @Override
+  public void writeExternal(ObjectOutput out) throws IOException {
+    out.writeInt(bytes.length);
+    out.write(bytes);
+  }
+
+  @Override
+  public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+    setByteLength(in.readInt());
+    in.readFully(bytes);
   }
 }

--- a/lang/java/avro/src/test/java/org/apache/avro/util/TestUtf8.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/util/TestUtf8.java
@@ -17,10 +17,17 @@
  */
 package org.apache.avro.util;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertEquals;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.nio.charset.StandardCharsets;
 
 import org.junit.Test;
@@ -90,4 +97,28 @@ public class TestUtf8 {
     u.setByteLength(4);
     assertEquals(3198781, u.hashCode());
   }
+
+  @Test
+  public void testSerialization() throws IOException, ClassNotFoundException {
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+
+      Utf8 originalEmpty = new Utf8();
+      Utf8 originalBytes = new Utf8("originalBytes".getBytes(StandardCharsets.UTF_8));
+      Utf8 originalString = new Utf8("originalString");
+
+      oos.writeObject(originalEmpty);
+      oos.writeObject(originalBytes);
+      oos.writeObject(originalString);
+      oos.flush();
+
+      try (ByteArrayInputStream bis = new ByteArrayInputStream(bos.toByteArray());
+          ObjectInputStream ois = new ObjectInputStream(bis)) {
+        assertThat(ois.readObject(), is(originalEmpty));
+        assertThat(ois.readObject(), is(originalBytes));
+        assertThat(ois.readObject(), is(originalString));
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
Related to https://issues.apache.org/jira/browse/BEAM-12628 

It's very common in big data to have a key/value pair where the key is extracted from a record in the value.  This is currently unnecessarily complicated because if the key is a Utf8 datum that does not implement Serializable (although it is serializable inside the record itself).

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3208
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests : `testSerializable` 

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
