### PR TITLE
AVRO-3245 Rust: Replace crc crate with crc32fast

### DIFF
--- a/lang/rust/Cargo.toml
+++ b/lang/rust/Cargo.toml
@@ -29,7 +29,7 @@ categories = ["encoding"]
 documentation = "https://docs.rs/avro-rs"
 
 [features]
-snappy = ["crc", "snap"]
+snappy = ["crc32fast", "snap"]
 zstandard = ["zstd"]
 bzip = ["bzip2"]
 
@@ -53,7 +53,7 @@ harness = false
 [dependencies]
 byteorder = "1.4.3"
 bzip2 = { version = "0.4.3", optional = true }
-crc = { version = "1.8.1", optional = true }
+crc32fast = { version = "1.2.1", optional = true }
 digest = "0.9"
 libflate = "1.1.1"
 num-bigint = "0.4.2"


### PR DESCRIPTION

### Jira

- [X] My PR addresses the following [AVRO-3245](https://issues.apache.org/jira/browse/AVRO-3245) issue

### Tests

- [X] My PR does not need new testing because it replaces one library with another. All old tests still pass! 

### Commits

- [X] My commits all reference Jira issues in their subject lines.

### Documentation

- [X] No new functionality!