### PR TITLE
AVRO-3342 Updated CodeGenUtil to standard documentation styling 

### DIFF
--- a/lang/csharp/src/apache/main/CodeGen/CodeGenUtil.cs
+++ b/lang/csharp/src/apache/main/CodeGen/CodeGenUtil.cs
@@ -22,38 +22,53 @@ using System.CodeDom;
 namespace Avro
 {
     /// <summary>
-    /// A singleton class containing data used by codegen
+    /// A singleton class containing data used by codegen.
     /// </summary>
     public sealed class CodeGenUtil
     {
         /// <summary>
-        /// Singleton instance of this class.
+        /// Gets singleton instance of this class.
         /// </summary>
+        /// <value>
+        /// The instance.
+        /// </value>
         public static CodeGenUtil Instance { get; } = new CodeGenUtil();
 
         /// <summary>
-        /// Namespaces to import in generated code.
+        /// Gets namespaces to import in generated code.
         /// </summary>
+        /// <value>
+        /// The namespace imports.
+        /// </value>
         public CodeNamespaceImport[] NamespaceImports { get; private set; }
 
         /// <summary>
-        /// Comment included at the top of each generated code file.
+        /// Gets comment included at the top of each generated code file.
         /// </summary>
+        /// <value>
+        /// The file comment.
+        /// </value>
         public CodeCommentStatement FileComment { get; private set; }
 
         /// <summary>
-        /// Reserved keywords in the C# language.
+        /// Gets reserved keywords in the C# language.
         /// </summary>
+        /// <value>
+        /// The reserved keywords.
+        /// </value>
         public HashSet<string> ReservedKeywords { get; private set; }
 
         private const char At = '@';
         private const char Dot = '.';
 
         /// <summary>
-        /// Fully-qualified name of a <see cref="Object"/> type.
+        /// Fully-qualified name of a <see cref="Object" /> type.
         /// </summary>
         public const string Object = "System.Object";
 
+        /// <summary>
+        /// Prevents a default instance of the <see cref="CodeGenUtil"/> class from being created.
+        /// </summary>
         private CodeGenUtil()
         {
             NamespaceImports = new CodeNamespaceImport[] {
@@ -85,10 +100,10 @@ namespace Avro
         }
 
         /// <summary>
-        /// Append @ to all reserved keywords that appear on the given name
+        /// Append @ to all reserved keywords that appear on the given name.
         /// </summary>
-        /// <param name="name"></param>
-        /// <returns></returns>
+        /// <param name="name">The name.</param>
+        /// <returns>updated string.</returns>
         public string Mangle(string name)
         {
             var builder = new StringBuilder();
@@ -105,10 +120,10 @@ namespace Avro
         }
 
         /// <summary>
-        /// Remove all the @
+        /// Remove all the @.
         /// </summary>
-        /// <param name="name"></param>
-        /// <returns></returns>
+        /// <param name="name">The name.</param>
+        /// <returns>updated string.</returns>
         public string UnMangle(string name)
         {
             var builder = new StringBuilder(name.Length);


### PR DESCRIPTION
### Jira

- [ ] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3342

### Tests

- [ ] My PR does not need testing for this extremely good reason: non functional change

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
