### PR TITLE
AVRO-3251: Minor testcase fix after merge

### DIFF
--- a/lang/java/compiler/src/test/idl/output/uuid.avpr
+++ b/lang/java/compiler/src/test/idl/output/uuid.avpr
@@ -15,7 +15,7 @@
     }, {
       "name" : "uuid",
       "type" : "string",
-      "doc" : "* A string field with a special name"
+      "doc" : "A string field with a special name"
     }, {
       "name" : "optionalString",
       "type" : [ "null", {


### PR DESCRIPTION
Minor Java failure caused by merging https://github.com/apache/avro/pull/1377 separately.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3251
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR does not need testing for this extremely good reason: Fixing a test case.

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
