### PR TITLE
AVRO-3440: Fix bug in Protocol.createMessage

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/Protocol.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Protocol.java
@@ -332,7 +332,7 @@ public class Protocol extends JsonProperties {
    * {@code props} of {@code m}.
    */
   public Message createMessage(Message m, Schema request) {
-    return new Message(name, doc, m, request);
+    return new Message(m.name, m.doc, m, request);
   }
 
   /** Create a one-way message. */

--- a/lang/java/avro/src/test/java/org/apache/avro/TestProtocol.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestProtocol.java
@@ -17,6 +17,10 @@
  */
 package org.apache.avro;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 import static org.junit.Assert.*;
 
 import org.junit.Test;
@@ -47,5 +51,19 @@ public class TestProtocol {
     assertNotNull(parsedStringProtocol);
     assertNotNull(parsedArrayOfStringProtocol);
     assertEquals(parsedStringProtocol.toString(), parsedArrayOfStringProtocol.toString());
+  }
+
+
+  @Test
+  public void testCopyMessage() {
+    Protocol p = new Protocol("P", "protocol", "foo");
+    Schema req1 = SchemaBuilder.record("foo.req1").fields().endRecord();
+    Protocol.Message m1 = p.createMessage("M", "message", singletonMap("foo", "bar"), req1);
+    Schema req2 = SchemaBuilder.record("foo.req2").fields().name("test").type().booleanType().noDefault().endRecord();
+
+    Protocol.Message m2 = p.createMessage(m1, req2);
+    assertEquals(m1.getName(), m2.getName());
+    assertEquals(m1.getDoc(), m2.getDoc());
+    assertEquals(m1.getProp("foo"), m2.getProp("foo"));
   }
 }

--- a/lang/java/avro/src/test/java/org/apache/avro/TestProtocol.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestProtocol.java
@@ -53,7 +53,6 @@ public class TestProtocol {
     assertEquals(parsedStringProtocol.toString(), parsedArrayOfStringProtocol.toString());
   }
 
-
   @Test
   public void testCopyMessage() {
     Protocol p = new Protocol("P", "protocol", "foo");


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3440
  - ~In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).~

### Tests

- [X] My PR adds the following unit tests ~__OR__ does not need testing for this extremely good reason~:
  `org.apache.avro.TestProtocol#testCopyMessage`

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
