### PR TITLE
AVRO-3212: fix specification to allow doc in fixed types

### DIFF
--- a/doc/src/content/xdocs/spec.xml
+++ b/doc/src/content/xdocs/spec.xml
@@ -86,11 +86,11 @@
         <section id="schema_record">
           <title>Records</title>
 
-	  <p>Records use the type name "record" and support three attributes:</p>
+	  <p>Records use the type name "record" and support the following attributes:</p>
 	  <ul>
 	    <li><code>name</code>: a JSON string providing the name
 	    of the record (required).</li>
-	    <li><em>namespace</em>, a JSON string that qualifies the name;</li>
+	    <li><code>namespace</code>, a JSON string that qualifies the name;</li>
 	    <li><code>doc</code>: a JSON string providing documentation to the
 	    user of this schema (optional).</li>
 	    <li><code>aliases:</code> a JSON array of strings, providing
@@ -254,14 +254,16 @@
         <section>
           <title>Fixed</title>
           <p>Fixed uses the type name <code>"fixed"</code> and supports
-          two attributes:</p>
+          the following attributes:</p>
 	  <ul>
 	    <li><code>name</code>: a string naming this fixed (required).</li>
-	    <li><em>namespace</em>, a string that qualifies the name;</li>
+	    <li><code>namespace</code>, a string that qualifies the name;</li>
 	    <li><code>aliases:</code> a JSON array of strings, providing
 	      alternate names for this enum (optional).</li>
-            <li><code>size</code>: an integer, specifying the number
-            of bytes per value (required).</li>
+      <li><code>doc</code>: a JSON string providing documentation to the
+        user of this schema (optional).</li>
+      <li><code>size</code>: an integer, specifying the number
+        of bytes per value (required).</li>
 	  </ul>
 	  <p>For example, 16-byte quantity may be declared with:</p>
 	  <source>{"type": "fixed", "size": 16, "name": "md5"}</source>


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

https://issues.apache.org/jira/browse/AVRO-3212

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

this is just a text change in the docs

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
