### PR TITLE
AVRO-3294: Improve IDL doc comment handling

### DIFF
--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/idl/DocCommentHelper.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/idl/DocCommentHelper.java
@@ -74,6 +74,14 @@ public class DocCommentHelper {
     DOC.set(newDocComment);
   }
 
+  /**
+   * Clear any documentation (and generate a warning if there was).
+   *
+   * This method should NOT be used after an optional component in a grammar
+   * (i.e., after a @code{[…]} or @code{…*} construct), because the optional
+   * grammar part may have already caused parsing a doc comment special token
+   * placed after the code block.
+   */
   static void clearDoc() {
     DocComment oldDocComment = DOC.get();
     if (oldDocComment != null) {

--- a/lang/java/compiler/src/main/javacc/org/apache/avro/compiler/idl/idl.jj
+++ b/lang/java/compiler/src/main/javacc/org/apache/avro/compiler/idl/idl.jj
@@ -209,7 +209,6 @@ public class Idl implements Closeable {
     }
     return schema;
   }
-
 }
 
 PARSER_END(Idl)

--- a/lang/java/compiler/src/main/javacc/org/apache/avro/compiler/idl/idl.jj
+++ b/lang/java/compiler/src/main/javacc/org/apache/avro/compiler/idl/idl.jj
@@ -1065,7 +1065,7 @@ Protocol CompilationUnit():
 /*
  * Declaration syntax follows.
  */
-private Schema NamedSchemaDeclaration(Map<String, JsonNode> props):
+private Schema NamedSchemaDeclaration(String doc, Map<String, JsonNode> props):
 {
   Schema s;
   String savedSpace = this.namespace;
@@ -1076,9 +1076,9 @@ private Schema NamedSchemaDeclaration(Map<String, JsonNode> props):
       this.namespace = getTextProp("namespace", props, token);
   }
  (
-     s = FixedDeclaration()
-   | s = EnumDeclaration()
-   | s = RecordDeclaration()
+     s = FixedDeclaration(doc)
+   | s = EnumDeclaration(doc)
+   | s = RecordDeclaration(doc)
  )
  {
    this.namespace = savedSpace;
@@ -1125,11 +1125,12 @@ Schema UnionDefinition():
 
 Protocol ProtocolDeclaration():
 {
-  String name;
+  String doc, name;
   Protocol p;
   Map<String, JsonNode> props = new LinkedHashMap<String, JsonNode>();
 }
 {
+  doc = Documentation()
   ( SchemaProperty(props) )*
   {
     if (props.containsKey("namespace"))
@@ -1138,7 +1139,7 @@ Protocol ProtocolDeclaration():
  "protocol"
    name = Identifier()
  {
-   p = new Protocol(name, DocCommentHelper.getDoc(), namespace);
+   p = new Protocol(name, doc, namespace);
    for (String key : props.keySet())
      if ("namespace".equals(key)) {               // already handled: ignore
      } else {                                     // add all other properties
@@ -1152,17 +1153,30 @@ Protocol ProtocolDeclaration():
 }
 
 
-Schema EnumDeclaration():
+String Documentation():
+{
+  //noinspection ResultOfMethodCallIgnored
+  getToken(1); // Parse, but don't consume, at least one token; this triggers parsing special tokens like doc comments.
+}
+{
+   // Don't parse anything, just return the doc string
+   {
+       return DocCommentHelper.getDoc();
+   }
+}
+
+
+Schema EnumDeclaration(String doc):
 {
   String name;
   List<String> symbols;
   String defaultSymbol = null;
 }
 {
-  "enum" {   String doc = DocCommentHelper.getDoc(); }
+  "enum"
   name = Identifier()
   symbols = EnumBody()
-      [ <EQUALS> defaultSymbol=Identifier() <SEMICOLON>]
+      [ <EQUALS> defaultSymbol=Identifier() <SEMICOLON> { DocCommentHelper.clearDoc(); } ]
   {
     Schema s = Schema.createEnum(name, doc, this.namespace, symbols,
                                  defaultSymbol);
@@ -1176,10 +1190,11 @@ List<String> EnumBody():
   List<String> symbols = new ArrayList<String>();
 }
 {
-  "{"
+  "{" { DocCommentHelper.clearDoc(); }
   [ EnumConstant(symbols) ( "," EnumConstant(symbols) )* ]
   "}"
   {
+    DocCommentHelper.clearDoc();
     return symbols;
   }
 }
@@ -1194,13 +1209,14 @@ void EnumConstant(List<String> symbols):
 
 void ProtocolBody(Protocol p):
 {
+  String doc;
   Schema schema;
   Message message;
   Protocol importProtocol;
   Map<String, JsonNode> props = new LinkedHashMap<String, JsonNode>();
 }
 {
-  "{"
+  "{" { DocCommentHelper.clearDoc(); }
   (
    <IMPORT>
    ((( importProtocol = ImportIdl() | importProtocol = ImportProtocol()) {
@@ -1209,21 +1225,26 @@ void ProtocolBody(Protocol p):
        p.getMessages().putAll(importProtocol.getMessages());
      })
      | schema = ImportSchema()
-     )
+     ) {
+       DocCommentHelper.clearDoc();
+     }
    |
+   doc = Documentation()
    ( SchemaProperty(props) )*
    (
-     schema = NamedSchemaDeclaration(props)
+     schema = NamedSchemaDeclaration(doc, props)
      |
-     message = MessageDeclaration(p, props) {
+     message = MessageDeclaration(p, doc, props) {
        p.getMessages().put(message.getName(), message);
      }
-    )  { props.clear(); }
+    ) {
+      props.clear();
+    }
   ) *
   "}"
-
   {
     p.setTypes(names.values());
+    DocCommentHelper.clearDoc();
   }
 }
 
@@ -1290,7 +1311,7 @@ Schema ImportSchema() : {
     }
 }
 
-Schema FixedDeclaration():
+Schema FixedDeclaration(String doc):
 {
   String name;
   Token sizeTok;
@@ -1299,14 +1320,14 @@ Schema FixedDeclaration():
   "fixed" name = Identifier() "(" sizeTok = <INTEGER_LITERAL> ")"
   ";"
   {
-    Schema s = Schema.createFixed(name, DocCommentHelper.getDoc(), this.namespace,
-                                  Integer.parseInt(sizeTok.image));
+    DocCommentHelper.clearDoc();
+    Schema s = Schema.createFixed(name, doc, this.namespace, Integer.parseInt(sizeTok.image));
     names.put(s.getFullName(), s);
     return s;
   }
 }
 
-Schema RecordDeclaration():
+Schema RecordDeclaration(String doc):
 {
   String name;
   List<Field> fields = new ArrayList<Field>();
@@ -1319,14 +1340,14 @@ Schema RecordDeclaration():
   )
   name = Identifier()
   {
-    Schema result = Schema.createRecord(
-      name, DocCommentHelper.getDoc(), this.namespace, isError);
+    Schema result = Schema.createRecord(name, doc, this.namespace, isError);
     names.put(result.getFullName(), result);
   }
-  "{"
+  "{" { DocCommentHelper.clearDoc(); }
     ( FieldDeclaration(fields) )*
   "}"
   {
+    DocCommentHelper.clearDoc();
     result.setFields(fields);
     return result;
   }
@@ -1349,27 +1370,27 @@ private void SchemaProperty(Map<String, JsonNode> properties):
 
 void FieldDeclaration(List<Field> fields):
 {
+  String defaultDoc;
   Schema type;
 }
 {
+  defaultDoc = Documentation()
   type = Type()
-  VariableDeclarator(type, fields) ( "," VariableDeclarator(type, fields) )*
-  ";"
+  VariableDeclarator(type, defaultDoc, fields) ( "," VariableDeclarator(type, defaultDoc, fields) )*
+  ";" { DocCommentHelper.clearDoc(); }
 }
 
-void VariableDeclarator(Schema type, List<Field> fields):
+void VariableDeclarator(Schema type, String defaultDoc, List<Field> fields):
 {
-  String name;
+  String doc, name;
   JsonNode defaultValue = null;
   Map<String, JsonNode> props = new LinkedHashMap<String, JsonNode>();
 }
 {
-    ( SchemaProperty(props) )*
-
+  doc = Documentation()
+  ( SchemaProperty(props) )*
   name = Identifier()
-
-    [ <EQUALS> defaultValue=Json() ]
-
+  [ <EQUALS> defaultValue=Json() ]
   {
     Field.Order order = Field.Order.ASCENDING;
     for (String key : props.keySet())
@@ -1378,7 +1399,7 @@ void VariableDeclarator(Schema type, List<Field> fields):
 
     boolean validate = SchemaResolver.isFullyResolvedSchema(type);
     Schema fieldType = fixOptionalSchema(type, defaultValue);
-    Field field = Accessor.createField(name, fieldType, DocCommentHelper.getDoc(), defaultValue, validate, order);
+    Field field = Accessor.createField(name, fieldType, doc == null ? defaultDoc : doc, defaultValue, validate, order);
     for (String key : props.keySet())
       if ("order".equals(key)) {                  // already handled: ignore
       } else if ("aliases".equals(key)) {         // aliases
@@ -1388,22 +1409,13 @@ void VariableDeclarator(Schema type, List<Field> fields):
         Accessor.addProp(field, key, props.get(key));
       }
     fields.add(field);
+    DocCommentHelper.clearDoc();
   }
 }
 
 
-String MessageDocumentation():
-{}
+private Message MessageDeclaration(Protocol p, String msgDoc, Map<String, JsonNode> props):
 {
-   // Don't parse anything, just return the doc string
-   {
-       return DocCommentHelper.getDoc();
-   }
-}
-
-private Message MessageDeclaration(Protocol p, Map<String, JsonNode> props):
-{
-  String msgDoc;
   String name;
   Schema request;
   Schema response;
@@ -1412,13 +1424,12 @@ private Message MessageDeclaration(Protocol p, Map<String, JsonNode> props):
   errorSchemata.add(Protocol.SYSTEM_ERROR);
 }
 {
-  msgDoc = MessageDocumentation()
-  response = ResultType()
-  name = Identifier()
+  response = ResultType()  name = Identifier()
   request = FormalParameters()
   [ "oneway" {oneWay = true; } | "throws" ErrorList(errorSchemata) ]
   ";"
   {
+    DocCommentHelper.clearDoc();
     Schema errors = Schema.createUnion(errorSchemata);
     if (oneWay && response.getType() != Type.NULL)
       throw error("One-way message'"+name+"' must return void", token);
@@ -1443,21 +1454,23 @@ Schema FormalParameters():
   List<Field> fields = new ArrayList<Field>();
 }
 {
-  (
-    "(" [ FormalParameter(fields) ( "," FormalParameter(fields) )* ] ")"
-  )
+  "(" { DocCommentHelper.clearDoc(); }
+  [ FormalParameter(fields) ( "," FormalParameter(fields) )* ] ")"
   {
-    return Schema.createRecord(fields);
+    DocCommentHelper.clearDoc();
+    return Schema.createRecord(null, null, null, false, fields);
   }
 }
 
 void FormalParameter(List<Field> fields):
 {
+  String doc;
   Schema type;
 }
 {
+  doc = Documentation()
   type = Type()
-  VariableDeclarator(type, fields)
+  VariableDeclarator(type, doc, fields)
 }
 
 Schema Type():

--- a/lang/java/compiler/src/test/idl/input/comments.avdl
+++ b/lang/java/compiler/src/test/idl/input/comments.avdl
@@ -27,41 +27,38 @@ protocol Comments {
     /** Dangling Enum8 */ A
     /** Dangling Enum9 */;
 
-    // The "Dangling Enum9" doc comment above will be attributed to this enum.
-    enum NotUndocumentedEnum {D,E}
+    enum UndocumentedEnum {D,E}
 
-    /** Dangling Fixed1 */ fixed
-    /** Dangling Fixed2 */ DocumentedFixed
-    /** Dangling Fixed3 */(
-    /** Dangling Fixed4 */ 16
-    /** Dangling Fixed5 */)
-    /** Documented Fixed Type */;
+    /** Documented Fixed Type */ fixed
+    /** Dangling Fixed1 */ DocumentedFixed
+    /** Dangling Fixed2 */(
+    /** Dangling Fixed3 */ 16
+    /** Dangling Fixed4 */)
+    /** Dangling Fixed5 */;
 
     fixed UndocumentedFixed(16);
 
-    /** Dangling Error1 */ error
-    /** Documented Error */ DocumentedError
+    /** Documented Error */ error
+    /** Dangling Error1 */ DocumentedError
     /** Dangling Field1 */{
-    /** Dangling Field2 */string
-    /** Dangling Field3 */reason
-    /** Documented Field */;
+    /** Default Doc Explanation Field */string
+    /** Documented Reason Field */reason, explanation
+    /** Dangling Field2 */;
     /** Dangling Error2 */}
 
-    // The "Dangling Error2" doc comment above will be attributed to this record.
-    record NotUndocumentedRecord {
+    record UndocumentedRecord {
         string description;
     }
 
     /** Documented Method */ void
     /** Dangling Param1 */ documentedMethod
     /** Dangling Param2 */(
-        /** Dangling Param3 */ string
-        /** Dangling Param4 */ message
-    /** Documented Parameter */)
+        string /** Documented Parameter */ message,
+        /** Default Documented Parameter */ string defMsg
+    /** Dangling Param3 */)
     /** Dangling Method1 */ throws
     /** Dangling Method2 */ DocumentedError
     /** Dangling Method3 */;
 
-    // The "Dangling Method3" doc comment above will be attributed to this method.
-    void notUndocumentedMethod(string message);
+    void undocumentedMethod(string message);
 }

--- a/lang/java/compiler/src/test/idl/output/comments.avpr
+++ b/lang/java/compiler/src/test/idl/output/comments.avpr
@@ -9,8 +9,7 @@
     "default" : "A"
   }, {
     "type" : "enum",
-    "name" : "NotUndocumentedEnum",
-    "doc" : "Dangling Enum9",
+    "name" : "UndocumentedEnum",
     "symbols" : [ "D", "E" ]
   }, {
     "type" : "fixed",
@@ -28,12 +27,15 @@
     "fields" : [ {
       "name" : "reason",
       "type" : "string",
-      "doc" : "Documented Field"
+      "doc" : "Documented Reason Field"
+    }, {
+      "name" : "explanation",
+      "type" : "string",
+      "doc" : "Default Doc Explanation Field"
     } ]
   }, {
     "type" : "record",
-    "name" : "NotUndocumentedRecord",
-    "doc" : "Dangling Error2",
+    "name" : "UndocumentedRecord",
     "fields" : [ {
       "name" : "description",
       "type" : "string"
@@ -46,12 +48,15 @@
         "name" : "message",
         "type" : "string",
         "doc" : "Documented Parameter"
+      }, {
+        "name" : "defMsg",
+        "type" : "string",
+        "doc" : "Default Documented Parameter"
       } ],
       "response" : "null",
       "errors" : [ "DocumentedError" ]
     },
-    "notUndocumentedMethod" : {
-      "doc" : "Dangling Method3",
+    "undocumentedMethod" : {
       "request" : [ {
         "name" : "message",
         "type" : "string"


### PR DESCRIPTION
Use the previously introduced method `DocCommentHandler#clearDoc()` to
generate warnings for misplaced documentation. Also add documentation to
describe the tricky bits when using this method.

The brittleness of the solution proves that doc comments as special
tokens are a hack. However, making regular tokens out of them may break
existing `.avdl` files.

Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3294
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR ~adds~ updates the following unit tests ~__OR__ does not need testing for this extremely good reason~:
  -  `org.apache.avro.compiler.idl.TestIdl#testDocCommentsAndWarnings`
  -  `input/comments.avdl` & `output/comments.avpr`

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
