### PR TITLE
AVRO-3407: Add user_metadats interop tests in C#

### DIFF
--- a/lang/csharp/src/apache/test/Interop/InteropDataGenerator.cs
+++ b/lang/csharp/src/apache/test/Interop/InteropDataGenerator.cs
@@ -86,6 +86,7 @@ namespace Avro.Test.Interop
                 var codec = Codec.CreateCodecFromString(codecName);
                 using (var dataFileWriter = DataFileWriter<GenericRecord>.OpenWriter(datumWriter, outputPath, codec))
                 {
+                    dataFileWriter.SetMeta("user_metadata", "someByteArray");
                     dataFileWriter.Append(record);
                 }
             }

--- a/lang/csharp/src/apache/test/Interop/InteropDataTests.cs
+++ b/lang/csharp/src/apache/test/Interop/InteropDataTests.cs
@@ -48,6 +48,11 @@ namespace Avro.Test.Interop
                 using(var reader = DataFileReader<GenericRecord>.OpenReader(avroFile))
                 {
                     int i = 0;
+                    string userMetadata = reader.GetMetaString("user_metadata");
+                    if (userMetadata != null)
+                    {
+                        Assert.AreEqual("someByteArray", userMetadata);
+                    }
                     foreach (var record in reader.NextEntries)
                     {
                         i++;


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3407
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
