### PR TITLE
AVRO-3451: Reuse Resolved Schemas

### DIFF
--- a/lang/rust/avro/src/encode.rs
+++ b/lang/rust/avro/src/encode.rs
@@ -47,7 +47,7 @@ fn encode_int(i: i32, buffer: &mut Vec<u8>) {
     zig_i32(i, buffer)
 }
 
-fn encode_internal(
+pub(crate) fn encode_internal(
     value: &Value,
     schema: &Schema,
     names: &NamesRef,

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -355,7 +355,10 @@ impl<'s> TryFrom<&'s Schema> for ResolvedSchema<'s> {
 }
 
 impl<'s> ResolvedSchema<'s> {
-    pub fn get_names(&self) -> &NamesRef<'s> {
+    pub(crate) fn get_root_schema(&self) -> &'s Schema {
+        self.root_schema
+    }
+    pub(crate) fn get_names(&self) -> &NamesRef<'s> {
         &self.names_ref
     }
 

--- a/lang/rust/avro/src/writer.rs
+++ b/lang/rust/avro/src/writer.rs
@@ -124,10 +124,8 @@ impl<'a, W: Write> Writer<'a, W> {
                 Ok(n)
             }
             None => {
-                if !self.attempted_resolve {
-                    self.attempted_resolve = true;
-                }
                 let rs = ResolvedSchema::try_from(self.schema)?;
+                self.attempted_resolve = true;
                 self.resolved_schema = Some(rs);
                 self.append_value_ref(value)
             }

--- a/lang/rust/avro/src/writer.rs
+++ b/lang/rust/avro/src/writer.rs
@@ -37,8 +37,6 @@ pub struct Writer<'a, W> {
     writer: W,
     #[builder(default, setter(skip))]
     resolved_schema: Option<ResolvedSchema<'a>>,
-    #[builder(default = false, setter(skip))]
-    attempted_resolve: bool,
     #[builder(default = Codec::Null)]
     codec: Codec,
     #[builder(default = DEFAULT_BLOCK_SIZE)]
@@ -64,7 +62,6 @@ impl<'a, W: Write> Writer<'a, W> {
     pub fn new(schema: &'a Schema, writer: W) -> Self {
         let mut w = Self::builder().schema(schema).writer(writer).build();
         w.resolved_schema = ResolvedSchema::try_from(schema).ok();
-        w.attempted_resolve = true;
         w
     }
 
@@ -77,7 +74,6 @@ impl<'a, W: Write> Writer<'a, W> {
             .codec(codec)
             .build();
         w.resolved_schema = ResolvedSchema::try_from(schema).ok();
-        w.attempted_resolve = true;
         w
     }
 
@@ -125,7 +121,6 @@ impl<'a, W: Write> Writer<'a, W> {
             }
             None => {
                 let rs = ResolvedSchema::try_from(self.schema)?;
-                self.attempted_resolve = true;
                 self.resolved_schema = Some(rs);
                 self.append_value_ref(value)
             }

--- a/lang/rust/avro/src/writer.rs
+++ b/lang/rust/avro/src/writer.rs
@@ -17,15 +17,15 @@
 
 //! Logic handling writing in Avro format at user level.
 use crate::{
-    encode::{encode, encode_to_vec},
-    schema::Schema,
+    encode::{encode, encode_internal, encode_to_vec},
+    schema::{ResolvedSchema, Schema},
     ser::Serializer,
     types::Value,
     AvroResult, Codec, Error,
 };
 use rand::random;
 use serde::Serialize;
-use std::{collections::HashMap, io::Write};
+use std::{collections::HashMap, convert::TryFrom, io::Write};
 
 const DEFAULT_BLOCK_SIZE: usize = 16000;
 const AVRO_OBJECT_HEADER: &[u8] = b"Obj\x01";
@@ -35,6 +35,10 @@ const AVRO_OBJECT_HEADER: &[u8] = b"Obj\x01";
 pub struct Writer<'a, W> {
     schema: &'a Schema,
     writer: W,
+    #[builder(default, setter(skip))]
+    resolved_schema: Option<ResolvedSchema<'a>>,
+    #[builder(default = false, setter(skip))]
+    attempted_resolve: bool,
     #[builder(default = Codec::Null)]
     codec: Codec,
     #[builder(default = DEFAULT_BLOCK_SIZE)]
@@ -58,17 +62,23 @@ impl<'a, W: Write> Writer<'a, W> {
     /// to.
     /// No compression `Codec` will be used.
     pub fn new(schema: &'a Schema, writer: W) -> Self {
-        Self::builder().schema(schema).writer(writer).build()
+        let mut w = Self::builder().schema(schema).writer(writer).build();
+        w.resolved_schema = ResolvedSchema::try_from(schema).ok();
+        w.attempted_resolve = true;
+        w
     }
 
     /// Creates a `Writer` with a specific `Codec` given a `Schema` and something implementing the
     /// `io::Write` trait to write to.
     pub fn with_codec(schema: &'a Schema, writer: W, codec: Codec) -> Self {
-        Self::builder()
+        let mut w = Self::builder()
             .schema(schema)
             .writer(writer)
             .codec(codec)
-            .build()
+            .build();
+        w.resolved_schema = ResolvedSchema::try_from(schema).ok();
+        w.attempted_resolve = true;
+        w
     }
 
     /// Get a reference to the `Schema` associated to a `Writer`.
@@ -88,15 +98,7 @@ impl<'a, W: Write> Writer<'a, W> {
         let n = self.maybe_write_header()?;
 
         let avro = value.into();
-        write_value_ref(self.schema, &avro, &mut self.buffer)?;
-
-        self.num_values += 1;
-
-        if self.buffer.len() >= self.block_size {
-            return self.flush().map(|b| b + n);
-        }
-
-        Ok(n)
+        self.append_value_ref(&avro).map(|m| m + n)
     }
 
     /// Append a compatible value to a `Writer`, also performing schema validation.
@@ -109,15 +111,27 @@ impl<'a, W: Write> Writer<'a, W> {
     pub fn append_value_ref(&mut self, value: &Value) -> AvroResult<usize> {
         let n = self.maybe_write_header()?;
 
-        write_value_ref(self.schema, value, &mut self.buffer)?;
+        // Lazy init for users using the builder pattern with error throwing
+        match self.resolved_schema {
+            Some(ref rs) => {
+                write_value_ref_resolved(rs, value, &mut self.buffer)?;
+                self.num_values += 1;
 
-        self.num_values += 1;
+                if self.buffer.len() >= self.block_size {
+                    return self.flush().map(|b| b + n);
+                }
 
-        if self.buffer.len() >= self.block_size {
-            return self.flush().map(|b| b + n);
+                Ok(n)
+            }
+            None => {
+                if !self.attempted_resolve {
+                    self.attempted_resolve = true;
+                }
+                let rs = ResolvedSchema::try_from(self.schema)?;
+                self.resolved_schema = Some(rs);
+                self.append_value_ref(value)
+            }
         }
-
-        Ok(n)
     }
 
     /// Append anything implementing the `Serialize` trait to a `Writer` for
@@ -345,11 +359,21 @@ fn write_avro_datum<T: Into<Value>>(
     Ok(())
 }
 
-fn write_value_ref(schema: &Schema, value: &Value, buffer: &mut Vec<u8>) -> AvroResult<()> {
-    if !value.validate(schema) {
+fn write_value_ref_resolved(
+    resolved_schema: &ResolvedSchema,
+    value: &Value,
+    buffer: &mut Vec<u8>,
+) -> AvroResult<()> {
+    if !value.validate(resolved_schema.get_root_schema()) {
         return Err(Error::Validation);
     }
-    encode(value, schema, buffer)?;
+    encode_internal(
+        value,
+        resolved_schema.get_root_schema(),
+        resolved_schema.get_names(),
+        &None,
+        buffer,
+    )?;
     Ok(())
 }
 


### PR DESCRIPTION
A reuse of the resolved schema struct to help improve performance when possible. Currently every write/append into a writer would use the same schema and resolve it to index all the named schemas for every object being written. Because a writer has a consistent schema it is trivial to reuse the same resolved schema for every write. This improvement was brought up in collaboration with @travisbrown 

What made the implementation less straightforward were the following design constraints:
- absolutely no API breaking changes
- Want to keep Resolved Schema crate private for simplicity

As a result there is some complexity to how the resolved schema is initialized within the writer but I believe it is handled.

### Benchmark results:
Using the example/benchmark.rs to get a csv output. I ran data for pre 1602 code (which the JIRA is based on) and on the latest commit of this branch. This is run on a 2016 macbook pro. I ran multiple times to confirm that the results were consistent and chose the last run for comparisons. 

#### Pre 1602
| count |  runs  |  big_or_small |  total_write_secs | 
|-------|--------|---------------|-------------------| 
| 10000 | 1      | Small         | 0.080105792       | 
| 10000 | 1      | Big           | 0.363642778       | 
| 1     | 100000 | Small         | 5.450658665       | 
| 100   | 1000   | Small         | 0.844267501       | 
| 10000 | 10     | Small         | 0.799961709       | 
| 1     | 100000 | Big           | 13.395100232      | 
| 100   | 1000   | Big           | 4.254442101       | 
| 10000 | 10     | Big           | 3.755155395       | 

#### This branch 
| count |  runs  |  big_or_small |  total_write_secs | 
|-------|--------|---------------|-------------------| 
| 10000 | 1      | Small         | 0.019134068       | 
| 10000 | 1      | Big           | 0.089809544       | 
| 1     | 100000 | Small         | 4.449467382       | 
| 100   | 1000   | Small         | 0.307506175       | 
| 10000 | 10     | Small         | 0.190783385       | 
| 1     | 100000 | Big           | 11.514703263      | 
| 100   | 1000   | Big           | 0.931118263       | 
| 10000 | 10     | Big           | 1.042874368       | 

#### Percent change (initial - final) / initial 
| count |  runs  |  big_or_small | % reduction | 
|-------|--------|---------------|-------------| 
| 10000 | 1      | Small         | 0.761140018 | 
| 10000 | 1      | Big           | 0.753028110 | 
| 1     | 100000 | Small         | 0.183682623 | 
| 100   | 1000   | Small         | 0.635771631 | 
| 10000 | 10     | Small         | 0.761509354 | 
| 1     | 100000 | Big           | 0.140379462 | 
| 100   | 1000   | Big           | 0.781142100 | 
| 10000 | 10     | Big           | 0.722281968 | 

This is consistent with whats expected as we get the least performance improvements when the writer is constantly being remade. The 14/18 improvement, is a result of changes in #1602 that seem to have a highly variable performance impact  depending on schema. 

### Jira

- [ ] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO-3451) 

### Tests

My Pr does not add tests because it does not add functionality. All tests pass as before. 

### Documentation

No new user facing changes
