### PR TITLE
AVRO-1965: Add the unit test from the patch attached to AVRO-1965

### DIFF
--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemaBuilder.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemaBuilder.java
@@ -841,4 +841,19 @@ public class TestSchemaBuilder {
     Assert.assertEquals("Schema is able to be successfully created as is without validation", defaultValue,
         schema.getField(fieldName).defaultValue().asText());
   }
+
+  /**
+   * https://issues.apache.org/jira/browse/AVRO-1965
+   */
+  @Test
+  public void testNamespaceDefaulting() {
+    Schema d = SchemaBuilder.builder().intType();
+    Schema c = SchemaBuilder.record("c").fields().name("d").type(d).noDefault().endRecord();
+    Schema b = SchemaBuilder.record("b").fields().name("c").type(c).noDefault().endRecord();
+
+    Schema a1 = SchemaBuilder.record("default.a").fields().name("b").type(b).noDefault().endRecord();
+    Schema a2 = new Schema.Parser().parse(a1.toString());
+
+    Assert.assertEquals(a2, a1);
+  }
 }


### PR DESCRIPTION
The bug was fixed with AVRO-1646.
This PR just adds the test case from the patch attached to AVRO-1945

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-1965

### Tests

- [X] My PR adds  a new unit test

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] No need of documentation