### PR TITLE
AVRO-3350 Validate default enum value exists before returning.

### DIFF
--- a/lang/csharp/src/apache/main/Schema/EnumSchema.cs
+++ b/lang/csharp/src/apache/main/Schema/EnumSchema.cs
@@ -139,16 +139,24 @@ namespace Avro
         /// Throws AvroException if the symbol is not found in this enum.
         /// </summary>
         /// <param name="symbol">name of the symbol to find</param>
-        /// <returns>position of the given symbol in this enum schema</returns>
+        /// <returns>
+        /// position of the given symbol in this enum schema
+        /// </returns>
+        /// <exception cref="Avro.AvroException">No such symbol: {symbol}</exception>
         public int Ordinal(string symbol)
         {
             int result;
             if (symbolMap.TryGetValue(symbol, out result))
+            {
                 return result;
-            if (null != Default)
-                return symbolMap[Default];
+            }
 
-            throw new AvroException("No such symbol: " + symbol);
+            if (Default != null && symbolMap.TryGetValue(Default, out result))
+            {
+                return result;
+            }
+
+            throw new AvroException($"No such symbol: {symbol}");
         }
 
         /// <summary>

--- a/lang/csharp/src/apache/test/Schema/SchemaTests.cs
+++ b/lang/csharp/src/apache/test/Schema/SchemaTests.cs
@@ -167,6 +167,24 @@ namespace Avro.Test
             }
         }
 
+        private static void testToString(Schema sc, string schema)
+        {
+            try
+            {
+                //remove any excess spaces in the JSON to normalize the match with toString 
+                schema = schema.Replace("{ ", "{")
+                    .Replace("} ", "}")
+                    .Replace("\" ", "\"")
+                    .Replace(", ", ",")
+                    .Replace(": ", ":");
+                Assert.AreEqual(sc.ToString(), schema);
+            }
+            catch (Exception e)
+            {
+                throw new AvroException($"{e} : {sc}", e);
+            }
+        }
+
         [TestCase("{\"type\":\"record\",\"name\":\"LongList\"," +
             "\"fields\":[{\"name\":\"f1\",\"type\":\"long\"}," +
             "{\"name\":\"f2\",\"type\": \"int\"}]}",
@@ -231,6 +249,8 @@ namespace Avro.Test
 
         [TestCase("{\"type\": \"enum\", \"name\": \"Test\", \"symbols\": [\"A\", \"B\"]}",
             new string[] { "A", "B" })]
+        [TestCase("{\"type\": \"enum\",\"name\":\"Market\",\"symbols\":[\"UNKNOWN\",\"A\",\"B\"],\"default\":\"UNKNOWN\"}",
+            new string[] { "UNKNOWN", "A", "B" })]
         public void TestEnum(string s, string[] symbols)
         {
             Schema sc = Schema.Parse(s);
@@ -239,13 +259,13 @@ namespace Avro.Test
             Assert.AreEqual(symbols.Length, es.Count);
 
             int i = 0;
-            foreach (String str in es)
+            foreach (string str in es)
             {
                 Assert.AreEqual(symbols[i++], str);
             }
 
             testEquality(s, sc);
-            testToString(sc);
+            testToString(sc, s);
         }
 
         [TestCase("{\"type\": \"enum\", \"name\": \"Test\", \"symbols\": [\"A\", \"B\"]}", null)]


### PR DESCRIPTION
Current implementation could return a KeyNotFoundException

### Jira

- [ ] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3350

### Tests

- [ ] My PR adds the following unit tests: Added additional enum unit tests and string validation

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
