### PR TITLE
AVRO-3265: Fix avrogen code generation for Avro namespaces

### DIFF
--- a/lang/csharp/src/apache/main/CodeGen/CodeGen.cs
+++ b/lang/csharp/src/apache/main/CodeGen/CodeGen.cs
@@ -558,7 +558,10 @@ namespace Avro
 
             // declare the class
             var ctd = new CodeTypeDeclaration(CodeGenUtil.Instance.Mangle(recordSchema.Name));
-            ctd.BaseTypes.Add(isError ? "SpecificException" : "ISpecificRecord");
+            var baseTypeReference = new CodeTypeReference(
+                isError ? typeof(Specific.SpecificException) : typeof(Specific.ISpecificRecord),
+                CodeTypeReferenceOptions.GlobalReference);
+            ctd.BaseTypes.Add(baseTypeReference);
 
             ctd.Attributes = MemberAttributes.Public;
             ctd.IsClass = true;
@@ -675,14 +678,14 @@ namespace Avro
             }
 
             // end switch block for Get()
-            getFieldStmt.AppendLine("\t\t\tdefault: throw new AvroRuntimeException(\"Bad index \" + fieldPos + \" in Get()\");")
+            getFieldStmt.AppendLine("\t\t\tdefault: throw new global::Avro.AvroRuntimeException(\"Bad index \" + fieldPos + \" in Get()\");")
                 .Append("\t\t\t}");
             var cseGet = new CodeSnippetExpression(getFieldStmt.ToString());
             cmmGet.Statements.Add(cseGet);
             ctd.Members.Add(cmmGet);
 
             // end switch block for Put()
-            putFieldStmt.AppendLine("\t\t\tdefault: throw new AvroRuntimeException(\"Bad index \" + fieldPos + \" in Put()\");")
+            putFieldStmt.AppendLine("\t\t\tdefault: throw new global::Avro.AvroRuntimeException(\"Bad index \" + fieldPos + \" in Put()\");")
                 .Append("\t\t\t}");
             var csePut = new CodeSnippetExpression(putFieldStmt.ToString());
             cmmPut.Statements.Add(csePut);
@@ -831,14 +834,14 @@ namespace Avro
         protected virtual void createSchemaField(Schema schema, CodeTypeDeclaration ctd, bool overrideFlag)
         {
             // create schema field
-            var ctrfield = new CodeTypeReference("Schema");
+            var ctrfield = new CodeTypeReference(typeof(Schema), CodeTypeReferenceOptions.GlobalReference);
             string schemaFname = "_SCHEMA";
             var codeField = new CodeMemberField(ctrfield, schemaFname);
             codeField.Attributes = MemberAttributes.Public | MemberAttributes.Static;
             // create function call Schema.Parse(json)
             var cpe = new CodePrimitiveExpression(schema.ToString());
             var cmie = new CodeMethodInvokeExpression(
-                new CodeMethodReferenceExpression(new CodeTypeReferenceExpression(typeof(Schema)), "Parse"),
+                new CodeMethodReferenceExpression(new CodeTypeReferenceExpression(ctrfield), "Parse"),
                 new CodeExpression[] { cpe });
             codeField.InitExpression = cmie;
             ctd.Members.Add(codeField);

--- a/lang/csharp/src/apache/main/CodeGen/CodeGenUtil.cs
+++ b/lang/csharp/src/apache/main/CodeGen/CodeGenUtil.cs
@@ -60,8 +60,8 @@ namespace Avro
                 new CodeNamespaceImport("System"),
                 new CodeNamespaceImport("System.Collections.Generic"),
                 new CodeNamespaceImport("System.Text"),
-                new CodeNamespaceImport("Avro"),
-                new CodeNamespaceImport("Avro.Specific") };
+                new CodeNamespaceImport("global::Avro"),
+                new CodeNamespaceImport("global::Avro.Specific") };
 
             FileComment = new CodeCommentStatement(
 @"------------------------------------------------------------------------------

--- a/lang/csharp/src/apache/test/CodGen/CodeGenTest.cs
+++ b/lang/csharp/src/apache/test/CodGen/CodeGenTest.cs
@@ -51,6 +51,16 @@ namespace Avro.Test
 ", new object[] {"com.base.ClassKeywords", typeof(int), typeof(long), typeof(bool), typeof(double), typeof(float), typeof(byte[]), typeof(string),typeof(object),"com.base.class", "com.base.static"}, TestName = "TestCodeGen0")]
         [TestCase(@"{
 ""type"" : ""record"",
+""name"" : ""AvroNamespaceType"",
+""namespace"" : ""My.Avro"",
+""fields"" :
+		[
+			{ ""name"" : ""justenum"", ""type"" : { ""type"" : ""enum"", ""name"" : ""justenumEnum"", ""symbols"" : [ ""One"", ""Two"" ] } },
+		]
+}
+", new object[] {"My.Avro.AvroNamespaceType", "My.Avro.justenumEnum"}, TestName = "TestCodeGen3 - Avro namespace conflict")]
+        [TestCase(@"{
+""type"" : ""record"",
 ""name"" : ""SchemaObject"",
 ""namespace"" : ""schematest"",
 ""fields"" :


### PR DESCRIPTION
Fix for uncompilable code generation in case when the namespace ends with ".Avro".

Make sure you have checked _all_ steps below.

### Jira

- [ x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

NOTE: Tests are suppressed for .NET Core environment. I reviewed the changes I've added to tests but unfortunately could not run them on MacOS / .NET 5-6. I did manually tested the changes in logic though.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
