### PR TITLE
AVRO-3370: Allow complex types as names

### DIFF
--- a/lang/py/avro/name.py
+++ b/lang/py/avro/name.py
@@ -20,7 +20,7 @@
 """Contains the Name classes."""
 from typing import TYPE_CHECKING, Dict, Optional
 
-from avro.constants import VALID_TYPES
+from avro.constants import PRIMITIVE_TYPES
 
 if TYPE_CHECKING:
     from avro.schema import NamedSchema
@@ -154,7 +154,7 @@ class Names:
         """
         to_add = Name(name_attr, space_attr, self.default_namespace)
 
-        if to_add.fullname in VALID_TYPES:
+        if to_add.fullname in PRIMITIVE_TYPES:
             raise avro.errors.SchemaParseException(f"{to_add.fullname} is a reserved type name.")
         if to_add.fullname in self.names:
             raise avro.errors.SchemaParseException(f'The name "{to_add.fullname}" is already in use.')

--- a/lang/py/avro/test/test_io.py
+++ b/lang/py/avro/test/test_io.py
@@ -163,6 +163,14 @@ SCHEMAS_TO_VALIDATE = tuple(
             },
             {"value": {"car": {"value": "head"}, "cdr": {"value": None}}},
         ),
+        (
+            {"type": "record", "name": "record", "fields": [{"name": "value", "type": "int"}, {"name": "next", "type": ["null", "record"]}]},
+            {"value": 0, "next": {"value": 1, "next": None}},
+        ),
+        (
+            {"type": "record", "name": "ns.long", "fields": [{"name": "value", "type": "int"}, {"name": "next", "type": ["null", "ns.long"]}]},
+            {"value": 0, "next": {"value": 1, "next": None}},
+        ),
     )
 )
 

--- a/lang/py/avro/test/test_schema.py
+++ b/lang/py/avro/test/test_schema.py
@@ -120,6 +120,19 @@ UNION_EXAMPLES = [
     InvalidTestSchema([{"type": "array", "items": "long"}, {"type": "array", "items": "string"}]),
 ]
 
+NAME_EXAMPLES = [
+    ValidTestSchema({"type": "enum", "name": "record", "symbols": ["A", "B"]}),
+    ValidTestSchema({"type": "record", "name": "record", "fields": [{"name": "f", "type": "long"}]}),
+    InvalidTestSchema({"type": "enum", "name": "int", "symbols": ["A", "B"]}),
+    ValidTestSchema({"type": "enum", "name": "ns.int", "symbols": ["A", "B"]}),
+    ValidTestSchema({"type": "enum", "namespace": "ns", "name": "int", "symbols": ["A", "B"]}),
+    ValidTestSchema(
+        {"type": "record", "name": "LinkedList", "fields": [{"name": "value", "type": "int"}, {"name": "next", "type": ["null", "LinkedList"]}]}
+    ),
+    ValidTestSchema({"type": "record", "name": "record", "fields": [{"name": "value", "type": "int"}, {"name": "next", "type": ["null", "record"]}]}),
+    ValidTestSchema({"type": "record", "name": "ns.int", "fields": [{"name": "value", "type": "int"}, {"name": "next", "type": ["null", "ns.int"]}]}),
+]
+
 NAMED_IN_UNION_EXAMPLES = [
     ValidTestSchema(
         {
@@ -512,6 +525,7 @@ EXAMPLES += ENUM_EXAMPLES
 EXAMPLES += ARRAY_EXAMPLES
 EXAMPLES += MAP_EXAMPLES
 EXAMPLES += UNION_EXAMPLES
+EXAMPLES += NAME_EXAMPLES
 EXAMPLES += NAMED_IN_UNION_EXAMPLES
 EXAMPLES += RECORD_EXAMPLES
 EXAMPLES += DOC_EXAMPLES


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3370
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
