### PR TITLE
AVRO-3252: Add hasattr check for mode attr in DataFileReader

### DIFF
--- a/lang/py/avro/datafile.py
+++ b/lang/py/avro/datafile.py
@@ -315,7 +315,7 @@ class DataFileReader(_DataFileMetadata):
     # TODO(hammer): allow user to specify the encoder
 
     def __init__(self, reader: IO[AnyStr], datum_reader: avro.io.DatumReader) -> None:
-        if "b" not in reader.mode:
+        if hasattr(reader, "mode") and "b" not in reader.mode:
             warnings.warn(avro.errors.AvroWarning(f"Reader binary data from a reader {reader!r} that's opened for text"))
         bytes_reader = getattr(reader, "buffer", reader)
         self._reader = bytes_reader


### PR DESCRIPTION
The `DataFileWriter` class constructor checks for the presence of a `mode` attribute before accessing it, but the `DataFileReader` does not. This means that it is possible to use the `DataFileWriter` to write data to in memory binary streams using `io.BytesIO`, but it is not possible to read from them in the same manner. This commit adds the same check to the `DataFileReader` class.

The following code can trivially reproduce the issue:

```
import io

import avro.schema
from avro.datafile import DataFileReader, DataFileWriter
from avro.io import DatumReader, DatumWriter

schema = """
{
 "namespace": "example.avro",
 "type": "record",
 "name": "User",
 "fields": [
     {"name": "name", "type": "string"},
     {"name": "favorite_number",  "type": ["int", "null"]},
     {"name": "favorite_color", "type": ["string", "null"]}
 ]
}
"""

writer_buf = io.BytesIO()
writer = DataFileWriter(writer_buf, DatumWriter(), avro.schema.parse(schema))

reader_buf = io.BytesIO()
reader = DataFileReader(reader_buf, DatumReader())  # exception raised
```

Which produces the following output when run:
```
Traceback (most recent call last):
  File "/Users/ter0/tmp/avro-test/test.py", line 24, in <module>
    reader = DataFileReader(reader_buf, DatumReader())  # exception raised
  File "/Users/ter0/Library/Caches/pypoetry/virtualenvs/avro-test-mTZxhLc6-py3.9/lib/python3.9/site-packages/avro/datafile.py", line 318, in __init__
    if "b" not in reader.mode:
AttributeError: '_io.BytesIO' object has no attribute 'mode'
```