### PR TITLE
AVRO-3219: Add nullable enum type field support in Avro.Reflect

### DIFF
--- a/lang/csharp/src/apache/main/Reflect/ClassCache.cs
+++ b/lang/csharp/src/apache/main/Reflect/ClassCache.cs
@@ -270,7 +270,7 @@ namespace Avro.Reflect
                             }
 
                             var innerType = Nullable.GetUnderlyingType(objType);
-                            if (innerType != null)
+                            if (innerType != null && innerType.IsEnum)
                             {
                                 LoadClassCache(innerType, o);
                             }

--- a/lang/csharp/src/apache/main/Reflect/ClassCache.cs
+++ b/lang/csharp/src/apache/main/Reflect/ClassCache.cs
@@ -269,18 +269,12 @@ namespace Avro.Reflect
                                 LoadClassCache(objType, o);
                             }
 
-                            if (objType.IsGenericType)
+                            var innerType = Nullable.GetUnderlyingType(objType);
+                            if (innerType != null)
                             {
-                                var genericType = objType.GetGenericTypeDefinition();
-                                var isNullable = genericType == typeof(Nullable<>);
-                                var innerType = objType.GetGenericArguments()[0];
-                                if (isNullable && innerType.IsEnum)
-                                {
-                                    LoadClassCache(objType.GetGenericArguments()[0], o);
-                                }
+                                LoadClassCache(innerType, o);
                             }
                         }
-
                     }
                     else
                     {

--- a/lang/csharp/src/apache/main/Reflect/ClassCache.cs
+++ b/lang/csharp/src/apache/main/Reflect/ClassCache.cs
@@ -254,14 +254,30 @@ namespace Avro.Reflect
                     EnumCache.AddEnumNameMapItem(ns, objType);
                     break;
                 case UnionSchema us:
-                    if (us.Schemas.Count == 2 && (us.Schemas[0].Tag == Schema.Type.Null || us.Schemas[1].Tag == Schema.Type.Null) && objType.IsClass)
+                    if (us.Schemas.Count == 2 && (us.Schemas[0].Tag == Schema.Type.Null || us.Schemas[1].Tag == Schema.Type.Null))
                     {
                         // in this case objType will match the non null type in the union
                         foreach (var o in us.Schemas)
                         {
-                            if (o.Tag != Schema.Type.Null)
+                            if (o.Tag == Schema.Type.Null)
+                            {
+                                continue;
+                            }
+
+                            if (objType.IsClass)
                             {
                                 LoadClassCache(objType, o);
+                            }
+
+                            if (objType.IsGenericType)
+                            {
+                                var genericType = objType.GetGenericTypeDefinition();
+                                var isNullable = genericType == typeof(Nullable<>);
+                                var innerType = objType.GetGenericArguments()[0];
+                                if (isNullable && innerType.IsEnum)
+                                {
+                                    LoadClassCache(objType.GetGenericArguments()[0], o);
+                                }
                             }
                         }
 

--- a/lang/csharp/src/apache/test/Reflect/TestReflect.cs
+++ b/lang/csharp/src/apache/test/Reflect/TestReflect.cs
@@ -40,17 +40,22 @@ namespace Avro.Test
             public EnumResolutionEnum enumType { get; set; }
         }
 
+        class NullableEnumResolutionRecord
+        {
+            public EnumResolutionEnum? enumType { get; set; }
+        }
+
         [TestCase]
         public void TestEnumResolution()
         {
             Schema writerSchema = Schema.Parse("{\"type\":\"record\",\"name\":\"EnumRecord\",\"namespace\":\"Avro.Test\"," +
-                                        "\"fields\":[{\"name\":\"enumType\",\"type\": { \"type\": \"enum\", \"name\": \"EnumType\", \"symbols\": [\"FIRST\", \"SECOND\"]} }]}");
+                                               "\"fields\":[{\"name\":\"enumType\",\"type\": { \"type\": \"enum\", \"name\": \"EnumType\", \"symbols\": [\"FIRST\", \"SECOND\"]} }]}");
 
             var testRecord = new EnumResolutionRecord();
 
             Schema readerSchema = Schema.Parse("{\"type\":\"record\",\"name\":\"EnumRecord\",\"namespace\":\"Avro.Test\"," +
-                                        "\"fields\":[{\"name\":\"enumType\",\"type\": { \"type\": \"enum\", \"name\":" +
-                                        " \"EnumType\", \"symbols\": [\"THIRD\", \"FIRST\", \"SECOND\"]} }]}");;
+                                               "\"fields\":[{\"name\":\"enumType\",\"type\": { \"type\": \"enum\", \"name\":" +
+                                               " \"EnumType\", \"symbols\": [\"THIRD\", \"FIRST\", \"SECOND\"]} }]}");;
             testRecord.enumType = EnumResolutionEnum.SECOND;
 
             // serialize
@@ -58,6 +63,28 @@ namespace Avro.Test
 
             // deserialize
             var rec2 = deserialize<EnumResolutionRecord>(stream, writerSchema, readerSchema);
+            Assert.AreEqual( EnumResolutionEnum.SECOND, rec2.enumType );
+        }
+
+        [TestCase]
+        public void TestNullableEnumResolution()
+        {
+            Schema writerSchema = Schema.Parse("{\"type\":\"record\",\"name\":\"EnumRecord\",\"namespace\":\"Avro.Test\"," +
+                                        "\"fields\":[{\"name\":\"enumType\",\"type\":[\"null\", { \"type\": \"enum\", \"name\": " +
+                                        "\"EnumType\",\"symbols\": [\"THIRD\", \"FIRST\", \"SECOND\"]}] }]}");
+
+            var testRecord = new NullableEnumResolutionRecord();
+
+            Schema readerSchema = Schema.Parse("{\"type\":\"record\",\"name\":\"EnumRecord\",\"namespace\":\"Avro.Test\"," +
+                                               "\"fields\":[{\"name\":\"enumType\",\"type\":[\"null\", { \"type\": \"enum\", \"name\": " +
+                                               "\"EnumType\", \"symbols\": [\"THIRD\", \"FIRST\", \"SECOND\"]}] }]}");
+            testRecord.enumType = EnumResolutionEnum.SECOND;
+
+            // serialize
+            var stream = serialize(writerSchema, testRecord);
+
+            // deserialize
+            var rec2 = deserialize<NullableEnumResolutionRecord>(stream, writerSchema, readerSchema);
             Assert.AreEqual( EnumResolutionEnum.SECOND, rec2.enumType );
         }
 


### PR DESCRIPTION
Signed-off-by: Zike Yang <zike@apache.org>

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. 
  - https://issues.apache.org/jira/browse/AVRO-3219

### Tests

- [x] My PR adds the following unit tests: `TestNullableEnumResolution `

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] This is just a bug fix. No need doc.
