### PR TITLE
AVRO-3460: [rust] Value::validate does not validate against Schema Refs

### DIFF
--- a/lang/rust/avro/examples/generate_interop_data.rs
+++ b/lang/rust/avro/examples/generate_interop_data.rs
@@ -78,6 +78,8 @@ fn main() -> anyhow::Result<()> {
     let schema_str = std::fs::read_to_string("../../share/test/schemas/interop.avsc")
         .expect("Unable to read the interop Avro schema");
     let schema = Schema::parse_str(schema_str.as_str())?;
+    let data_folder = "../../build/interop/data";
+    std::fs::create_dir_all(data_folder)?;
 
     for codec in Codec::iter() {
         let codec_name = <&str>::from(codec);
@@ -87,7 +89,7 @@ fn main() -> anyhow::Result<()> {
             format!("_{}", codec_name)
         };
 
-        let file_name = format!("../../build/interop/data/rust{}.avro", suffix);
+        let file_name = format!("{}/rust{}.avro", data_folder, suffix);
         let output_file = std::fs::File::create(&file_name)?;
 
         let mut writer = Writer::with_codec(&schema, BufWriter::new(output_file), codec);

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -339,7 +339,9 @@ impl Value {
 
     fn validate_internal(&self, schema: &Schema, names: &NamesRef) -> bool {
         match (self, schema) {
-            (_, &Schema::Ref { ref name }) => names.get(name).map_or(false, |s| self.validate(s)),
+            (_, &Schema::Ref { ref name }) => names
+                .get(name)
+                .map_or(false, |s| self.validate_internal(s, names)),
             (&Value::Null, &Schema::Null) => true,
             (&Value::Boolean(_), &Schema::Boolean) => true,
             (&Value::Int(_), &Schema::Int) => true,

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -333,8 +333,13 @@ impl Value {
     /// See the [Avro specification](https://avro.apache.org/docs/current/spec.html)
     /// for the full set of rules of schema validation.
     pub fn validate(&self, schema: &Schema) -> bool {
+        let rs = ResolvedSchema::try_from(schema).expect("Schema didn't successfully parse");
+        self.validate_internal(schema, rs.get_names())
+    }
+
+    fn validate_internal(&self, schema: &Schema, names: &NamesRef) -> bool {
         match (self, schema) {
-            (_, &Schema::Ref { name: _ }) => true,
+            (_, &Schema::Ref { ref name }) => names.get(name).map_or(false, |s| self.validate(s)),
             (&Value::Null, &Schema::Null) => true,
             (&Value::Boolean(_), &Schema::Boolean) => true,
             (&Value::Int(_), &Schema::Int) => true,
@@ -372,26 +377,26 @@ impl Value {
             (&Value::Union(i, ref value), &Schema::Union(ref inner)) => inner
                 .variants()
                 .get(i as usize)
-                .map(|schema| value.validate(schema))
+                .map(|schema| value.validate_internal(schema, names))
                 .unwrap_or(false),
-            (&Value::Array(ref items), &Schema::Array(ref inner)) => {
-                items.iter().all(|item| item.validate(inner))
-            }
-            (&Value::Map(ref items), &Schema::Map(ref inner)) => {
-                items.iter().all(|(_, value)| value.validate(inner))
-            }
+            (&Value::Array(ref items), &Schema::Array(ref inner)) => items
+                .iter()
+                .all(|item| item.validate_internal(inner, names)),
+            (&Value::Map(ref items), &Schema::Map(ref inner)) => items
+                .iter()
+                .all(|(_, value)| value.validate_internal(inner, names)),
             (&Value::Record(ref record_fields), &Schema::Record { ref fields, .. }) => {
                 fields.len() == record_fields.len()
                     && fields.iter().zip(record_fields.iter()).all(
                         |(field, &(ref name, ref value))| {
-                            field.name == *name && value.validate(&field.schema)
+                            field.name == *name && value.validate_internal(&field.schema, names)
                         },
                     )
             }
             (&Value::Map(ref items), &Schema::Record { ref fields, .. }) => {
                 fields.iter().all(|field| {
                     if let Some(item) = items.get(&field.name) {
-                        item.validate(&field.schema)
+                        item.validate_internal(&field.schema, names)
                     } else {
                         false
                     }
@@ -1846,5 +1851,145 @@ mod tests {
         outer_record_variation_3
             .resolve(&schema)
             .expect("Should be able to resolve value to the schema that is it's definition");
+    }
+
+    #[test]
+    fn test_avro_3460_validation_with_refs() {
+        let schema = Schema::parse_str(
+            r#"
+        {
+            "type":"record",
+            "name":"TestStruct",
+            "fields": [
+                {
+                    "name":"a",
+                    "type":{
+                        "type":"record",
+                        "name": "Inner",
+                        "fields": [ {
+                            "name":"z",
+                            "type":"int"
+                        }]
+                    }
+                },
+                {
+                    "name":"b",
+                    "type":"Inner"
+                }
+            ]
+        }"#,
+        )
+        .unwrap();
+
+        let inner_value_right = Value::Record(vec![("z".into(), Value::Int(3))]);
+        let inner_value_wrong1 = Value::Record(vec![("z".into(), Value::Null)]);
+        let inner_value_wrong2 = Value::Record(vec![("a".into(), Value::String("testing".into()))]);
+        let outer1 = Value::Record(vec![
+            ("a".into(), inner_value_right.clone()),
+            ("b".into(), inner_value_wrong1),
+        ]);
+
+        let outer2 = Value::Record(vec![
+            ("a".into(), inner_value_right),
+            ("b".into(), inner_value_wrong2),
+        ]);
+
+        assert!(
+            !outer1.validate(&schema),
+            "field b record is invalid against the schema"
+        ); // this should pass, but doesn't
+        assert!(
+            !outer2.validate(&schema),
+            "field b record is invalid against the schema"
+        ); // this should pass, but doesn't
+    }
+
+    #[test]
+    fn test_avro_3460_validation_with_refs_real_struct() {
+        use crate::ser::Serializer;
+        use serde::Serialize;
+
+        #[derive(Serialize, Clone)]
+        struct TestInner {
+            z: i32,
+        }
+
+        #[derive(Serialize)]
+        struct TestRefSchemaStruct1 {
+            a: TestInner,
+            b: String, // could be literally anything
+        }
+
+        #[derive(Serialize)]
+        struct TestRefSchemaStruct2 {
+            a: TestInner,
+            b: i32, // could be literally anything
+        }
+
+        #[derive(Serialize)]
+        struct TestRefSchemaStruct3 {
+            a: TestInner,
+            b: Option<TestInner>, // could be literally anything
+        }
+
+        let schema = Schema::parse_str(
+            r#"
+        {
+            "type":"record",
+            "name":"TestStruct",
+            "fields": [
+                {
+                    "name":"a",
+                    "type":{
+                        "type":"record",
+                        "name": "Inner",
+                        "fields": [ {
+                            "name":"z",
+                            "type":"int"
+                        }]
+                    }
+                },
+                {
+                    "name":"b",
+                    "type":"Inner"
+                }
+            ]
+        }"#,
+        )
+        .unwrap();
+
+        let test_inner = TestInner { z: 3 };
+        let test_outer1 = TestRefSchemaStruct1 {
+            a: test_inner.clone(),
+            b: "testing".into(),
+        };
+        let test_outer2 = TestRefSchemaStruct2 {
+            a: test_inner.clone(),
+            b: 24,
+        };
+        let test_outer3 = TestRefSchemaStruct3 {
+            a: test_inner,
+            b: None,
+        };
+
+        let mut ser = Serializer::default();
+        let test_outer1: Value = test_outer1.serialize(&mut ser).unwrap();
+        let mut ser = Serializer::default();
+        let test_outer2: Value = test_outer2.serialize(&mut ser).unwrap();
+        let mut ser = Serializer::default();
+        let test_outer3: Value = test_outer3.serialize(&mut ser).unwrap();
+
+        assert!(
+            !test_outer1.validate(&schema),
+            "field b record is invalid against the schema"
+        ); // this should pass, but doesn't
+        assert!(
+            !test_outer2.validate(&schema),
+            "field b record is invalid against the schema"
+        ); // this should pass, but doesn't
+        assert!(
+            !test_outer3.validate(&schema),
+            "field b record is invalid against the schema"
+        ); // this should pass, but doesn't
     }
 }


### PR DESCRIPTION

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3460
  - 
### Tests

- [X] My PR adds new unit tests

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] No need of new documentation
