### PR TITLE
AVRO-3441: ServiceLoader for LogicalTypeFactory

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/LogicalTypes.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/LogicalTypes.java
@@ -21,6 +21,7 @@ package org.apache.avro;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
+import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.slf4j.Logger;
@@ -30,6 +31,22 @@ public class LogicalTypes {
 
   private static final Logger LOG = LoggerFactory.getLogger(LogicalTypes.class);
 
+  /**
+   * Factory interface and SPI for logical types. A {@code LogicalTypeFactory} can
+   * be registered in two ways:
+   *
+   * <ol>
+   * <li>Manually, via {@link #register(LogicalTypeFactory)} or
+   * {@link #register(String, LogicalTypeFactory)}</li>
+   *
+   * <li>Automatically, when the {@code LogicalTypeFactory} implementation is a
+   * public class with a public no-arg constructor, is named in a file called
+   * {@code /META-INF/services/org.apache.avro.LogicalTypes$LogicalTypeFactory},
+   * and both are available in the classpath</li>
+   * </ol>
+   *
+   * @see ServiceLoader
+   */
   public interface LogicalTypeFactory {
     LogicalType fromSchema(Schema schema);
 
@@ -39,6 +56,12 @@ public class LogicalTypes {
   }
 
   private static final Map<String, LogicalTypeFactory> REGISTERED_TYPES = new ConcurrentHashMap<>();
+
+  static {
+    for (LogicalTypeFactory logicalTypeFactory : ServiceLoader.load(LogicalTypeFactory.class)) {
+      register(logicalTypeFactory);
+    }
+  }
 
   /**
    * Register a logical type.

--- a/lang/java/avro/src/test/java/org/apache/avro/DummyLogicalTypeFactory.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/DummyLogicalTypeFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.avro;
+
+public class DummyLogicalTypeFactory implements LogicalTypes.LogicalTypeFactory {
+  @Override
+  public LogicalType fromSchema(Schema schema) {
+    return LogicalTypes.date();
+  }
+
+  @Override
+  public String getTypeName() {
+    return "service-example";
+  }
+}

--- a/lang/java/avro/src/test/java/org/apache/avro/TestLogicalType.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestLogicalType.java
@@ -26,6 +26,9 @@ import org.hamcrest.collection.IsMapContaining;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+
 public class TestLogicalType {
 
   @Test
@@ -285,14 +288,20 @@ public class TestLogicalType {
         IsMapContaining.hasEntry("logicalTypeName", factory));
   }
 
+  @Test
+  public void testRegisterLogicalTypeFactoryByServiceLoader() {
+    MatcherAssert.assertThat(LogicalTypes.getCustomRegisteredTypes(),
+        IsMapContaining.hasEntry(equalTo("service-example"), instanceOf(LogicalTypes.LogicalTypeFactory.class)));
+  }
+
   public static void assertEqualsTrue(String message, Object o1, Object o2) {
-    Assert.assertTrue("Should be equal (forward): " + message, o1.equals(o2));
-    Assert.assertTrue("Should be equal (reverse): " + message, o2.equals(o1));
+    Assert.assertEquals("Should be equal (forward): " + message, o1, o2);
+    Assert.assertEquals("Should be equal (reverse): " + message, o2, o1);
   }
 
   public static void assertEqualsFalse(String message, Object o1, Object o2) {
-    Assert.assertFalse("Should be equal (forward): " + message, o1.equals(o2));
-    Assert.assertFalse("Should be equal (reverse): " + message, o2.equals(o1));
+    Assert.assertNotEquals("Should be equal (forward): " + message, o1, o2);
+    Assert.assertNotEquals("Should be equal (reverse): " + message, o2, o1);
   }
 
   /**
@@ -305,7 +314,7 @@ public class TestLogicalType {
    * @param callable           A Callable that is expected to throw the exception
    */
   public static void assertThrows(String message, Class<? extends Exception> expected, String containedInMessage,
-      Callable callable) {
+      Callable<?> callable) {
     try {
       callable.call();
       Assert.fail("No exception was thrown (" + message + "), expected: " + expected.getName());

--- a/lang/java/avro/src/test/resources/META-INF/services/org.apache.avro.LogicalTypes$LogicalTypeFactory
+++ b/lang/java/avro/src/test/resources/META-INF/services/org.apache.avro.LogicalTypes$LogicalTypeFactory
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.avro.DummyLogicalTypeFactory


### PR DESCRIPTION
Automatically register LogicalTypeFactory classes using the Java 6
service loader upon startup. This works for any LogicalTypeFactory that
does not need constructor parameters.

Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3441
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests ~__OR__ does not need testing for this extremely good reason~:
   `org.apache.avro.TestLogicalType#testRegisterLogicalTypeFactoryByServiceLoader`

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
