### PR TITLE
AVRO-3380: Raise an exception if invalid number of bytes read

### DIFF
--- a/lang/py/avro/errors.py
+++ b/lang/py/avro/errors.py
@@ -32,7 +32,7 @@ class AvroException(Exception):
     """The base class for exceptions in avro."""
 
 
-class InvalidBytesRead(AvroException):
+class InvalidAvroBinaryEncoding(AvroException):
     """For invalid numbers of bytes read."""
 
 

--- a/lang/py/avro/errors.py
+++ b/lang/py/avro/errors.py
@@ -32,6 +32,10 @@ class AvroException(Exception):
     """The base class for exceptions in avro."""
 
 
+class InvalidBytesRead(AvroException):
+    """For invalid numbers of bytes read."""
+
+
 class SchemaParseException(AvroException):
     """Raised when a schema failed to parse."""
 

--- a/lang/py/avro/io.py
+++ b/lang/py/avro/io.py
@@ -222,6 +222,8 @@ class BinaryDecoder:
         """
         Read n bytes.
         """
+        if n < 0:
+            raise avro.errors.InvalidAvroBinaryEncoding(f"Requested {n} bytes to read, expected positive integer.")
         read_bytes = self.reader.read(n)
         if len(read_bytes) != n:
             raise avro.errors.InvalidAvroBinaryEncoding(f"Read {len(read_bytes)} bytes, expected {n} bytes")

--- a/lang/py/avro/io.py
+++ b/lang/py/avro/io.py
@@ -668,69 +668,63 @@ class DatumReader:
             # This shouldn't happen because of the match check at the start of this method.
             raise avro.errors.SchemaResolutionException("Schemas do not match.", writers_schema, readers_schema)
 
-        try:
-            if writers_schema.type == "null":
-                return None
-            if writers_schema.type == "boolean":
-                return decoder.read_boolean()
-            if writers_schema.type == "string":
-                return decoder.read_utf8()
-            if writers_schema.type == "int":
-                if logical_type == avro.constants.DATE:
-                    return decoder.read_date_from_int()
-                if logical_type == avro.constants.TIME_MILLIS:
-                    return decoder.read_time_millis_from_int()
-                return decoder.read_int()
-            if writers_schema.type == "long":
-                if logical_type == avro.constants.TIME_MICROS:
-                    return decoder.read_time_micros_from_long()
-                if logical_type == avro.constants.TIMESTAMP_MILLIS:
-                    return decoder.read_timestamp_millis_from_long()
-                if logical_type == avro.constants.TIMESTAMP_MICROS:
-                    return decoder.read_timestamp_micros_from_long()
-                return decoder.read_long()
-            if writers_schema.type == "float":
-                return decoder.read_float()
-            if writers_schema.type == "double":
-                return decoder.read_double()
-            if writers_schema.type == "bytes":
-                if logical_type == "decimal":
-                    precision = writers_schema.get_prop("precision")
-                    if not (isinstance(precision, int) and precision > 0):
-                        warnings.warn(avro.errors.IgnoredLogicalType(f"Invalid decimal precision {precision}. Must be a positive integer."))
-                        return decoder.read_bytes()
-                    scale = writers_schema.get_prop("scale")
-                    if not (isinstance(scale, int) and scale > 0):
-                        warnings.warn(avro.errors.IgnoredLogicalType(f"Invalid decimal scale {scale}. Must be a positive integer."))
-                        return decoder.read_bytes()
-                    return decoder.read_decimal_from_bytes(precision, scale)
-                return decoder.read_bytes()
-            if isinstance(writers_schema, avro.schema.FixedSchema) and isinstance(readers_schema, avro.schema.FixedSchema):
-                if logical_type == "decimal":
-                    precision = writers_schema.get_prop("precision")
-                    if not (isinstance(precision, int) and precision > 0):
-                        warnings.warn(avro.errors.IgnoredLogicalType(f"Invalid decimal precision {precision}. Must be a positive integer."))
-                        return self.read_fixed(writers_schema, readers_schema, decoder)
-                    scale = writers_schema.get_prop("scale")
-                    if not (isinstance(scale, int) and scale > 0):
-                        warnings.warn(avro.errors.IgnoredLogicalType(f"Invalid decimal scale {scale}. Must be a positive integer."))
-                        return self.read_fixed(writers_schema, readers_schema, decoder)
-                    return decoder.read_decimal_from_fixed(precision, scale, writers_schema.size)
-                return self.read_fixed(writers_schema, readers_schema, decoder)
-            if isinstance(writers_schema, avro.schema.EnumSchema) and isinstance(readers_schema, avro.schema.EnumSchema):
-                return self.read_enum(writers_schema, readers_schema, decoder)
-            if isinstance(writers_schema, avro.schema.ArraySchema) and isinstance(readers_schema, avro.schema.ArraySchema):
-                return self.read_array(writers_schema, readers_schema, decoder)
-            if isinstance(writers_schema, avro.schema.MapSchema) and isinstance(readers_schema, avro.schema.MapSchema):
-                return self.read_map(writers_schema, readers_schema, decoder)
-            if isinstance(writers_schema, avro.schema.RecordSchema) and isinstance(readers_schema, avro.schema.RecordSchema):
-                # .type in ["record", "error", "request"]:
-                return self.read_record(writers_schema, readers_schema, decoder)
-        except avro.errors.InvalidAvroBinaryEncoding as e:
-            decoder.reader.seek(0)
-            datum = decoder.reader.read(-1)
-            assert self.readers_schema is not None # Make mypy happy, readers schema is set in this point.
-            raise avro.errors.AvroTypeException(self.readers_schema, self.readers_schema.type, datum) from e
+        if writers_schema.type == "null":
+            return None
+        if writers_schema.type == "boolean":
+            return decoder.read_boolean()
+        if writers_schema.type == "string":
+            return decoder.read_utf8()
+        if writers_schema.type == "int":
+            if logical_type == avro.constants.DATE:
+                return decoder.read_date_from_int()
+            if logical_type == avro.constants.TIME_MILLIS:
+                return decoder.read_time_millis_from_int()
+            return decoder.read_int()
+        if writers_schema.type == "long":
+            if logical_type == avro.constants.TIME_MICROS:
+                return decoder.read_time_micros_from_long()
+            if logical_type == avro.constants.TIMESTAMP_MILLIS:
+                return decoder.read_timestamp_millis_from_long()
+            if logical_type == avro.constants.TIMESTAMP_MICROS:
+                return decoder.read_timestamp_micros_from_long()
+            return decoder.read_long()
+        if writers_schema.type == "float":
+            return decoder.read_float()
+        if writers_schema.type == "double":
+            return decoder.read_double()
+        if writers_schema.type == "bytes":
+            if logical_type == "decimal":
+                precision = writers_schema.get_prop("precision")
+                if not (isinstance(precision, int) and precision > 0):
+                    warnings.warn(avro.errors.IgnoredLogicalType(f"Invalid decimal precision {precision}. Must be a positive integer."))
+                    return decoder.read_bytes()
+                scale = writers_schema.get_prop("scale")
+                if not (isinstance(scale, int) and scale > 0):
+                    warnings.warn(avro.errors.IgnoredLogicalType(f"Invalid decimal scale {scale}. Must be a positive integer."))
+                    return decoder.read_bytes()
+                return decoder.read_decimal_from_bytes(precision, scale)
+            return decoder.read_bytes()
+        if isinstance(writers_schema, avro.schema.FixedSchema) and isinstance(readers_schema, avro.schema.FixedSchema):
+            if logical_type == "decimal":
+                precision = writers_schema.get_prop("precision")
+                if not (isinstance(precision, int) and precision > 0):
+                    warnings.warn(avro.errors.IgnoredLogicalType(f"Invalid decimal precision {precision}. Must be a positive integer."))
+                    return self.read_fixed(writers_schema, readers_schema, decoder)
+                scale = writers_schema.get_prop("scale")
+                if not (isinstance(scale, int) and scale > 0):
+                    warnings.warn(avro.errors.IgnoredLogicalType(f"Invalid decimal scale {scale}. Must be a positive integer."))
+                    return self.read_fixed(writers_schema, readers_schema, decoder)
+                return decoder.read_decimal_from_fixed(precision, scale, writers_schema.size)
+            return self.read_fixed(writers_schema, readers_schema, decoder)
+        if isinstance(writers_schema, avro.schema.EnumSchema) and isinstance(readers_schema, avro.schema.EnumSchema):
+            return self.read_enum(writers_schema, readers_schema, decoder)
+        if isinstance(writers_schema, avro.schema.ArraySchema) and isinstance(readers_schema, avro.schema.ArraySchema):
+            return self.read_array(writers_schema, readers_schema, decoder)
+        if isinstance(writers_schema, avro.schema.MapSchema) and isinstance(readers_schema, avro.schema.MapSchema):
+            return self.read_map(writers_schema, readers_schema, decoder)
+        if isinstance(writers_schema, avro.schema.RecordSchema) and isinstance(readers_schema, avro.schema.RecordSchema):
+            # .type in ["record", "error", "request"]:
+            return self.read_record(writers_schema, readers_schema, decoder)
         raise avro.errors.AvroException(f"Cannot read unknown schema type: {writers_schema.type}")
 
     def skip_data(self, writers_schema: avro.schema.Schema, decoder: BinaryDecoder) -> None:

--- a/lang/py/avro/io.py
+++ b/lang/py/avro/io.py
@@ -224,7 +224,7 @@ class BinaryDecoder:
         """
         read_bytes = self.reader.read(n)
         if len(read_bytes) != n:
-            raise avro.errors.InvalidBytesRead(f"Read {len(read_bytes)} bytes, expected {n} bytes")
+            raise avro.errors.InvalidAvroBinaryEncoding(f"Read {len(read_bytes)} bytes, expected {n} bytes")
         return read_bytes
 
     def read_null(self) -> None:
@@ -724,7 +724,7 @@ class DatumReader:
             if isinstance(writers_schema, avro.schema.RecordSchema) and isinstance(readers_schema, avro.schema.RecordSchema):
                 # .type in ["record", "error", "request"]:
                 return self.read_record(writers_schema, readers_schema, decoder)
-        except avro.errors.InvalidBytesRead as e:
+        except avro.errors.InvalidAvroBinaryEncoding as e:
             decoder.reader.seek(0)
             datum = decoder.reader.read(-1)
             assert self.readers_schema is not None # Make mypy happy, readers schema is set in this point.

--- a/lang/py/avro/test/test_io.py
+++ b/lang/py/avro/test/test_io.py
@@ -468,6 +468,15 @@ class TestIncompatibleSchemaReading(unittest.TestCase):
         with io.BytesIO(enc_bytes) as reader_bio:
             self.assertRaises(avro.errors.AvroTypeException, reader.read, avro.io.BinaryDecoder(reader_bio))
 
+        incompatibleUserRecord = {"name": -10, "age": 21, "location": "Woodford"}
+        with io.BytesIO() as writer_bio:
+            enc = avro.io.BinaryEncoder(writer_bio)
+            writer.write(incompatibleUserRecord, enc)
+            enc_bytes = writer_bio.getvalue()
+        reader = avro.io.DatumReader(reader_schema)
+        with io.BytesIO(enc_bytes) as reader_bio:
+            self.assertRaises(avro.errors.InvalidAvroBinaryEncoding, reader.read, avro.io.BinaryDecoder(reader_bio))
+
 
 class TestMisc(unittest.TestCase):
     def test_decimal_bytes_small_scale(self) -> None:

--- a/lang/py/avro/test/test_io.py
+++ b/lang/py/avro/test/test_io.py
@@ -466,7 +466,7 @@ class TestIncompatibleSchemaReading(unittest.TestCase):
             enc_bytes = writer_bio.getvalue()
         reader = avro.io.DatumReader(reader_schema)
         with io.BytesIO(enc_bytes) as reader_bio:
-            self.assertRaises(avro.errors.AvroTypeException, reader.read, avro.io.BinaryDecoder(reader_bio))
+            self.assertRaises(avro.errors.InvalidAvroBinaryEncoding, reader.read, avro.io.BinaryDecoder(reader_bio))
 
         incompatibleUserRecord = {"name": -10, "age": 21, "location": "Woodford"}
         with io.BytesIO() as writer_bio:

--- a/lang/py/avro/test/test_io.py
+++ b/lang/py/avro/test/test_io.py
@@ -426,6 +426,49 @@ class DefaultValueTestCase(unittest.TestCase):
             self.assertEqual(datum_to_read, datum_read)
 
 
+class TestIncompatibleSchemaReading(unittest.TestCase):
+    def test_deserialization_fails(self) -> None:
+
+        reader_schema = avro.schema.parse(
+            json.dumps(
+                {
+                    "namespace": "example.avro",
+                    "type": "record",
+                    "name": "User",
+                    "fields": [
+                        {"name": "name", "type": "string"},
+                        {"name": "age", "type": "int"},
+                        {"name": "location", "type": "string"},
+                    ],
+                }
+            )
+        )
+        writer_schema = avro.schema.parse(
+            json.dumps(
+                {
+                    "namespace": "example.avro",
+                    "type": "record",
+                    "name": "IncompatibleUser",
+                    "fields": [
+                        {"name": "name", "type": "int"},
+                        {"name": "age", "type": "int"},
+                        {"name": "location", "type": "string"},
+                    ],
+                }
+            )
+        )
+
+        incompatibleUserRecord = {"name": 100, "age": 21, "location": "Woodford"}
+        writer = avro.io.DatumWriter(writer_schema)
+        with io.BytesIO() as writer_bio:
+            enc = avro.io.BinaryEncoder(writer_bio)
+            writer.write(incompatibleUserRecord, enc)
+            enc_bytes = writer_bio.getvalue()
+        reader = avro.io.DatumReader(reader_schema)
+        with io.BytesIO(enc_bytes) as reader_bio:
+            self.assertRaises(avro.errors.AvroTypeException, reader.read, avro.io.BinaryDecoder(reader_bio))
+
+
 class TestMisc(unittest.TestCase):
     def test_decimal_bytes_small_scale(self) -> None:
         """Avro should raise an AvroTypeException when attempting to write a decimal with a larger exponent than the schema's scale."""
@@ -585,6 +628,7 @@ def load_tests(loader: unittest.TestLoader, default_tests: None, pattern: None) 
         SchemaPromotionTestCase(write_type, read_type) for write_type, read_type in itertools.combinations(("int", "long", "float", "double"), 2)
     )
     suite.addTests(DefaultValueTestCase(field_type, default) for field_type, default in DEFAULT_VALUE_EXAMPLES)
+    suite.addTests(loader.loadTestsFromTestCase(TestIncompatibleSchemaReading))
     return suite
 
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira-3380](https://issues.apache.org/jira/browse/AVRO-3380/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3380
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
* lang/py/avro/test/test_io.py::TestIncompatibleSchemaReading

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
