### PR TITLE
AVRO-3229: Raise Exception on Invalid Enum Default

### DIFF
--- a/lang/py/avro/errors.py
+++ b/lang/py/avro/errors.py
@@ -40,6 +40,10 @@ class InvalidName(SchemaParseException):
     """User attempted to parse a schema with an invalid name."""
 
 
+class InvalidDefault(SchemaParseException):
+    """User attempted to parse a schema with an invalid default."""
+
+
 class AvroWarning(UserWarning):
     """Base class for warnings."""
 

--- a/lang/py/avro/schema.py
+++ b/lang/py/avro/schema.py
@@ -583,6 +583,11 @@ class EnumSchema(EqualByPropsMixin, NamedSchema):
         if doc is not None:
             self.set_prop("doc", doc)
 
+        if other_props and "default" in other_props:
+            default = other_props["default"]
+            if default not in symbols:
+                raise avro.errors.InvalidDefault(f"Enum default '{default}' is not a valid member of symbols '{symbols}'")
+
     @property
     def symbols(self) -> Sequence[str]:
         symbols = self.get_prop("symbols")

--- a/lang/py/avro/test/test_schema.py
+++ b/lang/py/avro/test/test_schema.py
@@ -85,6 +85,7 @@ FIXED_EXAMPLES = [
 ENUM_EXAMPLES = [
     ValidTestSchema({"type": "enum", "name": "Test", "symbols": ["A", "B"]}),
     ValidTestSchema({"type": "enum", "name": "AVRO2174", "symbols": ["nowhitespace"]}),
+    InvalidTestSchema({"type": "enum", "name": "bad_default", "symbols": ["A"], "default": "B"}, comment="AVRO-3229"),
     InvalidTestSchema({"type": "enum", "name": "Status", "symbols": "Normal Caution Critical"}),
     InvalidTestSchema({"type": "enum", "name": [0, 1, 1, 2, 3, 5, 8], "symbols": ["Golden", "Mean"]}),
     InvalidTestSchema({"type": "enum", "symbols": ["I", "will", "fail", "no", "name"]}),


### PR DESCRIPTION
Raise an InvalidDefault exception when attempting to parse an enumschema with a default value that isn't one of the enum's symbols.

### Jira

- [x] Addresses [AVRO-3229](https://issues.apache.org/jira/browse/AVRO-3229)
- [x] References it in the PR title.
- [x] Adds no dependency

### Tests

- [x] Adds a unit test to ensure the schema is invalid as expected.

### Commits

- [x] Commits all reference the Jira issue.
- [x] Commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] N/A
