### PR TITLE
AVRO-3217: Allow any identifier as annotation name

### DIFF
--- a/lang/java/compiler/src/main/javacc/org/apache/avro/compiler/idl/idl.jj
+++ b/lang/java/compiler/src/main/javacc/org/apache/avro/compiler/idl/idl.jj
@@ -1551,14 +1551,15 @@ Schema ResultType():
 String PropertyName():
 {
   Token t;
+  String s;
   StringBuilder name = new StringBuilder();
 }
 {
-  t = <IDENTIFIER>   { name.append(t.image); }
+  s = Identifier()   { name.append(s); }
   ( t = <DASH>       { name.append(t.image); }
-    t = <IDENTIFIER> { name.append(t.image); } |
+    s = Identifier() { name.append(s); } |
     t = <DOT>        { name.append(t.image); }
-    t = <IDENTIFIER> { name.append(t.image); }
+    s = Identifier() { name.append(s); }
   ) *
   { return name.toString(); }
 }

--- a/lang/java/compiler/src/test/idl/input/simple.avdl
+++ b/lang/java/compiler/src/test/idl/input/simple.avdl
@@ -42,7 +42,7 @@ protocol Simple {
   /** A TestRecord. */
   @my-property({"key":3})
   record TestRecord {
-    string @order("ignore") name = "foo";
+    @avro.java.`string`("String") string @order("ignore") name = "foo";
 
     /** The kind of record. */
     Kind @order("descending") kind;

--- a/lang/java/compiler/src/test/idl/output/simple.avpr
+++ b/lang/java/compiler/src/test/idl/output/simple.avpr
@@ -26,7 +26,10 @@
     "doc" : "A TestRecord.",
     "fields" : [ {
       "name" : "name",
-      "type" : "string",
+      "type" : {
+        "type": "string",
+        "avro.java.string": "String"
+      },
       "default" : "foo",
       "order" : "ignore"
     }, {


### PR DESCRIPTION
A field schema can be annotated with the property `avro.java.string`:

    {
      "name": "fieldName",
      "type": {
        "type": "string",
        "avro.java.string": "String"
      }
    }

The corresponding IDL is:

    @avro.java.`string`("String") string fieldName;

The IDL parser fails on the `. This change fixes that.

Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3217
  - ~In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).~

### Tests

- [X] My PR adds the following unit tests ~__OR__ does not need testing for this extremely good reason~:
  Adjusted the `simple.avdl` and `simple.avpr` test

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
