### PR TITLE
AVRO-3211: Refactor PrintingVisitor to improve testing logic

### DIFF
--- a/lang/java/compiler/src/test/java/org/apache/avro/compiler/schema/TestSchemas.java
+++ b/lang/java/compiler/src/test/java/org/apache/avro/compiler/schema/TestSchemas.java
@@ -38,36 +38,9 @@ public class TestSchemas {
       + "                     {\"name\":\"methodName\",\"type\":{\"type\":\"string\",\"avro.java.string\":\"String\"}}\n"
       + "                  ]}},\n" + "              {\"name\":\"node\",\"type\":\"SampleNode\"}]}}}" + "]}";
 
-  private static class PrintingVisitor implements SchemaVisitor {
-
-    @Override
-    public SchemaVisitorAction visitTerminal(Schema terminal) {
-      System.out.println("Terminal: " + terminal.getFullName());
-      return SchemaVisitorAction.CONTINUE;
-    }
-
-    @Override
-    public SchemaVisitorAction visitNonTerminal(Schema terminal) {
-      System.out.println("NONTerminal start: " + terminal.getFullName());
-      return SchemaVisitorAction.CONTINUE;
-    }
-
-    @Override
-    public SchemaVisitorAction afterVisitNonTerminal(Schema terminal) {
-      System.out.println("NONTerminal end: " + terminal.getFullName());
-      return SchemaVisitorAction.CONTINUE;
-    }
-
-    @Override
-    public Object get() {
-      return null;
-    }
-  }
-
   @Test
   public void textCloning() {
     Schema recSchema = new Schema.Parser().parse(SCHEMA);
-    Schemas.visit(recSchema, new PrintingVisitor());
 
     CloningVisitor cv = new CloningVisitor(recSchema);
     Schema trimmed = Schemas.visit(recSchema, cv);
@@ -85,7 +58,6 @@ public class TestSchemas {
   @Test
   public void textCloningCopyDocs() {
     Schema recSchema = new Schema.Parser().parse(SCHEMA);
-    Schemas.visit(recSchema, new PrintingVisitor());
 
     Schema trimmed = Schemas.visit(recSchema, new CloningVisitor(new CloningVisitor.PropertyCopier() {
       @Override


### PR DESCRIPTION

### Jira

- AVRO-3211: Refactor PrintingVisitor to improve test design

### Description

#### Replace test class [PrintingVisitor](https://github.com/apache/avro/blob/42822886c28ea74a744abb7e7a80a942c540faa5/lang/java/compiler/src/test/java/org/apache/avro/compiler/schema/TestSchemas.java#L41) by mocking object and improve test design
<hr>

##### Motivation

- Decouple test class `PrintingVisitor` from production interface `SchemaVisitor`.
- Remove the redundant test child class `PrintingVisitor`.

<hr>

##### Key changed/added classes in this PR
 * Created mocking object to replace test subclass `PrintingVisitor`, decoupled test from production code.
 * Created method that return the mocking object for code reuse.
 * Make test logic more clear by using method stub instead of method overriding.
 * Remove redundant overridden method `get()`.
 * Add Mockito dependency.

<hr>