### PR TITLE
AVRO-3248 Rust: Support named types in UnionSchema

### DIFF
--- a/lang/rust/src/lib.rs
+++ b/lang/rust/src/lib.rs
@@ -744,7 +744,7 @@ pub use codec::Codec;
 pub use de::from_value;
 pub use decimal::Decimal;
 pub use duration::{Days, Duration, Millis, Months};
-pub use error::{Error, Error as DeError, Error as SerError};
+pub use error::Error;
 pub use reader::{from_avro_datum, Reader};
 pub use schema::Schema;
 pub use ser::to_value;


### PR DESCRIPTION
Drop the index map in UnionSchema. It is not common to have many schemata in the union. Usually it is either "null"+otherType or just a few of otherType. Iterating over a short list is not that slow

### Jira

- [X] My PR addresses the following [AVRO-3248](https://issues.apache.org/jira/browse/AVRO-3248) issue

### Tests

- [X] My PR adds new unit tests

### Commits

- [X] My commits all reference Jira issues in their subject lines.

