### PR TITLE
AVRO-3345: Made Magic readonly in DataFileConstants

### DIFF
--- a/lang/csharp/src/apache/main/File/DataFileConstants.cs
+++ b/lang/csharp/src/apache/main/File/DataFileConstants.cs
@@ -21,9 +21,6 @@ namespace Avro.File
     /// <summary>
     /// Constants used in data files.
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design",
-        "CA1052:Static holder types should be Static or NotInheritable",
-        Justification = "Maintain public API")]
     public class DataFileConstants
     {
         /// <summary>
@@ -64,10 +61,13 @@ namespace Avro.File
         /// <summary>
         /// Magic bytes at the beginning of an Avro data file.
         /// </summary>
-        public static byte[] Magic = { (byte)'O',
-                                       (byte)'b',
-                                       (byte)'j',
-                                       Version };
+        public static readonly byte[] Magic =
+        {
+            (byte)'O',
+            (byte)'b',
+            (byte)'j',
+            Version,
+        };
 
         /// <summary>
         /// Hash code for the null codec.


### PR DESCRIPTION
### Jira

- [ ] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3345

### Tests

- [ ] My PR does not need testing for this extremely good reason: non functional change

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
