### PR TITLE
AVRO-3259: Throw exception if unknown codec

### DIFF
--- a/lang/csharp/src/apache/main/File/Codec.cs
+++ b/lang/csharp/src/apache/main/File/Codec.cs
@@ -142,8 +142,7 @@ namespace Avro.File
                     return new NullCodec();
             }
 
-            throw new AvroException($"Unknown codec type: {codecType}");
-
+            throw new AvroRuntimeException($"Unrecognized codec: {codecType}");
         }
 
         /// <summary>
@@ -177,7 +176,7 @@ namespace Avro.File
                     return CreateCodec(Type.Null);
             }
 
-            throw new AvroException($"Unknown codec type: {codecType}");
+            throw new AvroRuntimeException($"Unrecognized codec: {codecType}");
         }
 
         /// <summary>

--- a/lang/csharp/src/apache/main/File/Codec.cs
+++ b/lang/csharp/src/apache/main/File/Codec.cs
@@ -153,6 +153,13 @@ namespace Avro.File
         /// <returns>Codec based on type.</returns>
         public static Codec CreateCodecFromString(string codecType)
         {
+            if (codecType == null)
+            {
+                // If codec is absent, it is assumed to be "null"
+                // https://avro.apache.org/docs/current/spec.html
+                return CreateCodec(Type.Null);
+            }
+
             foreach (var resolver in _codecResolvers)
             {
                 var candidateCodec = resolver(codecType);

--- a/lang/csharp/src/apache/main/File/Codec.cs
+++ b/lang/csharp/src/apache/main/File/Codec.cs
@@ -138,9 +138,12 @@ namespace Avro.File
             {
                 case Type.Deflate:
                     return new DeflateCodec();
-                default:
+                case Type.Null:
                     return new NullCodec();
             }
+
+            throw new AvroException($"Unknown codec type: {codecType}");
+
         }
 
         /// <summary>
@@ -162,10 +165,12 @@ namespace Avro.File
             switch (codecType)
             {
                 case DataFileConstants.DeflateCodec:
-                    return new DeflateCodec();
-                default:
-                    return new NullCodec();
+                    return CreateCodec(Type.Deflate);
+                case DataFileConstants.NullCodec:
+                    return CreateCodec(Type.Null);
             }
+
+            throw new AvroException($"Unknown codec type: {codecType}");
         }
 
         /// <summary>

--- a/lang/csharp/src/apache/main/File/DataFileReader.cs
+++ b/lang/csharp/src/apache/main/File/DataFileReader.cs
@@ -462,7 +462,13 @@ namespace Avro.File
         /// </returns>
         private Codec ResolveCodec()
         {
-            return Codec.CreateCodecFromString(GetMetaString(DataFileConstants.MetaDataCodec));
+            string codec = GetMetaString(DataFileConstants.MetaDataCodec);
+
+            // If codec is absent, it is assumed to be "null"
+            if (codec == null)
+                return Codec.CreateCodec(Codec.Type.Null);
+
+            return Codec.CreateCodecFromString(codec);
         }
 
         /// <inheritdoc/>

--- a/lang/csharp/src/apache/test/File/FileTests.cs
+++ b/lang/csharp/src/apache/test/File/FileTests.cs
@@ -870,6 +870,34 @@ namespace Avro.Test.File
             Assert.AreEqual(expectResolverProvidedCodec, resolverProvidedCodec);
         }
 
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("blahblahblah")]
+        public void UnknownCodecFromStringException(string codec)
+        {
+            Assert.Throws(typeof(AvroException), () => Codec.CreateCodecFromString(codec));
+        }
+
+        [TestCase((Codec.Type)(-1))]
+        public void UnknownCodecFromType(Codec.Type codec)
+        {
+            Assert.Throws(typeof(AvroException), () => Codec.CreateCodec(codec));
+        }
+
+        [TestCase("deflate")]
+        [TestCase("null")]
+        public void KnownCodecFromString(string codec)
+        {
+            Assert.NotNull(Codec.CreateCodecFromString(codec));
+        }
+
+        [TestCase(Codec.Type.Deflate)]
+        [TestCase(Codec.Type.Null)]
+        public void KnownCodecFromType(Codec.Type codec)
+        {
+            Assert.NotNull(Codec.CreateCodec(codec));
+        }
+
         private bool CheckPrimitive<T>(Stream input, T value, ReaderWriterSet<T>.ReaderFactory createReader)
         {
             IFileReader<T> reader = createReader(input, null);

--- a/lang/csharp/src/apache/test/File/FileTests.cs
+++ b/lang/csharp/src/apache/test/File/FileTests.cs
@@ -870,7 +870,6 @@ namespace Avro.Test.File
             Assert.AreEqual(expectResolverProvidedCodec, resolverProvidedCodec);
         }
 
-        [TestCase(null)]
         [TestCase("")]
         [TestCase("blahblahblah")]
         public void UnknownCodecFromStringException(string codec)
@@ -878,7 +877,7 @@ namespace Avro.Test.File
             Assert.Throws(typeof(AvroException), () => Codec.CreateCodecFromString(codec));
         }
 
-        [TestCase((Codec.Type)(-1))]
+        [TestCase((Codec.Type)(-1))] // "Invalid" Codec.Type
         public void UnknownCodecFromType(Codec.Type codec)
         {
             Assert.Throws(typeof(AvroException), () => Codec.CreateCodec(codec));
@@ -886,6 +885,7 @@ namespace Avro.Test.File
 
         [TestCase("deflate")]
         [TestCase("null")]
+        [TestCase(null)] // If codec is absent, it is assumed to be "null"
         public void KnownCodecFromString(string codec)
         {
             Assert.NotNull(Codec.CreateCodecFromString(codec));

--- a/lang/csharp/src/apache/test/File/FileTests.cs
+++ b/lang/csharp/src/apache/test/File/FileTests.cs
@@ -874,13 +874,13 @@ namespace Avro.Test.File
         [TestCase("blahblahblah")]
         public void UnknownCodecFromStringException(string codec)
         {
-            Assert.Throws(typeof(AvroException), () => Codec.CreateCodecFromString(codec));
+            Assert.Throws(typeof(AvroRuntimeException), () => Codec.CreateCodecFromString(codec));
         }
 
         [TestCase((Codec.Type)(-1))] // "Invalid" Codec.Type
         public void UnknownCodecFromType(Codec.Type codec)
         {
-            Assert.Throws(typeof(AvroException), () => Codec.CreateCodec(codec));
+            Assert.Throws(typeof(AvroRuntimeException), () => Codec.CreateCodec(codec));
         }
 
         [TestCase("deflate")]


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO-3259)
  - https://issues.apache.org/jira/browse/AVRO-3259
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
