### PR TITLE
AVRO-3382 (java) - require Schema argument be != null when creating a Schema.Field

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/Schema.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Schema.java
@@ -554,7 +554,7 @@ public abstract class Schema extends JsonProperties implements Serializable {
     Field(String name, Schema schema, String doc, JsonNode defaultValue, boolean validateDefault, Order order) {
       super(FIELD_RESERVED);
       this.name = validateName(name);
-      this.schema = schema;
+      this.schema = requireNotNull(schema, "schema");
       this.doc = doc;
       this.defaultValue = validateDefault ? validateDefault(name, schema, defaultValue) : defaultValue;
       this.order = Objects.requireNonNull(order, "Order cannot be null");
@@ -1583,6 +1583,13 @@ public abstract class Schema extends JsonProperties implements Serializable {
         throw new SchemaParseException("Illegal character in: " + name);
     }
     return name;
+  }
+
+  private static <T> T requireNotNull(T input, String name) {
+    if (input != null) {
+      return input;
+    }
+    throw new IllegalArgumentException(name + " is required and cannot be null");
   }
 
   private static final ThreadLocal<Boolean> VALIDATE_DEFAULTS = ThreadLocalWithInitial.of(() -> true);

--- a/lang/java/avro/src/main/java/org/apache/avro/Schema.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Schema.java
@@ -554,7 +554,7 @@ public abstract class Schema extends JsonProperties implements Serializable {
     Field(String name, Schema schema, String doc, JsonNode defaultValue, boolean validateDefault, Order order) {
       super(FIELD_RESERVED);
       this.name = validateName(name);
-      this.schema = requireNotNull(schema, "schema");
+      this.schema = Objects.requireNonNull(schema, "schema is required and cannot be null");
       this.doc = doc;
       this.defaultValue = validateDefault ? validateDefault(name, schema, defaultValue) : defaultValue;
       this.order = Objects.requireNonNull(order, "Order cannot be null");
@@ -1583,13 +1583,6 @@ public abstract class Schema extends JsonProperties implements Serializable {
         throw new SchemaParseException("Illegal character in: " + name);
     }
     return name;
-  }
-
-  private static <T> T requireNotNull(T input, String name) {
-    if (input != null) {
-      return input;
-    }
-    throw new IllegalArgumentException(name + " is required and cannot be null");
   }
 
   private static final ThreadLocal<Boolean> VALIDATE_DEFAULTS = ThreadLocalWithInitial.of(() -> true);

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchema.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchema.java
@@ -361,4 +361,9 @@ public class TestSchema {
   public void testEnumSymbolAsNull() {
     Schema.createEnum("myField", "doc", "namespace", Collections.singletonList(null));
   }
+
+  @Test(expected = NullPointerException.class)
+  public void testSchemaFieldWithoutSchema() {
+    new Schema.Field("f", null);
+  }
 }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3382
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
added a unit test for the new input validation

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
