### PR TITLE
AVRO-3306: Java: Build failure with JDK 18+

### DIFF
--- a/.github/workflows/test-lang-java.yml
+++ b/.github/workflows/test-lang-java.yml
@@ -39,6 +39,7 @@ jobs:
         - '8'
         - '11'
         - '17'
+        - '18-ea'
     steps:
       - uses: actions/checkout@v2
 
@@ -53,7 +54,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
 
       - name: Lint
@@ -85,7 +86,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
 
       - name: Setup Python for Generating Input Data

--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
@@ -857,7 +857,7 @@ public class SpecificCompiler {
   /**
    * Utility for template use. Returns the unboxed java type for a Schema.
    *
-   * @deprecated use javaUnbox(Schema, boolean), kept for backward compatibiliby
+   * @deprecated use javaUnbox(Schema, boolean), kept for backward compatibility
    *             of custom templates
    */
   @Deprecated


### PR DESCRIPTION
Ignore compilation warnings that member fields are not Serializable

### Jira

- [X] My PR addresses the following [AVRO-3306](https://issues.apache.org/jira/browse/AVRO-3306) issue.

### Tests

- [X] My PR reuses the old unit tests.

### Commits

- [X] My commits all reference Jira issues in their subject lines.

### Documentation

- [X] No need of new documentation
