### PR TITLE
AVRO-3095 Handle "classpath" resources only if resourceLoader is not null

### DIFF
--- a/lang/java/compiler/src/main/javacc/org/apache/avro/compiler/idl/idl.jj
+++ b/lang/java/compiler/src/main/javacc/org/apache/avro/compiler/idl/idl.jj
@@ -171,10 +171,11 @@ public class Idl implements Closeable {
     URL result = null;
     if (file != null && file.exists())
       result = file.toURI().toURL();
-    else if("classpath".equals(uri.getScheme()))
-      result = this.resourceLoader.getResource(uri.getPath().substring(1));
     else if (this.resourceLoader != null)
-      result = this.resourceLoader.getResource(importFile);
+      if ("classpath".equals(uri.getScheme()))
+        result = this.resourceLoader.getResource(uri.getPath().substring(1));
+      else
+        result = this.resourceLoader.getResource(importFile);
     if (result == null)
       throw new FileNotFoundException(importFile);
     return result;


### PR DESCRIPTION
Related to https://github.com/apache/avro/pull/1157#pullrequestreview-772364513

### Jira

- [ ] My PR addresses the following [AVRO-3095](https://issues.apache.org/jira/browse/AVRO-3095) issue
