### PR TITLE
AVRO-3222: Fix ruby interop scripts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -108,7 +108,7 @@ do
       #(cd lang/c++; make interop-data-generate)
       (cd lang/csharp; ./build.sh interop-data-generate)
       (cd lang/js; ./build.sh interop-data-generate)
-      (cd lang/ruby; rake generate_interop)
+      (cd lang/ruby; ./build.sh interop-data-generate)
       (cd lang/php; ./build.sh interop-data-generate)
       (cd lang/perl; ./build.sh interop-data-generate)
 
@@ -119,7 +119,7 @@ do
       #(cd lang/c++; make interop-data-test)
       (cd lang/csharp; ./build.sh interop-data-test)
       (cd lang/js; ./build.sh interop-data-test)
-      (cd lang/ruby; rake interop)
+      (cd lang/ruby; ./build.sh interop-data-test)
       (cd lang/php; ./build.sh test-interop)
       (cd lang/perl; ./build.sh interop-data-test)
 

--- a/lang/ruby/build.sh
+++ b/lang/ruby/build.sh
@@ -38,6 +38,14 @@ do
       bundle exec rubocop
       ;;
 
+    interop-data-generate)
+      bundle exec rake generate_interop
+      ;;
+
+    interop-data-test)
+      bundle exec rake interop
+      ;;
+
     test)
       bundle exec rake test
       ;;
@@ -57,7 +65,7 @@ do
       ;;
 
     *)
-      echo "Usage: $0 {lint|test|dist|clean}"
+      echo "Usage: $0 {clean|dist|interop-data-generate|interop-data-test|lint|test}"
       exit 1
   esac
 done

--- a/share/test/interop/bin/test_rpc_interop.sh
+++ b/share/test/interop/bin/test_rpc_interop.sh
@@ -21,6 +21,8 @@ cd "${0%/*}/../../../.."
 
 VERSION=$(<share/VERSION.txt)
 
+export GEM_HOME="$PWD/lang/ruby/.gem/"
+
 java_tool() {
   java -jar "lang/java/tools/target/avro-tools-$VERSION.jar" "$@"
 }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3222
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR does not need testing for this extremely good reason: manual build scripts for a release

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
