### PR TITLE
AVRO-3464: Print a header and use tabs as separators

### DIFF
--- a/lang/rust/avro/examples/benchmark.rs
+++ b/lang/rust/avro/examples/benchmark.rs
@@ -97,7 +97,7 @@ fn benchmark(
         (seconds(total_duration_write), seconds(total_duration_read));
 
     println!(
-        "{},{},{},{},{}",
+        "{}\t\t{}\t\t{}\t\t{}\t\t{}",
         count, runs, big_or_small, total_write_secs, total_read_secs
     );
     Ok(())
@@ -140,6 +140,7 @@ fn main() -> anyhow::Result<()> {
     let big_record = big_record.into();
 
     println!();
+    println!("Count\t\tRuns\t\tBig/Small\tTotal write secs\tTotal read secs");
 
     benchmark(&small_schema, &small_record, "Small", 10_000, 1)?;
     benchmark(&big_schema, &big_record, "Big", 10_000, 1)?;


### PR DESCRIPTION
Old:
```
10000,1,Small,0.007364553,0.031123657
10000,1,Big,0.035918282,0.070638095
1,100000,Small,2.581216969,12.182083002
100,1000,Small,0.104473121,0.429455526
10000,10,Small,0.083368471,0.312625975
1,100000,Big,5.799714721,44.469941304
100,1000,Big,0.421531543,1.295618375
10000,10,Big,0.572024442,1.554042001
```

New:
```
Count		Runs		Big/Small	Total write secs	Total read secs
10000		1		Small		0.0072546		0.030194991
10000		1		Big		0.03440565		0.072913845
1		100000		Small		2.562500111		11.847315748
100		1000		Small		0.106402492		0.409962211
10000		10		Small		0.076109698		0.289378503
1		100000		Big		5.566392901		43.606074983
100		1000		Big		0.39528024		1.203362874
10000		10		Big		0.356784052		0.72371213
```


### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3464

### Tests

- [X] No need of new tests

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] no need of new documentation