### PR TITLE
AVRO-3248: Rust: Support named types in UnionSchema

### DIFF
--- a/lang/rust/examples/generate_interop_data.rs
+++ b/lang/rust/examples/generate_interop_data.rs
@@ -51,7 +51,7 @@ fn create_datum(schema: &Schema) -> Record {
         Value::Record(vec![("label".into(), Value::String("cee".into()))]),
     );
     datum.put("mapField", Value::Map(map));
-    datum.put("unionField", Value::Union(Box::new(Value::Double(12.0))));
+    datum.put("unionField", Value::Union(0, Box::new(Value::Double(12.0))));
     datum.put("enumField", Value::Enum(2, "C".to_owned()));
     datum.put("fixedField", Value::Fixed(16, b"1019181716151413".to_vec()));
     datum.put(

--- a/lang/rust/examples/generate_interop_data.rs
+++ b/lang/rust/examples/generate_interop_data.rs
@@ -51,7 +51,7 @@ fn create_datum(schema: &Schema) -> Record {
         Value::Record(vec![("label".into(), Value::String("cee".into()))]),
     );
     datum.put("mapField", Value::Map(map));
-    datum.put("unionField", Value::Union(0, Box::new(Value::Double(12.0))));
+    datum.put("unionField", Value::Union(1, Box::new(Value::Double(12.0))));
     datum.put("enumField", Value::Enum(2, "C".to_owned()));
     datum.put("fixedField", Value::Fixed(16, b"1019181716151413".to_vec()));
     datum.put(

--- a/lang/rust/src/de.rs
+++ b/lang/rust/src/de.rs
@@ -804,10 +804,13 @@ mod tests {
                 ("type".to_owned(), Value::String("Val1".to_owned())),
                 (
                     "value".to_owned(),
-                    Value::Union(0, Box::new(Value::Record(vec![
-                        ("x".to_owned(), Value::Float(1.0)),
-                        ("y".to_owned(), Value::Float(2.0)),
-                    ]))),
+                    Value::Union(
+                        0,
+                        Box::new(Value::Record(vec![
+                            ("x".to_owned(), Value::Float(1.0)),
+                            ("y".to_owned(), Value::Float(2.0)),
+                        ])),
+                    ),
                 ),
             ]),
         )]);
@@ -830,10 +833,10 @@ mod tests {
                 ("type".to_owned(), Value::String("Val1".to_owned())),
                 (
                     "value".to_owned(),
-                    Value::Union(0, Box::new(Value::Array(vec![
-                        Value::Float(1.0),
-                        Value::Float(2.0),
-                    ]))),
+                    Value::Union(
+                        0,
+                        Box::new(Value::Array(vec![Value::Float(1.0), Value::Float(2.0)])),
+                    ),
                 ),
             ]),
         )]);
@@ -965,75 +968,84 @@ mod tests {
             ),
             (
                 "a_union_string".to_string(),
-                Value::Union(Box::new(Value::String("a union string".to_string()))),
+                Value::Union(0, Box::new(Value::String("a union string".to_string()))),
             ),
             (
                 "a_union_long".to_string(),
-                Value::Union(Box::new(Value::Long(412))),
+                Value::Union(0, Box::new(Value::Long(412))),
             ),
             (
                 "a_union_long".to_string(),
-                Value::Union(Box::new(Value::Long(412))),
+                Value::Union(0, Box::new(Value::Long(412))),
             ),
             (
                 "a_time_micros".to_string(),
-                Value::Union(Box::new(Value::TimeMicros(123))),
+                Value::Union(0, Box::new(Value::TimeMicros(123))),
             ),
             (
                 "a_non_existing_time_micros".to_string(),
-                Value::Union(Box::new(Value::TimeMicros(-123))),
+                Value::Union(0, Box::new(Value::TimeMicros(-123))),
             ),
             (
                 "a_timestamp_millis".to_string(),
-                Value::Union(Box::new(Value::TimestampMillis(234))),
+                Value::Union(0, Box::new(Value::TimestampMillis(234))),
             ),
             (
                 "a_non_existing_timestamp_millis".to_string(),
-                Value::Union(Box::new(Value::TimestampMillis(-234))),
+                Value::Union(0, Box::new(Value::TimestampMillis(-234))),
             ),
             (
                 "a_timestamp_micros".to_string(),
-                Value::Union(Box::new(Value::TimestampMicros(345))),
+                Value::Union(0, Box::new(Value::TimestampMicros(345))),
             ),
             (
                 "a_non_existing_timestamp_micros".to_string(),
-                Value::Union(Box::new(Value::TimestampMicros(-345))),
+                Value::Union(0, Box::new(Value::TimestampMicros(-345))),
             ),
             (
                 "a_record".to_string(),
-                Value::Union(Box::new(Value::Record(vec![(
-                    "record_in_union".to_string(),
-                    Value::Int(-2),
-                )]))),
+                Value::Union(
+                    0,
+                    Box::new(Value::Record(vec![(
+                        "record_in_union".to_string(),
+                        Value::Int(-2),
+                    )])),
+                ),
             ),
             (
                 "a_non_existing_record".to_string(),
-                Value::Union(Box::new(Value::Record(vec![(
-                    "blah".to_string(),
-                    Value::Int(-22),
-                )]))),
+                Value::Union(
+                    0,
+                    Box::new(Value::Record(vec![("blah".to_string(), Value::Int(-22))])),
+                ),
             ),
             (
                 "an_array".to_string(),
-                Value::Union(Box::new(Value::Array(vec![
-                    Value::Boolean(true),
-                    Value::Boolean(false),
-                ]))),
+                Value::Union(
+                    0,
+                    Box::new(Value::Array(vec![
+                        Value::Boolean(true),
+                        Value::Boolean(false),
+                    ])),
+                ),
             ),
             (
                 "a_non_existing_array".to_string(),
-                Value::Union(Box::new(Value::Array(vec![
-                    Value::Boolean(false),
-                    Value::Boolean(true),
-                ]))),
+                Value::Union(
+                    0,
+                    Box::new(Value::Array(vec![
+                        Value::Boolean(false),
+                        Value::Boolean(true),
+                    ])),
+                ),
             ),
             (
                 "a_union_map".to_string(),
-                Value::Union(Box::new(Value::Map(value_map))),
+                Value::Union(0, Box::new(Value::Map(value_map))),
             ),
             (
                 "a_non_existing_union_map".to_string(),
-                Value::Union(Box::new(Value::Map(HashMap::new()))),
+                Value::Union(0, Box::new(Value::Map(HashMap::new()))),
             ),
         ]);
 

--- a/lang/rust/src/de.rs
+++ b/lang/rust/src/de.rs
@@ -162,7 +162,7 @@ impl<'de> de::EnumAccess<'de> for EnumDeserializer<'de> {
         self.input.first().map_or(
             Err(de::Error::custom("A record must have a least one field")),
             |item| match (item.0.as_ref(), &item.1) {
-                ("type", Value::String(x)) => Ok((
+                ("type", Value::String(x)) | ("type", Value::Enum(_, x)) => Ok((
                     seed.deserialize(StringDeserializer {
                         input: x.to_owned(),
                     })?,
@@ -173,7 +173,7 @@ impl<'de> de::EnumAccess<'de> for EnumDeserializer<'de> {
                     field
                 ))),
                 (_, _) => Err(de::Error::custom(
-                    "Expected first field of type String for the type name".to_string(),
+                    "Expected first field of type String or Enum for the type name".to_string(),
                 )),
             },
         )
@@ -250,7 +250,7 @@ impl<'a, 'de> de::Deserializer<'de> for &'a Deserializer<'de> {
             | Value::TimestampMicros(i) => visitor.visit_i64(*i),
             &Value::Float(f) => visitor.visit_f32(f),
             &Value::Double(d) => visitor.visit_f64(d),
-            Value::Union(u) => match **u {
+            Value::Union(_i, u) => match **u {
                 Value::Null => visitor.visit_unit(),
                 Value::Boolean(b) => visitor.visit_bool(b),
                 Value::Int(i) => visitor.visit_i32(i),
@@ -316,7 +316,7 @@ impl<'a, 'de> de::Deserializer<'de> for &'a Deserializer<'de> {
                     .map_err(|e| de::Error::custom(e.to_string()))
                     .and_then(|s| visitor.visit_string(s))
             }
-            Value::Union(ref x) => match **x {
+            Value::Union(_i, ref x) => match **x {
                 Value::String(ref s) => visitor.visit_string(s.to_owned()),
                 _ => Err(de::Error::custom("not a string|bytes|fixed")),
             },
@@ -354,8 +354,8 @@ impl<'a, 'de> de::Deserializer<'de> for &'a Deserializer<'de> {
         V: Visitor<'de>,
     {
         match *self.input {
-            Value::Union(ref inner) if inner.as_ref() == &Value::Null => visitor.visit_none(),
-            Value::Union(ref inner) => visitor.visit_some(&Deserializer::new(inner)),
+            Value::Union(_i, ref inner) if inner.as_ref() == &Value::Null => visitor.visit_none(),
+            Value::Union(_i, ref inner) => visitor.visit_some(&Deserializer::new(inner)),
             _ => Err(de::Error::custom("not a union")),
         }
     }
@@ -398,7 +398,7 @@ impl<'a, 'de> de::Deserializer<'de> for &'a Deserializer<'de> {
     {
         match *self.input {
             Value::Array(ref items) => visitor.visit_seq(SeqDeserializer::new(items)),
-            Value::Union(ref inner) => match **inner {
+            Value::Union(_i, ref inner) => match **inner {
                 Value::Array(ref items) => visitor.visit_seq(SeqDeserializer::new(items)),
                 _ => Err(de::Error::custom("not an array")),
             },
@@ -446,7 +446,7 @@ impl<'a, 'de> de::Deserializer<'de> for &'a Deserializer<'de> {
     {
         match *self.input {
             Value::Record(ref fields) => visitor.visit_map(StructDeserializer::new(fields)),
-            Value::Union(ref inner) => match **inner {
+            Value::Union(_i, ref inner) => match **inner {
                 Value::Record(ref fields) => visitor.visit_map(StructDeserializer::new(fields)),
                 _ => Err(de::Error::custom("not a record")),
             },
@@ -781,7 +781,7 @@ mod tests {
                 ("type".to_owned(), Value::String("Double".to_owned())),
                 (
                     "value".to_owned(),
-                    Value::Union(Box::new(Value::Double(64.0))),
+                    Value::Union(1, Box::new(Value::Double(64.0))),
                 ),
             ]),
         )]);
@@ -804,7 +804,7 @@ mod tests {
                 ("type".to_owned(), Value::String("Val1".to_owned())),
                 (
                     "value".to_owned(),
-                    Value::Union(Box::new(Value::Record(vec![
+                    Value::Union(0, Box::new(Value::Record(vec![
                         ("x".to_owned(), Value::Float(1.0)),
                         ("y".to_owned(), Value::Float(2.0)),
                     ]))),
@@ -830,7 +830,7 @@ mod tests {
                 ("type".to_owned(), Value::String("Val1".to_owned())),
                 (
                     "value".to_owned(),
-                    Value::Union(Box::new(Value::Array(vec![
+                    Value::Union(0, Box::new(Value::Array(vec![
                         Value::Float(1.0),
                         Value::Float(2.0),
                     ]))),

--- a/lang/rust/src/decode.rs
+++ b/lang/rust/src/decode.rs
@@ -202,31 +202,18 @@ pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> AvroResult<Value> {
 
                 Ok(Value::Map(items))
             }
-            Schema::Union(ref inner) => match zag_i64(reader) {
-                Ok(index) => {
-                    let variants = inner.variants();
-                    let variant = variants
-                        .get(
-                            usize::try_from(index)
-                                .map_err(|e| Error::ConvertI64ToUsize(e, index))?,
-                        )
-                        .ok_or_else(|| Error::GetUnionVariant {
-                            index,
-                            num_variants: variants.len(),
-                        })?;
-                    let value = decode0(variant, reader, schemas_by_name)?;
-                    Ok(Value::Union(Box::new(value)))
-                }
-                Err(Error::ReadVariableIntegerBytes(io_err)) => {
-                    if let ErrorKind::UnexpectedEof = io_err.kind() {
-                        Ok(Value::Union(Box::new(Value::Null)))
-                    } else {
-                        Err(Error::ReadVariableIntegerBytes(io_err))
-                    }
-                }
-                Err(io_err) => Err(io_err),
-            },
-
+            Schema::Union(ref inner) => {
+                let index = zag_i64(reader)?;
+                let variants = inner.variants();
+                let variant = variants
+                    .get(usize::try_from(index).map_err(|e| Error::ConvertI64ToUsize(e, index))?)
+                    .ok_or_else(|| Error::GetUnionVariant {
+                        index,
+                        num_variants: variants.len(),
+                    })?;
+                let value = decode(variant, reader)?;
+                Ok(Value::Union(index as i32, Box::new(value)))
+            }
             Schema::Record {
                 ref name,
                 ref fields,

--- a/lang/rust/src/decode.rs
+++ b/lang/rust/src/decode.rs
@@ -206,7 +206,10 @@ pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> AvroResult<Value> {
                 Ok(index) => {
                     let variants = inner.variants();
                     let variant = variants
-                        .get(usize::try_from(index).map_err(|e| Error::ConvertI64ToUsize(e, index))?)
+                        .get(
+                            usize::try_from(index)
+                                .map_err(|e| Error::ConvertI64ToUsize(e, index))?,
+                        )
                         .ok_or_else(|| Error::GetUnionVariant {
                             index,
                             num_variants: variants.len(),
@@ -222,7 +225,7 @@ pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> AvroResult<Value> {
                     }
                 }
                 Err(io_err) => Err(io_err),
-            }
+            },
             Schema::Record {
                 ref name,
                 ref fields,

--- a/lang/rust/src/decode.rs
+++ b/lang/rust/src/decode.rs
@@ -214,7 +214,7 @@ pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> AvroResult<Value> {
                             index,
                             num_variants: variants.len(),
                         })?;
-                    let value = decode(variant, reader)?;
+                    let value = decode0(variant, reader, schemas_by_name)?;
                     Ok(Value::Union(index as i32, Box::new(value)))
                 }
                 Err(Error::ReadVariableIntegerBytes(io_err)) => {

--- a/lang/rust/src/encode.rs
+++ b/lang/rust/src/encode.rs
@@ -126,16 +126,14 @@ pub fn encode_ref(value: &Value, schema: &Schema, buffer: &mut Vec<u8>) {
             Value::Enum(i, _) => encode_int(*i, buffer),
             Value::Union(i, item) => {
                 if let Schema::Union(ref inner) = *schema {
-                    // Find the schema that is matched here. Due to validation, this should always
-                    // return a value.
                     let inner_schema = inner
                         .schemas
                         .get(*i as usize)
                         .expect("Invalid Union validation occurred");
-                    encode_long(idx as i64, buffer);
-                    encode_ref0(&*item, inner_schema, buffer, schemas_by_name);
+                    encode_long(*i as i64, buffer);
+                    encode_ref(&*item, inner_schema, buffer);
                 } else {
-                    error!("invalid schema type for Union: {:?}", schema);
+                    error!("invalid schema type for Array: {:?}", schema);
                 }
             }
             Value::Array(items) => {

--- a/lang/rust/src/encode.rs
+++ b/lang/rust/src/encode.rs
@@ -124,12 +124,13 @@ pub fn encode_ref(value: &Value, schema: &Schema, buffer: &mut Vec<u8>) {
             },
             Value::Fixed(_, bytes) => buffer.extend(bytes),
             Value::Enum(i, _) => encode_int(*i, buffer),
-            Value::Union(item) => {
+            Value::Union(i, item) => {
                 if let Schema::Union(ref inner) = *schema {
                     // Find the schema that is matched here. Due to validation, this should always
                     // return a value.
-                    let (idx, inner_schema) = inner
-                        .find_schema(item)
+                    let inner_schema = inner
+                        .schemas
+                        .get(*i as usize)
                         .expect("Invalid Union validation occurred");
                     encode_long(idx as i64, buffer);
                     encode_ref0(&*item, inner_schema, buffer, schemas_by_name);

--- a/lang/rust/src/encode.rs
+++ b/lang/rust/src/encode.rs
@@ -124,16 +124,16 @@ pub fn encode_ref(value: &Value, schema: &Schema, buffer: &mut Vec<u8>) {
             },
             Value::Fixed(_, bytes) => buffer.extend(bytes),
             Value::Enum(i, _) => encode_int(*i, buffer),
-            Value::Union(i, item) => {
+            Value::Union(idx, item) => {
                 if let Schema::Union(ref inner) = *schema {
                     let inner_schema = inner
                         .schemas
-                        .get(*i as usize)
+                        .get(*idx as usize)
                         .expect("Invalid Union validation occurred");
-                    encode_long(*i as i64, buffer);
-                    encode_ref(&*item, inner_schema, buffer);
+                    encode_long(*idx as i64, buffer);
+                    encode_ref0(&*item, inner_schema, buffer, schemas_by_name);
                 } else {
-                    error!("invalid schema type for Array: {:?}", schema);
+                    error!("invalid schema type for Union: {:?}", schema);
                 }
             }
             Value::Array(items) => {

--- a/lang/rust/src/reader.rs
+++ b/lang/rust/src/reader.rs
@@ -432,7 +432,7 @@ mod tests {
 
         assert_eq!(
             from_avro_datum(&schema, &mut encoded, None).unwrap(),
-            Value::Union(Box::new(Value::Long(0)))
+            Value::Union(1, Box::new(Value::Long(0)))
         );
     }
 

--- a/lang/rust/src/schema.rs
+++ b/lang/rust/src/schema.rs
@@ -1385,7 +1385,7 @@ mod tests {
     fn test_nullable_record() {
         use std::iter::FromIterator;
 
-        let schema_str_1 = r#"{
+        let schema_str_a = r#"{
             "name": "A",
             "type": "record",
             "fields": [
@@ -1394,7 +1394,7 @@ mod tests {
         }"#;
 
         // we get Error::GetNameField if we put ["null", "B"] directly here.
-        let schema_str_2 = r#"{
+        let schema_str_option_a = r#"{
             "name": "OptionA",
             "type": "record",
             "fields": [
@@ -1402,9 +1402,9 @@ mod tests {
             ]
         }"#;
 
-        let schema_a = Schema::parse_str(schema_str_1).unwrap();
+        let schema_a = Schema::parse_str(schema_str_a).unwrap();
 
-        let schema_option_a = Schema::parse_list(&[schema_str_1, schema_str_2])
+        let schema_option_a = Schema::parse_list(&[schema_str_a, schema_str_option_a])
             .unwrap()
             .last()
             .unwrap()

--- a/lang/rust/src/schema.rs
+++ b/lang/rust/src/schema.rs
@@ -1328,7 +1328,7 @@ mod tests {
         use std::iter::FromIterator;
 
         // A and B are the same except the name.
-        let schema_str_1 = r#"{
+        let schema_str_a = r#"{
             "name": "A",
             "type": "record",
             "fields": [
@@ -1336,7 +1336,7 @@ mod tests {
             ]
         }"#;
 
-        let schema_str_2 = r#"{
+        let schema_str_b = r#"{
             "name": "B",
             "type": "record",
             "fields": [
@@ -1345,7 +1345,7 @@ mod tests {
         }"#;
 
         // we get Error::GetNameField if we put ["A", "B"] directly here.
-        let schema_str_3 = r#"{
+        let schema_str_c = r#"{
             "name": "C",
             "type": "record",
             "fields": [
@@ -1353,10 +1353,10 @@ mod tests {
             ]
         }"#;
 
-        let schema_a = Schema::parse_str(schema_str_1).unwrap();
-        let schema_b = Schema::parse_str(schema_str_2).unwrap();
+        let schema_a = Schema::parse_str(schema_str_a).unwrap();
+        let schema_b = Schema::parse_str(schema_str_b).unwrap();
 
-        let schema_c = Schema::parse_list(&[schema_str_1, schema_str_2, schema_str_3])
+        let schema_c = Schema::parse_list(&[schema_str_a, schema_str_b, schema_str_c])
             .unwrap()
             .last()
             .unwrap()

--- a/lang/rust/src/schema.rs
+++ b/lang/rust/src/schema.rs
@@ -173,6 +173,13 @@ impl SchemaKind {
                 | SchemaKind::String,
         )
     }
+
+    pub fn is_named(self) -> bool {
+        matches!(
+            self,
+            SchemaKind::Record | SchemaKind::Enum | SchemaKind::Fixed
+        )
+    }
 }
 
 impl<'a> From<&'a types::Value> for SchemaKind {
@@ -189,7 +196,7 @@ impl<'a> From<&'a types::Value> for SchemaKind {
             Value::String(_) => Self::String,
             Value::Array(_) => Self::Array,
             Value::Map(_) => Self::Map,
-            Value::Union(_) => Self::Union,
+            Value::Union(_, _) => Self::Union,
             Value::Record(_) => Self::Record,
             Value::Enum(_, _) => Self::Enum,
             Value::Fixed(_, _) => Self::Fixed,
@@ -362,7 +369,7 @@ impl UnionSchema {
                 return Err(Error::GetNestedUnion);
             }
             let kind = SchemaKind::from(schema);
-            if vindex.insert(kind, i).is_some() {
+            if !kind.is_named() && vindex.insert(kind, i).is_some() {
                 return Err(Error::GetUnionDuplicate);
             }
         }
@@ -390,7 +397,7 @@ impl UnionSchema {
             // fast path
             Some((i, &self.schemas[i]))
         } else {
-            // slow path (required for matching logical types)
+            // slow path (required for matching logical or named types)
             self.schemas
                 .iter()
                 .enumerate()
@@ -1313,6 +1320,113 @@ mod tests {
             SchemaKind::Bytes
         );
         assert_eq!(variants.next(), None);
+    }
+
+
+    #[test]
+    fn test_union_of_records() {
+        use std::iter::FromIterator;
+
+        // A and B are the same except the name.
+        let schema_str_1 = r#"{
+            "name": "A",
+            "type": "record",
+            "fields": [
+                {"name": "field_one", "type": "float"}
+            ]
+        }"#;
+
+        let schema_str_2 = r#"{
+            "name": "B",
+            "type": "record",
+            "fields": [
+                {"name": "field_one", "type": "float"}
+            ]
+        }"#;
+
+        // we get Error::GetNameField if we put ["A", "B"] directly here.
+        let schema_str_3 = r#"{
+            "name": "C",
+            "type": "record",
+            "fields": [
+                {"name": "field_one",  "type": ["A", "B"]}
+            ]
+        }"#;
+
+        let schema_a = Schema::parse_str(schema_str_1).unwrap();
+        let schema_b = Schema::parse_str(schema_str_2).unwrap();
+
+        let schema_c = Schema::parse_list(&[schema_str_1, schema_str_2, schema_str_3])
+            .unwrap()
+            .last()
+            .unwrap()
+            .clone();
+
+        let schema_c_expected = Schema::Record {
+            name: Name::new("C"),
+            doc: None,
+            fields: vec![
+                RecordField {
+                    name: "field_one".to_string(),
+                    doc: None,
+                    default: None,
+                    schema: Schema::Union(UnionSchema::new(vec![schema_a, schema_b]).unwrap()),
+                    order: RecordFieldOrder::Ignore,
+                    position: 0,
+                },
+            ],
+            lookup: HashMap::from_iter(vec![("field_one".to_string(), 0)]),
+        };
+
+        assert_eq!(schema_c, schema_c_expected);
+    }
+
+    #[test]
+    fn test_nullable_record() {
+        use std::iter::FromIterator;
+
+        let schema_str_1 = r#"{
+            "name": "A",
+            "type": "record",
+            "fields": [
+                {"name": "field_one", "type": "float"}
+            ]
+        }"#;
+
+        // we get Error::GetNameField if we put ["null", "B"] directly here.
+        let schema_str_2 = r#"{
+            "name": "OptionA",
+            "type": "record",
+            "fields": [
+                {"name": "field_one",  "type": ["null", "A"], "default": "null"}
+            ]
+        }"#;
+
+        let schema_a = Schema::parse_str(schema_str_1).unwrap();
+
+        let schema_option_a = Schema::parse_list(&[schema_str_1, schema_str_2])
+            .unwrap()
+            .last()
+            .unwrap()
+            .clone();
+
+        let schema_option_a_expected = Schema::Record {
+            name: Name::new("OptionA"),
+            doc: None,
+            fields: vec![
+                RecordField {
+                    name: "field_one".to_string(),
+                    doc: None,
+                    default: Some(Value::Null),
+                    schema: Schema::Union(UnionSchema::new(vec![Schema::Null, schema_a]).unwrap()),
+                    order: RecordFieldOrder::Ignore,
+                    position: 0,
+                },
+            ],
+            lookup: HashMap::from_iter(vec![("field_one".to_string(), 0)]),
+        };
+
+        assert_eq!(schema_option_a, schema_option_a_expected);
     }
 
     #[test]

--- a/lang/rust/src/schema.rs
+++ b/lang/rust/src/schema.rs
@@ -1322,7 +1322,6 @@ mod tests {
         assert_eq!(variants.next(), None);
     }
 
-
     #[test]
     fn test_union_of_records() {
         use std::iter::FromIterator;
@@ -1365,16 +1364,14 @@ mod tests {
         let schema_c_expected = Schema::Record {
             name: Name::new("C"),
             doc: None,
-            fields: vec![
-                RecordField {
-                    name: "field_one".to_string(),
-                    doc: None,
-                    default: None,
-                    schema: Schema::Union(UnionSchema::new(vec![schema_a, schema_b]).unwrap()),
-                    order: RecordFieldOrder::Ignore,
-                    position: 0,
-                },
-            ],
+            fields: vec![RecordField {
+                name: "field_one".to_string(),
+                doc: None,
+                default: None,
+                schema: Schema::Union(UnionSchema::new(vec![schema_a, schema_b]).unwrap()),
+                order: RecordFieldOrder::Ignore,
+                position: 0,
+            }],
             lookup: HashMap::from_iter(vec![("field_one".to_string(), 0)]),
         };
 
@@ -1413,16 +1410,14 @@ mod tests {
         let schema_option_a_expected = Schema::Record {
             name: Name::new("OptionA"),
             doc: None,
-            fields: vec![
-                RecordField {
-                    name: "field_one".to_string(),
-                    doc: None,
-                    default: Some(Value::Null),
-                    schema: Schema::Union(UnionSchema::new(vec![Schema::Null, schema_a]).unwrap()),
-                    order: RecordFieldOrder::Ignore,
-                    position: 0,
-                },
-            ],
+            fields: vec![RecordField {
+                name: "field_one".to_string(),
+                doc: None,
+                default: Some(Value::Null),
+                schema: Schema::Union(UnionSchema::new(vec![Schema::Null, schema_a]).unwrap()),
+                order: RecordFieldOrder::Ignore,
+                position: 0,
+            }],
             lookup: HashMap::from_iter(vec![("field_one".to_string(), 0)]),
         };
 

--- a/lang/rust/src/schema.rs
+++ b/lang/rust/src/schema.rs
@@ -392,8 +392,8 @@ impl UnionSchema {
     /// Optionally returns a reference to the schema matched by this value, as well as its position
     /// within this union.
     pub fn find_schema(&self, value: &types::Value) -> Option<(usize, &Schema)> {
-        let type_index = &SchemaKind::from(value);
-        if let Some(&i) = self.variant_index.get(type_index) {
+        let schema_kind = SchemaKind::from(value);
+        if let Some(&i) = self.variant_index.get(&schema_kind) {
             // fast path
             Some((i, &self.schemas[i]))
         } else {
@@ -1322,6 +1322,7 @@ mod tests {
         assert_eq!(variants.next(), None);
     }
 
+    // AVRO-3248
     #[test]
     fn test_union_of_records() {
         use std::iter::FromIterator;
@@ -1378,6 +1379,7 @@ mod tests {
         assert_eq!(schema_c, schema_c_expected);
     }
 
+    // AVRO-3248
     #[test]
     fn test_nullable_record() {
         use std::iter::FromIterator;

--- a/lang/rust/src/ser.rs
+++ b/lang/rust/src/ser.rs
@@ -234,7 +234,7 @@ impl<'b> ser::Serializer for &'b mut Serializer {
             ),
             (
                 "value".to_owned(),
-                Value::Union(Box::new(value.serialize(self)?)),
+                Value::Union(index as i32, Box::new(value.serialize(self)?)),
             ),
         ]))
     }
@@ -346,9 +346,10 @@ impl<'a> ser::SerializeSeq for SeqVariantSerializer<'a> {
     where
         T: Serialize,
     {
-        self.items.push(Value::Union(Box::new(
-            value.serialize(&mut Serializer::default())?,
-        )));
+        self.items.push(Value::Union(
+            self.index as i32,
+            Box::new(value.serialize(&mut Serializer::default())?),
+        ));
         Ok(())
     }
 
@@ -469,7 +470,7 @@ impl<'a> ser::SerializeStructVariant for StructVariantSerializer<'a> {
             ),
             (
                 "value".to_owned(),
-                Value::Union(Box::new(Value::Record(self.fields))),
+                Value::Union(self.index as i32, Box::new(Value::Record(self.fields))),
             ),
         ]))
     }
@@ -776,7 +777,7 @@ mod tests {
                 ("type".to_owned(), Value::Enum(0, "Double".to_owned())),
                 (
                     "value".to_owned(),
-                    Value::Union(Box::new(Value::Double(64.0))),
+                    Value::Union(0, Box::new(Value::Double(64.0))),
                 ),
             ]),
         )]);
@@ -836,10 +837,13 @@ mod tests {
                 ("type".to_owned(), Value::Enum(0, "Val1".to_owned())),
                 (
                     "value".to_owned(),
-                    Value::Union(Box::new(Value::Record(vec![
-                        ("x".to_owned(), Value::Float(1.0)),
-                        ("y".to_owned(), Value::Float(2.0)),
-                    ]))),
+                    Value::Union(
+                        0,
+                        Box::new(Value::Record(vec![
+                            ("x".to_owned(), Value::Float(1.0)),
+                            ("y".to_owned(), Value::Float(2.0)),
+                        ])),
+                    ),
                 ),
             ]),
         )]);
@@ -946,9 +950,9 @@ mod tests {
                 (
                     "value".to_owned(),
                     Value::Array(vec![
-                        Value::Union(Box::new(Value::Float(1.0))),
-                        Value::Union(Box::new(Value::Float(2.0))),
-                        Value::Union(Box::new(Value::Float(3.0))),
+                        Value::Union(1, Box::new(Value::Float(1.0))),
+                        Value::Union(1, Box::new(Value::Float(2.0))),
+                        Value::Union(1, Box::new(Value::Float(3.0))),
                     ]),
                 ),
             ]),

--- a/lang/rust/src/types.rs
+++ b/lang/rust/src/types.rs
@@ -66,7 +66,12 @@ pub enum Value {
     /// reading values.
     Enum(i32, String),
     /// An `union` Avro value.
-    Union(Box<Value>),
+    ///
+    /// A Union is represented by the value it holds and its position in the type list
+    /// of its corresponding schema
+    /// This allows schema-less encoding, as well as schema resolution while
+    /// reading values.
+    Union(i32, Box<Value>),
     /// An `array` Avro value.
     Array(Vec<Value>),
     /// A `map` Avro value.
@@ -168,7 +173,11 @@ where
     T: Into<Self>,
 {
     fn from(value: Option<T>) -> Self {
-        Self::Union(Box::new(value.map_or_else(|| Self::Null, Into::into)))
+        // NOTE: this is incorrect in case first type in union is not "none"
+        Self::Union(
+            value.is_some() as i32,
+            Box::new(value.map_or_else(|| Self::Null, Into::into)),
+        )
     }
 }
 
@@ -285,7 +294,7 @@ impl std::convert::TryFrom<Value> for JsonValue {
                 Ok(Self::Array(items.into_iter().map(|v| v.into()).collect()))
             }
             Value::Enum(_i, s) => Ok(Self::String(s)),
-            Value::Union(b) => Self::try_from(*b),
+            Value::Union(_i, b) => Self::try_from(*b),
             Value::Array(items) => items
                 .into_iter()
                 .map(Self::try_from)
@@ -358,9 +367,11 @@ impl Value {
                 .map(|ref symbol| symbol == &s)
                 .unwrap_or(false),
             // (&Value::Union(None), &Schema::Union(_)) => true,
-            (&Value::Union(ref value), &Schema::Union(ref inner)) => {
-                inner.find_schema(value).is_some()
-            }
+            (&Value::Union(i, ref value), &Schema::Union(ref inner)) => inner
+                .variants()
+                .get(i as usize)
+                .map(|schema| value.validate(schema))
+                .unwrap_or(false),
             (&Value::Array(ref items), &Schema::Array(ref inner)) => {
                 items.iter().all(|item| item.validate(inner))
             }
@@ -409,7 +420,7 @@ impl Value {
             {
                 // Pull out the Union, and attempt to resolve against it.
                 let v = match value {
-                    Value::Union(b) => &**b,
+                    Value::Union(_i, b) => &**b,
                     _ => unreachable!(),
                 };
                 *value = v.clone();
@@ -703,13 +714,14 @@ impl Value {
     fn resolve_union(self, schema: &UnionSchema) -> Result<Self, Error> {
         let v = match self {
             // Both are unions case.
-            Value::Union(v) => *v,
+            Value::Union(_i, v) => *v,
             // Reader is a union, but writer is not.
             v => v,
         };
         // Find the first match in the reader schema.
-        let (_, inner) = schema.find_schema(&v).ok_or(Error::FindUnionVariant)?;
-        Ok(Value::Union(Box::new(v.resolve(inner)?)))
+        // FIXME: this is wrong when the union consists of multiple same records that have different names
+        let (i, inner) = schema.find_schema(&v).ok_or(Error::FindUnionVariant)?;
+        Ok(Value::Union(i as i32, Box::new(v.resolve(inner)?)))
     }
 
     fn resolve_array(self, schema: &Schema) -> Result<Self, Error> {
@@ -770,10 +782,11 @@ impl Value {
                                 // NOTE: this match exists only to optimize null defaults for large
                                 // backward-compatible schemas with many nullable fields
                                 match first {
-                                    Schema::Null => Value::Union(Box::new(Value::Null)),
-                                    _ => Value::Union(Box::new(
-                                        Value::from(value.clone()).resolve(first)?,
-                                    )),
+                                    Schema::Null => Value::Union(0, Box::new(Value::Null)),
+                                    _ => Value::Union(
+                                        0,
+                                        Box::new(Value::from(value.clone()).resolve(first)?),
+                                    ),
                                 }
                             }
                             _ => Value::from(value.clone()),
@@ -821,22 +834,22 @@ mod tests {
             (Value::Int(42), Schema::Int, true),
             (Value::Int(42), Schema::Boolean, false),
             (
-                Value::Union(Box::new(Value::Null)),
+                Value::Union(0, Box::new(Value::Null)),
                 Schema::Union(UnionSchema::new(vec![Schema::Null, Schema::Int]).unwrap()),
                 true,
             ),
             (
-                Value::Union(Box::new(Value::Int(42))),
+                Value::Union(1, Box::new(Value::Int(42))),
                 Schema::Union(UnionSchema::new(vec![Schema::Null, Schema::Int]).unwrap()),
                 true,
             ),
             (
-                Value::Union(Box::new(Value::Null)),
+                Value::Union(0, Box::new(Value::Null)),
                 Schema::Union(UnionSchema::new(vec![Schema::Double, Schema::Int]).unwrap()),
                 false,
             ),
             (
-                Value::Union(Box::new(Value::Int(42))),
+                Value::Union(3, Box::new(Value::Int(42))),
                 Schema::Union(
                     UnionSchema::new(vec![
                         Schema::Null,
@@ -849,7 +862,7 @@ mod tests {
                 true,
             ),
             (
-                Value::Union(Box::new(Value::Long(42i64))),
+                Value::Union(1, Box::new(Value::Long(42i64))),
                 Schema::Union(
                     UnionSchema::new(vec![Schema::Null, Schema::TimestampMillis]).unwrap(),
                 ),
@@ -997,20 +1010,26 @@ mod tests {
 
         let union_schema = Schema::Union(UnionSchema::new(vec![Schema::Null, schema]).unwrap());
 
-        assert!(Value::Union(Box::new(Value::Record(vec![
-            ("a".to_string(), Value::Long(42i64)),
-            ("b".to_string(), Value::String("foo".to_string())),
-        ])))
-        .validate(&union_schema));
-
-        assert!(Value::Union(Box::new(Value::Map(
-            vec![
+        assert!(Value::Union(
+            1,
+            Box::new(Value::Record(vec![
                 ("a".to_string(), Value::Long(42i64)),
                 ("b".to_string(), Value::String("foo".to_string())),
-            ]
-            .into_iter()
-            .collect()
-        )))
+            ]))
+        )
+        .validate(&union_schema));
+
+        assert!(Value::Union(
+            1,
+            Box::new(Value::Map(
+                vec![
+                    ("a".to_string(), Value::Long(42i64)),
+                    ("b".to_string(), Value::String("foo".to_string())),
+                ]
+                .into_iter()
+                .collect()
+            ))
+        )
         .validate(&union_schema));
     }
 
@@ -1193,7 +1212,8 @@ mod tests {
             JsonValue::String("test_enum".into())
         );
         assert_eq!(
-            JsonValue::try_from(Value::Union(Box::new(Value::String("test_enum".into())))).unwrap(),
+            JsonValue::try_from(Value::Union(1, Box::new(Value::String("test_enum".into()))))
+                .unwrap(),
             JsonValue::String("test_enum".into())
         );
         assert_eq!(

--- a/lang/rust/src/types.rs
+++ b/lang/rust/src/types.rs
@@ -173,7 +173,7 @@ where
     T: Into<Self>,
 {
     fn from(value: Option<T>) -> Self {
-        // NOTE: this is incorrect in case first type in union is not "none"
+        // FIXME: this is incorrect in case first type in union is not "none"
         Self::Union(
             value.is_some() as i32,
             Box::new(value.map_or_else(|| Self::Null, Into::into)),
@@ -719,7 +719,7 @@ impl Value {
             v => v,
         };
         // Find the first match in the reader schema.
-        // FIXME: this is wrong when the union consists of multiple same records that have different names
+        // FIXME: this might be wrong when the union consists of multiple same records that have different names
         let (i, inner) = schema.find_schema(&v).ok_or(Error::FindUnionVariant)?;
         Ok(Value::Union(i as i32, Box::new(v.resolve(inner)?)))
     }

--- a/lang/rust/src/writer.rs
+++ b/lang/rust/src/writer.rs
@@ -398,7 +398,7 @@ mod tests {
     #[test]
     fn test_union_not_null() {
         let schema = Schema::parse_str(UNION_SCHEMA).unwrap();
-        let union = Value::Union(Box::new(Value::Long(3)));
+        let union = Value::Union(1, Box::new(Value::Long(3)));
 
         let mut expected = Vec::new();
         zig_i64(1, &mut expected);
@@ -410,7 +410,7 @@ mod tests {
     #[test]
     fn test_union_null() {
         let schema = Schema::parse_str(UNION_SCHEMA).unwrap();
-        let union = Value::Union(Box::new(Value::Null));
+        let union = Value::Union(0, Box::new(Value::Null));
 
         let mut expected = Vec::new();
         zig_i64(0, &mut expected);
@@ -781,11 +781,11 @@ mod tests {
         let mut record1 = Record::new(&schema).unwrap();
         record1.put(
             "a",
-            Value::Union(Box::new(Value::TimestampMicros(1234_i64))),
+            Value::Union(1, Box::new(Value::TimestampMicros(1234_i64))),
         );
 
         let mut record2 = Record::new(&schema).unwrap();
-        record2.put("a", Value::Union(Box::new(Value::Null)));
+        record2.put("a", Value::Union(0, Box::new(Value::Null)));
 
         let n1 = writer.append(record1).unwrap();
         let n2 = writer.append(record2).unwrap();

--- a/lang/rust/tests/io.rs
+++ b/lang/rust/tests/io.rs
@@ -65,7 +65,7 @@ lazy_static! {
         (r#"{"type": "enum", "name": "F", "symbols": ["FOO", "BAR"]}"#, r#""FOO""#, Value::Enum(0, "FOO".to_string())),
         (r#"{"type": "array", "items": "int"}"#, "[1, 2, 3]", Value::Array(vec![Value::Int(1), Value::Int(2), Value::Int(3)])),
         (r#"{"type": "map", "values": "int"}"#, r#"{"a": 1, "b": 2}"#, Value::Map([("a".to_string(), Value::Int(1)), ("b".to_string(), Value::Int(2))].iter().cloned().collect())),
-        (r#"["int", "null"]"#, "5", Value::Union(0, Box::new(Value::Int(5)))), 
+        (r#"["int", "null"]"#, "5", Value::Union(0, Box::new(Value::Int(5)))),
         (r#"{"type": "record", "name": "F", "fields": [{"name": "A", "type": "int"}]}"#, r#"{"A": 5}"#,Value::Record(vec![("A".to_string(), Value::Int(5))])),
         (r#"["null", "int"]"#, "null", Value::Union(0, Box::new(Value::Null))),
     ];

--- a/lang/rust/tests/io.rs
+++ b/lang/rust/tests/io.rs
@@ -65,7 +65,8 @@ lazy_static! {
         (r#"{"type": "enum", "name": "F", "symbols": ["FOO", "BAR"]}"#, r#""FOO""#, Value::Enum(0, "FOO".to_string())),
         (r#"{"type": "array", "items": "int"}"#, "[1, 2, 3]", Value::Array(vec![Value::Int(1), Value::Int(2), Value::Int(3)])),
         (r#"{"type": "map", "values": "int"}"#, r#"{"a": 1, "b": 2}"#, Value::Map([("a".to_string(), Value::Int(1)), ("b".to_string(), Value::Int(2))].iter().cloned().collect())),
-        (r#"["int", "null"]"#, "5", Value::Union(0, Box::new(Value::Int(5)))), (r#"{"type": "record", "name": "F", "fields": [{"name": "A", "type": "int"}]}"#, r#"{"A": 5}"#,Value::Record(vec![("A".to_string(), Value::Int(5))])),
+        (r#"["int", "null"]"#, "5", Value::Union(0, Box::new(Value::Int(5)))), 
+        (r#"{"type": "record", "name": "F", "fields": [{"name": "A", "type": "int"}]}"#, r#"{"A": 5}"#,Value::Record(vec![("A".to_string(), Value::Int(5))])),
         (r#"["null", "int"]"#, "null", Value::Union(0, Box::new(Value::Null))),
     ];
 

--- a/lang/rust/tests/io.rs
+++ b/lang/rust/tests/io.rs
@@ -34,7 +34,7 @@ lazy_static! {
         (r#"{"type": "enum", "name": "Test", "symbols": ["A", "B"]}"#, Value::Enum(1, "B".to_string())),
         (r#"{"type": "array", "items": "long"}"#, Value::Array(vec![Value::Long(1), Value::Long(3), Value::Long(2)])),
         (r#"{"type": "map", "values": "long"}"#, Value::Map([("a".to_string(), Value::Long(1i64)), ("b".to_string(), Value::Long(3i64)), ("c".to_string(), Value::Long(2i64))].iter().cloned().collect())),
-        (r#"["string", "null", "long"]"#, Value::Union(Box::new(Value::Null))),
+        (r#"["string", "null", "long"]"#, Value::Union(1, Box::new(Value::Null))),
         (r#"{"type": "record", "name": "Test", "fields": [{"name": "f", "type": "long"}]}"#, Value::Record(vec![("f".to_string(), Value::Long(1))]))
     ];
 
@@ -65,8 +65,8 @@ lazy_static! {
         (r#"{"type": "enum", "name": "F", "symbols": ["FOO", "BAR"]}"#, r#""FOO""#, Value::Enum(0, "FOO".to_string())),
         (r#"{"type": "array", "items": "int"}"#, "[1, 2, 3]", Value::Array(vec![Value::Int(1), Value::Int(2), Value::Int(3)])),
         (r#"{"type": "map", "values": "int"}"#, r#"{"a": 1, "b": 2}"#, Value::Map([("a".to_string(), Value::Int(1)), ("b".to_string(), Value::Int(2))].iter().cloned().collect())),
-        (r#"["int", "null"]"#, "5", Value::Union(Box::new(Value::Int(5)))),
-        (r#"{"type": "record", "name": "F", "fields": [{"name": "A", "type": "int"}]}"#, r#"{"A": 5}"#,Value::Record(vec![("A".to_string(), Value::Int(5))])),
+        (r#"["int", "null"]"#, "5", Value::Union(0, Box::new(Value::Int(5)))), (r#"{"type": "record", "name": "F", "fields": [{"name": "A", "type": "int"}]}"#, r#"{"A": 5}"#,Value::Record(vec![("A".to_string(), Value::Int(5))])),
+        (r#"["null", "int"]"#, "null", Value::Union(0, Box::new(Value::Null))),
     ];
 
     static ref LONG_RECORD_SCHEMA: Schema = Schema::parse_str(r#"


### PR DESCRIPTION
change Value::Union to value it holds and its position in the type list,
this allows us to

Make sure you have checked _all_ steps below.

### Jira

- [x ] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO-3248) issues and references them in the PR title. 

### Tests

- [ x] My PR adds the following unit tests 
  1. schema::tests::test_union_of_records
  2. schema::tests::test_nullable_record

### Commits

- [x ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"


