### PR TITLE
AVRO-3216 Reuse records' schema by name

### DIFF
--- a/lang/rust/src/schema.rs
+++ b/lang/rust/src/schema.rs
@@ -714,14 +714,13 @@ impl Parser {
                     );
                 }
                 "timestamp-millis" => {
-                    return match logical_verify_type(complex, &[SchemaKind::Long], self) {
-                        Ok(_) => Ok(Schema::TimestampMillis),
-                        Err(Error::GetLogicalTypeVariant(json_value)) => match json_value {
-                            Value::String(typ) if typ == "string" => Ok(Schema::String),
-                            _ => Err(Error::GetLogicalTypeVariant(json_value)),
-                        },
-                        Err(error) => Err(error),
-                    }
+                    return try_logical_type(
+                        "timestamp-millis",
+                        complex,
+                        &[SchemaKind::Long],
+                        Schema::TimestampMillis,
+                        self,
+                    );
                 }
                 "timestamp-micros" => {
                     return try_logical_type(

--- a/lang/rust/src/schema.rs
+++ b/lang/rust/src/schema.rs
@@ -785,12 +785,16 @@ impl Parser {
             lookup.insert(field.name.clone(), field.position);
         }
 
-        Ok(Schema::Record {
-            name,
+        let schema = Schema::Record {
+            name: name.clone(),
             doc: complex.doc(),
             fields,
             lookup,
-        })
+        };
+
+        self.parsed_schemas
+            .insert(name.fullname(None), schema.clone());
+        Ok(schema)
     }
 
     /// Parse a `serde_json::Value` representing a Avro enum type into a

--- a/lang/rust/src/schema.rs
+++ b/lang/rust/src/schema.rs
@@ -717,7 +717,7 @@ impl Parser {
                     return match logical_verify_type(complex, &[SchemaKind::Long], self) {
                         Ok(_) => Ok(Schema::TimestampMillis),
                         Err(Error::GetLogicalTypeVariant(json_value)) => match json_value {
-                            Value::String(_) => Ok(Schema::String),
+                            Value::String(typ) if typ == "string" => Ok(Schema::String),
                             _ => Err(Error::GetLogicalTypeVariant(json_value)),
                         },
                         Err(error) => Err(error),

--- a/lang/rust/src/schema.rs
+++ b/lang/rust/src/schema.rs
@@ -714,13 +714,14 @@ impl Parser {
                     );
                 }
                 "timestamp-millis" => {
-                    return try_logical_type(
-                        "timestamp-millis",
-                        complex,
-                        &[SchemaKind::Long],
-                        Schema::TimestampMillis,
-                        self,
-                    );
+                    return match logical_verify_type(complex, &[SchemaKind::Long], self) {
+                        Ok(_) => Ok(Schema::TimestampMillis),
+                        Err(Error::GetLogicalTypeVariant(json_value)) => match json_value {
+                            Value::String(_) => Ok(Schema::String),
+                            _ => Err(Error::GetLogicalTypeVariant(json_value)),
+                        },
+                        Err(error) => Err(error),
+                    }
                 }
                 "timestamp-micros" => {
                     return try_logical_type(

--- a/lang/rust/tests/io.rs
+++ b/lang/rust/tests/io.rs
@@ -319,6 +319,6 @@ fn test_type_exception() -> Result<(), String> {
     match encoded {
         Ok(_) => Err(String::from("Expected ValidationError, got Ok")),
         Err(Error::Validation) => Ok(()),
-        Err(ref e) => Err(format!("Expected ValidationError, got {}", e)),
+        Err(ref e) => Err(format!("Expected ValidationError, got {:?}", e)),
     }
 }

--- a/lang/rust/tests/schema.rs
+++ b/lang/rust/tests/schema.rs
@@ -15,8 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Port of https://github.com/apache/avro/blob/release-1.9.1/lang/py/test/test_schema.py
-use avro_rs::{schema::Name, Error, Schema};
+use avro_rs::{
+    schema::{Name, RecordField},
+    Error, Schema,
+};
 use lazy_static::lazy_static;
 
 fn init() {
@@ -871,6 +873,43 @@ fn test_parse_reused_record_schema_by_fullname() {
 
     let schema = Schema::parse_str(schema_str);
     assert!(schema.is_ok());
+    match schema.unwrap() {
+        Schema::Record {
+            ref name,
+            doc: _,
+            ref fields,
+            lookup: _,
+        } => {
+            assert_eq!(name.fullname(None), "test.Weather", "Name does not match!");
+
+            assert_eq!(fields.len(), 3, "The number of the fields is not correct!");
+
+            let RecordField {
+                ref name,
+                doc: _,
+                default: _,
+                ref schema,
+                order: _,
+                position: _,
+            } = fields.get(2).unwrap();
+
+            assert_eq!(name, "min_temp");
+
+            match schema {
+                Schema::Record {
+                    ref name,
+                    doc: _,
+                    ref fields,
+                    lookup: _,
+                } => {
+                    assert_eq!(name.fullname(None), "prefix.Temp", "Name does not match!");
+                    assert_eq!(fields.len(), 1, "The number of the fields is not correct!");
+                }
+                unexpected => unreachable!("Unexpected schema type: {:?}", unexpected),
+            }
+        }
+        unexpected => unreachable!("Unexpected schema type: {:?}", unexpected),
+    }
 }
 
 /// Return all permutations of an input slice

--- a/lang/rust/tests/schema.rs
+++ b/lang/rust/tests/schema.rs
@@ -830,6 +830,49 @@ fn test_parse_list_with_cross_deps_and_namespaces_error() {
     let _ = Schema::parse_list(&schema_strs_second).expect_err("Test failed");
 }
 
+#[test]
+// <https://issues.apache.org/jira/browse/AVRO-3216>
+// test that field's RecordSchema could be referenced by a following field by full name
+fn test_parse_reused_record_schema_by_fullname() {
+    init();
+    let schema_str = r#"
+        {
+          "type" : "record",
+          "name" : "Weather",
+          "namespace" : "test",
+          "doc" : "A weather reading.",
+          "fields" : [
+            {
+                "name" : "station",
+                "type" : {
+                  "type" : "string",
+                  "avro.java.string" : "String"
+                }
+             },
+             {
+                "name" : "max_temp",
+                "type" : {
+                  "type" : "record",
+                  "name" : "Temp",
+                  "namespace": "prefix",
+                  "doc" : "A temperature reading.",
+                  "fields" : [ {
+                    "name" : "temp",
+                    "type" : "long"
+                  } ]
+                }
+            }, {
+                "name" : "min_temp",
+                "type" : "prefix.Temp"
+            }
+        ]
+       }
+    "#;
+
+    let schema = Schema::parse_str(schema_str);
+    assert!(schema.is_ok());
+}
+
 /// Return all permutations of an input slice
 fn permutations<T>(list: &[T]) -> Vec<Vec<&T>> {
     let size = list.len();


### PR DESCRIPTION
### Jira

- [X] My PR addresses the following [AVRO-3216](https://issues.apache.org/jira/browse/AVRO-3216) issue

### Tests

- [X] My PR adds the following unit tests: `tests/schema.rs#test_parse_reused_record_schema_by_fullname`

### Commits

- [X] My commits all reference Jira issues in their subject lines.
Only https://github.com/apache/avro/commit/06200ef388a99a92bfe1c419afc74264f6cc971e is part of this PR. The previous commits are from  [AVRO-3197](https://issues.apache.org/jira/browse/AVRO-3197) and they will disappear from this PR once #1340 is merged

### Documentation

- [X] This is a bug fix. No new functionality!