### PR TITLE
AVRO-3378: Map old links to new website

### DIFF
--- a/doc/content/en/blog/releases/_index.md
+++ b/doc/content/en/blog/releases/_index.md
@@ -1,7 +1,9 @@
 ---
-title: "New Releases"
+title: "Releases"
 linkTitle: "Releases"
 weight: 21
+aliases:
+- /releases.html
 ---
 
 <!--

--- a/doc/content/en/community/_index.md
+++ b/doc/content/en/community/_index.md
@@ -3,6 +3,12 @@ title: Community
 menu:
   main:
     weight: 40
+aliases:
+- /irc.html
+- /issue_tracking.html
+- /mailing_lists.html
+- /mail/
+- /version_control.html
 ---
 
 <!--

--- a/doc/content/en/project/Credits/_index.md
+++ b/doc/content/en/project/Credits/_index.md
@@ -2,6 +2,8 @@
 title: "Credits"
 linkTitle: "Credits"
 weight: 2
+aliases:
+- /credits.html
 ---
 
 <!--

--- a/doc/content/en/project/Donate/_index.md
+++ b/doc/content/en/project/Donate/_index.md
@@ -2,6 +2,7 @@
 title: "Donate"
 linkTitle: "Donate"
 weight: 6
+manualLink: https://www.apache.org/foundation/sponsorship.html
 ---
 
 <!--

--- a/doc/content/en/project/_index.md
+++ b/doc/content/en/project/_index.md
@@ -6,6 +6,9 @@ layout: project
 menu:
   main:
     weight: 1
+aliases:
+- /linkmap.html
+
 ---
 
 <!--
@@ -28,6 +31,5 @@ menu:
  under the License.
 
 -->
-
 
 Apache Avro project is a member of the Apache Software Foundation!

--- a/doc/layouts/project/list.html
+++ b/doc/layouts/project/list.html
@@ -1,3 +1,4 @@
+{{ define "main" }}
 <!--
 
  Licensed to the Apache Software Foundation (ASF) under one
@@ -18,8 +19,6 @@
  under the License.
 
 -->
-
-{{ define "main" }}
 <div class="td-content">
 	<h1>{{ .Title }}</h1>
   {{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}


### PR DESCRIPTION
Remapped some of the old links into their new locations in the website, using aliases.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3378
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR does not need testing for this extremely good reason: manually verified on the new website.

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
