### PR TITLE
AVRO-3263: Fix warning in Perl encoder when validating a long field

### DIFF
--- a/lang/perl/lib/Avro/Schema.pm
+++ b/lang/perl/lib/Avro/Schema.pm
@@ -284,6 +284,7 @@ sub is_data_valid {
     }
     if ($type eq 'long') {
         if ($Config{use64bitint}) {
+            no warnings;
             my $packed_int = pack "q", $data;
             my $unpacked_int = unpack "q", $packed_int;
             return $unpacked_int eq $data ? 1 : 0;

--- a/lang/perl/lib/Avro/Schema.pm
+++ b/lang/perl/lib/Avro/Schema.pm
@@ -284,7 +284,7 @@ sub is_data_valid {
     }
     if ($type eq 'long') {
         if ($Config{use64bitint}) {
-            no warnings;
+            return 0 unless defined $data;
             my $packed_int = pack "q", $data;
             my $unpacked_int = unpack "q", $packed_int;
             return $unpacked_int eq $data ? 1 : 0;

--- a/lang/perl/t/02_bin_encode.t
+++ b/lang/perl/t/02_bin_encode.t
@@ -153,4 +153,34 @@ EOJ
     is $enc, "\x00\x02\x61", "Binary_Encodings.Complex_Types.Unions-a";
 }
 
+# unions other cases
+{
+    my $schema = Avro::Schema->parse(<<EOJ);
+[
+    {
+        "type": "record",
+        "name": "rectangle",
+        "fields": [{ "name": "width", "type": "long" }, { "name": "height", "type": "long"}]
+    },
+    {
+        "type": "record",
+        "name": "square",
+        "fields": [{ "name": "dim", "type": "long" }]
+    }
+]
+EOJ
+    my $warning = 0;
+    local $SIG{__WARN__} = sub { $warning = 1; };
+    my $enc = '';
+    Avro::BinaryEncoder->encode(
+        schema  => $schema,
+        data    => { dim => 10 },
+        emit_cb => sub {
+            $enc .= ${ $_[0] }
+        },
+    );
+    is $enc, "\x02\x14", "Binary_Encodings.Complex_Types.Unions-record-with-long-field";
+    is $warning, 0, "Binary_Encodings.Complex_Types.Unions-record-with-long-field-nowarning";
+}
+
 done_testing;


### PR DESCRIPTION
- Disable warnings in the limited scope of "long" validation that uses pack and unpack. It is unnecessary as warnings don't affect the validation outcome and in some scenarios this validation is expected to fail.
- Add test cases to validate the fix

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO-3263) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AVRO-3263
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests:
- Binary_Encodings.Complex_Types.Unions-record-with-long-field
- Binary_Encodings.Complex_Types.Unions-record-with-long-field-nowarning

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
