### PR TITLE
AVRO-3205 Rust: Update Cargo.toml [package] information

### DIFF
--- a/lang/rust/CHANGELOG.md
+++ b/lang/rust/CHANGELOG.md
@@ -18,7 +18,10 @@
 -->
 
 # Changelog
-All notable changes to this project will be documented in this file.
+
+This file has been used by [avro-rs](https://github.com/flavray/avro-rs) before donating the project to Apache Avro.
+Apache Avro uses [JIRA](https://issues.apache.org/jira/browse/AVRO) for issue tracking and changelog!
+
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/lang/rust/Cargo.toml
+++ b/lang/rust/Cargo.toml
@@ -25,6 +25,7 @@ readme = "README.md"
 repository = "https://github.com/apache/avro"
 edition = "2018"
 keywords = ["avro", "data", "serialization"]
+categories = ["encoding"]
 documentation = "https://docs.rs/avro-rs"
 
 [features]

--- a/lang/rust/Cargo.toml
+++ b/lang/rust/Cargo.toml
@@ -17,12 +17,12 @@
 
 [package]
 name = "avro-rs"
-version = "0.13.0"
-authors = ["Flavien Raynaud <flavien.raynaud@gmail.com>", "Antonio Verardi <antonio.uccio.verardi@gmail.com>"]
-description = "Library for working with Apache Avro in Rust"
-license = "MIT"
+version = "0.14.0"
+authors = ["Apache Avro team <dev@avro.apache.org>"]
+description = "A library for working with Apache Avro in Rust"
+license = "Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/flavray/avro-rs"
+repository = "https://github.com/apache/avro"
 edition = "2018"
 
 [features]

--- a/lang/rust/Cargo.toml
+++ b/lang/rust/Cargo.toml
@@ -24,6 +24,8 @@ license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/apache/avro"
 edition = "2018"
+keywords = ["avro", "data", "serialization"]
+documentation = "https://docs.rs/avro-rs"
 
 [features]
 snappy = ["crc", "snap"]

--- a/lang/rust/README.md
+++ b/lang/rust/README.md
@@ -20,9 +20,9 @@
 # avro-rs
 
 [![Latest Version](https://img.shields.io/crates/v/avro-rs.svg)](https://crates.io/crates/avro-rs)
-[![Continuous Integration](https://github.com/flavray/avro-rs/workflows/Continuous%20Integration/badge.svg)](https://github.com/flavray/avro-rs/actions)
+[![Rust Continuous Integration](https://github.com/apache/avro/actions/workflows/test-lang-rust-ci.yml/badge.svg)](https://github.com/apache/avro/actions/workflows/test-lang-rust-ci.yml)
 [![Latest Documentation](https://docs.rs/avro-rs/badge.svg)](https://docs.rs/avro-rs)
-[![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/flavray/avro-rs/blob/main/LICENSE)
+[![Apache License 2.0](https://img.shields.io/badge/license-Apache%202-blue.svg](https://github.com/apache/avro/blob/master/LICENSE.txt)
 
 A library for working with [Apache Avro](https://avro.apache.org/) in Rust.
 
@@ -614,13 +614,12 @@ assert_eq!(false, SchemaCompatibility::can_read(&writers_schema, &readers_schema
 ```
 
 ## License
-This project is licensed under [MIT License](https://github.com/flavray/avro-rs/blob/main/LICENSE).
-Please note that this is not an official project maintained by [Apache Avro](https://avro.apache.org/).
+This project is licensed under [Apache License 2.0](https://github.com/apache/avro/blob/master/LICENSE.txt).
 
 ## Contributing
 Everyone is encouraged to contribute! You can contribute by forking the GitHub repo and making a pull request or opening an issue.
-All contributions will be licensed under [MIT License](https://github.com/flavray/avro-rs/blob/main/LICENSE).
+All contributions will be licensed under [Apache License 2.0](https://github.com/apache/avro/blob/master/LICENSE.txt).
 
-Please consider adding documentation, tests and a line for your change under the Unreleased section in the [CHANGELOG](https://github.com/flavray/avro-rs/blob/main/CHANGELOG.md).
+Please consider adding documentation and tests!
 If you introduce a backward-incompatible change, please consider adding instruction to migrate in the [Migration Guide](migration_guide.md)
 If you modify the crate documentation in `lib.rs`, run `make readme` to sync the README file.

--- a/lang/rust/README.tpl
+++ b/lang/rust/README.tpl
@@ -1,20 +1,19 @@
 # {{crate}}
 
 [![Latest Version](https://img.shields.io/crates/v/avro-rs.svg)](https://crates.io/crates/avro-rs)
-[![Continuous Integration](https://github.com/flavray/avro-rs/workflows/Continuous%20Integration/badge.svg)](https://github.com/flavray/avro-rs/actions)
+[![Rust Continuous Integration](https://github.com/apache/avro/actions/workflows/test-lang-rust-ci.yml/badge.svg)](https://github.com/apache/avro/actions/workflows/test-lang-rust-ci.yml)
 [![Latest Documentation](https://docs.rs/avro-rs/badge.svg)](https://docs.rs/avro-rs)
-[![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/flavray/avro-rs/blob/main/LICENSE)
+[![Apache License 2.0](https://img.shields.io/badge/license-Apache%202-blue.svg](https://github.com/apache/avro/blob/master/LICENSE.txt)
 
 {{readme}}
 
 ## License
-This project is licensed under [MIT License](https://github.com/flavray/avro-rs/blob/main/LICENSE).
-Please note that this is not an official project maintained by [Apache Avro](https://avro.apache.org/).
+This project is licensed under [Apache License 2.0](https://github.com/apache/avro/blob/master/LICENSE.txt).
 
 ## Contributing
 Everyone is encouraged to contribute! You can contribute by forking the GitHub repo and making a pull request or opening an issue.
-All contributions will be licensed under [MIT License](https://github.com/flavray/avro-rs/blob/main/LICENSE).
+All contributions will be licensed under [Apache License 2.0](https://github.com/apache/avro/blob/master/LICENSE.txt).
 
-Please consider adding documentation, tests and a line for your change under the Unreleased section in the [CHANGELOG](https://github.com/flavray/avro-rs/blob/main/CHANGELOG.md).
+Please consider adding documentation and tests!
 If you introduce a backward-incompatible change, please consider adding instruction to migrate in the [Migration Guide](migration_guide.md)
 If you modify the crate documentation in `lib.rs`, run `make readme` to sync the README file.

--- a/lang/rust/src/lib.rs
+++ b/lang/rust/src/lib.rs
@@ -693,7 +693,7 @@
 //! This library supports checking for schemas compatibility.
 //!
 //! Note: It does not yet support named schemas (more on
-//! https://github.com/flavray/avro-rs/pull/76).
+//! <https://github.com/flavray/avro-rs/pull/76>).
 //!
 //! Examples of checking for compatibility:
 //!


### PR DESCRIPTION
### Jira

- [X] My PR addresses the following [AVRO-3205](https://issues.apache.org/jira/browse/AVRO-3205) issue.

### Tests

- [X] My PR does not need testing for this extremely good reason: Only `[package]` in Cargo.toml is being changed 

### Commits

- [X] My commits all reference Jira issues in their subject lines.
 
### Documentation

- [X] No need of documentation
