### PR TITLE
AVRO-3266: Cast to PathOutputCommitter

### DIFF
--- a/lang/java/mapred/src/main/java/org/apache/avro/mapreduce/AvroOutputFormatBase.java
+++ b/lang/java/mapred/src/main/java/org/apache/avro/mapreduce/AvroOutputFormatBase.java
@@ -93,7 +93,7 @@ public abstract class AvroOutputFormatBase<K, V> extends FileOutputFormat<K, V> 
    * @return The target output stream.
    */
   protected OutputStream getAvroFileOutputStream(TaskAttemptContext context) throws IOException {
-    Path path = new Path(((FileOutputCommitter) getOutputCommitter(context)).getWorkPath(),
+    Path path = new Path(((PathOutputCommitter) getOutputCommitter(context)).getWorkPath(),
         getUniqueFile(context, context.getConfiguration().get("avro.mo.config.namedOutput", "part"),
             org.apache.avro.mapred.AvroOutputFormat.EXT));
     return path.getFileSystem(context.getConfiguration()).create(path);


### PR DESCRIPTION
Change the cast of the outputCommitter to a PathOutputCommitter.
This allows the system to use a different outputCommitter than just the
FileOutputCommitter, for example the MagicS3GuardCommitter.

Fixes [Output stream incompatible with MagicS3GuardCommitter](https://issues.apache.org/jira/browse/AVRO-3266)