### PR TITLE
AVRO-2722 C++: Move the 'random' variable to be local to the method where it is being used

### DIFF
--- a/lang/c++/impl/DataFile.cc
+++ b/lang/c++/impl/DataFile.cc
@@ -232,9 +232,8 @@ void DataFileWriterBase::flush() {
     sync();
 }
 
-boost::mt19937 random(static_cast<uint32_t>(time(nullptr)));
-
 DataFileSync DataFileWriterBase::makeSync() {
+    boost::mt19937 random(static_cast<uint32_t>(time(nullptr)));
     DataFileSync sync;
     std::generate(sync.begin(), sync.end(), random);
     return sync;


### PR DESCRIPTION
This avoids thread-safety issues.


### Jira

- [X] My PR addresses the following [AVRO-2722](https://issues.apache.org/jira/browse/AVRO-2722/) issue

### Tests

- [ ] My PR does not add a test because I don't know how to reproduce it at GitHub Actions (it has no Android ARM64 runners).

### Documentation

No need of documentation.