### PR TITLE
AVRO-3171: Use Active LTS Node.js 14

### DIFF
--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -109,7 +109,7 @@ RUN set -eux; \
 ENV PATH="/opt/maven/bin:${PATH}"
 
 # Install nodejs
-RUN curl -sSL https://deb.nodesource.com/setup_16.x \
+RUN curl -sSL https://deb.nodesource.com/setup_14.x \
   | bash - \
  && apt-get -qqy install nodejs \
  && apt-get -qqy clean \


### PR DESCRIPTION
The node.js tests were fixed for the "Active LTD" version 14 in AVRO-3171 but not yet for later versions.   The Dockerfile build should target this version until the version 16 fixes are done.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3171
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR does not need testing for this extremely good reason: Validated manually building release candidates.

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
