### PR TITLE
AVRO-3304: Drop-in reload4j to  mitigate log4j 1.x

### DIFF
--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -47,6 +47,7 @@
     <protobuf.version>3.19.1</protobuf.version>
     <thrift.version>0.15.0</thrift.version>
     <slf4j.version>1.7.32</slf4j.version>
+    <reload4j.version>1.2.18.0</reload4j.version>
     <snappy.version>1.1.8.4</snappy.version>
     <velocity.version>2.3</velocity.version>
     <maven.version>3.8.4</maven.version>

--- a/lang/java/tools/pom.xml
+++ b/lang/java/tools/pom.xml
@@ -272,6 +272,18 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
       <version>${slf4j.version}</version>
+      <!-- AVRO-3304: Drop-in reload4j replacement while waiting for downstream to bump log4j -->
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+      <version>${reload4j.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -301,6 +313,11 @@
         <exclusion>
           <groupId>org.apache.curator</groupId>
           <artifactId>curator-client</artifactId>
+        </exclusion>
+        <!-- AVRO-3304: Drop-in reload4j replacement while waiting for downstream to bump log4j -->
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
This is an alternative to https://github.com/apache/avro/pull/1458

That PR replaces the logging behind slf4j from log4j 1.x to slf4j-simple, while this PR drops in the reload4j replacement.

Both these solutions are "mitigation" solutions for current CVEs, while downstream projects still bring in log4j 1.x dependencies. 

I've verified that the classes in the generated avro-tools uberjar are the reload4j replacements.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3304
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR does not need testing for this extremely good reason: the equivalent of a version bump.

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
