### PR TITLE
AVRO-3355 Fix order of access modifier

### DIFF
--- a/lang/csharp/src/apache/main/File/Codec.cs
+++ b/lang/csharp/src/apache/main/File/Codec.cs
@@ -54,14 +54,14 @@ namespace Avro.File
         {
             return Decompress(compressedData, compressedData.Length);
         }
-        
+
         /// <summary>
         /// Decompress data using implemented codec
         /// </summary>
         /// <param name="compressedData">The buffer holding data to decompress.</param>
         /// <param name="length">The actual length of bytes to decompress from the buffer.</param>
         /// <returns>A byte array holding the decompressed data.</returns>
-        abstract public byte[] Decompress(byte[] compressedData, int length);
+        public abstract byte[] Decompress(byte[] compressedData, int length);
 
         /// <summary>
         /// Name of this codec type.
@@ -110,6 +110,9 @@ namespace Avro.File
         /// <param name="codecMetaString">The codec string</param>
         public delegate Codec CodecResolver(string codecMetaString);
 
+        /// <summary>
+        /// The codec resolvers
+        /// </summary>
         private static readonly List<CodecResolver> _codecResolvers = new List<CodecResolver>();
 
         /// <summary>
@@ -155,7 +158,7 @@ namespace Avro.File
                     return candidateCodec;
                 }
             }
-            
+
             switch (codecType)
             {
                 case DataFileConstants.DeflateCodec:


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3355

### Tests

- [ ] My PR  does not need testing for this extremely good reason: non functional change

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
