### PR TITLE
AVRO-3133: Fix enum resolution to be consistent with Apache Avro specification and the schema compatibility checks

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/Resolver.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Resolver.java
@@ -90,7 +90,7 @@ public class Resolver {
         return new DoNothing(w, r, d);
 
       case FIXED:
-        if (w.getFullName() != null && !w.getFullName().equals(r.getFullName())) {
+        if (w.getName() != null && !w.getName().equals(r.getName())) {
           return new ErrorAction(w, r, d, ErrorType.NAMES_DONT_MATCH);
         } else if (w.getFixedSize() != r.getFixedSize()) {
           return new ErrorAction(w, r, d, ErrorType.SIZES_DONT_MATCH);
@@ -388,7 +388,7 @@ public class Resolver {
      * appropriate {@link EnumAdjust} is.
      */
     public static Action resolve(Schema w, Schema r, GenericData d) {
-      if (w.getFullName() != null && !w.getFullName().equals(r.getFullName()))
+      if (w.getName() != null && !w.getName().equals(r.getName()))
         return new ErrorAction(w, r, d, ErrorType.NAMES_DONT_MATCH);
 
       final List<String> wsymbols = w.getEnumSymbols();

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemaCompatibility.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemaCompatibility.java
@@ -39,7 +39,8 @@ import static org.apache.avro.TestSchemas.EMPTY_RECORD1;
 import static org.apache.avro.TestSchemas.EMPTY_UNION_SCHEMA;
 import static org.apache.avro.TestSchemas.ENUM1_ABC_SCHEMA;
 import static org.apache.avro.TestSchemas.ENUM1_AB_SCHEMA;
-import static org.apache.avro.TestSchemas.ENUM1_AB_SCHEMA_NAMESPACE;
+import static org.apache.avro.TestSchemas.ENUM1_AB_SCHEMA_NAMESPACE_1;
+import static org.apache.avro.TestSchemas.ENUM1_AB_SCHEMA_NAMESPACE_2;
 import static org.apache.avro.TestSchemas.ENUM1_BC_SCHEMA;
 import static org.apache.avro.TestSchemas.ENUM_ABC_ENUM_DEFAULT_A_RECORD;
 import static org.apache.avro.TestSchemas.ENUM_ABC_ENUM_DEFAULT_A_SCHEMA;
@@ -261,7 +262,9 @@ public class TestSchemaCompatibility {
 
       new ReaderWriter(ENUM1_AB_SCHEMA, ENUM1_AB_SCHEMA), new ReaderWriter(ENUM1_ABC_SCHEMA, ENUM1_AB_SCHEMA),
 
-      new ReaderWriter(ENUM1_AB_SCHEMA, ENUM1_AB_SCHEMA_NAMESPACE),
+      new ReaderWriter(ENUM1_AB_SCHEMA, ENUM1_AB_SCHEMA_NAMESPACE_1),
+      new ReaderWriter(ENUM1_AB_SCHEMA_NAMESPACE_1, ENUM1_AB_SCHEMA),
+      new ReaderWriter(ENUM1_AB_SCHEMA_NAMESPACE_1, ENUM1_AB_SCHEMA_NAMESPACE_2),
 
       // String-to/from-bytes, introduced in Avro 1.7.7
       new ReaderWriter(STRING_SCHEMA, BYTES_SCHEMA), new ReaderWriter(BYTES_SCHEMA, STRING_SCHEMA),

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemaCompatibility.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemaCompatibility.java
@@ -39,6 +39,7 @@ import static org.apache.avro.TestSchemas.EMPTY_RECORD1;
 import static org.apache.avro.TestSchemas.EMPTY_UNION_SCHEMA;
 import static org.apache.avro.TestSchemas.ENUM1_ABC_SCHEMA;
 import static org.apache.avro.TestSchemas.ENUM1_AB_SCHEMA;
+import static org.apache.avro.TestSchemas.ENUM1_AB_SCHEMA_NAMESPACE;
 import static org.apache.avro.TestSchemas.ENUM1_BC_SCHEMA;
 import static org.apache.avro.TestSchemas.ENUM_ABC_ENUM_DEFAULT_A_RECORD;
 import static org.apache.avro.TestSchemas.ENUM_ABC_ENUM_DEFAULT_A_SCHEMA;
@@ -259,6 +260,10 @@ public class TestSchemaCompatibility {
       new ReaderWriter(INT_MAP_SCHEMA, INT_MAP_SCHEMA), new ReaderWriter(LONG_MAP_SCHEMA, INT_MAP_SCHEMA),
 
       new ReaderWriter(ENUM1_AB_SCHEMA, ENUM1_AB_SCHEMA), new ReaderWriter(ENUM1_ABC_SCHEMA, ENUM1_AB_SCHEMA),
+
+      new ReaderWriter(ENUM1_AB_SCHEMA, ENUM1_AB_SCHEMA),
+
+      new ReaderWriter(ENUM1_AB_SCHEMA, ENUM1_AB_SCHEMA_NAMESPACE),
 
       // String-to/from-bytes, introduced in Avro 1.7.7
       new ReaderWriter(STRING_SCHEMA, BYTES_SCHEMA), new ReaderWriter(BYTES_SCHEMA, STRING_SCHEMA),

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemaCompatibility.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemaCompatibility.java
@@ -39,6 +39,7 @@ import static org.apache.avro.TestSchemas.EMPTY_RECORD1;
 import static org.apache.avro.TestSchemas.EMPTY_UNION_SCHEMA;
 import static org.apache.avro.TestSchemas.ENUM1_ABC_SCHEMA;
 import static org.apache.avro.TestSchemas.ENUM1_AB_SCHEMA;
+import static org.apache.avro.TestSchemas.ENUM1_AB_SCHEMA_DEFAULT;
 import static org.apache.avro.TestSchemas.ENUM1_AB_SCHEMA_NAMESPACE_1;
 import static org.apache.avro.TestSchemas.ENUM1_AB_SCHEMA_NAMESPACE_2;
 import static org.apache.avro.TestSchemas.ENUM1_BC_SCHEMA;
@@ -261,7 +262,7 @@ public class TestSchemaCompatibility {
       new ReaderWriter(INT_MAP_SCHEMA, INT_MAP_SCHEMA), new ReaderWriter(LONG_MAP_SCHEMA, INT_MAP_SCHEMA),
 
       new ReaderWriter(ENUM1_AB_SCHEMA, ENUM1_AB_SCHEMA), new ReaderWriter(ENUM1_ABC_SCHEMA, ENUM1_AB_SCHEMA),
-
+      new ReaderWriter(ENUM1_AB_SCHEMA_DEFAULT, ENUM1_ABC_SCHEMA),
       new ReaderWriter(ENUM1_AB_SCHEMA, ENUM1_AB_SCHEMA_NAMESPACE_1),
       new ReaderWriter(ENUM1_AB_SCHEMA_NAMESPACE_1, ENUM1_AB_SCHEMA),
       new ReaderWriter(ENUM1_AB_SCHEMA_NAMESPACE_1, ENUM1_AB_SCHEMA_NAMESPACE_2),

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemaCompatibility.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemaCompatibility.java
@@ -261,8 +261,6 @@ public class TestSchemaCompatibility {
 
       new ReaderWriter(ENUM1_AB_SCHEMA, ENUM1_AB_SCHEMA), new ReaderWriter(ENUM1_ABC_SCHEMA, ENUM1_AB_SCHEMA),
 
-      new ReaderWriter(ENUM1_AB_SCHEMA, ENUM1_AB_SCHEMA),
-
       new ReaderWriter(ENUM1_AB_SCHEMA, ENUM1_AB_SCHEMA_NAMESPACE),
 
       // String-to/from-bytes, introduced in Avro 1.7.7

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemas.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemas.java
@@ -45,7 +45,8 @@ public class TestSchemas {
   static final Schema STRING_MAP_SCHEMA = Schema.createMap(STRING_SCHEMA);
 
   static final Schema ENUM1_AB_SCHEMA = Schema.createEnum("Enum1", null, null, list("A", "B"));
-  static final Schema ENUM1_AB_SCHEMA_NAMESPACE = Schema.createEnum("Enum1", null, "namespace", list("A", "B"));
+  static final Schema ENUM1_AB_SCHEMA_NAMESPACE_1 = Schema.createEnum("Enum1", null, "namespace1", list("A", "B"));
+  static final Schema ENUM1_AB_SCHEMA_NAMESPACE_2 = Schema.createEnum("Enum1", null, "namespace2", list("A", "B"));
   static final Schema ENUM1_ABC_SCHEMA = Schema.createEnum("Enum1", null, null, list("A", "B", "C"));
   static final Schema ENUM1_BC_SCHEMA = Schema.createEnum("Enum1", null, null, list("B", "C"));
   static final Schema ENUM2_AB_SCHEMA = Schema.createEnum("Enum2", null, null, list("A", "B"));

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemas.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemas.java
@@ -24,7 +24,10 @@ import java.util.Collections;
 
 import org.apache.avro.Schema.Field;
 
-/** Schemas used by other tests in this package. Therefore mostly package protected. */
+/**
+ * Schemas used by other tests in this package. Therefore mostly package
+ * protected.
+ */
 public class TestSchemas {
 
   static final Schema NULL_SCHEMA = Schema.create(Schema.Type.NULL);
@@ -46,8 +49,10 @@ public class TestSchemas {
 
   static final Schema ENUM1_AB_SCHEMA = Schema.createEnum("Enum1", null, null, list("A", "B"));
   static final Schema ENUM1_AB_SCHEMA_DEFAULT = Schema.createEnum("Enum1", null, null, list("A", "B"), "A");
-  public static final Schema ENUM1_AB_SCHEMA_NAMESPACE_1 = Schema.createEnum("Enum1", null, "namespace1", list("A", "B"));
-  public static final Schema ENUM1_AB_SCHEMA_NAMESPACE_2 = Schema.createEnum("Enum1", null, "namespace2", list("A", "B"));
+  public static final Schema ENUM1_AB_SCHEMA_NAMESPACE_1 = Schema.createEnum("Enum1", null, "namespace1",
+      list("A", "B"));
+  public static final Schema ENUM1_AB_SCHEMA_NAMESPACE_2 = Schema.createEnum("Enum1", null, "namespace2",
+      list("A", "B"));
   static final Schema ENUM1_ABC_SCHEMA = Schema.createEnum("Enum1", null, null, list("A", "B", "C"));
   static final Schema ENUM1_BC_SCHEMA = Schema.createEnum("Enum1", null, null, list("B", "C"));
   static final Schema ENUM2_AB_SCHEMA = Schema.createEnum("Enum2", null, null, list("A", "B"));

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemas.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemas.java
@@ -45,6 +45,7 @@ public class TestSchemas {
   static final Schema STRING_MAP_SCHEMA = Schema.createMap(STRING_SCHEMA);
 
   static final Schema ENUM1_AB_SCHEMA = Schema.createEnum("Enum1", null, null, list("A", "B"));
+  static final Schema ENUM1_AB_SCHEMA_DEFAULT = Schema.createEnum("Enum1", null, null, list("A", "B"), "A");
   static final Schema ENUM1_AB_SCHEMA_NAMESPACE_1 = Schema.createEnum("Enum1", null, "namespace1", list("A", "B"));
   static final Schema ENUM1_AB_SCHEMA_NAMESPACE_2 = Schema.createEnum("Enum1", null, "namespace2", list("A", "B"));
   static final Schema ENUM1_ABC_SCHEMA = Schema.createEnum("Enum1", null, null, list("A", "B", "C"));

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemas.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemas.java
@@ -45,6 +45,7 @@ public class TestSchemas {
   static final Schema STRING_MAP_SCHEMA = Schema.createMap(STRING_SCHEMA);
 
   static final Schema ENUM1_AB_SCHEMA = Schema.createEnum("Enum1", null, null, list("A", "B"));
+  static final Schema ENUM1_AB_SCHEMA_NAMESPACE = Schema.createEnum("Enum1", null, "namespace", list("A", "B"));
   static final Schema ENUM1_ABC_SCHEMA = Schema.createEnum("Enum1", null, null, list("A", "B", "C"));
   static final Schema ENUM1_BC_SCHEMA = Schema.createEnum("Enum1", null, null, list("B", "C"));
   static final Schema ENUM2_AB_SCHEMA = Schema.createEnum("Enum2", null, null, list("A", "B"));

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemas.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemas.java
@@ -24,7 +24,7 @@ import java.util.Collections;
 
 import org.apache.avro.Schema.Field;
 
-/** Schemas used by other tests in this package. Therefore package protected. */
+/** Schemas used by other tests in this package. Therefore mostly package protected. */
 public class TestSchemas {
 
   static final Schema NULL_SCHEMA = Schema.create(Schema.Type.NULL);
@@ -46,8 +46,8 @@ public class TestSchemas {
 
   static final Schema ENUM1_AB_SCHEMA = Schema.createEnum("Enum1", null, null, list("A", "B"));
   static final Schema ENUM1_AB_SCHEMA_DEFAULT = Schema.createEnum("Enum1", null, null, list("A", "B"), "A");
-  static final Schema ENUM1_AB_SCHEMA_NAMESPACE_1 = Schema.createEnum("Enum1", null, "namespace1", list("A", "B"));
-  static final Schema ENUM1_AB_SCHEMA_NAMESPACE_2 = Schema.createEnum("Enum1", null, "namespace2", list("A", "B"));
+  public static final Schema ENUM1_AB_SCHEMA_NAMESPACE_1 = Schema.createEnum("Enum1", null, "namespace1", list("A", "B"));
+  public static final Schema ENUM1_AB_SCHEMA_NAMESPACE_2 = Schema.createEnum("Enum1", null, "namespace2", list("A", "B"));
   static final Schema ENUM1_ABC_SCHEMA = Schema.createEnum("Enum1", null, null, list("A", "B", "C"));
   static final Schema ENUM1_BC_SCHEMA = Schema.createEnum("Enum1", null, null, list("B", "C"));
   static final Schema ENUM2_AB_SCHEMA = Schema.createEnum("Enum2", null, null, list("A", "B"));

--- a/lang/java/avro/src/test/java/org/apache/avro/io/parsing/TestResolvingGrammarGenerator.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/io/parsing/TestResolvingGrammarGenerator.java
@@ -43,6 +43,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import static org.apache.avro.TestSchemas.ENUM1_AB_SCHEMA_NAMESPACE_1;
+import static org.apache.avro.TestSchemas.ENUM1_AB_SCHEMA_NAMESPACE_2;
+
 @RunWith(Parameterized.class)
 public class TestResolvingGrammarGenerator {
   private final Schema schema;
@@ -85,13 +88,9 @@ public class TestResolvingGrammarGenerator {
 
   @Test
   public void testDifferingEnumNamespaces() throws Exception {
-    Schema enumSchema1 = SchemaBuilder.builder().enumeration("Enum").namespace("namespace1").symbols("Symbol1",
-        "Symbol2");
-    Schema enumSchema2 = SchemaBuilder.builder().enumeration("Enum").namespace("namespace2").symbols("Symbol1",
-        "Symbol2");
-    Schema schema1 = SchemaBuilder.record("MyRecord").fields().name("field").type(enumSchema1).noDefault().endRecord();
-    Schema schema2 = SchemaBuilder.record("MyRecord").fields().name("field").type(enumSchema2).noDefault().endRecord();
-    GenericData.EnumSymbol genericEnumSymbol = new GenericData.EnumSymbol(enumSchema1, "Symbol1");
+    Schema schema1 = SchemaBuilder.record("MyRecord").fields().name("field").type(ENUM1_AB_SCHEMA_NAMESPACE_1).noDefault().endRecord();
+    Schema schema2 = SchemaBuilder.record("MyRecord").fields().name("field").type(ENUM1_AB_SCHEMA_NAMESPACE_2).noDefault().endRecord();
+    GenericData.EnumSymbol genericEnumSymbol = new GenericData.EnumSymbol(ENUM1_AB_SCHEMA_NAMESPACE_1, "A");
     GenericData.Record record = new GenericRecordBuilder(schema1).set("field", genericEnumSymbol).build();
     byte[] data = writeRecord(schema1, record);
     Assert.assertEquals(genericEnumSymbol, readRecord(schema1, data).get("field"));

--- a/lang/java/avro/src/test/java/org/apache/avro/io/parsing/TestResolvingGrammarGenerator.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/io/parsing/TestResolvingGrammarGenerator.java
@@ -88,8 +88,10 @@ public class TestResolvingGrammarGenerator {
 
   @Test
   public void testDifferingEnumNamespaces() throws Exception {
-    Schema schema1 = SchemaBuilder.record("MyRecord").fields().name("field").type(ENUM1_AB_SCHEMA_NAMESPACE_1).noDefault().endRecord();
-    Schema schema2 = SchemaBuilder.record("MyRecord").fields().name("field").type(ENUM1_AB_SCHEMA_NAMESPACE_2).noDefault().endRecord();
+    Schema schema1 = SchemaBuilder.record("MyRecord").fields().name("field").type(ENUM1_AB_SCHEMA_NAMESPACE_1)
+        .noDefault().endRecord();
+    Schema schema2 = SchemaBuilder.record("MyRecord").fields().name("field").type(ENUM1_AB_SCHEMA_NAMESPACE_2)
+        .noDefault().endRecord();
     GenericData.EnumSymbol genericEnumSymbol = new GenericData.EnumSymbol(ENUM1_AB_SCHEMA_NAMESPACE_1, "A");
     GenericData.Record record = new GenericRecordBuilder(schema1).set("field", genericEnumSymbol).build();
     byte[] data = writeRecord(schema1, record);

--- a/lang/java/avro/src/test/java/org/apache/avro/io/parsing/TestResolvingGrammarGenerator.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/io/parsing/TestResolvingGrammarGenerator.java
@@ -83,6 +83,21 @@ public class TestResolvingGrammarGenerator {
     }
   }
 
+  @Test
+  public void testDifferingEnumNamespaces() throws Exception {
+    Schema enumSchema1 = SchemaBuilder.builder().enumeration("Enum").namespace("namespace1").symbols("Symbol1",
+        "Symbol2");
+    Schema enumSchema2 = SchemaBuilder.builder().enumeration("Enum").namespace("namespace2").symbols("Symbol1",
+        "Symbol2");
+    Schema schema1 = SchemaBuilder.record("MyRecord").fields().name("field").type(enumSchema1).noDefault().endRecord();
+    Schema schema2 = SchemaBuilder.record("MyRecord").fields().name("field").type(enumSchema2).noDefault().endRecord();
+    GenericData.EnumSymbol genericEnumSymbol = new GenericData.EnumSymbol(enumSchema1, "Symbol1");
+    GenericData.Record record = new GenericRecordBuilder(schema1).set("field", genericEnumSymbol).build();
+    byte[] data = writeRecord(schema1, record);
+    Assert.assertEquals(genericEnumSymbol, readRecord(schema1, data).get("field"));
+    Assert.assertEquals(genericEnumSymbol, readRecord(schema2, data).get("field"));
+  }
+
   @Parameterized.Parameters
   public static Collection<Object[]> data() {
     Collection<Object[]> ret = Arrays.asList(new Object[][] {


### PR DESCRIPTION
Hello! This inconsistency between the schema compatibility checks and the resolver has tripped me up a few times, so I'd like to put in a fix for it. I didn't get any comments on my original issue and never got around to bumping it, so hopefully I've not misinterpreted this as a bug - it does seem to me to be an inconsistency with the specification.

(It looks like neither unqualified nor qualified name is used for resolving records, and [this comment](https://github.com/apache/avro/blob/98ee7b0c1fa815271a3da4e033bd4781748b0409/lang/java/avro/src/main/java/org/apache/avro/Resolver.java#L507) explains that it breaks some regression tests. Changing it to compare unqualified name (in line with the specification) would be a breaking change, and so I believe it to be out of the scope of this issue. So this PR only deals with ENUM types and FIXED types.)

I don't believe this issue to be a breaking change, as it will not make the resolver return errors anywhere that it previously didn't.

---

Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issue and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - [Avro-3133: EnumAdjust.resolve should compare unqualified name rather than full name](https://issues.apache.org/jira/browse/AVRO-3133)
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
 - unit test to demonstrate that schema compatibility checks are consistent with the spec in that they use unqualified namespaces for an ENUM
 - unit test to demonstrate that resolver has been fixed to be consistent with the spec, and now uses unqualified namespaces for resolving an ENUM or FIXED

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
 
