### PR TITLE
AVRO-3003: Fully qualify enum default value in C# code gen

### DIFF
--- a/lang/csharp/src/apache/main/CodeGen/CodeGen.cs
+++ b/lang/csharp/src/apache/main/CodeGen/CodeGen.cs
@@ -779,7 +779,7 @@ namespace Avro
                 codeField.Attributes = MemberAttributes.Private;
                 if (field.Schema is EnumSchema es && es.Default != null)
                 {
-                    codeField.InitExpression = new CodeTypeReferenceExpression($"{es.Name}.{es.Default}");
+                    codeField.InitExpression = new CodeTypeReferenceExpression($"{es.Namespace}.{es.Name}.{es.Default}");
                 }
 
                 // Process field documentation if it exist and add to the field

--- a/lang/csharp/src/apache/test/AvroGen/AvroGenTests.cs
+++ b/lang/csharp/src/apache/test/AvroGen/AvroGenTests.cs
@@ -416,7 +416,7 @@ namespace Avro.Test.AvroGen
         {
             TestSchema(schema, typeNamesToCheck, generatedFilesToCheck: generatedFilesToCheck);
         }
-        
+
         [TestCase(
             _nullableLogicalTypesArray,
             "org.apache.avro.codegentest.testdata", "org.apache.csharp.codegentest.testdata",
@@ -547,7 +547,7 @@ namespace Avro.Test.AvroGen
     ""name"" : ""ClassKeywords"",
     ""namespace"" : ""com.base"",
     ""fields"" :
-        [ 	
+        [
             { ""name"" : ""int"", ""type"" : ""int"" },
             { ""name"" : ""base"", ""type"" : ""long"" },
             { ""name"" : ""event"", ""type"" : ""boolean"" },
@@ -578,7 +578,7 @@ namespace Avro.Test.AvroGen
     ""name"" : ""SchemaObject"",
     ""namespace"" : ""schematest"",
     ""fields"" :
-        [ 	
+        [
             { ""name"" : ""myobject"", ""type"" :
                 [
                     ""null"",
@@ -600,7 +600,7 @@ namespace Avro.Test.AvroGen
 	""name"" : ""LogicalTypes"",
 	""namespace"" : ""schematest"",
 	""fields"" :
-		[ 	
+		[
 			{ ""name"" : ""nullibleguid"", ""type"" : [""null"", {""type"": ""string"", ""logicalType"": ""uuid"" } ]},
 			{ ""name"" : ""guid"", ""type"" : {""type"": ""string"", ""logicalType"": ""uuid"" } },
 			{ ""name"" : ""nullibletimestampmillis"", ""type"" : [""null"", {""type"": ""long"", ""logicalType"": ""timestamp-millis""}]  },
@@ -616,6 +616,29 @@ namespace Avro.Test.AvroGen
 		]
 }",
             new object[] { "schematest.LogicalTypes", typeof(Guid?), typeof(Guid), typeof(DateTime?), typeof(DateTime), typeof(DateTime?), typeof(DateTime), typeof(TimeSpan?), typeof(TimeSpan), typeof(TimeSpan?), typeof(TimeSpan), typeof(AvroDecimal?), typeof(AvroDecimal) })]
+        [TestCase(@"
+{
+  ""namespace"": ""enum.base"",
+  ""type"": ""record"",
+  ""name"": ""EnumInDifferentNamespace"",
+  ""doc"": ""Test enum with a default value in a different namespace"",
+  ""fields"": [
+    {
+      ""name"": ""anEnum"",
+      ""type"": {
+        ""namespace"": ""enum.base.other"",
+        ""type"": ""enum"",
+        ""name"": ""AnEnum"",
+        ""symbols"": [
+          ""A"",
+          ""B""
+        ],
+        ""default"": ""A""
+      }
+    }
+  ]
+}",
+            new object[] { "enum.base.EnumInDifferentNamespace", "enum.base.other.AnEnum" })]
         public void GenerateSchemaCheckFields(string schema, object[] result)
         {
             Assembly assembly = TestSchema(schema);


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO-3003)
  - https://issues.apache.org/jira/browse/AVRO-3003
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
- Add a new test case to the Avro.Test.AvroGen.GenerateSchemaCheckFields unit test

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
