### PR TITLE
AVRO-3120: Support Next Java LTS (Java 17)

### DIFF
--- a/.github/workflows/test-lang-java.yml
+++ b/.github/workflows/test-lang-java.yml
@@ -38,6 +38,7 @@ jobs:
         java:
         - '8'
         - '11'
+        - '17'
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/test-lang-java.yml
+++ b/.github/workflows/test-lang-java.yml
@@ -70,6 +70,7 @@ jobs:
         java:
         - '8'
         - '11'
+        - '17'
     steps:
       - uses: actions/checkout@v2
 

--- a/lang/java/mapred/pom.xml
+++ b/lang/java/mapred/pom.xml
@@ -194,8 +194,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.easymock</groupId>
-      <artifactId>easymock</artifactId>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/lang/java/mapred/src/test/java/org/apache/avro/mapreduce/TestAvroKeyInputFormat.java
+++ b/lang/java/mapred/src/test/java/org/apache/avro/mapreduce/TestAvroKeyInputFormat.java
@@ -19,7 +19,7 @@
 package org.apache.avro.mapreduce;
 
 import static org.junit.Assert.*;
-import static org.easymock.EasyMock.*;
+import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 
@@ -45,12 +45,9 @@ public class TestAvroKeyInputFormat {
     AvroJob.setInputKeySchema(job, Schema.create(Schema.Type.STRING));
     Configuration conf = job.getConfiguration();
 
-    FileSplit inputSplit = createMock(FileSplit.class);
-    TaskAttemptContext context = createMock(TaskAttemptContext.class);
-    expect(context.getConfiguration()).andReturn(conf).anyTimes();
-
-    replay(inputSplit);
-    replay(context);
+    FileSplit inputSplit = mock(FileSplit.class);
+    TaskAttemptContext context = mock(TaskAttemptContext.class);
+    when(context.getConfiguration()).thenReturn(conf);
 
     AvroKeyInputFormat inputFormat = new AvroKeyInputFormat();
     @SuppressWarnings("unchecked")
@@ -58,7 +55,6 @@ public class TestAvroKeyInputFormat {
     assertNotNull(inputFormat);
     recordReader.close();
 
-    verify(inputSplit);
-    verify(context);
+    verify(context).getConfiguration();
   }
 }

--- a/lang/java/mapred/src/test/java/org/apache/avro/mapreduce/TestAvroKeyOutputFormat.java
+++ b/lang/java/mapred/src/test/java/org/apache/avro/mapreduce/TestAvroKeyOutputFormat.java
@@ -151,7 +151,8 @@ public class TestAvroKeyOutputFormat {
     assertEquals(expectedCodec.toString(), capturedCodecFactory.getValue().toString());
 
     verify(context, atLeastOnce()).getConfiguration();
-    verify(recordWriterFactory).create(eq(writerSchema), any(ReflectData.class), any(CodecFactory.class), any(OutputStream.class), anyInt());
+    verify(recordWriterFactory).create(eq(writerSchema), any(ReflectData.class), any(CodecFactory.class),
+        any(OutputStream.class), anyInt());
 
     assertNotNull(recordWriter);
     assertSame(expectedRecordWriter, recordWriter);

--- a/lang/java/mapred/src/test/java/org/apache/avro/mapreduce/TestAvroKeyRecordReader.java
+++ b/lang/java/mapred/src/test/java/org/apache/avro/mapreduce/TestAvroKeyRecordReader.java
@@ -18,8 +18,8 @@
 
 package org.apache.avro.mapreduce;
 
-import static org.easymock.EasyMock.*;
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -68,18 +68,16 @@ public class TestAvroKeyRecordReader {
     Configuration conf = new Configuration();
 
     // Create a mock input split for this record reader.
-    FileSplit inputSplit = createMock(FileSplit.class);
-    expect(inputSplit.getPath()).andReturn(new Path("/path/to/an/avro/file")).anyTimes();
-    expect(inputSplit.getStart()).andReturn(0L).anyTimes();
-    expect(inputSplit.getLength()).andReturn(avroFileInput.length()).anyTimes();
+    FileSplit inputSplit = mock(FileSplit.class);
+    when(inputSplit.getPath()).thenReturn(new Path("/path/to/an/avro/file"));
+    when(inputSplit.getStart()).thenReturn(0L);
+    when(inputSplit.getLength()).thenReturn(avroFileInput.length());
 
     // Create a mock task attempt context for this record reader.
-    TaskAttemptContext context = createMock(TaskAttemptContext.class);
-    expect(context.getConfiguration()).andReturn(conf).anyTimes();
+    TaskAttemptContext context = mock(TaskAttemptContext.class);
+    when(context.getConfiguration()).thenReturn(conf);
 
     // Initialize the record reader.
-    replay(inputSplit);
-    replay(context);
     recordReader.initialize(inputSplit, context);
 
     assertEquals("Progress should be zero before any records are read", 0.0f, recordReader.getProgress(), 0.0f);
@@ -123,7 +121,9 @@ public class TestAvroKeyRecordReader {
     recordReader.close();
 
     // Verify the expected calls on the mocks.
-    verify(inputSplit);
-    verify(context);
+    verify(inputSplit).getPath();
+    verify(inputSplit, times(2)).getStart();
+    verify(inputSplit).getLength();
+    verify(context, atLeastOnce()).getConfiguration();
   }
 }

--- a/lang/java/mapred/src/test/java/org/apache/avro/mapreduce/TestAvroKeyRecordWriter.java
+++ b/lang/java/mapred/src/test/java/org/apache/avro/mapreduce/TestAvroKeyRecordWriter.java
@@ -18,12 +18,10 @@
 
 package org.apache.avro.mapreduce;
 
-import static org.easymock.EasyMock.createMock;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -55,9 +53,7 @@ public class TestAvroKeyRecordWriter {
     GenericData dataModel = new ReflectData();
     CodecFactory compressionCodec = CodecFactory.nullCodec();
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-    TaskAttemptContext context = createMock(TaskAttemptContext.class);
-
-    replay(context);
+    TaskAttemptContext context = mock(TaskAttemptContext.class);
 
     // Write an avro container file with two records: 1 and 2.
     AvroKeyRecordWriter<Integer> recordWriter = new AvroKeyRecordWriter<>(writerSchema, dataModel, compressionCodec,
@@ -65,8 +61,6 @@ public class TestAvroKeyRecordWriter {
     recordWriter.write(new AvroKey<>(1), NullWritable.get());
     recordWriter.write(new AvroKey<>(2), NullWritable.get());
     recordWriter.close(context);
-
-    verify(context);
 
     // Verify that the file was written as expected.
     InputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
@@ -81,6 +75,8 @@ public class TestAvroKeyRecordWriter {
     assertFalse(dataFileReader.hasNext()); // No more records.
 
     dataFileReader.close();
+
+    verify(context, never()).getConfiguration();
   }
 
   @Test
@@ -89,9 +85,7 @@ public class TestAvroKeyRecordWriter {
     GenericData dataModel = new ReflectData();
     CodecFactory compressionCodec = CodecFactory.nullCodec();
     FileOutputStream outputStream = new FileOutputStream(new File("target/temp.avro"));
-    TaskAttemptContext context = createMock(TaskAttemptContext.class);
-
-    replay(context);
+    TaskAttemptContext context = mock(TaskAttemptContext.class);
 
     // Write an avro container file with two records: 1 and 2.
     AvroKeyRecordWriter<Integer> recordWriter = new AvroKeyRecordWriter<>(writerSchema, dataModel, compressionCodec,
@@ -101,8 +95,6 @@ public class TestAvroKeyRecordWriter {
     long positionTwo = recordWriter.sync();
     recordWriter.write(new AvroKey<>(2), NullWritable.get());
     recordWriter.close(context);
-
-    verify(context);
 
     // Verify that the file was written as expected.
     Configuration conf = new Configuration();
@@ -120,5 +112,7 @@ public class TestAvroKeyRecordWriter {
     assertEquals(1, dataFileReader.next());
 
     dataFileReader.close();
+
+    verify(context, never()).getConfiguration();
   }
 }

--- a/lang/java/mapred/src/test/java/org/apache/avro/mapreduce/TestAvroKeyValueRecordReader.java
+++ b/lang/java/mapred/src/test/java/org/apache/avro/mapreduce/TestAvroKeyValueRecordReader.java
@@ -18,8 +18,8 @@
 
 package org.apache.avro.mapreduce;
 
-import static org.easymock.EasyMock.*;
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -80,18 +80,16 @@ public class TestAvroKeyValueRecordReader {
     Configuration conf = new Configuration();
 
     // Create a mock input split for this record reader.
-    FileSplit inputSplit = createMock(FileSplit.class);
-    expect(inputSplit.getPath()).andReturn(new Path("/path/to/an/avro/file")).anyTimes();
-    expect(inputSplit.getStart()).andReturn(0L).anyTimes();
-    expect(inputSplit.getLength()).andReturn(avroFileInput.length()).anyTimes();
+    FileSplit inputSplit = mock(FileSplit.class);
+    when(inputSplit.getPath()).thenReturn(new Path("/path/to/an/avro/file"));
+    when(inputSplit.getStart()).thenReturn(0L);
+    when(inputSplit.getLength()).thenReturn(avroFileInput.length());
 
     // Create a mock task attempt context for this record reader.
-    TaskAttemptContext context = createMock(TaskAttemptContext.class);
-    expect(context.getConfiguration()).andReturn(conf).anyTimes();
+    TaskAttemptContext context = mock(TaskAttemptContext.class);
+    when(context.getConfiguration()).thenReturn(conf);
 
     // Initialize the record reader.
-    replay(inputSplit);
-    replay(context);
     recordReader.initialize(inputSplit, context);
 
     assertEquals("Progress should be zero before any records are read", 0.0f, recordReader.getProgress(), 0.0f);
@@ -135,7 +133,9 @@ public class TestAvroKeyValueRecordReader {
     recordReader.close();
 
     // Verify the expected calls on the mocks.
-    verify(inputSplit);
-    verify(context);
+    verify(inputSplit).getPath();
+    verify(inputSplit, times(2)).getStart();
+    verify(inputSplit).getLength();
+    verify(context, atLeastOnce()).getConfiguration();
   }
 }

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -289,7 +289,7 @@
               <!-- Avro uses Sun's java code style conventions with 2 spaces, this is a modified version of
                    the eclipse formatter -->
               <file>${main.basedir}/lang/java/eclipse-java-formatter.xml</file>
-              <version>4.21.0</version>
+              <version>4.19.0</version>
             </eclipse>
             <!-- Temporarily disabled for JDK 16+ builds -->
             <!--<removeUnusedImports/>-->

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -55,7 +55,7 @@
     <commons-compress.version>1.21</commons-compress.version>
     <commons-lang.version>3.12.0</commons-lang.version>
     <tukaani.version>1.9</tukaani.version>
-    <easymock.version>4.3</easymock.version>
+    <mockito.version>4.2.0</mockito.version>
     <hamcrest.version>2.2</hamcrest.version>
     <grpc.version>1.43.1</grpc.version>
     <zstd-jni.version>1.5.1-1</zstd-jni.version>
@@ -289,9 +289,10 @@
               <!-- Avro uses Sun's java code style conventions with 2 spaces, this is a modified version of
                    the eclipse formatter -->
               <file>${main.basedir}/lang/java/eclipse-java-formatter.xml</file>
-              <version>4.19.0</version>
+              <version>4.21.0</version>
             </eclipse>
-            <removeUnusedImports/>
+            <!-- Temporarily disabled for JDK 16+ builds -->
+            <!--<removeUnusedImports/>-->
             <replaceRegex>
               <name>Remove wildcard imports</name>
               <searchRegex>import\s+[^\*\s]+\*;(\r\n|\r|\n)</searchRegex>
@@ -522,9 +523,9 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.easymock</groupId>
-        <artifactId>easymock</artifactId>
-        <version>${easymock.version}</version>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>${mockito.version}</version>
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>

--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -52,6 +52,7 @@ RUN apt-get -qqy update \
                                                  libssl-dev \
                                                  make \
                                                  mypy \
+                                                 openjdk-17-jdk \
                                                  openjdk-11-jdk \
                                                  openjdk-8-jdk \
                                                  perl \
@@ -191,6 +192,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --de
 # Note: This "ubertool" container has two JDK versions:
 # - OpenJDK 8
 # - OpenJDK 11
+# - OpenJDK 17
 # - The root build.sh script switches between the versions according to
 #   the JAVA environment variable.
 


### PR DESCRIPTION
- Disable Spotless' removeUnusedImports
(https://github.com/diffplug/spotless/issues/834). It will be re-enabled
once Avro is updated to JDK 11+. Then we can add .mvn/jvm.config (see
https://github.com/diffplug/spotless/issues/834#issuecomment-817524058)

- Replace Easymock with Mockito.

### Jira

- [X] My PR addresses the following [AVRO-3120](https://issues.apache.org/jira/browse/AVRO-3120) issue
- 
### Tests

- [X] My PR updates several unit tests to use Mockito instead of Easymock

### Commits

- [X] My commits all reference Jira issues in their subject lines. 

### Documentation

- [] TODO: Probably I should update the website and/or README