### PR TITLE
AVRO-3231 C#: Enable build of Avro.dll for .NET 5

### DIFF
--- a/lang/csharp/build.sh
+++ b/lang/csharp/build.sh
@@ -35,7 +35,7 @@ do
     test)
       dotnet build --configuration Release Avro.sln
 
-      # AVRO-2442: Explictly set LANG to work around ICU bug in `dotnet test`
+      # AVRO-2442: Explicitly set LANG to work around ICU bug in `dotnet test`
       LANG=en_US.UTF-8 dotnet test  --configuration Release --no-build \
           --filter "TestCategory!=Interop" Avro.sln
       ;;

--- a/lang/csharp/src/apache/main/Avro.main.csproj
+++ b/lang/csharp/src/apache/main/Avro.main.csproj
@@ -20,7 +20,7 @@
   <Import Project="../../../versions.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp2.1;net5.0</TargetFrameworks>
     <AssemblyName>Avro</AssemblyName>
     <RootNamespace>Avro</RootNamespace>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
Fix a minor typo in build.sh

With this change `./build.sh dist` produces `main/net5.0/` folder in `dist/csharp/avro-csharp-**.tar.gz`. 
`codegen/net5.0/` is already there!

### Jira

- [X] My PR addresses the following [AVRO-3231](https://issues.apache.org/jira/browse/is already ) issue

### Tests

- [X] My PR does not need testing for this extremely good reason: it changes just the build.

### Commits

- [X] My commits all reference Jira issues in their subject lines.

### Documentation

The JIRA changelog should be enough