### PR TITLE
AVRO-2867: Fix NullPointerException on record-valued defaults

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/Schema.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Schema.java
@@ -282,6 +282,13 @@ public abstract class Schema extends JsonProperties implements Serializable {
   }
 
   /**
+   * If this is a record, returns whether the fields have been set.
+   */
+  public boolean hasFields() {
+    throw new AvroRuntimeException("Not a record: " + this);
+  }
+
+  /**
    * If this is a record, set its fields. The fields can be set only once in a
    * schema.
    */
@@ -902,6 +909,11 @@ public abstract class Schema extends JsonProperties implements Serializable {
       if (fields == null)
         throw new AvroRuntimeException("Schema fields not set yet");
       return fields;
+    }
+
+    @Override
+    public boolean hasFields() {
+      return fields != null;
     }
 
     @Override

--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/idl/IsResolvedSchemaVisitor.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/idl/IsResolvedSchemaVisitor.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.avro.compiler.idl;
+
+import org.apache.avro.Schema;
+import org.apache.avro.compiler.schema.SchemaVisitor;
+import org.apache.avro.compiler.schema.SchemaVisitorAction;
+
+/**
+ * This visitor checks if the current schema is fully resolved.
+ */
+public final class IsResolvedSchemaVisitor implements SchemaVisitor<Boolean> {
+  boolean hasUnresolvedParts;
+
+  IsResolvedSchemaVisitor() {
+    hasUnresolvedParts = false;
+  }
+
+  @Override
+  public SchemaVisitorAction visitTerminal(Schema terminal) {
+    hasUnresolvedParts = SchemaResolver.isUnresolvedSchema(terminal);
+    return hasUnresolvedParts ? SchemaVisitorAction.TERMINATE : SchemaVisitorAction.CONTINUE;
+  }
+
+  @Override
+  public SchemaVisitorAction visitNonTerminal(Schema nonTerminal) {
+    hasUnresolvedParts = SchemaResolver.isUnresolvedSchema(nonTerminal);
+    if (hasUnresolvedParts) {
+      return SchemaVisitorAction.TERMINATE;
+    }
+    if (nonTerminal.getType() == Schema.Type.RECORD && !nonTerminal.hasFields()) {
+      // We're still initializing the type...
+      return SchemaVisitorAction.SKIP_SUBTREE;
+    }
+    return SchemaVisitorAction.CONTINUE;
+  }
+
+  @Override
+  public SchemaVisitorAction afterVisitNonTerminal(Schema nonTerminal) {
+    return SchemaVisitorAction.CONTINUE;
+  }
+
+  @Override
+  public Boolean get() {
+    return !hasUnresolvedParts;
+  }
+}

--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/idl/ResolvingVisitor.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/idl/ResolvingVisitor.java
@@ -139,10 +139,7 @@ public final class ResolvingVisitor implements SchemaVisitor<Schema> {
         List<Schema.Field> fields = nt.getFields();
         List<Schema.Field> newFields = new ArrayList<>(fields.size());
         for (Schema.Field field : fields) {
-          Schema.Field newField = new Schema.Field(field.name(), replace.get(field.schema()), field.doc(),
-              field.defaultVal(), field.order());
-          copyAllProperties(field, newField);
-          newFields.add(newField);
+          newFields.add(new Field(field, replace.get(field.schema())));
         }
         newSchema.setFields(newFields);
       }

--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/idl/SchemaResolver.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/idl/SchemaResolver.java
@@ -84,6 +84,20 @@ final class SchemaResolver {
   }
 
   /**
+   * Is this a unresolved schema.
+   *
+   * @param schema
+   * @return
+   */
+  static boolean isFullyResolvedSchema(final Schema schema) {
+    if (isUnresolvedSchema(schema)) {
+      return false;
+    } else {
+      return Schemas.visit(schema, new IsResolvedSchemaVisitor());
+    }
+  }
+
+  /**
    * Will clone the provided protocol while resolving all unreferenced schemas
    *
    * @param protocol

--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/schema/Schemas.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/schema/Schemas.java
@@ -21,7 +21,6 @@ import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.IdentityHashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -141,9 +140,8 @@ public final class Schemas {
             visited.put(schema, schema);
             break;
           case RECORD:
-            Iterator<Schema> reverseSchemas = schema.getFields().stream().map(Field::schema)
-                .collect(Collectors.toCollection(ArrayDeque::new)).descendingIterator();
-            terminate = visitNonTerminal(visitor, schema, dq, () -> reverseSchemas);
+            terminate = visitNonTerminal(visitor, schema, dq, () -> schema.getFields().stream().map(Field::schema)
+                .collect(Collectors.toCollection(ArrayDeque::new)).descendingIterator());
             visited.put(schema, schema);
             break;
           case UNION:

--- a/lang/java/compiler/src/main/javacc/org/apache/avro/compiler/idl/idl.jj
+++ b/lang/java/compiler/src/main/javacc/org/apache/avro/compiler/idl/idl.jj
@@ -1349,7 +1349,7 @@ void VariableDeclarator(Schema type, List<Field> fields):
       if ("order".equals(key))
         order = Field.Order.valueOf(getTextProp(key,props,token).toUpperCase());
 
-    boolean validate = !SchemaResolver.isUnresolvedSchema(type);
+    boolean validate = SchemaResolver.isFullyResolvedSchema(type);
     Field field = Accessor.createField(name, type, getDoc(), defaultValue, validate, order);
     for (String key : props.keySet())
       if ("order".equals(key)) {                  // already handled: ignore

--- a/lang/java/compiler/src/test/idl/input/simple.avdl
+++ b/lang/java/compiler/src/test/idl/input/simple.avdl
@@ -36,9 +36,6 @@ protocol Simple {
     C
   } = C;
 
-  /** An MD5 hash. */
-  fixed MD5(16);
-
   /** A TestRecord. */
   @my-property({"key":3})
   record TestRecord {
@@ -62,6 +59,9 @@ protocol Simple {
     @foo.bar("bar.foo") long l = 0;
     union {null, @foo.foo.bar(42) @foo.foo.foo("3foo") string} prop = null;
   }
+
+  /** An MD5 hash. */
+  fixed MD5(16);
 
   error TestError {
     string message;

--- a/lang/java/compiler/src/test/idl/output/forward_ref.avpr
+++ b/lang/java/compiler/src/test/idl/output/forward_ref.avpr
@@ -8,7 +8,7 @@
       "fields": [
         { "name":"name", "type": "string", "doc":"the name" },
         { "name": "value", "type": "string", "doc": "the value" },
-        { "name": "type", "type": { "type": "enum", "name":"ValueType", "symbols": ["JSON","BASE64BIN","PLAIN"] } }
+        { "name": "type", "type": { "type": "enum", "name":"ValueType", "symbols": ["JSON","BASE64BIN","PLAIN"] }, "default": "PLAIN" }
       ]
     }
   ],

--- a/lang/java/compiler/src/test/idl/output/simple.avpr
+++ b/lang/java/compiler/src/test/idl/output/simple.avpr
@@ -15,12 +15,6 @@
    "symbols" : [ "A", "B", "C" ],
    "default" : "C"
   }, {
-    "type" : "fixed",
-    "name" : "MD5",
-    "doc" : "An MD5 hash.",
-    "size" : 16,
-    "foo" : "bar"
-  }, {
     "type" : "record",
     "name" : "TestRecord",
     "doc" : "A TestRecord.",
@@ -41,7 +35,12 @@
       "default" : "A"
     }, {
       "name" : "hash",
-      "type" : "MD5",
+      "type" : {
+        "type" : "fixed",
+        "name" : "MD5",
+        "doc" : "An MD5 hash.",
+        "size" : 16
+      },
       "default" : "0000000000000000"
     }, {
       "name" : "nullableHash",


### PR DESCRIPTION
If the IDL file defines the schema of a field after the field, record
valued defaults cause a NullPointerException. This PR fixes that.

The fix addresses two situations:
1. The field schema itself is a forward reference
   (tested by fixing the missing default value in `forward_ref.avpr`)
2. The field schema contains a forward reference
   (tested by the `echo` message in the updated `simple.avdl`)

Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2867
  - ~In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).~

### Tests

- [X] My PR adds the following unit tests ~__OR__ does not need testing for this extremely good reason~: see above

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
