### PR TITLE
AVRO-3275: Clarify specification on naming

### DIFF
--- a/doc/src/content/xdocs/spec.xml
+++ b/doc/src/content/xdocs/spec.xml
@@ -307,7 +307,8 @@
 	  fullname <code>org.foo.X</code>.</li>
 	  <li>A name only is specified, i.e., a name that contains no
 	  dots.  In this case the namespace is taken from the most
-	  tightly enclosing schema or protocol.  For example,
+	  tightly enclosing schema or protocol, and the fullname is
+    constructed from that namespace and the name.  For example,
 	  if <code>"name": "X"</code> is specified, and this occurs
 	  within a field of the record definition
 	  of <code>org.foo.Y</code>, then the fullname


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3275
  - ~In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).~

### Tests

- [X] My PR ~adds the following unit tests __OR__~ does not need testing for this extremely good reason: it's a text change in specification

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
