### PR TITLE
AVRO-3331: Rust: Cannot extract Decimal value

### DIFF
--- a/lang/rust/Cargo.toml
+++ b/lang/rust/Cargo.toml
@@ -59,6 +59,7 @@ digest = "0.10.1"
 libflate = "1.1.1"
 xz2 = { version = "0.1.6", optional = true }
 num-bigint = "0.4.2"
+num-traits = "0.2.14"
 rand = "0.8.4"
 regex = "1.5.4"
 serde_json = "1.0.67"

--- a/lang/rust/src/decimal.rs
+++ b/lang/rust/src/decimal.rs
@@ -17,11 +17,33 @@
 
 use crate::{AvroResult, Error};
 use num_bigint::{BigInt, Sign};
+use num_traits::ToPrimitive;
+use std::str::FromStr;
 
+/// A struct used to hold decimal values
+///
+/// Usage:
+///
+/// ```rust
+/// use apache_avro::{Decimal, Error};
+/// use num_bigint::ToBigInt;
+/// use std::convert::TryFrom;
+///
+/// let decimal1 = Decimal::from_f64(9936.45).unwrap();
+/// let decimal1_as_f64 = decimal1.to_f64();
+///
+/// let precision = 4;
+/// let scale = 2;
+/// let decimal2 = Decimal::from_bytes(vec![9, 9, 3, 6], precision, scale);
+/// let decimal2_as_f64 = decimal2.to_f64();
+///
+/// ```
 #[derive(Debug, Clone)]
 pub struct Decimal {
     value: BigInt,
     len: usize,
+    precision: usize,
+    scale: usize,
 }
 
 // We only care about value equality, not byte length. Can two equal `BigInt`s have two different
@@ -45,30 +67,130 @@ impl Decimal {
         let sign_byte = 0xFF * u8::from(self.value.sign() == Sign::Minus);
         let mut decimal_bytes = vec![sign_byte; len];
         let raw_bytes = self.value.to_signed_bytes_be();
-        let num_raw_bytes = raw_bytes.len();
-        let start_byte_index = len.checked_sub(num_raw_bytes).ok_or(Error::SignExtend {
+        let raw_bytes_len = raw_bytes.len();
+        let start_byte_index = len.checked_sub(raw_bytes_len).ok_or(Error::SignExtend {
             requested: len,
-            needed: num_raw_bytes,
+            needed: raw_bytes_len,
         })?;
         decimal_bytes[start_byte_index..].copy_from_slice(&raw_bytes);
         Ok(decimal_bytes)
+    }
+
+    pub fn from_f64(decimal: f64) -> AvroResult<Self> {
+        let as_str = format!("{}", decimal);
+        let (decimal_str, precision, scale) = match as_str.find('.') {
+            Some(index) => {
+                let lhs = as_str.get(..index).unwrap();
+                let rhs = as_str.get(index + 1..).unwrap();
+                let number = format!("{}{}", lhs, rhs);
+                let rhs_len = rhs.len();
+                (number, lhs.len() + rhs_len, rhs_len)
+            }
+            None => (as_str.clone(), as_str.len(), 0),
+        };
+
+        Ok(Self {
+            value: BigInt::from_str(decimal_str.as_str()).unwrap(),
+            len: decimal_str.len(),
+            precision,
+            scale,
+        })
+    }
+
+    /// Create a new decimal from a signed Big-Endian encoded byte array
+    pub fn from_bytes<T: AsRef<[u8]>>(bytes: T, precision: usize, scale: usize) -> Self {
+        let bytes_ref = bytes.as_ref();
+        Self {
+            value: BigInt::from_signed_bytes_be(bytes_ref),
+            len: bytes_ref.len(),
+            precision,
+            scale,
+        }
+    }
+
+    pub fn scale(&self) -> usize {
+        self.scale
+    }
+
+    pub fn precision(&self) -> usize {
+        self.precision
+    }
+
+    pub fn to_f64(&self) -> f64 {
+        let unsigned = self.value.to_u128().unwrap();
+
+        if self.scale == 0 {
+            unsigned.to_f64().unwrap()
+        } else {
+            let mut f = unsigned.to_f64().unwrap();
+            let mut scale = self.scale;
+            while scale > 0 {
+                f /= 10.0;
+                scale -= 1;
+            }
+            f
+        }
     }
 }
 
 impl std::convert::TryFrom<&Decimal> for Vec<u8> {
     type Error = Error;
 
+    #[inline]
     fn try_from(decimal: &Decimal) -> Result<Self, Self::Error> {
         decimal.to_vec()
     }
 }
 
-impl<T: AsRef<[u8]>> From<T> for Decimal {
-    fn from(bytes: T) -> Self {
-        let bytes_ref = bytes.as_ref();
-        Self {
-            value: BigInt::from_signed_bytes_be(bytes_ref),
-            len: bytes_ref.len(),
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{schema::Schema, types::Record, Codec, Reader, Writer};
+
+    #[test]
+    fn test_decimal_schema() {
+        let schema_str = r#"
+            {
+                "type": "record",
+                "name":"DecimalTest",
+                "fields": [
+                   {
+                        "name": "decimal",
+                        "type": {
+                            "type": "bytes",
+                            "logicalType": "decimal",
+                            "precision": 10,
+                            "scale": 2
+                        }
+                    }
+                ]
+            }
+        "#;
+        let schema = Schema::parse_str(schema_str).unwrap();
+        let mut datum = Record::new(&schema).unwrap();
+        let decimal_value = 9936.23_f64;
+        datum.put("decimal", Decimal::from_f64(decimal_value).unwrap());
+        let mut writer = Writer::with_codec(&schema, Vec::new(), Codec::Null);
+        writer.append(datum).unwrap();
+        let bytes = writer.into_inner().unwrap();
+
+        let reader = Reader::new(&bytes[..]).unwrap();
+        for value in reader {
+            let value = value.unwrap();
+            match value {
+                crate::types::Value::Record(fields) => {
+                    let (_name, decimal) = fields.get(0).unwrap();
+                    match decimal {
+                        crate::types::Value::Decimal(decimal) => {
+                            assert_eq!(decimal.to_f64(), decimal_value);
+                            assert_eq!(decimal.precision(), 10);
+                            assert_eq!(decimal.scale(), 2);
+                        }
+                        _ => panic!("unexpected value: {:?}", decimal),
+                    }
+                }
+                _ => panic!("unexpected type: {:?}", value),
+            }
         }
     }
 }

--- a/lang/rust/src/decode.rs
+++ b/lang/rust/src/decode.rs
@@ -104,11 +104,9 @@ pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> AvroResult<Value> {
                     value => Err(Error::FixedValue(value.into())),
                 },
                 Schema::Bytes => match decode0(inner, reader, schemas_by_name)? {
-                    Value::Bytes(bytes) => {
-                        Ok(Value::Decimal(Decimal::from_bytes(
-                            bytes, precision, scale,
-                        )?))
-                    }
+                    Value::Bytes(bytes) => Ok(Value::Decimal(Decimal::from_bytes(
+                        bytes, precision, scale,
+                    )?)),
                     value => Err(Error::BytesValue(value.into())),
                 },
                 schema => Err(Error::ResolveDecimalSchema(schema.into())),

--- a/lang/rust/src/decode.rs
+++ b/lang/rust/src/decode.rs
@@ -98,14 +98,16 @@ pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> AvroResult<Value> {
                 scale,
             } => match &**inner {
                 Schema::Fixed { .. } => match decode0(inner, reader, schemas_by_name)? {
-                    Value::Fixed(_, bytes) => {
-                        Ok(Value::Decimal(Decimal::from_bytes(bytes, precision, scale)))
-                    }
+                    Value::Fixed(_, bytes) => Ok(Value::Decimal(Decimal::from_bytes(
+                        bytes, precision, scale,
+                    )?)),
                     value => Err(Error::FixedValue(value.into())),
                 },
                 Schema::Bytes => match decode0(inner, reader, schemas_by_name)? {
                     Value::Bytes(bytes) => {
-                        Ok(Value::Decimal(Decimal::from_bytes(bytes, precision, scale)))
+                        Ok(Value::Decimal(Decimal::from_bytes(
+                            bytes, precision, scale,
+                        )?))
                     }
                     value => Err(Error::BytesValue(value.into())),
                 },
@@ -351,11 +353,9 @@ mod tests {
             scale,
         };
         let bigint = (-423).to_bigint().unwrap();
-        let value = Value::Decimal(Decimal::from_bytes(
-            bigint.to_signed_bytes_be(),
-            precision,
-            scale,
-        ));
+        let value = Value::Decimal(
+            Decimal::from_bytes(bigint.to_signed_bytes_be(), precision, scale).unwrap(),
+        );
 
         let mut buffer = Vec::new();
         encode(&value, &schema, &mut buffer);
@@ -381,11 +381,14 @@ mod tests {
             precision,
             scale,
         };
-        let value = Value::Decimal(Decimal::from_bytes(
-            ((-423).to_bigint().unwrap()).to_signed_bytes_be(),
-            precision,
-            scale,
-        ));
+        let value = Value::Decimal(
+            Decimal::from_bytes(
+                ((-423).to_bigint().unwrap()).to_signed_bytes_be(),
+                precision,
+                scale,
+            )
+            .unwrap(),
+        );
         let mut buffer = Vec::<u8>::new();
 
         encode(&value, &schema, &mut buffer);

--- a/lang/rust/src/error.rs
+++ b/lang/rust/src/error.rs
@@ -252,7 +252,9 @@ pub enum Error {
         precision: serde_json::Value,
     },
 
-    #[error("Decimal's precision could be up to 308 (to fit in f64::MAX). Requested {precision:?}")]
+    #[error(
+        "Decimal's precision could be up to 308 (to fit in f64::MAX). Requested {precision:?}"
+    )]
     DecimalPrecisionTooLarge { precision: usize },
 
     #[error("Decimal's precision could not be NAN.")]

--- a/lang/rust/src/error.rs
+++ b/lang/rust/src/error.rs
@@ -252,6 +252,9 @@ pub enum Error {
         precision: serde_json::Value,
     },
 
+    #[error("Decimal's precision could be up to 128. Requested {precision:?}")]
+    DecimalPrecisionTooLarge { precision: usize },
+
     #[error("Unexpected `type` {0} variant for `logicalType`")]
     GetLogicalTypeVariant(serde_json::Value),
 

--- a/lang/rust/src/error.rs
+++ b/lang/rust/src/error.rs
@@ -252,8 +252,11 @@ pub enum Error {
         precision: serde_json::Value,
     },
 
-    #[error("Decimal's precision could be up to 128. Requested {precision:?}")]
+    #[error("Decimal's precision could be up to 308 (to fit in f64::MAX). Requested {precision:?}")]
     DecimalPrecisionTooLarge { precision: usize },
+
+    #[error("Decimal's precision could not be NAN.")]
+    DecimalPrecisionNAN,
 
     #[error("Unexpected `type` {0} variant for `logicalType`")]
     GetLogicalTypeVariant(serde_json::Value),

--- a/lang/rust/src/lib.rs
+++ b/lang/rust/src/lib.rs
@@ -602,8 +602,8 @@
 //!     let mut writer = Writer::with_codec(&schema, Vec::new(), Codec::Deflate);
 //!
 //!     let mut record = Record::new(writer.schema()).unwrap();
-//!     record.put("decimal_fixed", Decimal::from(9936.to_bigint().unwrap().to_signed_bytes_be()));
-//!     record.put("decimal_var", Decimal::from((-32442.to_bigint().unwrap()).to_signed_bytes_be()));
+//!     record.put("decimal_fixed", Decimal::from_f64(36.12).unwrap());
+//!     record.put("decimal_var", Decimal::from_f64(-32442.23).unwrap());
 //!     record.put("uuid", uuid::Uuid::new_v4());
 //!     record.put("date", Value::Date(1));
 //!     record.put("time_millis", Value::TimeMillis(2));

--- a/lang/rust/src/schema.rs
+++ b/lang/rust/src/schema.rs
@@ -120,8 +120,8 @@ pub enum Schema {
     /// `scale` defaults to 0 and is an integer greater than or equal to 0 and `precision` is an
     /// integer greater than 0.
     Decimal {
-        precision: DecimalMetadata,
-        scale: DecimalMetadata,
+        precision: Precision,
+        scale: Scale,
         inner: Box<Schema>,
     },
     /// A universally unique identifier, annotating a string.

--- a/lang/rust/src/types.rs
+++ b/lang/rust/src/types.rs
@@ -549,7 +549,9 @@ impl Value {
                     })
                 } else {
                     // precision and scale match, can we assume the underlying type can hold the data?
-                    Ok(Value::Decimal(Decimal::from_bytes(bytes, precision, scale)))
+                    Ok(Value::Decimal(Decimal::from_bytes(
+                        bytes, precision, scale,
+                    )?))
                 }
             }
             other => Err(Error::ResolveDecimal(other.into())),
@@ -1052,7 +1054,7 @@ mod tests {
     fn resolve_decimal_bytes() {
         let precision = 10;
         let scale = 4;
-        let value = Value::Decimal(Decimal::from_bytes(vec![1, 2], precision, scale));
+        let value = Value::Decimal(Decimal::from_bytes(vec![1, 2], precision, scale).unwrap());
         value
             .clone()
             .resolve(&Schema::Decimal {
@@ -1068,7 +1070,7 @@ mod tests {
     fn resolve_decimal_invalid_scale() {
         let precision = 2;
         let scale = 3;
-        let value = Value::Decimal(Decimal::from_bytes(vec![1], precision, scale));
+        let value = Value::Decimal(Decimal::from_bytes(vec![1], precision, scale).unwrap());
         assert!(value
             .resolve(&Schema::Decimal {
                 precision,
@@ -1082,11 +1084,9 @@ mod tests {
     fn resolve_decimal_invalid_precision_for_length() {
         let precision = 1;
         let scale = 0;
-        let value = Value::Decimal(Decimal::from_bytes(
-            (1u8..=8u8).rev().collect::<Vec<_>>(),
-            precision,
-            scale,
-        ));
+        let value = Value::Decimal(
+            Decimal::from_bytes((1u8..=8u8).rev().collect::<Vec<_>>(), 100, scale).unwrap(),
+        );
         assert!(value
             .resolve(&Schema::Decimal {
                 precision,
@@ -1100,7 +1100,7 @@ mod tests {
     fn resolve_decimal_fixed() {
         let precision = 10;
         let scale = 1;
-        let value = Value::Decimal(Decimal::from_bytes(vec![1, 2], precision, scale));
+        let value = Value::Decimal(Decimal::from_bytes(vec![1, 2], precision, scale).unwrap());
         assert!(value
             .clone()
             .resolve(&Schema::Decimal {
@@ -1284,7 +1284,10 @@ mod tests {
             JsonValue::Number(1_i32.into())
         );
         assert_eq!(
-            JsonValue::try_from(Value::Decimal(Decimal::from_bytes(vec![1, 2, 3], 3, 0))).unwrap(),
+            JsonValue::try_from(Value::Decimal(
+                Decimal::from_bytes(vec![1, 2, 3], 5, 0).unwrap()
+            ))
+            .unwrap(),
             JsonValue::Array(vec![
                 JsonValue::Number(1_i32.into()),
                 JsonValue::Number(2_i32.into()),

--- a/lang/rust/src/writer.rs
+++ b/lang/rust/src/writer.rs
@@ -507,14 +507,16 @@ mod tests {
             size,
         };
         let value = vec![0u8; size];
+        let precision = 20;
+        let scale = 5;
         logical_type_test(
             r#"{"type": {"type": "fixed", "size": 30, "name": "decimal"}, "logicalType": "decimal", "precision": 20, "scale": 5}"#,
             &Schema::Decimal {
-                precision: 20,
-                scale: 5,
+                precision,
+                scale,
                 inner: Box::new(inner.clone()),
             },
-            Value::Decimal(Decimal::from(value.clone())),
+            Value::Decimal(Decimal::from_bytes(value.clone(), precision, scale)),
             &inner,
             Value::Fixed(size, value),
         )
@@ -524,14 +526,16 @@ mod tests {
     fn decimal_bytes() -> TestResult<()> {
         let inner = Schema::Bytes;
         let value = vec![0u8; 10];
+        let precision = 4;
+        let scale = 3;
         logical_type_test(
             r#"{"type": "bytes", "logicalType": "decimal", "precision": 4, "scale": 3}"#,
             &Schema::Decimal {
-                precision: 4,
-                scale: 3,
+                precision,
+                scale,
                 inner: Box::new(inner.clone()),
             },
-            Value::Decimal(Decimal::from(value.clone())),
+            Value::Decimal(Decimal::from_bytes(value.clone(), precision, scale)),
             &inner,
             value,
         )

--- a/lang/rust/src/writer.rs
+++ b/lang/rust/src/writer.rs
@@ -516,7 +516,7 @@ mod tests {
                 scale,
                 inner: Box::new(inner.clone()),
             },
-            Value::Decimal(Decimal::from_bytes(value.clone(), precision, scale)),
+            Value::Decimal(Decimal::from_bytes(value.clone(), precision, scale).unwrap()),
             &inner,
             Value::Fixed(size, value),
         )
@@ -535,7 +535,7 @@ mod tests {
                 scale,
                 inner: Box::new(inner.clone()),
             },
-            Value::Decimal(Decimal::from_bytes(value.clone(), precision, scale)),
+            Value::Decimal(Decimal::from_bytes(value.clone(), precision, scale).unwrap()),
             &inner,
             value,
         )


### PR DESCRIPTION
Introduce apache_avro::Decimal #from_f64 and #to_f64() which use the
configured/calculated scale to convert to/from BigInt

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3331
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x) - added `num-traits` dependency that is `MIT OR Apache-2.0`.

### Tests

- [X] My PR adds new unit tests

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [] TODO