### PR TITLE
AVRO-3255: Ruby: specify rubygems_mfa_required in gemspec metadata

### DIFF
--- a/lang/ruby/avro.gemspec
+++ b/lang/ruby/avro.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
   s.metadata["bug_tracker_uri"] = "https://issues.apache.org/jira/browse/AVRO"
   s.metadata["source_code_uri"] = "https://github.com/apache/avro"
   s.metadata["documentation_uri"] = "https://avro.apache.org/docs/#{s.version}/"
+  s.metadata["rubygems_mfa_required"] = "true"
 
   files = File.read("Manifest").split("\n")
   s.files = files.reject { |f| f.start_with?("test/") }


### PR DESCRIPTION
Add metadata to make the published Ruby gem more secure by requiring a one-time password (OTP) for all privileged operations: https://guides.rubygems.org/mfa-requirement-opt-in/

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3255

### Tests

Packaging change only for the Ruby gem.
