### PR TITLE
AVRO-3240: fix deserializer schema backward compatibility

### DIFF
--- a/lang/rust/src/decode.rs
+++ b/lang/rust/src/decode.rs
@@ -23,7 +23,7 @@ use crate::{
     util::{safe_len, zag_i32, zag_i64},
     AvroResult, Error,
 };
-use std::{collections::HashMap, convert::TryFrom, io::Read, str::FromStr};
+use std::{collections::HashMap, convert::TryFrom, io::{ErrorKind,Read}, str::FromStr};
 use uuid::Uuid;
 
 #[inline]
@@ -67,15 +67,23 @@ pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> AvroResult<Value> {
         Schema::Null => Ok(Value::Null),
         Schema::Boolean => {
             let mut buf = [0u8; 1];
-            reader
-                .read_exact(&mut buf[..])
-                .map_err(Error::ReadBoolean)?;
-
-            match buf[0] {
-                0u8 => Ok(Value::Boolean(false)),
-                1u8 => Ok(Value::Boolean(true)),
-                _ => Err(Error::BoolValue(buf[0])),
-            }
+            match reader
+                .read_exact(&mut buf[..]) {
+                    Ok(_) => {
+                        match buf[0] {
+                            0u8 => Ok(Value::Boolean(false)),
+                            1u8 => Ok(Value::Boolean(true)),
+                            _ => Err(Error::BoolValue(buf[0])),
+                        }
+                    },
+                    Err(io_err) => {
+                        if let ErrorKind::UnexpectedEof = io_err.kind() {
+                            Ok(Value::Null)
+                        } else {
+                            Err(Error::ReadBoolean(io_err))
+                        }
+                    },
+                }
         }
         Schema::Decimal { ref inner, .. } => match &**inner {
             Schema::Fixed { .. } => match decode(inner, reader)? {
@@ -180,16 +188,27 @@ pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> AvroResult<Value> {
             Ok(Value::Map(items))
         }
         Schema::Union(ref inner) => {
-            let index = zag_i64(reader)?;
-            let variants = inner.variants();
-            let variant = variants
-                .get(usize::try_from(index).map_err(|e| Error::ConvertI64ToUsize(e, index))?)
-                .ok_or_else(|| Error::GetUnionVariant {
-                    index,
-                    num_variants: variants.len(),
-                })?;
-            let value = decode(variant, reader)?;
-            Ok(Value::Union(Box::new(value)))
+            match zag_i64(reader) {
+                Ok(index) => {
+                    let variants = inner.variants();
+                    let variant = variants
+                        .get(usize::try_from(index).map_err(|e| Error::ConvertI64ToUsize(e, index))?)
+                        .ok_or_else(|| Error::GetUnionVariant {
+                            index,
+                            num_variants: variants.len(),
+                        })?;
+                    let value = decode(variant, reader)?;
+                    Ok(Value::Union(Box::new(value)))
+                },
+                Err(Error::ReadVariableIntegerBytes(io_err)) => {
+                    if let ErrorKind::UnexpectedEof = io_err.kind() {
+                        Ok(Value::Union(Box::new(Value::Null)))
+                    } else {
+                        Err(Error::ReadVariableIntegerBytes(io_err))
+                    }
+                },
+                Err(io_err) => Err(io_err),
+            }
         }
         Schema::Record { ref fields, .. } => {
             // Benchmarks indicate ~10% improvement using this method.


### PR DESCRIPTION
When providing your own schema to `from_avro_datum`,
the deserialization is not backward compatible with messages
containing a previous schema even if the schemas are created
to be backward compatible.

This is due to the `decode_variable` function in `utils` returning
`Error::ReadVariableIntegerBytes` when the reader object is
smaller than expected and thus cannot fill the read_exact buffer.

Reading a message generated with an older schema version than the
one we are statically using, the payload buffer is by essence
smaller than the expected payload from a message serialized with
a newer schema (backward compatible schemas are basically append
only).

The proposed fix takes that into account and just returns empty
Ok() which will be interpreted as null. This is in line with the
fact that a backward compatible schema has to allow for null
values to the newly added fields.

Make sure you have checked _all_ steps below.

### Jira

- [x] [AVRO-3240](https://issues.apache.org/jira/browse/AVRO-3240)

### Tests

- [x] I have implemented a test to demonstrate the problem