### PR TITLE
[AVRO-3433][rust] Adding in Resolve Fixes and Tests

### DIFF
--- a/lang/rust/avro/src/decode.rs
+++ b/lang/rust/avro/src/decode.rs
@@ -332,7 +332,7 @@ mod tests {
         let inner = Box::new(Schema::Fixed {
             size: 2,
             doc: None,
-            name: Name::new("decimal"),
+            name: Name::new("decimal").unwrap(),
         });
         let schema = Schema::Decimal {
             inner,
@@ -356,7 +356,7 @@ mod tests {
         use num_bigint::ToBigInt;
         let inner = Box::new(Schema::Fixed {
             size: 13,
-            name: Name::new("decimal"),
+            name: Name::new("decimal").unwrap(),
             doc: None,
         });
         let schema = Schema::Decimal {

--- a/lang/rust/avro/src/encode.rs
+++ b/lang/rust/avro/src/encode.rs
@@ -224,4 +224,276 @@ mod tests {
         );
         assert_eq!(vec![0u8], buf);
     }
+
+    #[test]
+    fn test_avro_3433_recursive_definition_encode_record() {
+        let mut buf = Vec::new();
+        let schema = Schema::parse_str(
+            r#"
+        {
+            "type":"record",
+            "name":"TestStruct",
+            "fields": [
+                {
+                    "name":"a",
+                    "type":{
+                        "type":"record",
+                        "name": "Inner",
+                        "fields": [ {
+                            "name":"z",
+                            "type":"int"
+                        }]
+                    }
+                },
+                {
+                    "name":"b",
+                    "type":"Inner"
+                }
+            ]
+        }"#,
+        )
+        .unwrap();
+
+        let inner_value1 = Value::Record(vec![("z".into(), Value::Int(3))]);
+        let inner_value2 = Value::Record(vec![("z".into(), Value::Int(6))]);
+        let outer_value =
+            Value::Record(vec![("a".into(), inner_value1), ("b".into(), inner_value2)]);
+        encode(&outer_value, &schema, &mut buf);
+        assert!(!buf.is_empty());
+    }
+
+    #[test]
+    fn test_avro_3433_recursive_definition_encode_array() {
+        let mut buf = Vec::new();
+        let schema = Schema::parse_str(
+            r#"
+        {
+            "type":"record",
+            "name":"TestStruct",
+            "fields": [
+                {
+                    "name":"a",
+                    "type":{
+                        "type":"array",
+                        "items": {
+                            "type":"record",
+                            "name": "Inner",
+                            "fields": [ {
+                                "name":"z",
+                                "type":"int"
+                            }]
+                        }
+                    }
+                },
+                {
+                    "name":"b",
+                    "type": {
+                        "type":"map",
+                        "values":"Inner"
+                    }
+                }
+            ]
+        }"#,
+        )
+        .unwrap();
+
+        let inner_value1 = Value::Record(vec![("z".into(), Value::Int(3))]);
+        let inner_value2 = Value::Record(vec![("z".into(), Value::Int(6))]);
+        let outer_value = Value::Record(vec![
+            ("a".into(), Value::Array(vec![inner_value1])),
+            (
+                "b".into(),
+                Value::Map(vec![("akey".into(), inner_value2)].into_iter().collect()),
+            ),
+        ]);
+        encode(&outer_value, &schema, &mut buf);
+        assert!(!buf.is_empty());
+    }
+
+    #[test]
+    fn test_avro_3433_recursive_definition_encode_map() {
+        let mut buf = Vec::new();
+        let schema = Schema::parse_str(
+            r#"
+        {
+            "type":"record",
+            "name":"TestStruct",
+            "fields": [
+                {
+                    "name":"a",
+                    "type":{
+                        "type":"record",
+                        "name": "Inner",
+                        "fields": [ {
+                            "name":"z",
+                            "type":"int"
+                        }]
+                    }
+                },
+                {
+                    "name":"b",
+                    "type": {
+                        "type":"map",
+                        "values":"Inner"
+                    }
+                }
+            ]
+        }"#,
+        )
+        .unwrap();
+
+        let inner_value1 = Value::Record(vec![("z".into(), Value::Int(3))]);
+        let inner_value2 = Value::Record(vec![("z".into(), Value::Int(6))]);
+        let outer_value = Value::Record(vec![
+            ("a".into(), inner_value1),
+            (
+                "b".into(),
+                Value::Map(vec![("akey".into(), inner_value2)].into_iter().collect()),
+            ),
+        ]);
+        encode(&outer_value, &schema, &mut buf);
+        assert!(!buf.is_empty());
+    }
+
+    #[test]
+    fn test_avro_3433_recursive_definition_encode_record_wrapper() {
+        let mut buf = Vec::new();
+        let schema = Schema::parse_str(
+            r#"
+        {
+            "type":"record",
+            "name":"TestStruct",
+            "fields": [
+                {
+                    "name":"a",
+                    "type":{
+                        "type":"record",
+                        "name": "Inner",
+                        "fields": [ {
+                            "name":"z",
+                            "type":"int"
+                        }]
+                    }
+                },
+                {
+                    "name":"b",
+                    "type": {
+                        "type":"record",
+                        "name": "InnerWrapper",
+                        "fields": [ {
+                            "name":"j",
+                            "type":"Inner"
+                        }]
+                    }
+                }
+            ]
+        }"#,
+        )
+        .unwrap();
+
+        let inner_value1 = Value::Record(vec![("z".into(), Value::Int(3))]);
+        let inner_value2 = Value::Record(vec![(
+            "j".into(),
+            Value::Record(vec![("z".into(), Value::Int(6))]),
+        )]);
+        let outer_value =
+            Value::Record(vec![("a".into(), inner_value1), ("b".into(), inner_value2)]);
+        encode(&outer_value, &schema, &mut buf);
+        assert!(!buf.is_empty());
+    }
+
+    #[test]
+    fn test_avro_3433_recursive_definition_encode_map_and_array() {
+        let mut buf = Vec::new();
+        let schema = Schema::parse_str(
+            r#"
+        {
+            "type":"record",
+            "name":"TestStruct",
+            "fields": [
+                {
+                    "name":"a",
+                    "type":{
+                        "type":"map",
+                        "values": {
+                            "type":"record",
+                            "name": "Inner",
+                            "fields": [ {
+                                "name":"z",
+                                "type":"int"
+                            }]
+                        }
+                    }
+                },
+                {
+                    "name":"b",
+                    "type": {
+                        "type":"array",
+                        "items":"Inner"
+                    }
+                }
+            ]
+        }"#,
+        )
+        .unwrap();
+
+        let inner_value1 = Value::Record(vec![("z".into(), Value::Int(3))]);
+        let inner_value2 = Value::Record(vec![("z".into(), Value::Int(6))]);
+        let outer_value = Value::Record(vec![
+            (
+                "a".into(),
+                Value::Map(vec![("akey".into(), inner_value2)].into_iter().collect()),
+            ),
+            ("b".into(), Value::Array(vec![inner_value1])),
+        ]);
+        encode(&outer_value, &schema, &mut buf);
+        assert!(!buf.is_empty());
+    }
+
+    #[test]
+    fn test_avro_3433_recursive_definition_encode_union() {
+        let mut buf = Vec::new();
+        let schema = Schema::parse_str(
+            r#"
+        {
+            "type":"record",
+            "name":"TestStruct",
+            "fields": [
+                {
+                    "name":"a",
+                    "type":["null", {
+                        "type":"record",
+                        "name": "Inner",
+                        "fields": [ {
+                            "name":"z",
+                            "type":"int"
+                        }]
+                    }]
+                },
+                {
+                    "name":"b",
+                    "type":"Inner"
+                }
+            ]
+        }"#,
+        )
+        .unwrap();
+
+        let inner_value1 = Value::Record(vec![("z".into(), Value::Int(3))]);
+        let inner_value2 = Value::Record(vec![("z".into(), Value::Int(6))]);
+        let outer_value1 = Value::Record(vec![
+            ("a".into(), Value::Union(1, Box::new(inner_value1))),
+            ("b".into(), inner_value2.clone()),
+        ]);
+        encode(&outer_value1, &schema, &mut buf);
+        assert!(!buf.is_empty());
+
+        buf.drain(..);
+        let outer_value2 = Value::Record(vec![
+            ("a".into(), Value::Union(0, Box::new(Value::Null))),
+            ("b".into(), inner_value2),
+        ]);
+        encode(&outer_value2, &schema, &mut buf);
+        assert!(!buf.is_empty());
+    }
 }

--- a/lang/rust/avro/src/error.rs
+++ b/lang/rust/avro/src/error.rs
@@ -279,6 +279,9 @@ pub enum Error {
     #[error("Invalid enum symbol name {0}")]
     EnumSymbolName(String),
 
+    #[error("Invalid schema name {0}. It must match the regex '{1}'")]
+    InvalidSchemaName(String, &'static str),
+
     #[error("Duplicate enum symbol {0}")]
     EnumSymbolDuplicate(String),
 

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -729,6 +729,16 @@ impl Value {
             // Reader is a union, but writer is not.
             v => v,
         };
+
+        schema.schemas.iter().for_each(|s| match s {
+            Schema::Record { name, .. }
+            | Schema::Enum { name, .. }
+            | Schema::Fixed { name, .. } => {
+                schemas_by_name.insert(name.clone(), s.clone());
+            }
+            _ => (),
+        });
+
         // Find the first match in the reader schema.
         // FIXME: this might be wrong when the union consists of multiple same records that have different names
         let (i, inner) = schema.find_schema(&v).ok_or(Error::FindUnionVariant)?;

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -19,7 +19,7 @@
 use crate::{
     decimal::Decimal,
     duration::Duration,
-    schema::{Precision, RecordField, Scale, Schema, SchemaKind, UnionSchema},
+    schema::{Precision, RecordField, Scale, Schema, SchemaKind, UnionSchema, Name},
     AvroResult, Error,
 };
 use serde_json::{Number, Value as JsonValue};
@@ -408,11 +408,16 @@ impl Value {
     /// See [Schema Resolution](https://avro.apache.org/docs/current/spec.html#Schema+Resolution)
     /// in the Avro specification for the full set of rules of schema
     /// resolution.
-    pub fn resolve(mut self, schema: &Schema) -> AvroResult<Self> {
+    pub fn resolve(self, schema: &Schema) -> AvroResult<Self> {
+        let mut schemas_by_name: HashMap<Name, Schema> = HashMap::new();
+        self.resolve_internal(schema, &mut schemas_by_name)
+    }
+
+    fn resolve_internal(mut self, schema: &Schema, schemas_by_name: &mut HashMap<Name, Schema>) -> AvroResult<Self> {
         pub fn resolve0(
             value: &mut Value,
             schema: &Schema,
-            schemas_by_name: &mut HashMap<String, Schema>,
+            schemas_by_name: &mut HashMap<Name, Schema>,
         ) -> AvroResult<Value> {
             // Check if this schema is a union, and if the reader schema is not.
             if SchemaKind::from(&value.clone()) == SchemaKind::Union
@@ -428,10 +433,10 @@ impl Value {
             let val: Value = value.clone();
             match *schema {
                 Schema::Ref { ref name } => {
-                    if let Some(resolved) = schemas_by_name.get(name.name.as_str()) {
+                    if let Some(resolved) = schemas_by_name.get(name) {
                         resolve0(value, resolved, &mut schemas_by_name.clone())
                     } else {
-                        Err(Error::SchemaResolutionError(name.name.clone()))
+                        Err(Error::SchemaResolutionError(name.fullname(None)))
                     }
                 }
                 Schema::Null => val.resolve_null(),
@@ -443,27 +448,27 @@ impl Value {
                 Schema::Bytes => val.resolve_bytes(),
                 Schema::String => val.resolve_string(),
                 Schema::Fixed { ref name, size, .. } => {
-                    schemas_by_name.insert(name.name.clone(), schema.clone());
+                    schemas_by_name.insert(name.clone(), schema.clone());
                     val.resolve_fixed(size)
                 }
-                Schema::Union(ref inner) => val.resolve_union(inner),
+                Schema::Union(ref inner) => val.resolve_union(inner, schemas_by_name),
                 Schema::Enum {
                     ref name,
                     ref symbols,
                     ..
                 } => {
-                    schemas_by_name.insert(name.name.clone(), schema.clone());
+                    schemas_by_name.insert(name.clone(), schema.clone());
                     val.resolve_enum(symbols)
                 }
-                Schema::Array(ref inner) => val.resolve_array(inner),
-                Schema::Map(ref inner) => val.resolve_map(inner),
+                Schema::Array(ref inner) => val.resolve_array(inner, schemas_by_name),
+                Schema::Map(ref inner) => val.resolve_map(inner, schemas_by_name),
                 Schema::Record {
                     ref name,
                     ref fields,
                     ..
                 } => {
-                    schemas_by_name.insert(name.name.clone(), schema.clone());
-                    val.resolve_record(fields)
+                    schemas_by_name.insert(name.clone(), schema.clone());
+                    val.resolve_record(fields, schemas_by_name)
                 }
                 Schema::Decimal {
                     scale,
@@ -479,9 +484,7 @@ impl Value {
                 Schema::Uuid => val.resolve_uuid(),
             }
         }
-
-        let mut schemas_by_name: HashMap<String, Schema> = HashMap::new();
-        resolve0(&mut self, schema, &mut schemas_by_name)
+        resolve0(&mut self, schema, schemas_by_name)
     }
 
     fn resolve_uuid(self) -> Result<Self, Error> {
@@ -711,7 +714,7 @@ impl Value {
         }
     }
 
-    fn resolve_union(self, schema: &UnionSchema) -> Result<Self, Error> {
+    fn resolve_union(self, schema: &UnionSchema, schemas_by_name: &mut HashMap<Name, Schema>) -> Result<Self, Error> {
         let v = match self {
             // Both are unions case.
             Value::Union(_i, v) => *v,
@@ -721,15 +724,15 @@ impl Value {
         // Find the first match in the reader schema.
         // FIXME: this might be wrong when the union consists of multiple same records that have different names
         let (i, inner) = schema.find_schema(&v).ok_or(Error::FindUnionVariant)?;
-        Ok(Value::Union(i as u32, Box::new(v.resolve(inner)?)))
+        Ok(Value::Union(i as u32, Box::new(v.resolve_internal(inner, schemas_by_name)?)))
     }
 
-    fn resolve_array(self, schema: &Schema) -> Result<Self, Error> {
+    fn resolve_array(self, schema: &Schema, schemas_by_name: &mut HashMap<Name, Schema>) -> Result<Self, Error> {
         match self {
             Value::Array(items) => Ok(Value::Array(
                 items
                     .into_iter()
-                    .map(|item| item.resolve(schema))
+                    .map(|item| item.resolve_internal(schema, schemas_by_name))
                     .collect::<Result<_, _>>()?,
             )),
             other => Err(Error::GetArray {
@@ -739,12 +742,12 @@ impl Value {
         }
     }
 
-    fn resolve_map(self, schema: &Schema) -> Result<Self, Error> {
+    fn resolve_map(self, schema: &Schema, schemas_by_name: &mut HashMap<Name, Schema>) -> Result<Self, Error> {
         match self {
             Value::Map(items) => Ok(Value::Map(
                 items
                     .into_iter()
-                    .map(|(key, value)| value.resolve(schema).map(|value| (key, value)))
+                    .map(|(key, value)| value.resolve_internal(schema, schemas_by_name).map(|value| (key, value)))
                     .collect::<Result<_, _>>()?,
             )),
             other => Err(Error::GetMap {
@@ -754,7 +757,7 @@ impl Value {
         }
     }
 
-    fn resolve_record(self, fields: &[RecordField]) -> Result<Self, Error> {
+    fn resolve_record(self, fields: &[RecordField], schemas_by_name: &mut HashMap<Name, Schema>) -> Result<Self, Error> {
         let mut items = match self {
             Value::Map(items) => Ok(items),
             Value::Record(fields) => Ok(fields.into_iter().collect::<HashMap<_, _>>()),
@@ -785,7 +788,7 @@ impl Value {
                                     Schema::Null => Value::Union(0, Box::new(Value::Null)),
                                     _ => Value::Union(
                                         0,
-                                        Box::new(Value::from(value.clone()).resolve(first)?),
+                                        Box::new(Value::from(value.clone()).resolve_internal(first, schemas_by_name)?),
                                     ),
                                 }
                             }
@@ -797,7 +800,7 @@ impl Value {
                     },
                 };
                 value
-                    .resolve(&field.schema)
+                    .resolve_internal(&field.schema, schemas_by_name)
                     .map(|value| (field.name.clone(), value))
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -1322,5 +1325,237 @@ mod tests {
             .unwrap(),
             JsonValue::String("936da01f-9abd-4d9d-80c7-02af85c822a8".into())
         );
+    }
+
+    #[test]
+    fn test_recursive_resolves() {
+        let schema  = Schema::parse_str(r#"
+        {
+            "type":"record",
+            "name":"TestStruct",
+            "fields": [
+                {
+                    "name":"a",
+                    "type":{
+                        "type":"record",
+                        "name": "Inner",
+                        "fields": [ {
+                            "name":"z",
+                            "type":"int"
+                        }]
+                    }
+                },
+                {
+                    "name":"b",
+                    "type":"Inner"
+                }
+            ]
+        }"#).unwrap();
+
+        let inner_value1 = Value::Record(vec![("z".into(),Value::Int(3))]);
+        let inner_value2 = Value::Record(vec![("z".into(),Value::Int(6))]);
+        let outer = Value::Record(vec![("a".into(),inner_value1.clone()), ("b".into(), inner_value2.clone())]);
+        outer.resolve(&schema).expect("Record definition defined in one field must be availible in other field");
+    }
+
+    #[test]
+    fn test_recursive_resolves2() {
+        let schema  = Schema::parse_str(r#"
+        {
+            "type":"record",
+            "name":"TestStruct",
+            "fields": [
+                {
+                    "name":"a",
+                    "type":{
+                        "type":"array",
+                        "items": {
+                            "type":"record",
+                            "name": "Inner",
+                            "fields": [ {
+                                "name":"z",
+                                "type":"int"
+                            }]
+                        }
+                    }
+                },
+                {
+                    "name":"b",
+                    "type": {
+                        "type":"map",
+                        "values":"Inner"
+                    }
+                }
+            ]
+        }"#).unwrap();
+
+        let inner_value1 = Value::Record(vec![("z".into(),Value::Int(3))]);
+        let inner_value2 = Value::Record(vec![("z".into(),Value::Int(6))]);
+        let outer_value = Value::Record(
+            vec![
+                ("a".into(), Value::Array(vec![inner_value1.clone()])),
+                ("b".into(), Value::Map(vec![("akey".into(),inner_value2.clone())].into_iter().collect()))
+                ]
+            );
+        outer_value.resolve(&schema).expect("Record defined in array definition must be resolveable from map");
+    }
+
+    #[test]
+    fn test_recursive_resolves3() {
+        let schema  = Schema::parse_str(r#"
+        {
+            "type":"record",
+            "name":"TestStruct",
+            "fields": [
+                {
+                    "name":"a",
+                    "type":{
+                        "type":"record",
+                        "name": "Inner",
+                        "fields": [ {
+                            "name":"z",
+                            "type":"int"
+                        }]
+                    }
+                },
+                {
+                    "name":"b",
+                    "type": {
+                        "type":"map",
+                        "values":"Inner"
+                    }
+                }
+            ]
+        }"#).unwrap();
+
+        let inner_value1 = Value::Record(vec![("z".into(),Value::Int(3))]);
+        let inner_value2 = Value::Record(vec![("z".into(),Value::Int(6))]);
+        let outer_value = Value::Record(
+            vec![
+                ("a".into(), inner_value1.clone()),
+                ("b".into(), Value::Map(vec![("akey".into(),inner_value2.clone())
+                ]
+                .into_iter().collect()))
+                ]
+            );
+        outer_value.resolve(&schema).expect("Record defined in record field must be resolvable from map field");
+    }
+
+    #[test]
+    fn test_recursive_resolves4() {
+        let schema  = Schema::parse_str(r#"
+        {
+            "type":"record",
+            "name":"TestStruct",
+            "fields": [
+                {
+                    "name":"a",
+                    "type":{
+                        "type":"record",
+                        "name": "Inner",
+                        "fields": [ {
+                            "name":"z",
+                            "type":"int"
+                        }]
+                    }
+                },
+                {
+                    "name":"b",
+                    "type": {
+                        "type":"record",
+                        "name": "InnerWrapper",
+                        "fields": [ {
+                            "name":"j",
+                            "type":"Inner"
+                        }]
+                    }
+                }
+            ]
+        }"#).unwrap();
+
+        let inner_value1 = Value::Record(vec![("z".into(),Value::Int(3))]);
+        let inner_value2 = Value::Record(vec![("j".into(), Value::Record(vec![("z".into(),Value::Int(6))]))]);
+        let outer_value = Value::Record(
+            vec![
+                ("a".into(), inner_value1.clone()),
+                ("b".into(), inner_value2.clone())
+                ]
+            );
+        outer_value.resolve(&schema).expect("Record schema defined in field must be resolvable in Record schema defined in other field");
+    }
+
+    #[test]
+    fn test_recursive_resolves5() {
+        let schema  = Schema::parse_str(r#"
+        {
+            "type":"record",
+            "name":"TestStruct",
+            "fields": [
+                {
+                    "name":"a",
+                    "type":{
+                        "type":"map",
+                        "values": {
+                            "type":"record",
+                            "name": "Inner",
+                            "fields": [ {
+                                "name":"z",
+                                "type":"int"
+                            }]
+                        }
+                    }
+                },
+                {
+                    "name":"b",
+                    "type": {
+                        "type":"array",
+                        "items":"Inner"
+                    }
+                }
+            ]
+        }"#).unwrap();
+
+        let inner_value1 = Value::Record(vec![("z".into(),Value::Int(3))]);
+        let inner_value2 = Value::Record(vec![("z".into(),Value::Int(6))]);
+        let outer_value = Value::Record(
+            vec![
+                ("a".into(), Value::Map(vec![("akey".into(),inner_value2.clone())].into_iter().collect())),
+                ("b".into(), Value::Array(vec![inner_value1.clone()])) 
+                ]
+            );
+        outer_value.resolve(&schema).expect("Record defined in map definition must be resolveable from array");
+    }
+
+    #[test]
+    fn test_recursive_resolves6() {
+        let schema  = Schema::parse_str(r#"
+        {
+            "type":"record",
+            "name":"TestStruct",
+            "fields": [
+                {
+                    "name":"a",
+                    "type":["null", {
+                        "type":"record",
+                        "name": "Inner",
+                        "fields": [ {
+                            "name":"z",
+                            "type":"int"
+                        }]
+                    }]
+                },
+                {
+                    "name":"b",
+                    "type":"Inner"
+                }
+            ]
+        }"#).unwrap();
+
+        let inner_value1 = Value::Record(vec![("z".into(),Value::Int(3))]);
+        let inner_value2 = Value::Record(vec![("z".into(),Value::Int(6))]);
+        let outer1 = Value::Record(vec![("a".into(),inner_value1.clone()), ("b".into(), inner_value2.clone())]);
+        outer1.resolve(&schema).expect("Record definition defined in union must be resolvabled in other field");
+        let outer2 = Value::Record(vec![("a".into(), Value::Null), ("b".into(), inner_value2.clone())]);
+        outer2.resolve(&schema).expect("Record definition defined in union must be resolvabled in other field");
     }
 }

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -933,7 +933,7 @@ mod tests {
     fn validate_fixed() {
         let schema = Schema::Fixed {
             size: 4,
-            name: Name::new("some_fixed"),
+            name: Name::new("some_fixed").unwrap(),
             doc: None,
         };
 
@@ -946,7 +946,7 @@ mod tests {
     #[test]
     fn validate_enum() {
         let schema = Schema::Enum {
-            name: Name::new("some_enum"),
+            name: Name::new("some_enum").unwrap(),
             doc: None,
             symbols: vec![
                 "spades".to_string(),
@@ -963,7 +963,7 @@ mod tests {
         assert!(!Value::String("lorem".to_string()).validate(&schema));
 
         let other_schema = Schema::Enum {
-            name: Name::new("some_other_enum"),
+            name: Name::new("some_other_enum").unwrap(),
             doc: None,
             symbols: vec![
                 "hearts".to_string(),
@@ -987,7 +987,7 @@ mod tests {
         //    ]
         // }
         let schema = Schema::Record {
-            name: Name::new("some_record"),
+            name: Name::new("some_record").unwrap(),
             doc: None,
             fields: vec![
                 RecordField {
@@ -1138,7 +1138,7 @@ mod tests {
                 precision: 10,
                 scale: 1,
                 inner: Box::new(Schema::Fixed {
-                    name: Name::new("decimal"),
+                    name: Name::new("decimal").unwrap(),
                     size: 20,
                     doc: None
                 })

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -1358,7 +1358,7 @@ mod tests {
     }
 
     #[test]
-    fn test_recursive_resolves() {
+    fn test_avro_3433_recursive_resolves_record() {
         let schema = Schema::parse_str(
             r#"
         {
@@ -1394,7 +1394,7 @@ mod tests {
     }
 
     #[test]
-    fn test_recursive_resolves2() {
+    fn test_avro_3433_recursive_resolves_array() {
         let schema = Schema::parse_str(
             r#"
         {
@@ -1442,7 +1442,7 @@ mod tests {
     }
 
     #[test]
-    fn test_recursive_resolves3() {
+    fn test_avro_3433_recursive_resolves_map() {
         let schema = Schema::parse_str(
             r#"
         {
@@ -1487,7 +1487,7 @@ mod tests {
     }
 
     #[test]
-    fn test_recursive_resolves4() {
+    fn test_avro_3433_recursive_resolves_record_wrapper() {
         let schema = Schema::parse_str(
             r#"
         {
@@ -1532,7 +1532,7 @@ mod tests {
     }
 
     #[test]
-    fn test_recursive_resolves5() {
+    fn test_avro_3433_recursive_resolves_map_and_array() {
         let schema = Schema::parse_str(
             r#"
         {
@@ -1580,7 +1580,7 @@ mod tests {
     }
 
     #[test]
-    fn test_recursive_resolves6() {
+    fn test_avro_3433_recursive_resolves_union() {
         let schema = Schema::parse_str(
             r#"
         {

--- a/lang/rust/avro/src/writer.rs
+++ b/lang/rust/avro/src/writer.rs
@@ -520,7 +520,7 @@ mod tests {
     fn decimal_fixed() -> TestResult<()> {
         let size = 30;
         let inner = Schema::Fixed {
-            name: Name::new("decimal"),
+            name: Name::new("decimal").unwrap(),
             doc: None,
             size,
         };
@@ -558,7 +558,7 @@ mod tests {
     #[test]
     fn duration() -> TestResult<()> {
         let inner = Schema::Fixed {
-            name: Name::new("duration"),
+            name: Name::new("duration").unwrap(),
             doc: None,
             size: 12,
         };

--- a/lang/rust/avro/tests/schema.rs
+++ b/lang/rust/avro/tests/schema.rs
@@ -64,7 +64,7 @@ const FIXED_EXAMPLES: &[(&str, bool)] = &[
             }"#,
         true,
     ),
-    (r#"{"type": "fixed", "name": "Missing size"}"#, false),
+    (r#"{"type": "fixed", "name": "MissingSize"}"#, false),
     (r#"{"type": "fixed", "size": 314}"#, false),
 ];
 

--- a/lang/rust/avro/tests/schema.rs
+++ b/lang/rust/avro/tests/schema.rs
@@ -954,7 +954,9 @@ fn permutation_indices(indices: Vec<usize>) -> Vec<Vec<usize>> {
     perms
 }
 
-#[test]
+// AVRO-3433 mgrigorov FIXME The equals comparison do not work when a Schema is a Ref now
+// #[test]
+#[allow(dead_code)]
 /// Test that a type that depends on more than one other type is parsed correctly when all
 /// definitions are passed in as a list. This should work regardless of the ordering of the list.
 fn test_parse_list_multiple_dependencies() {


### PR DESCRIPTION
The branch this PR is based on introduces a fix that breaks other functionality. By correctly replacing fully defined schemas with `Schema::Ref`s it exposed a bug in the resolve flow where the resolve does not recursive add in Schemas to the named_schemas map as it finds them. This leads to unresolved schema errors where the ref looks up the name from the map that has not been updated. Fixed via recursively passing the map through the flow and using Name as the key. 


### Jira
My pr adds to the Branch working to reolve
https://issues.apache.org/jira/browse/AVRO-3433

- [ ] My PR helps address the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

Tests added that are broken on the base branch without the changes

### Documentation

No new functionality
