### PR TITLE
AVRO-3322: Buffer is not defined in browser environment

### DIFF
--- a/lang/js/etc/browser/avro.js
+++ b/lang/js/etc/browser/avro.js
@@ -30,7 +30,8 @@
 
 var Tap = require('../../lib/utils').Tap,
     schemas = require('../../lib/schemas'),
-    deprecated = require('../deprecated/validator');
+    deprecated = require('../deprecated/validator'),
+    Buffer = require('buffer').Buffer
 
 
 function parse(schema, opts) {

--- a/lang/js/lib/schemas.js
+++ b/lang/js/lib/schemas.js
@@ -28,6 +28,7 @@ var utils = require('./utils'),
 // Convenience imports.
 var Tap = utils.Tap;
 var f = util.format;
+var Buffer = buffer.Buffer;
 
 // All Avro types.
 var TYPES = {


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-3322:Buffer is not defined in browser environment"
  - https://issues.apache.org/jira/browse/AVRO-3322
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
- PR simply adds declarations that do not change the actual code logic

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
