### PR TITLE
AVRO-3405: Add API to write/read user metadata in .avro file

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/util/RandomData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/util/RandomData.java
@@ -170,6 +170,8 @@ public class RandomData implements Iterable<Object> {
     Schema sch = new Schema.Parser().parse(new File(args[0]));
     try (DataFileWriter<Object> writer = new DataFileWriter<>(new GenericDatumWriter<>())) {
       writer.setCodec(CodecFactory.fromString(args.length >= 4 ? args[3] : "null"));
+      writer.setMeta("stringKey", "stringValue");
+      writer.setMeta("bytesKey", "bytesValue".getBytes(StandardCharsets.UTF_8));
       writer.create(sch, new File(args[1]));
 
       for (Object datum : new RandomData(sch, Integer.parseInt(args[2]))) {

--- a/lang/perl/share/interop-data-generate
+++ b/lang/perl/share/interop-data-generate
@@ -54,6 +54,11 @@ my $datum = {
     },
 };
 
+my $metadata = {
+    stringKey => 'stringValue',
+    bytesKey => 'bytesValue'
+};
+
 while (my ($codec, $enabled) = each(%Avro::DataFile::ValidCodec)) {
     next unless $enabled;
     my $outdir = '../../build/interop/data';
@@ -65,6 +70,7 @@ while (my ($codec, $enabled) = each(%Avro::DataFile::ValidCodec)) {
     my $writer = Avro::DataFileWriter->new(
         fh => $fh,
         codec => $codec,
+        metadata => $metadata,
         writer_schema => $writer_schema
     );
     $writer->print($datum);

--- a/lang/perl/xt/interop.t
+++ b/lang/perl/xt/interop.t
@@ -44,10 +44,11 @@ for my $path (glob '../../build/interop/data/*.avro') {
     my $reader = Avro::DataFileReader->new(fh => $fh);
 
     my $metadata = $reader->metadata;
-    delete $metadata->{'avro.schema'};
-    delete $metadata->{'avro.codec'};
-    if (keys %$metadata) {
-        is_deeply($metadata, $expected_metadata, "user metadata check");
+    if (exists $metadata->{stringKey}) {
+        is($metadata->{stringKey}, $expected_metadata->{stringKey}, "check user metadata: stringKey ");
+    }
+    if (exists $metadata->{bytesKey}) {
+        is($metadata->{bytesKey}, join('', $expected_metadata->{bytesKey}), "check user metadata: bytesKey ");
     }
     diag("Succeeded: ${path}");
 }

--- a/lang/perl/xt/interop.t
+++ b/lang/perl/xt/interop.t
@@ -24,6 +24,11 @@ use IO::File;
 use_ok 'Avro::DataFile';
 use_ok 'Avro::DataFileReader';
 
+my $expected_metadata = {
+    stringKey => 'stringValue',
+    bytesKey => 'bytesValue'
+};
+
 for my $path (glob '../../build/interop/data/*.avro') {
     my $fn = basename($path);
     substr($fn, rindex $fn, '.') = '';
@@ -36,7 +41,14 @@ for my $path (glob '../../build/interop/data/*.avro') {
         }
     }
     my $fh = IO::File->new($path);
-    Avro::DataFileReader->new(fh => $fh);
+    my $reader = Avro::DataFileReader->new(fh => $fh);
+
+    my $metadata = $reader->metadata;
+    delete $metadata->{'avro.schema'};
+    delete $metadata->{'avro.codec'};
+    if (keys %$metadata) {
+        is_deeply($metadata, $expected_metadata, "user metadata check");
+    }
     diag("Succeeded: ${path}");
 }
 

--- a/lang/rust/examples/generate_interop_data.rs
+++ b/lang/rust/examples/generate_interop_data.rs
@@ -78,6 +78,8 @@ fn main() -> anyhow::Result<()> {
 
     for codec in Codec::iter() {
         let mut writer = Writer::with_codec(&schema, Vec::new(), codec);
+        write_user_metadata(&mut writer)?;
+
         let datum = create_datum(&schema);
         writer.append(datum)?;
         let bytes = writer.into_inner()?;
@@ -94,6 +96,15 @@ fn main() -> anyhow::Result<()> {
             bytes,
         )?;
     }
+
+    Ok(())
+}
+
+fn write_user_metadata(writer: &mut Writer<Vec<u8>>) -> anyhow::Result<()> {
+    writer.add_user_metadata("stringKey".to_string(), "stringValue".to_string())?;
+    writer.add_user_metadata("strKey".to_string(), "strValue")?;
+    writer.add_user_metadata("bytesKey".to_string(), b"bytesValue")?;
+    writer.add_user_metadata("vecKey".to_string(), vec![1, 2, 3])?;
 
     Ok(())
 }

--- a/lang/rust/examples/generate_interop_data.rs
+++ b/lang/rust/examples/generate_interop_data.rs
@@ -101,7 +101,7 @@ fn main() -> anyhow::Result<()> {
 }
 
 fn write_user_metadata(writer: &mut Writer<Vec<u8>>) -> anyhow::Result<()> {
-    writer.add_user_metadata("stringKey".to_string(), "stringValue".to_string())?;
+    writer.add_user_metadata("stringKey".to_string(), "stringValue")?;
     writer.add_user_metadata("bytesKey".to_string(), b"bytesValue")?;
 
     Ok(())

--- a/lang/rust/examples/generate_interop_data.rs
+++ b/lang/rust/examples/generate_interop_data.rs
@@ -102,9 +102,7 @@ fn main() -> anyhow::Result<()> {
 
 fn write_user_metadata(writer: &mut Writer<Vec<u8>>) -> anyhow::Result<()> {
     writer.add_user_metadata("stringKey".to_string(), "stringValue".to_string())?;
-    writer.add_user_metadata("strKey".to_string(), "strValue")?;
     writer.add_user_metadata("bytesKey".to_string(), b"bytesValue")?;
-    writer.add_user_metadata("vecKey".to_string(), vec![1, 2, 3])?;
 
     Ok(())
 }

--- a/lang/rust/examples/test_interop_data.rs
+++ b/lang/rust/examples/test_interop_data.rs
@@ -16,9 +16,11 @@
 // under the License.
 
 use apache_avro::Reader;
-use std::ffi::OsStr;
+use std::{collections::HashMap, ffi::OsStr, fs::File};
 
 fn main() -> anyhow::Result<()> {
+    let expected_user_metadata: HashMap<String, Vec<u8>> = create_expected_user_metadata();
+
     let data_dir = std::fs::read_dir("../../build/interop/data/")
         .expect("Unable to list the interop data directory");
 
@@ -36,6 +38,9 @@ fn main() -> anyhow::Result<()> {
                 println!("Checking {:?}", &path);
                 let content = std::fs::File::open(&path)?;
                 let reader = Reader::new(&content)?;
+
+                test_user_metadata(&reader, &expected_user_metadata);
+
                 for value in reader {
                     if let Err(e) = value {
                         errors.push(format!(
@@ -55,5 +60,24 @@ fn main() -> anyhow::Result<()> {
             "There were errors reading some .avro files:\n{}",
             errors.join(", ")
         );
+    }
+}
+
+fn create_expected_user_metadata() -> HashMap<String, Vec<u8>> {
+    let mut user_metadata: HashMap<String, Vec<u8>> = HashMap::new();
+    user_metadata.insert(
+        "stringKey".to_string(),
+        "stringValue".to_string().into_bytes(),
+    );
+    user_metadata.insert("strKey".to_string(), "strValue".as_bytes().to_vec());
+    user_metadata.insert("bytesKey".to_string(), b"bytesValue".to_vec());
+    user_metadata.insert("vecKey".to_string(), vec![1, 2, 3]);
+    user_metadata
+}
+
+fn test_user_metadata(reader: &Reader<&File>, expected_user_metadata: &HashMap<String, Vec<u8>>) {
+    let user_metadata = reader.user_metadata();
+    if !user_metadata.is_empty() {
+        assert_eq!(user_metadata, expected_user_metadata);
     }
 }

--- a/lang/rust/examples/test_interop_data.rs
+++ b/lang/rust/examples/test_interop_data.rs
@@ -69,9 +69,7 @@ fn create_expected_user_metadata() -> HashMap<String, Vec<u8>> {
         "stringKey".to_string(),
         "stringValue".to_string().into_bytes(),
     );
-    user_metadata.insert("strKey".to_string(), "strValue".as_bytes().to_vec());
     user_metadata.insert("bytesKey".to_string(), b"bytesValue".to_vec());
-    user_metadata.insert("vecKey".to_string(), vec![1, 2, 3]);
     user_metadata
 }
 

--- a/lang/rust/src/error.rs
+++ b/lang/rust/src/error.rs
@@ -376,6 +376,9 @@ pub enum Error {
     /// Error while resolving Schema::Ref
     #[error("Unresolved schema reference: {0}")]
     SchemaResolutionError(String),
+
+    #[error("The file metadata is already flushed.")]
+    FileHeaderAlreadyWritten,
 }
 
 impl serde::ser::Error for Error {

--- a/lang/rust/src/error.rs
+++ b/lang/rust/src/error.rs
@@ -379,6 +379,9 @@ pub enum Error {
 
     #[error("The file metadata is already flushed.")]
     FileHeaderAlreadyWritten,
+
+    #[error("Metadata keys starting with 'avro.' are reserved for internal usage: {0}.")]
+    InvalidMetadataKey(String),
 }
 
 impl serde::ser::Error for Error {

--- a/lang/rust/src/reader.rs
+++ b/lang/rust/src/reader.rs
@@ -213,7 +213,7 @@ impl<R: Read> Block<R> {
                 Ok(())
             }
             wrong => {
-                warn!("User metadata values must be strings, found {:?}", wrong);
+                warn!("User metadata values must be Value::Bytes, found {:?}", wrong);
                 Ok(())
             }
         }

--- a/lang/rust/src/reader.rs
+++ b/lang/rust/src/reader.rs
@@ -290,15 +290,19 @@ impl<'a, R: Read> Reader<'a, R> {
     }
 
     /// Get a reference to the writer `Schema`.
+    #[inline]
     pub fn writer_schema(&self) -> &Schema {
         &self.block.writer_schema
     }
 
     /// Get a reference to the optional reader `Schema`.
+    #[inline]
     pub fn reader_schema(&self) -> Option<&Schema> {
         self.reader_schema
     }
 
+    /// Get a reference to the user metadata
+    #[inline]
     pub fn user_metadata(&self) -> &HashMap<String, String> {
         &self.block.user_metadata
     }

--- a/lang/rust/src/reader.rs
+++ b/lang/rust/src/reader.rs
@@ -213,7 +213,10 @@ impl<R: Read> Block<R> {
                 Ok(())
             }
             wrong => {
-                warn!("User metadata values must be Value::Bytes, found {:?}", wrong);
+                warn!(
+                    "User metadata values must be Value::Bytes, found {:?}",
+                    wrong
+                );
                 Ok(())
             }
         }


### PR DESCRIPTION

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3405

### Tests

- [X] My PR adds new unit tests

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Rustdoc that explain what it does
