### PR TITLE
AVRO-3234: add new codec to lang/rust: zstandard

### DIFF
--- a/.github/workflows/test-lang-rust-ci.yml
+++ b/.github/workflows/test-lang-rust-ci.yml
@@ -39,7 +39,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.48.0  # MSRV
+          - 1.51.0  # MSRV
 
     steps:
       - name: Checkout

--- a/lang/rust/Cargo.toml
+++ b/lang/rust/Cargo.toml
@@ -27,6 +27,7 @@ edition = "2018"
 
 [features]
 snappy = ["crc", "snap"]
+zstandard = ["zstd"]
 
 [lib]
 path = "src/lib.rs"
@@ -63,6 +64,7 @@ typed-builder = "0.9.1"
 uuid = { version = "0.8.2", features = ["serde", "v4"] }
 zerocopy = "0.3.0"
 lazy_static = "1.1.1"
+zstd = { version = "0.9.0+zstd.1.5.0" , optional = true }
 
 [dev-dependencies]
 md-5 = "0.9.1"

--- a/lang/rust/README.md
+++ b/lang/rust/README.md
@@ -71,6 +71,14 @@ version = "x.y"
 features = ["snappy"]
 ```
 
+Or in case you want to leverage the **Zstandard** codec:
+
+```toml
+[dependencies.avro-rs]
+version = "x.y"
+features = ["zstandard"]
+```
+
 ## Upgrading to a newer minor version
 
 The library is still in beta, so there might be backward-incompatible changes between minor
@@ -244,6 +252,8 @@ RFC 1950) does not have a checksum.
 * **Snappy**: uses Google's [Snappy](http://google.github.io/snappy/) compression library. Each
 compressed block is followed by the 4-byte, big-endianCRC32 checksum of the uncompressed data in
 the block. You must enable the `snappy` feature to use this codec.
+* **Zstandard**: uses Facebook's [Zstandard](https://facebook.github.io/zstd/) compression library.
+You must enable the `zstandard` feature to use this codec.
 
 To specify a codec to use to compress data, just specify it while creating a `Writer`:
 ```rust

--- a/lang/rust/src/error.rs
+++ b/lang/rust/src/error.rs
@@ -309,6 +309,12 @@ pub enum Error {
     #[error("Failed to decompress with snappy")]
     SnappyDecompress(#[source] snap::Error),
 
+    #[error("Failed to compress with zstd")]
+    ZstdCompress(#[source] std::io::Error),
+
+    #[error("Failed to decompress with zstd")]
+    ZstdDecompress(#[source] std::io::Error),
+
     #[error("Failed to read header")]
     ReadHeader(#[source] std::io::Error),
 


### PR DESCRIPTION
Add new codec: zstandard

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3234
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: add unit test for compression and decompression

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
