### PR TITLE
AVRO-3266: Work with hadoop 3.x PathOutputComitters

### DIFF
--- a/lang/java/mapred/src/main/java/org/apache/avro/mapreduce/AvroOutputFormatBase.java
+++ b/lang/java/mapred/src/main/java/org/apache/avro/mapreduce/AvroOutputFormatBase.java
@@ -87,6 +87,8 @@ public abstract class AvroOutputFormatBase<K, V> extends FileOutputFormat<K, V> 
   }
 
   private Path getWorkPathFromCommitter(TaskAttemptContext context) throws IOException {
+    // When Hadoop 2 support is dropped, this method removed to a simple cast
+    // See https://github.com/apache/avro/pull/1431/
     OutputCommitter committer = getOutputCommitter(context);
     try {
       return (Path) committer.getClass().getMethod("getWorkPath").invoke(committer);

--- a/lang/java/mapred/src/main/java/org/apache/avro/mapreduce/AvroOutputFormatBase.java
+++ b/lang/java/mapred/src/main/java/org/apache/avro/mapreduce/AvroOutputFormatBase.java
@@ -87,11 +87,12 @@ public abstract class AvroOutputFormatBase<K, V> extends FileOutputFormat<K, V> 
   }
 
   private Path getWorkPathFromCommitter(TaskAttemptContext context) throws IOException {
+    OutputCommitter committer = getOutputCommitter(context);
     try {
-      OutputCommitter committer = getOutputCommitter(context);
       return (Path) committer.getClass().getMethod("getWorkPath").invoke(committer);
     } catch (ReflectiveOperationException e) {
-      throw new AvroRuntimeException("Committer does not have method getWorkPath", e);
+      throw new AvroRuntimeException(
+          "Committer: " + committer.getClass().getName() + " does not have method getWorkPath", e);
     }
   }
 


### PR DESCRIPTION
In hadoop 3.x the abstract class PathOutputCommitter defines the method `getWorkPath()`, but in hadoop 2.x it only defined on FileOutputCommitter. So to be compatible with both hadoop 2.x and 3.x and support committers that only implements PathOutputComitter and not FileOutputCommitter we make the call to getWorkPath using reflection.

The implementation is based on the suggestions in https://github.com/apache/avro/pull/1431 but as that PR has no updates from the author in 3 months I create a new PR.

This fixes [AVRO-3266](https://issues.apache.org/jira/browse/AVRO-3266)

### Tests

Is covered by existing tests.

### Documentation

No new public methods.
