### PR TITLE
[AVRO-3448][rust] Rust name/namespace spec adherence work

### DIFF
--- a/lang/rust/avro/src/decode.rs
+++ b/lang/rust/avro/src/decode.rs
@@ -267,7 +267,7 @@ fn decode_internal<R: Read>(
                     });
                 }
             } else {
-                return Err(Error::GetEnumUnknonwIndexValue);
+                return Err(Error::GetEnumUnknownIndexValue);
             })
         }
         Schema::Ref { ref name } => {

--- a/lang/rust/avro/src/decode.rs
+++ b/lang/rust/avro/src/decode.rs
@@ -616,7 +616,7 @@ mod tests {
                 "outer_field_1".into(),
                 Value::Union(1, Box::new(middle_record_variation_2)),
             ),
-            ("outer_field_2".into(), inner_record.clone()),
+            ("outer_field_2".into(), inner_record),
         ]);
 
         let mut buf = Vec::new();
@@ -722,7 +722,7 @@ mod tests {
                 "outer_field_1".into(),
                 Value::Union(1, Box::new(middle_record_variation_2)),
             ),
-            ("outer_field_2".into(), inner_record.clone()),
+            ("outer_field_2".into(), inner_record),
         ]);
 
         let mut buf = Vec::new();

--- a/lang/rust/avro/src/decode.rs
+++ b/lang/rust/avro/src/decode.rs
@@ -333,6 +333,7 @@ mod tests {
             size: 2,
             doc: None,
             name: Name::new("decimal").unwrap(),
+            aliases: None,
         });
         let schema = Schema::Decimal {
             inner,
@@ -357,6 +358,7 @@ mod tests {
         let inner = Box::new(Schema::Fixed {
             size: 13,
             name: Name::new("decimal").unwrap(),
+            aliases: None,
             doc: None,
         });
         let schema = Schema::Decimal {

--- a/lang/rust/avro/src/encode.rs
+++ b/lang/rust/avro/src/encode.rs
@@ -568,7 +568,7 @@ mod tests {
                 "outer_field_1".into(),
                 Value::Union(1, Box::new(middle_record_variation_2)),
             ),
-            ("outer_field_2".into(), inner_record.clone()),
+            ("outer_field_2".into(), inner_record),
         ]);
 
         // TODO add in error result wrapping to encoding flow
@@ -656,7 +656,7 @@ mod tests {
                 "outer_field_1".into(),
                 Value::Union(1, Box::new(middle_record_variation_2)),
             ),
-            ("outer_field_2".into(), inner_record.clone()),
+            ("outer_field_2".into(), inner_record),
         ]);
 
         // TODO add in error result wrapping to encoding flow
@@ -745,7 +745,7 @@ mod tests {
                 "outer_field_1".into(),
                 Value::Union(1, Box::new(middle_record_variation_2)),
             ),
-            ("outer_field_2".into(), inner_record.clone()),
+            ("outer_field_2".into(), inner_record),
         ]);
 
         // TODO add in error result wrapping to encoding flow

--- a/lang/rust/avro/src/error.rs
+++ b/lang/rust/avro/src/error.rs
@@ -95,7 +95,7 @@ pub enum Error {
     GetEnumSymbol(String),
 
     #[error("Unable to decode enum index")]
-    GetEnumUnknonwIndexValue,
+    GetEnumUnknownIndexValue,
 
     #[error("Scale {scale} is greater than precision {precision}")]
     GetScaleAndPrecision { scale: usize, precision: usize },

--- a/lang/rust/avro/src/error.rs
+++ b/lang/rust/avro/src/error.rs
@@ -15,7 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::{schema::SchemaKind, types::ValueKind};
+use crate::{
+    schema::{Name, SchemaKind},
+    types::ValueKind,
+};
 use std::fmt;
 
 #[derive(thiserror::Error, Debug)]
@@ -378,13 +381,26 @@ pub enum Error {
 
     /// Error while resolving Schema::Ref
     #[error("Unresolved schema reference: {0}")]
-    SchemaResolutionError(String),
+    SchemaResolutionError(Name),
 
     #[error("The file metadata is already flushed.")]
     FileHeaderAlreadyWritten,
 
     #[error("Metadata keys starting with 'avro.' are reserved for internal usage: {0}.")]
     InvalidMetadataKey(String),
+
+    /// Error when two named schema have the same fully qualified name
+    #[error("Two named schema defined for same fullname: {0}.")]
+    AmbiguousSchemaDefinition(Name),
+
+    #[error("Signed decimal bytes length {0} not equal to fixed schema size {1}.")]
+    EncodeDecimalAsFixedError(usize, usize),
+
+    #[error("Can only encode value type {value_kind:?} as one of {supported_schema:?}")]
+    EncodeValueAsSchemaError {
+        value_kind: ValueKind,
+        supported_schema: Vec<SchemaKind>,
+    },
 }
 
 impl serde::ser::Error for Error {

--- a/lang/rust/avro/src/error.rs
+++ b/lang/rust/avro/src/error.rs
@@ -91,8 +91,11 @@ pub enum Error {
     #[error("Enum symbol index out of bounds: {num_variants}")]
     EnumSymbolIndex { index: usize, num_variants: usize },
 
-    #[error("Enum symbol not found")]
-    GetEnumSymbol,
+    #[error("Enum symbol not found {0}")]
+    GetEnumSymbol(String),
+
+    #[error("Unable to decode enum index")]
+    GetEnumUnknonwIndexValue,
 
     #[error("Scale {scale} is greater than precision {precision}")]
     GetScaleAndPrecision { scale: usize, precision: usize },

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -2547,7 +2547,7 @@ mod tests {
         "#;
         let schema = Schema::parse_str(schema).unwrap();
         let rs = ResolvedSchema::from(&schema);
-        for s in vec!["space.record_name", "space.inner_record_name"] {
+        for s in &["space.record_name", "space.inner_record_name"] {
             assert!(rs.get_names().contains_key(&Name::new(s).unwrap()));
         }
     }
@@ -2585,7 +2585,7 @@ mod tests {
         "#;
         let schema = Schema::parse_str(schema).unwrap();
         let rs = ResolvedSchema::from(&schema);
-        for s in vec!["space.record_name", "space.inner_record_name"] {
+        for s in &["space.record_name", "space.inner_record_name"] {
             assert!(rs.get_names().contains_key(&Name::new(s).unwrap()));
         }
     }
@@ -2618,7 +2618,7 @@ mod tests {
         "#;
         let schema = Schema::parse_str(schema).unwrap();
         let rs = ResolvedSchema::from(&schema);
-        for s in vec!["space.record_name", "space.inner_enum_name"] {
+        for s in &["space.record_name", "space.inner_enum_name"] {
             assert!(rs.get_names().contains_key(&Name::new(s).unwrap()));
         }
     }
@@ -2651,7 +2651,7 @@ mod tests {
         "#;
         let schema = Schema::parse_str(schema).unwrap();
         let rs = ResolvedSchema::from(&schema);
-        for s in vec!["space.record_name", "space.inner_enum_name"] {
+        for s in &["space.record_name", "space.inner_enum_name"] {
             assert!(rs.get_names().contains_key(&Name::new(s).unwrap()));
         }
     }
@@ -2684,7 +2684,7 @@ mod tests {
         "#;
         let schema = Schema::parse_str(schema).unwrap();
         let rs = ResolvedSchema::from(&schema);
-        for s in vec!["space.record_name", "space.inner_fixed_name"] {
+        for s in &["space.record_name", "space.inner_fixed_name"] {
             assert!(rs.get_names().contains_key(&Name::new(s).unwrap()));
         }
     }
@@ -2717,7 +2717,7 @@ mod tests {
         "#;
         let schema = Schema::parse_str(schema).unwrap();
         let rs = ResolvedSchema::from(&schema);
-        for s in vec!["space.record_name", "space.inner_fixed_name"] {
+        for s in &["space.record_name", "space.inner_fixed_name"] {
             assert!(rs.get_names().contains_key(&Name::new(s).unwrap()));
         }
     }
@@ -2756,7 +2756,7 @@ mod tests {
         "#;
         let schema = Schema::parse_str(schema).unwrap();
         let rs = ResolvedSchema::from(&schema);
-        for s in vec!["space.record_name", "inner_space.inner_record_name"] {
+        for s in &["space.record_name", "inner_space.inner_record_name"] {
             assert!(rs.get_names().contains_key(&Name::new(s).unwrap()));
         }
     }
@@ -2790,7 +2790,7 @@ mod tests {
         "#;
         let schema = Schema::parse_str(schema).unwrap();
         let rs = ResolvedSchema::from(&schema);
-        for s in vec!["space.record_name", "inner_space.inner_enum_name"] {
+        for s in &["space.record_name", "inner_space.inner_enum_name"] {
             assert!(rs.get_names().contains_key(&Name::new(s).unwrap()));
         }
     }
@@ -2824,7 +2824,7 @@ mod tests {
         "#;
         let schema = Schema::parse_str(schema).unwrap();
         let rs = ResolvedSchema::from(&schema);
-        for s in vec!["space.record_name", "inner_space.inner_fixed_name"] {
+        for s in &["space.record_name", "inner_space.inner_fixed_name"] {
             assert!(rs.get_names().contains_key(&Name::new(s).unwrap()));
         }
     }
@@ -2874,7 +2874,7 @@ mod tests {
         "#;
         let schema = Schema::parse_str(schema).unwrap();
         let rs = ResolvedSchema::from(&schema);
-        for s in vec![
+        for s in &[
             "space.record_name",
             "space.middle_record_name",
             "space.inner_record_name",
@@ -2929,7 +2929,7 @@ mod tests {
         "#;
         let schema = Schema::parse_str(schema).unwrap();
         let rs = ResolvedSchema::from(&schema);
-        for s in vec![
+        for s in &[
             "space.record_name",
             "middle_namespace.middle_record_name",
             "middle_namespace.inner_record_name",
@@ -2985,7 +2985,7 @@ mod tests {
         "#;
         let schema = Schema::parse_str(schema).unwrap();
         let rs = ResolvedSchema::from(&schema);
-        for s in vec![
+        for s in &[
             "space.record_name",
             "middle_namespace.middle_record_name",
             "inner_namespace.inner_record_name",
@@ -3027,7 +3027,7 @@ mod tests {
         "#;
         let schema = Schema::parse_str(schema).unwrap();
         let rs = ResolvedSchema::from(&schema);
-        for s in vec!["space.record_name", "space.in_array_record"] {
+        for s in &["space.record_name", "space.in_array_record"] {
             assert!(rs.get_names().contains_key(&Name::new(s).unwrap()));
         }
     }
@@ -3065,7 +3065,7 @@ mod tests {
         "#;
         let schema = Schema::parse_str(schema).unwrap();
         let rs = ResolvedSchema::from(&schema);
-        for s in vec!["space.record_name", "space.in_map_record"] {
+        for s in &["space.record_name", "space.in_map_record"] {
             assert!(rs.get_names().contains_key(&Name::new(s).unwrap()));
         }
     }

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -732,7 +732,7 @@ impl Parser {
         let value = self
             .input_schemas
             .remove(&fully_qualified_name)
-            // TODO make a better descriptive error message here that conveys that a names schema cannot be found
+            // TODO make a better descriptive error message here that conveys that a named schema cannot be found
             .ok_or_else(|| Error::ParsePrimitive(name.fullname(None)))?;
 
         // parsing a full schema from inside another schema. Other full schema will not inherit namespace

--- a/lang/rust/avro/src/schema_compatibility.rs
+++ b/lang/rust/avro/src/schema_compatibility.rs
@@ -232,12 +232,14 @@ impl SchemaCompatibility {
                 SchemaKind::Fixed => {
                     if let Schema::Fixed {
                         name: w_name,
+                        aliases: _,
                         doc: _w_doc,
                         size: w_size,
                     } = writers_schema
                     {
                         if let Schema::Fixed {
                             name: r_name,
+                            aliases: _,
                             doc: _r_doc,
                             size: r_size,
                         } = readers_schema

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -934,6 +934,7 @@ mod tests {
         let schema = Schema::Fixed {
             size: 4,
             name: Name::new("some_fixed").unwrap(),
+            aliases: None,
             doc: None,
         };
 
@@ -947,6 +948,7 @@ mod tests {
     fn validate_enum() {
         let schema = Schema::Enum {
             name: Name::new("some_enum").unwrap(),
+            aliases: None,
             doc: None,
             symbols: vec![
                 "spades".to_string(),
@@ -964,6 +966,7 @@ mod tests {
 
         let other_schema = Schema::Enum {
             name: Name::new("some_other_enum").unwrap(),
+            aliases: None,
             doc: None,
             symbols: vec![
                 "hearts".to_string(),
@@ -988,6 +991,7 @@ mod tests {
         // }
         let schema = Schema::Record {
             name: Name::new("some_record").unwrap(),
+            aliases: None,
             doc: None,
             fields: vec![
                 RecordField {
@@ -1139,6 +1143,7 @@ mod tests {
                 scale: 1,
                 inner: Box::new(Schema::Fixed {
                     name: Name::new("decimal").unwrap(),
+                    aliases: None,
                     size: 20,
                     doc: None
                 })

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -409,6 +409,7 @@ impl Value {
     /// in the Avro specification for the full set of rules of schema
     /// resolution.
     pub fn resolve(self, schema: &Schema) -> AvroResult<Self> {
+        // FIXME transition to using resolved Schema
         let mut schemas_by_name: HashMap<Name, Schema> = HashMap::new();
         self.resolve_internal(schema, &mut schemas_by_name)
     }
@@ -440,7 +441,7 @@ impl Value {
                     if let Some(resolved) = schemas_by_name.get(name) {
                         resolve0(value, resolved, &mut schemas_by_name.clone())
                     } else {
-                        Err(Error::SchemaResolutionError(name.fullname(None)))
+                        Err(Error::SchemaResolutionError(name.clone()))
                     }
                 }
                 Schema::Null => val.resolve_null(),

--- a/lang/rust/avro/src/util.rs
+++ b/lang/rust/avro/src/util.rs
@@ -15,7 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::{AvroResult, Error, schema::{Aliases, Documentation}};
+use crate::{
+    schema::{Aliases, Documentation},
+    AvroResult, Error,
+};
 use serde_json::{Map, Value};
 use std::{convert::TryFrom, i64, io::Read, sync::Once};
 
@@ -49,16 +52,15 @@ impl MapHelper for Map<String, Value> {
 
     fn aliases(&self) -> Aliases {
         // FIXME no warning with aliases isn't a json array of json strings
-        self
-        .get("aliases")
-        .and_then(|aliases| aliases.as_array())
-        .and_then(|aliases| {
-            aliases
-                .iter()
-                .map(|alias| alias.as_str())
-                .map(|alias| alias.map(|a| a.to_string()))
-                .collect::<Option<_>>()
-        })
+        self.get("aliases")
+            .and_then(|aliases| aliases.as_array())
+            .and_then(|aliases| {
+                aliases
+                    .iter()
+                    .map(|alias| alias.as_str())
+                    .map(|alias| alias.map(|a| a.to_string()))
+                    .collect::<Option<_>>()
+            })
     }
 }
 

--- a/lang/rust/avro/src/util.rs
+++ b/lang/rust/avro/src/util.rs
@@ -51,7 +51,7 @@ impl MapHelper for Map<String, Value> {
     }
 
     fn aliases(&self) -> Aliases {
-        // FIXME no warning with aliases isn't a json array of json strings
+        // FIXME no warning when aliases aren't a json array of json strings
         self.get("aliases")
             .and_then(|aliases| aliases.as_array())
             .and_then(|aliases| {

--- a/lang/rust/avro/src/writer.rs
+++ b/lang/rust/avro/src/writer.rs
@@ -349,7 +349,7 @@ fn write_value_ref(schema: &Schema, value: &Value, buffer: &mut Vec<u8>) -> Avro
     if !value.validate(schema) {
         return Err(Error::Validation);
     }
-    encode_ref(value, schema, buffer);
+    encode(value, schema, buffer);
     Ok(())
 }
 
@@ -521,6 +521,7 @@ mod tests {
         let size = 30;
         let inner = Schema::Fixed {
             name: Name::new("decimal").unwrap(),
+            aliases: None,
             doc: None,
             size,
         };
@@ -559,6 +560,7 @@ mod tests {
     fn duration() -> TestResult<()> {
         let inner = Schema::Fixed {
             name: Name::new("duration").unwrap(),
+            aliases: None,
             doc: None,
             size: 12,
         };

--- a/lang/rust/avro/src/writer.rs
+++ b/lang/rust/avro/src/writer.rs
@@ -17,7 +17,7 @@
 
 //! Logic handling writing in Avro format at user level.
 use crate::{
-    encode::{encode, encode_ref, encode_to_vec},
+    encode::{encode, encode_to_vec},
     schema::Schema,
     ser::Serializer,
     types::Value,

--- a/lang/rust/avro/src/writer.rs
+++ b/lang/rust/avro/src/writer.rs
@@ -266,7 +266,7 @@ impl<'a, W: Write> Writer<'a, W> {
 
     /// Append a raw Avro Value to the payload avoiding to encode it again.
     fn append_raw(&mut self, value: &Value, schema: &Schema) -> AvroResult<usize> {
-        self.append_bytes(encode_to_vec(value, schema).as_ref())
+        self.append_bytes(encode_to_vec(value, schema)?.as_ref())
     }
 
     /// Append pure bytes to the payload.
@@ -309,7 +309,7 @@ impl<'a, W: Write> Writer<'a, W> {
             &metadata.into(),
             &Schema::Map(Box::new(Schema::Bytes)),
             &mut header,
-        );
+        )?;
         header.extend_from_slice(&self.marker);
 
         Ok(header)
@@ -341,7 +341,7 @@ fn write_avro_datum<T: Into<Value>>(
     if !avro.validate(schema) {
         return Err(Error::Validation);
     }
-    encode(&avro, schema, buffer);
+    encode(&avro, schema, buffer)?;
     Ok(())
 }
 
@@ -349,7 +349,7 @@ fn write_value_ref(schema: &Schema, value: &Value, buffer: &mut Vec<u8>) -> Avro
     if !value.validate(schema) {
         return Err(Error::Validation);
     }
-    encode(value, schema, buffer);
+    encode(value, schema, buffer)?;
     Ok(())
 }
 

--- a/lang/rust/avro/tests/schema.rs
+++ b/lang/rust/avro/tests/schema.rs
@@ -845,6 +845,7 @@ fn test_parse_reused_record_schema_by_fullname() {
     match schema.unwrap() {
         Schema::Record {
             ref name,
+            aliases: _,
             doc: _,
             ref fields,
             lookup: _,
@@ -1088,7 +1089,7 @@ fn test_fullname_name_and_default_namespace_specified() {
     init();
     let name: Name =
         serde_json::from_str(r#"{"name": "a", "namespace": null, "aliases": null}"#).unwrap();
-    let fullname = name.fullname(Some("b.c.d"));
+    let fullname = name.fullname(Some("b.c.d".into()));
     assert_eq!("b.c.d.a", fullname);
 }
 
@@ -1097,7 +1098,7 @@ fn test_fullname_fullname_and_default_namespace_specified() {
     init();
     let name: Name =
         serde_json::from_str(r#"{"name": "a.b.c.d", "namespace": null, "aliases": null}"#).unwrap();
-    let fullname = name.fullname(Some("o.a.h"));
+    let fullname = name.fullname(Some("o.a.h".into()));
     assert_eq!("a.b.c.d", fullname);
 }
 
@@ -1107,7 +1108,7 @@ fn test_fullname_fullname_namespace_and_default_namespace_specified() {
     let name: Name =
         serde_json::from_str(r#"{"name": "a.b.c.d", "namespace": "o.a.a", "aliases": null}"#)
             .unwrap();
-    let fullname = name.fullname(Some("o.a.h"));
+    let fullname = name.fullname(Some("o.a.h".into()));
     assert_eq!("a.b.c.d", fullname);
 }
 
@@ -1116,7 +1117,7 @@ fn test_fullname_name_namespace_and_default_namespace_specified() {
     init();
     let name: Name =
         serde_json::from_str(r#"{"name": "a", "namespace": "o.a.a", "aliases": null}"#).unwrap();
-    let fullname = name.fullname(Some("o.a.h"));
+    let fullname = name.fullname(Some("o.a.h".into()));
     assert_eq!("o.a.a.a", fullname);
 }
 


### PR DESCRIPTION
### Description
In the Encoding and Decoding recursive flows, the schema definitions are being added to a map ad hoc. This means for input values that do not recurse to the schema definition needed by a later schema ref, there is an encoding error when both the input schema and input Value/bytes are valid. 
Ex: The following schema fails to encode/decode when a is the first union variant (null)
```json
{
            "type":"record",
            "name":"TestStruct",
            "fields": [
                {
                    "name":"a",
                    "type":[ "null", {
                        "type":"record",
                        "name": "Inner",
                        "fields": [ {
                            "name":"z",
                            "type":"int"
                        }]
                    }]
                },
                {
                    "name":"b",
                    "type":"Inner"
                }
            ]
        }
```

In the parsing, encoding, and decoding recursive workflow, the enclosing namespace needed to globally uniquely define a named schema type is not being passed recursively to help fully qualify a schema's name. This leads to the potential of ambiguous or undefined schema errors.
Ex: the following fails to parse when it should
```json
{
          "name": "record_name",
          "namespace": "space",
          "type": "record",
          "fields": [
            {
              "name": "outer_field_1",
              "type": [
                        "null",
                        {
                            "type":"record",
                            "name":"inner_record_name",
                            "fields":[
                                {
                                    "name":"inner_field_1",
                                    "type":"double"
                                }
                            ]
                        }
                    ]
            },
            {
                "name": "outer_field_2",
                "type" : "space.inner_record_name"
            }
          ]
        }
```
Ex the following succeeds when it should fail
```json
{
            "type":"record",
            "name":"outer",
            "namesapce":"outer.space",
            "fields":[
                {
                    "name": "field1",
                    "type": {
                        "type" : "record",
                        "name" : "middle",
                        "namespace":"middle.space",
                        "fields":[
                            {
                                "name":"middle_field_1",
                                "type": {
                                    "type":"record",
                                    "name":"inner",
                                    "fields":[
                                        {
                                            "name":"inner_field_1",
                                            "type":"double"
                                        }
                                    ]
                                }
                            }
                        ]
                    }
                },
                {
                    "name":"field2",
                    "type":"inner"
                }
            ]
        }
```

The proposed solution here extends from the conversation has in the comments of https://github.com/apache/avro/pull/1582 by fulling resolving all the names to schema reference before all encoding and decoding workflows. In addition, this PR also updates the classes, and types that work with names to make them easier to work with. It uses these updated classes and types to passes a namespace type recursively so it can be used in fully qualifying the name of Named types in parsing, encoding and decoding workflows. The fully qualified name is ultimately what is used for schema lookup to avoid all ambiguity.

### Breaking Changes 
- [ergo] Aliases moved out of the name struct to match with Java SDK (something suggested by @[travisbrown](https://github.com/travisbrown) with regards to another struct that I echo), and for clarity within this flow that uses names as a HashTable index.
- [ergo]  encode_ref now includes the names lookup table and enclosing namespace input arguments. Can be replaces by the encode function which I believe was serving the same purpose)
- [functional] users with incorrect schemas that were parsing for the wrong reasons will have errors (hopefully few)
- [functional] users who were for some reason catching panics on the encode flow will no longer be able to catch their errors that way and must unwrap the Result (Compiler warning only to let them know)
 
### Future work
- Use the fulling indexed schema (now called resolved schema) to help speed up encoding and decoding workflows ( avoid indexing schemas every time)
- Better type/name resolution error messages
- ~Avoid panics on encoding flow and set up AvroResult<()> returns with proper errors~
- Value Resolution flow can make use of resolved schema with enclosing namespace (Its recursively adding schemas to hashmap). Believe it might have the same bug as the encoding flow. 

### Jira
https://issues.apache.org/jira/browse/AVRO-3448

### Tests
- My PR adds unit tests that are design to test taking the name/namespacing spec to the extreme.
- I including many of the same schema in tests for the parsing/encoding/decoding workflows. The test dependency (have to parse a schema to encode with it, have to encode with a schema before decoding with it, etc) 
- All previous unit tests unchanged except for trivial constructor changes. 

### Documentation
- I have added docs in some places where I believe the flow or use case to be non obvious
- more can be added based on review feedback and what gets questions. 
