### PR TITLE
AVRO-3254: Automatically scale up or down decimal values when serializing

### DIFF
--- a/lang/csharp/src/apache/main/AvroDecimal.cs
+++ b/lang/csharp/src/apache/main/AvroDecimal.cs
@@ -159,7 +159,7 @@ namespace Avro
         {
             if (newScale < 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(newScale), "Must be greater than or queal to 0");
+                throw new ArgumentOutOfRangeException(nameof(newScale), "Must be greater than or equal to 0");
             }
 
             if (this.Scale == newScale)

--- a/lang/csharp/src/apache/test/AvroDecimalTest.cs
+++ b/lang/csharp/src/apache/test/AvroDecimalTest.cs
@@ -17,30 +17,72 @@
  */
 using NUnit.Framework;
 
+using System;
+using System.Collections.Generic;
+
 namespace Avro.test
 {
     [TestFixture]
     class AvroDecimalTest
     {
-        [TestCase(1)]
-        [TestCase(1000)]
-        [TestCase(10.10)]
-        [TestCase(0)]
-        [TestCase(0.1)]
-        [TestCase(0.01)]
-        [TestCase(-1)]
-        [TestCase(-1000)]
-        [TestCase(-10.10)]
-        [TestCase(-0.1)]
-        [TestCase(-0.01)]
+        public static IEnumerable<decimal> DecimalTestCases = new[]
+        {
+            1m,
+            1000m,
+            10.10m,
+            0m,
+            0.1m,
+            0.01m,
+            -1m,
+            -1000m,
+            -10.10m,
+            -9.9999m,
+            9.9999999999m,
+            -0.1m,
+            -0.01m,
+        };
+
+        public static IEnumerable<int> ScaleTestCases = new[]
+        {
+            0,
+            1,
+            2,
+            10,
+            5
+        };
+
+        [TestCaseSource(nameof(DecimalTestCases))]
         public void TestAvroDecimalToString(decimal value)
         {
             var valueString = value.ToString();
 
-            var avroDecimal = new AvroDecimal(value);            
+            var avroDecimal = new AvroDecimal(value);
             var avroDecimalString = avroDecimal.ToString();
 
             Assert.AreEqual(valueString, avroDecimalString);
+        }
+
+        [Test]
+        public void TestAvroDecimalReScaling(
+            [ValueSource(nameof(DecimalTestCases))] decimal value,
+            [ValueSource(nameof(ScaleTestCases))] int scale)
+        {
+            var before = new AvroDecimal(value);
+
+            // Determine if an overflow would happen by just counting the decimal places in the string representation
+            var split = value.ToString("0.##########").Split('.');
+            var decimalPlaces = split.Length == 1 ? 0 : split[1].Length;
+            var wouldOverflow = decimalPlaces > scale;
+
+            if (wouldOverflow)
+            {
+                Assert.That(() => before.ReScale(scale), Throws.Exception.InstanceOf<OverflowException>());
+            }
+            else
+            {
+                var after = before.ReScale(scale);
+                Assert.AreEqual((decimal)before, (decimal)after);
+            }
         }
     }
 }

--- a/lang/csharp/src/apache/test/Util/LogicalTypeTests.cs
+++ b/lang/csharp/src/apache/test/Util/LogicalTypeTests.cs
@@ -70,6 +70,42 @@ namespace Avro.Test
             Assert.Throws<ArgumentOutOfRangeException>(() => avroDecimal.ConvertToBaseValue(decimalVal, schema));
         }
 
+        [TestCase]
+        public void TestDecimalScalesDown()
+        {
+            var schema = (LogicalSchema)Schema.Parse("{\"type\": \"bytes\", \"logicalType\": \"decimal\", \"precision\": 4, \"scale\": 2 }");
+
+            var avroDecimal = new Avro.Util.Decimal();
+            var decimalVal = (AvroDecimal)1234.500M; // scale is 1 and should re-scale to 2
+
+            var convertedDecimalVal = (AvroDecimal)avroDecimal.ConvertToLogicalValue(avroDecimal.ConvertToBaseValue(decimalVal, schema), schema);
+            Assert.AreEqual((decimal)decimalVal, (decimal)convertedDecimalVal);
+        }
+
+        [TestCase]
+        public void TestDecimalScalesDownToZero()
+        {
+            var schema = (LogicalSchema)Schema.Parse("{\"type\": \"bytes\", \"logicalType\": \"decimal\", \"precision\": 4, \"scale\": 0 }");
+
+            var avroDecimal = new Avro.Util.Decimal();
+            var decimalVal = (AvroDecimal)1234.0000M; // scale is 1 and should re-scale to 2
+
+            var convertedDecimalVal = (AvroDecimal)avroDecimal.ConvertToLogicalValue(avroDecimal.ConvertToBaseValue(decimalVal, schema), schema);
+            Assert.AreEqual((decimal)decimalVal, (decimal)convertedDecimalVal);
+        }
+
+        [TestCase]
+        public void TestDecimalScalesUp()
+        {
+            var schema = (LogicalSchema)Schema.Parse("{\"type\": \"bytes\", \"logicalType\": \"decimal\", \"precision\": 4, \"scale\": 2 }");
+
+            var avroDecimal = new Avro.Util.Decimal();
+            var decimalVal = (AvroDecimal)1234.5M; // scale is 1 and should re-scale to 2
+
+            var convertedDecimalVal = (AvroDecimal)avroDecimal.ConvertToLogicalValue(avroDecimal.ConvertToBaseValue(decimalVal, schema), schema);
+            Assert.AreEqual((decimal)decimalVal, (decimal)convertedDecimalVal);
+        }
+
         [TestCase("01/01/2019")]
         [TestCase("05/05/2019")]
         [TestCase("05/05/2019 00:00:00Z")]


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AVRO-3254

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  - TestDecimalScalesDown
  - TestDecimalScalesDownToZero
  - TestDecimalScalesUp
  - TestAvroDecimalReScaling (65 test cases)

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain ~Javadoc~ xml doc that explain what it does
