### PR TITLE
AVRO-3471: Fix microsecond logical types resolution

### DIFF
--- a/lang/csharp/src/apache/main/Util/TimeMicrosecond.cs
+++ b/lang/csharp/src/apache/main/Util/TimeMicrosecond.cs
@@ -25,7 +25,7 @@ namespace Avro.Util
     /// </summary>
     public class TimeMicrosecond : LogicalUnixEpochType<TimeSpan>
     {
-        private static readonly TimeSpan _maxTime = new TimeSpan(23, 59, 59);
+        private static readonly TimeSpan _maxTime = new TimeSpan(24, 00, 00);
         private const long _ticksPerMicrosecond = TimeSpan.TicksPerMillisecond / 1000;
         
         /// <summary>
@@ -51,7 +51,7 @@ namespace Avro.Util
         {
             var time = (TimeSpan)logicalValue;
 
-            if (time > _maxTime)
+            if (time >= _maxTime)
                 throw new ArgumentOutOfRangeException(nameof(logicalValue), "A 'time-micros' value can only have the range '00:00:00' to '23:59:59'.");
 
             return (time - UnixEpochDateTime.TimeOfDay).Ticks / _ticksPerMicrosecond;

--- a/lang/csharp/src/apache/main/Util/TimeMicrosecond.cs
+++ b/lang/csharp/src/apache/main/Util/TimeMicrosecond.cs
@@ -25,7 +25,7 @@ namespace Avro.Util
     /// </summary>
     public class TimeMicrosecond : LogicalUnixEpochType<TimeSpan>
     {
-        private static readonly TimeSpan _maxTime = new TimeSpan(24, 00, 00);
+        private static readonly TimeSpan _exclusiveUpperBound = new TimeSpan(24, 00, 00);
         private const long _ticksPerMicrosecond = TimeSpan.TicksPerMillisecond / 1000;
         
         /// <summary>
@@ -51,7 +51,7 @@ namespace Avro.Util
         {
             var time = (TimeSpan)logicalValue;
 
-            if (time >= _maxTime)
+            if (time >= _exclusiveUpperBound)
                 throw new ArgumentOutOfRangeException(nameof(logicalValue), "A 'time-micros' value can only have the range '00:00:00' to '23:59:59'.");
 
             return (time - UnixEpochDateTime.TimeOfDay).Ticks / _ticksPerMicrosecond;

--- a/lang/csharp/src/apache/main/Util/TimeMicrosecond.cs
+++ b/lang/csharp/src/apache/main/Util/TimeMicrosecond.cs
@@ -26,6 +26,7 @@ namespace Avro.Util
     public class TimeMicrosecond : LogicalUnixEpochType<TimeSpan>
     {
         private static readonly TimeSpan _maxTime = new TimeSpan(23, 59, 59);
+        private const long _ticksPerMicrosecond = TimeSpan.TicksPerMillisecond / 1000;
         
         /// <summary>
         /// The logical type name for TimeMicrosecond.
@@ -53,14 +54,13 @@ namespace Avro.Util
             if (time > _maxTime)
                 throw new ArgumentOutOfRangeException(nameof(logicalValue), "A 'time-micros' value can only have the range '00:00:00' to '23:59:59'.");
 
-            return (long)(time - UnixEpochDateTime.TimeOfDay).TotalMilliseconds * 1000;
+            return (time - UnixEpochDateTime.TimeOfDay).Ticks / _ticksPerMicrosecond;
         }
 
         /// <inheritdoc/>
         public override object ConvertToLogicalValue(object baseValue, LogicalSchema schema)
         {
-            var noMs = (long)baseValue / 1000;
-            return UnixEpochDateTime.TimeOfDay.Add(TimeSpan.FromMilliseconds(noMs));
+            return UnixEpochDateTime.TimeOfDay.Add(TimeSpan.FromTicks((long)baseValue * _ticksPerMicrosecond));
         }
     }
 }

--- a/lang/csharp/src/apache/main/Util/TimeMicrosecond.cs
+++ b/lang/csharp/src/apache/main/Util/TimeMicrosecond.cs
@@ -25,7 +25,7 @@ namespace Avro.Util
     /// </summary>
     public class TimeMicrosecond : LogicalUnixEpochType<TimeSpan>
     {
-        private static readonly TimeSpan _exclusiveUpperBound = new TimeSpan(24, 00, 00);
+        private static readonly TimeSpan _exclusiveUpperBound = TimeSpan.FromDays(1);
         private const long _ticksPerMicrosecond = TimeSpan.TicksPerMillisecond / 1000;
         
         /// <summary>

--- a/lang/csharp/src/apache/main/Util/TimeMillisecond.cs
+++ b/lang/csharp/src/apache/main/Util/TimeMillisecond.cs
@@ -25,7 +25,7 @@ namespace Avro.Util
     /// </summary>
     public class TimeMillisecond : LogicalUnixEpochType<TimeSpan>
     {
-        private static readonly TimeSpan _maxTime = new TimeSpan(23, 59, 59);
+        private static readonly TimeSpan _maxTime = new TimeSpan(24, 00, 00);
 
         /// <summary>
         /// The logical type name for TimeMillisecond.
@@ -50,7 +50,7 @@ namespace Avro.Util
         {
             var time = (TimeSpan)logicalValue;
 
-            if (time > _maxTime)
+            if (time >= _maxTime)
                 throw new ArgumentOutOfRangeException(nameof(logicalValue), "A 'time-millis' value can only have the range '00:00:00' to '23:59:59'.");
 
             return (int)(time - UnixEpochDateTime.TimeOfDay).TotalMilliseconds;

--- a/lang/csharp/src/apache/main/Util/TimeMillisecond.cs
+++ b/lang/csharp/src/apache/main/Util/TimeMillisecond.cs
@@ -25,7 +25,7 @@ namespace Avro.Util
     /// </summary>
     public class TimeMillisecond : LogicalUnixEpochType<TimeSpan>
     {
-        private static readonly TimeSpan _maxTime = new TimeSpan(24, 00, 00);
+        private static readonly TimeSpan _exclusiveUpperBound = new TimeSpan(24, 00, 00);
 
         /// <summary>
         /// The logical type name for TimeMillisecond.
@@ -50,7 +50,7 @@ namespace Avro.Util
         {
             var time = (TimeSpan)logicalValue;
 
-            if (time >= _maxTime)
+            if (time >= _exclusiveUpperBound)
                 throw new ArgumentOutOfRangeException(nameof(logicalValue), "A 'time-millis' value can only have the range '00:00:00' to '23:59:59'.");
 
             return (int)(time - UnixEpochDateTime.TimeOfDay).TotalMilliseconds;

--- a/lang/csharp/src/apache/main/Util/TimeMillisecond.cs
+++ b/lang/csharp/src/apache/main/Util/TimeMillisecond.cs
@@ -25,7 +25,7 @@ namespace Avro.Util
     /// </summary>
     public class TimeMillisecond : LogicalUnixEpochType<TimeSpan>
     {
-        private static readonly TimeSpan _exclusiveUpperBound = new TimeSpan(24, 00, 00);
+        private static readonly TimeSpan _exclusiveUpperBound = TimeSpan.FromDays(1);
 
         /// <summary>
         /// The logical type name for TimeMillisecond.

--- a/lang/csharp/src/apache/main/Util/TimestampMicrosecond.cs
+++ b/lang/csharp/src/apache/main/Util/TimestampMicrosecond.cs
@@ -25,6 +25,8 @@ namespace Avro.Util
     /// </summary>
     public class TimestampMicrosecond : LogicalUnixEpochType<DateTime>
     {
+        private const long _ticksPerMicrosecond = TimeSpan.TicksPerMillisecond / 1000;
+
         /// <summary>
         /// The logical type name for TimestampMicrosecond.
         /// </summary>
@@ -47,14 +49,13 @@ namespace Avro.Util
         public override object ConvertToBaseValue(object logicalValue, LogicalSchema schema)
         {
             var date = ((DateTime)logicalValue).ToUniversalTime();
-            return (long)((date - UnixEpochDateTime).TotalMilliseconds * 1000);
+            return (date - UnixEpochDateTime).Ticks / _ticksPerMicrosecond;
         }
 
         /// <inheritdoc/>
         public override object ConvertToLogicalValue(object baseValue, LogicalSchema schema)
         {
-            var noMs = (long)baseValue / 1000;
-            return UnixEpochDateTime.AddMilliseconds(noMs);
+            return UnixEpochDateTime.AddTicks((long)baseValue * _ticksPerMicrosecond);
         }
     }
 }

--- a/lang/csharp/src/apache/test/Generic/GenericTests.cs
+++ b/lang/csharp/src/apache/test/Generic/GenericTests.cs
@@ -126,46 +126,97 @@ namespace Avro.Test.Generic
         [TestCase()]
         public void TestLogical_TimeMillisecond()
         {
-            test("{\"type\": \"int\", \"logicalType\": \"time-millis\"}", new TimeSpan(3, 0, 0));
+            string typeDef = "{\"type\": \"int\", \"logicalType\": \"time-millis\"}";
+
+            test(typeDef, new TimeSpan(3, 0, 0));
+            test(typeDef, TimeSpan.FromMilliseconds(0));
+            test(typeDef, TimeSpan.FromMilliseconds(1));
+            test(typeDef, TimeSpan.FromMilliseconds(11));
+            test(typeDef, TimeSpan.FromMilliseconds(101));
+            test(typeDef, TimeSpan.FromMilliseconds(1001));
+            test(typeDef, TimeSpan.FromMilliseconds(10001));
+            test(typeDef, TimeSpan.FromMilliseconds(100001));
+            test(typeDef, TimeSpan.FromMilliseconds(1000001));
+            test(typeDef, TimeSpan.FromMilliseconds(10000001));
+            
+            test(typeDef, TimeSpan.Parse("00:00:00"));
+            test(typeDef, TimeSpan.Parse("01:02:03"));
+            test(typeDef, TimeSpan.Parse("01:02:03.000"));
+            test(typeDef, TimeSpan.Parse("01:02:03.004"));
+            test(typeDef, TimeSpan.Parse("23:59:59.999"));
         }
 
         [TestCase()]
         public void TestLogical_TimeMicrosecond()
         {
+            string typeDef = "{\"type\": \"long\", \"logicalType\": \"time-micros\"}";
             long ticksPerMicroSeconds = TimeSpan.TicksPerMillisecond / 1000;
 
-            test("{\"type\": \"long\", \"logicalType\": \"time-micros\"}", new TimeSpan(3, 0, 0)); // 3 hours
-            test("{\"type\": \"long\", \"logicalType\": \"time-micros\"}", new TimeSpan(1 * ticksPerMicroSeconds)); // 1 microsecond
-            test("{\"type\": \"long\", \"logicalType\": \"time-micros\"}", new TimeSpan(10 * ticksPerMicroSeconds)); // 10 microseconds
-            test("{\"type\": \"long\", \"logicalType\": \"time-micros\"}", new TimeSpan(100 * ticksPerMicroSeconds)); // 100 microseconds
-            test("{\"type\": \"long\", \"logicalType\": \"time-micros\"}", new TimeSpan(1000 * ticksPerMicroSeconds)); // 1 millisecond
-            test("{\"type\": \"long\", \"logicalType\": \"time-micros\"}", new TimeSpan(1001 * ticksPerMicroSeconds));  // 1 millisecond + 1 microsecond
-            test("{\"type\": \"long\", \"logicalType\": \"time-micros\"}", new TimeSpan(10001 * ticksPerMicroSeconds)); // 10 millisecond + 1 microseconds
-            test("{\"type\": \"long\", \"logicalType\": \"time-micros\"}", new TimeSpan(100001 * ticksPerMicroSeconds)); // 100 milliseconds + 1 microsecond
-            test("{\"type\": \"long\", \"logicalType\": \"time-micros\"}", new TimeSpan(1000001 * ticksPerMicroSeconds)); // 1 second + 1 microsecond
+            test(typeDef, new TimeSpan(3, 0, 0)); // 3 hours
+            test(typeDef, new TimeSpan(1 * ticksPerMicroSeconds)); // 1 microsecond
+            test(typeDef, new TimeSpan(10 * ticksPerMicroSeconds)); // 10 microseconds
+            test(typeDef, new TimeSpan(100 * ticksPerMicroSeconds)); // 100 microseconds
+            test(typeDef, new TimeSpan(1000 * ticksPerMicroSeconds)); // 1 millisecond
+            test(typeDef, new TimeSpan(1001 * ticksPerMicroSeconds));  // 1 millisecond + 1 microsecond
+            test(typeDef, new TimeSpan(10001 * ticksPerMicroSeconds)); // 10 millisecond + 1 microseconds
+            test(typeDef, new TimeSpan(100001 * ticksPerMicroSeconds)); // 100 milliseconds + 1 microsecond
+            test(typeDef, new TimeSpan(1000001 * ticksPerMicroSeconds)); // 1 second + 1 microsecond
+
+            test(typeDef, TimeSpan.Parse("00:00:00"));
+            test(typeDef, TimeSpan.Parse("01:02:03"));
+            test(typeDef, TimeSpan.Parse("01:02:03.004"));
+            test(typeDef, TimeSpan.Parse("01:02:03.0004"));
+            test(typeDef, TimeSpan.Parse("01:02:03.00004"));
+            test(typeDef, TimeSpan.Parse("01:02:03.000004"));
+            test(typeDef, TimeSpan.Parse("23:59:59.999999"));
         }
 
         [TestCase()]
         public void TestLogical_TimestampMillisecond()
         {
-            test("{\"type\": \"long\", \"logicalType\": \"timestamp-millis\"}", new DateTime(1990, 1, 1, 14, 15, 30, DateTimeKind.Utc));
+            string typeDef = "{\"type\": \"long\", \"logicalType\": \"timestamp-millis\"}";
+            DateTime dateTime = new DateTime(1990, 1, 1, 14, 15, 30, DateTimeKind.Utc);
+
+            test(typeDef, dateTime);
+            test(typeDef, dateTime.AddMilliseconds(0));
+            test(typeDef, dateTime.AddMilliseconds(1));
+            test(typeDef, dateTime.AddMilliseconds(10));
+            test(typeDef, dateTime.AddMilliseconds(11));
+            test(typeDef, dateTime.AddMilliseconds(100));
+            test(typeDef, dateTime.AddMilliseconds(101));
+            test(typeDef, dateTime.AddMilliseconds(1000));
+            test(typeDef, dateTime.AddMilliseconds(1001));
+
+            test(typeDef, DateTime.Parse("2022-03-24T11:12:13").ToUniversalTime());
+            test(typeDef, DateTime.Parse("2022-03-24T11:12:13.1").ToUniversalTime());
+            test(typeDef, DateTime.Parse("2022-03-24T11:12:13.01").ToUniversalTime());
+            test(typeDef, DateTime.Parse("2022-03-24T11:12:13.001").ToUniversalTime());
         }
 
         [TestCase()]
         public void TestLogical_TimestampMicrosecond()
         {
+            string typeDef = "{\"type\": \"long\", \"logicalType\": \"timestamp-micros\"}";
             DateTime dateTime = new DateTime(1990, 1, 1, 14, 15, 30, DateTimeKind.Utc);
             long ticksPerMicroSeconds = TimeSpan.TicksPerMillisecond / 1000;
 
-            test("{\"type\": \"long\", \"logicalType\": \"timestamp-micros\"}", dateTime);
-            test("{\"type\": \"long\", \"logicalType\": \"timestamp-micros\"}", dateTime.AddTicks(1 * ticksPerMicroSeconds));
-            test("{\"type\": \"long\", \"logicalType\": \"timestamp-micros\"}", dateTime.AddTicks(10 * ticksPerMicroSeconds));
-            test("{\"type\": \"long\", \"logicalType\": \"timestamp-micros\"}", dateTime.AddTicks(100 * ticksPerMicroSeconds));
-            test("{\"type\": \"long\", \"logicalType\": \"timestamp-micros\"}", dateTime.AddTicks(1000 * ticksPerMicroSeconds));
-            test("{\"type\": \"long\", \"logicalType\": \"timestamp-micros\"}", dateTime.AddTicks(1001 * ticksPerMicroSeconds));
-            test("{\"type\": \"long\", \"logicalType\": \"timestamp-micros\"}", dateTime.AddTicks(10001 * ticksPerMicroSeconds));
-            test("{\"type\": \"long\", \"logicalType\": \"timestamp-micros\"}", dateTime.AddTicks(100001 * ticksPerMicroSeconds));
-            test("{\"type\": \"long\", \"logicalType\": \"timestamp-micros\"}", dateTime.AddTicks(1000001 * ticksPerMicroSeconds));
+            test(typeDef, dateTime);
+            test(typeDef, dateTime.AddTicks(1 * ticksPerMicroSeconds));
+            test(typeDef, dateTime.AddTicks(10 * ticksPerMicroSeconds));
+            test(typeDef, dateTime.AddTicks(100 * ticksPerMicroSeconds));
+            test(typeDef, dateTime.AddTicks(1000 * ticksPerMicroSeconds));
+            test(typeDef, dateTime.AddTicks(1001 * ticksPerMicroSeconds));
+            test(typeDef, dateTime.AddTicks(10001 * ticksPerMicroSeconds));
+            test(typeDef, dateTime.AddTicks(100001 * ticksPerMicroSeconds));
+            test(typeDef, dateTime.AddTicks(1000001 * ticksPerMicroSeconds));
+
+            test(typeDef, DateTime.Parse("2022-03-24T11:12:13").ToUniversalTime());
+            test(typeDef, DateTime.Parse("2022-03-24T11:12:13.1").ToUniversalTime());
+            test(typeDef, DateTime.Parse("2022-03-24T11:12:13.01").ToUniversalTime());
+            test(typeDef, DateTime.Parse("2022-03-24T11:12:13.001").ToUniversalTime());
+            test(typeDef, DateTime.Parse("2022-03-24T11:12:13.0001").ToUniversalTime());
+            test(typeDef, DateTime.Parse("2022-03-24T11:12:13.00001").ToUniversalTime());
+            test(typeDef, DateTime.Parse("2022-03-24T11:12:13.000001").ToUniversalTime());
         }
 
         [TestCase()]

--- a/lang/csharp/src/apache/test/Generic/GenericTests.cs
+++ b/lang/csharp/src/apache/test/Generic/GenericTests.cs
@@ -126,97 +126,25 @@ namespace Avro.Test.Generic
         [TestCase()]
         public void TestLogical_TimeMillisecond()
         {
-            string typeDef = "{\"type\": \"int\", \"logicalType\": \"time-millis\"}";
-
-            test(typeDef, new TimeSpan(3, 0, 0));
-            test(typeDef, TimeSpan.FromMilliseconds(0));
-            test(typeDef, TimeSpan.FromMilliseconds(1));
-            test(typeDef, TimeSpan.FromMilliseconds(11));
-            test(typeDef, TimeSpan.FromMilliseconds(101));
-            test(typeDef, TimeSpan.FromMilliseconds(1001));
-            test(typeDef, TimeSpan.FromMilliseconds(10001));
-            test(typeDef, TimeSpan.FromMilliseconds(100001));
-            test(typeDef, TimeSpan.FromMilliseconds(1000001));
-            test(typeDef, TimeSpan.FromMilliseconds(10000001));
-            
-            test(typeDef, TimeSpan.Parse("00:00:00"));
-            test(typeDef, TimeSpan.Parse("01:02:03"));
-            test(typeDef, TimeSpan.Parse("01:02:03.000"));
-            test(typeDef, TimeSpan.Parse("01:02:03.004"));
-            test(typeDef, TimeSpan.Parse("23:59:59.999"));
+            test("{\"type\": \"int\", \"logicalType\": \"time-millis\"}", new TimeSpan(3, 0, 0));
         }
 
         [TestCase()]
         public void TestLogical_TimeMicrosecond()
         {
-            string typeDef = "{\"type\": \"long\", \"logicalType\": \"time-micros\"}";
-            long ticksPerMicroSeconds = TimeSpan.TicksPerMillisecond / 1000;
-
-            test(typeDef, new TimeSpan(3, 0, 0)); // 3 hours
-            test(typeDef, new TimeSpan(1 * ticksPerMicroSeconds)); // 1 microsecond
-            test(typeDef, new TimeSpan(10 * ticksPerMicroSeconds)); // 10 microseconds
-            test(typeDef, new TimeSpan(100 * ticksPerMicroSeconds)); // 100 microseconds
-            test(typeDef, new TimeSpan(1000 * ticksPerMicroSeconds)); // 1 millisecond
-            test(typeDef, new TimeSpan(1001 * ticksPerMicroSeconds));  // 1 millisecond + 1 microsecond
-            test(typeDef, new TimeSpan(10001 * ticksPerMicroSeconds)); // 10 millisecond + 1 microseconds
-            test(typeDef, new TimeSpan(100001 * ticksPerMicroSeconds)); // 100 milliseconds + 1 microsecond
-            test(typeDef, new TimeSpan(1000001 * ticksPerMicroSeconds)); // 1 second + 1 microsecond
-
-            test(typeDef, TimeSpan.Parse("00:00:00"));
-            test(typeDef, TimeSpan.Parse("01:02:03"));
-            test(typeDef, TimeSpan.Parse("01:02:03.004"));
-            test(typeDef, TimeSpan.Parse("01:02:03.0004"));
-            test(typeDef, TimeSpan.Parse("01:02:03.00004"));
-            test(typeDef, TimeSpan.Parse("01:02:03.000004"));
-            test(typeDef, TimeSpan.Parse("23:59:59.999999"));
+            test("{\"type\": \"long\", \"logicalType\": \"time-micros\"}", new TimeSpan(3, 0, 0));
         }
 
         [TestCase()]
         public void TestLogical_TimestampMillisecond()
         {
-            string typeDef = "{\"type\": \"long\", \"logicalType\": \"timestamp-millis\"}";
-            DateTime dateTime = new DateTime(1990, 1, 1, 14, 15, 30, DateTimeKind.Utc);
-
-            test(typeDef, dateTime);
-            test(typeDef, dateTime.AddMilliseconds(0));
-            test(typeDef, dateTime.AddMilliseconds(1));
-            test(typeDef, dateTime.AddMilliseconds(10));
-            test(typeDef, dateTime.AddMilliseconds(11));
-            test(typeDef, dateTime.AddMilliseconds(100));
-            test(typeDef, dateTime.AddMilliseconds(101));
-            test(typeDef, dateTime.AddMilliseconds(1000));
-            test(typeDef, dateTime.AddMilliseconds(1001));
-
-            test(typeDef, DateTime.Parse("2022-03-24T11:12:13").ToUniversalTime());
-            test(typeDef, DateTime.Parse("2022-03-24T11:12:13.1").ToUniversalTime());
-            test(typeDef, DateTime.Parse("2022-03-24T11:12:13.01").ToUniversalTime());
-            test(typeDef, DateTime.Parse("2022-03-24T11:12:13.001").ToUniversalTime());
+            test("{\"type\": \"long\", \"logicalType\": \"timestamp-millis\"}", new DateTime(1990, 1, 1, 14, 15, 30, DateTimeKind.Utc));
         }
 
         [TestCase()]
         public void TestLogical_TimestampMicrosecond()
         {
-            string typeDef = "{\"type\": \"long\", \"logicalType\": \"timestamp-micros\"}";
-            DateTime dateTime = new DateTime(1990, 1, 1, 14, 15, 30, DateTimeKind.Utc);
-            long ticksPerMicroSeconds = TimeSpan.TicksPerMillisecond / 1000;
-
-            test(typeDef, dateTime);
-            test(typeDef, dateTime.AddTicks(1 * ticksPerMicroSeconds));
-            test(typeDef, dateTime.AddTicks(10 * ticksPerMicroSeconds));
-            test(typeDef, dateTime.AddTicks(100 * ticksPerMicroSeconds));
-            test(typeDef, dateTime.AddTicks(1000 * ticksPerMicroSeconds));
-            test(typeDef, dateTime.AddTicks(1001 * ticksPerMicroSeconds));
-            test(typeDef, dateTime.AddTicks(10001 * ticksPerMicroSeconds));
-            test(typeDef, dateTime.AddTicks(100001 * ticksPerMicroSeconds));
-            test(typeDef, dateTime.AddTicks(1000001 * ticksPerMicroSeconds));
-
-            test(typeDef, DateTime.Parse("2022-03-24T11:12:13").ToUniversalTime());
-            test(typeDef, DateTime.Parse("2022-03-24T11:12:13.1").ToUniversalTime());
-            test(typeDef, DateTime.Parse("2022-03-24T11:12:13.01").ToUniversalTime());
-            test(typeDef, DateTime.Parse("2022-03-24T11:12:13.001").ToUniversalTime());
-            test(typeDef, DateTime.Parse("2022-03-24T11:12:13.0001").ToUniversalTime());
-            test(typeDef, DateTime.Parse("2022-03-24T11:12:13.00001").ToUniversalTime());
-            test(typeDef, DateTime.Parse("2022-03-24T11:12:13.000001").ToUniversalTime());
+            test("{\"type\": \"long\", \"logicalType\": \"timestamp-micros\"}", new DateTime(1990, 1, 1, 14, 15, 30, DateTimeKind.Utc));
         }
 
         [TestCase()]

--- a/lang/csharp/src/apache/test/Generic/GenericTests.cs
+++ b/lang/csharp/src/apache/test/Generic/GenericTests.cs
@@ -132,7 +132,17 @@ namespace Avro.Test.Generic
         [TestCase()]
         public void TestLogical_TimeMicrosecond()
         {
-            test("{\"type\": \"long\", \"logicalType\": \"time-micros\"}", new TimeSpan(3, 0, 0));
+            long ticksPerMicroSeconds = TimeSpan.TicksPerMillisecond / 1000;
+
+            test("{\"type\": \"long\", \"logicalType\": \"time-micros\"}", new TimeSpan(3, 0, 0)); // 3 hours
+            test("{\"type\": \"long\", \"logicalType\": \"time-micros\"}", new TimeSpan(1 * ticksPerMicroSeconds)); // 1 microsecond
+            test("{\"type\": \"long\", \"logicalType\": \"time-micros\"}", new TimeSpan(10 * ticksPerMicroSeconds)); // 10 microseconds
+            test("{\"type\": \"long\", \"logicalType\": \"time-micros\"}", new TimeSpan(100 * ticksPerMicroSeconds)); // 100 microseconds
+            test("{\"type\": \"long\", \"logicalType\": \"time-micros\"}", new TimeSpan(1000 * ticksPerMicroSeconds)); // 1 millisecond
+            test("{\"type\": \"long\", \"logicalType\": \"time-micros\"}", new TimeSpan(1001 * ticksPerMicroSeconds));  // 1 millisecond + 1 microsecond
+            test("{\"type\": \"long\", \"logicalType\": \"time-micros\"}", new TimeSpan(10001 * ticksPerMicroSeconds)); // 10 millisecond + 1 microseconds
+            test("{\"type\": \"long\", \"logicalType\": \"time-micros\"}", new TimeSpan(100001 * ticksPerMicroSeconds)); // 100 milliseconds + 1 microsecond
+            test("{\"type\": \"long\", \"logicalType\": \"time-micros\"}", new TimeSpan(1000001 * ticksPerMicroSeconds)); // 1 second + 1 microsecond
         }
 
         [TestCase()]
@@ -144,7 +154,18 @@ namespace Avro.Test.Generic
         [TestCase()]
         public void TestLogical_TimestampMicrosecond()
         {
-            test("{\"type\": \"long\", \"logicalType\": \"timestamp-micros\"}", new DateTime(1990, 1, 1, 14, 15, 30, DateTimeKind.Utc));
+            DateTime dateTime = new DateTime(1990, 1, 1, 14, 15, 30, DateTimeKind.Utc);
+            long ticksPerMicroSeconds = TimeSpan.TicksPerMillisecond / 1000;
+
+            test("{\"type\": \"long\", \"logicalType\": \"timestamp-micros\"}", dateTime);
+            test("{\"type\": \"long\", \"logicalType\": \"timestamp-micros\"}", dateTime.AddTicks(1 * ticksPerMicroSeconds));
+            test("{\"type\": \"long\", \"logicalType\": \"timestamp-micros\"}", dateTime.AddTicks(10 * ticksPerMicroSeconds));
+            test("{\"type\": \"long\", \"logicalType\": \"timestamp-micros\"}", dateTime.AddTicks(100 * ticksPerMicroSeconds));
+            test("{\"type\": \"long\", \"logicalType\": \"timestamp-micros\"}", dateTime.AddTicks(1000 * ticksPerMicroSeconds));
+            test("{\"type\": \"long\", \"logicalType\": \"timestamp-micros\"}", dateTime.AddTicks(1001 * ticksPerMicroSeconds));
+            test("{\"type\": \"long\", \"logicalType\": \"timestamp-micros\"}", dateTime.AddTicks(10001 * ticksPerMicroSeconds));
+            test("{\"type\": \"long\", \"logicalType\": \"timestamp-micros\"}", dateTime.AddTicks(100001 * ticksPerMicroSeconds));
+            test("{\"type\": \"long\", \"logicalType\": \"timestamp-micros\"}", dateTime.AddTicks(1000001 * ticksPerMicroSeconds));
         }
 
         [TestCase()]

--- a/lang/csharp/src/apache/test/Util/LogicalTypeTests.cs
+++ b/lang/csharp/src/apache/test/Util/LogicalTypeTests.cs
@@ -75,6 +75,14 @@ namespace Avro.Test
         [TestCase("05/05/2019 00:00:00Z")]
         [TestCase("05/05/2019 01:00:00Z")]
         [TestCase("05/05/2019 01:00:00+01:00")]
+        [TestCase("05/05/2019 01:00:00.1Z")]
+        [TestCase("05/05/2019 01:00:00.01Z")]
+        [TestCase("05/05/2019 01:00:00.001Z")]
+        [TestCase("05/05/2019 01:00:00.0001Z")]
+        [TestCase("05/05/2019 01:00:00.00001Z")]
+        [TestCase("05/05/2019 01:00:00.000001Z")]
+        [TestCase("05/05/2019 01:00:00.0000001Z")]
+        [TestCase("05/05/2019 01:00:00.00000001Z")]
         public void TestDate(string s)
         {
             var schema = (LogicalSchema)Schema.Parse("{\"type\": \"int\", \"logicalType\": \"date\"}");
@@ -100,6 +108,12 @@ namespace Avro.Test
         [TestCase("05/05/2019 14:20:00+01:00", "05/05/2019 13:20:00Z")]
         [TestCase("05/05/2019 00:00:00Z", "05/05/2019 00:00:00Z")]
         [TestCase("05/05/2019 00:00:00+01:00", "05/04/2019 23:00:00Z")] // adjusted to UTC
+        [TestCase("01/01/2019 14:20:00.1Z", "01/01/2019 14:20:00.1Z")]
+        [TestCase("01/01/2019 14:20:00.01Z", "01/01/2019 14:20:00.01Z")]
+        [TestCase("01/01/2019 14:20:00.001Z", "01/01/2019 14:20:00.001Z")]
+        [TestCase("01/01/2019 14:20:00.0001Z", "01/01/2019 14:20:00Z")]
+        [TestCase("01/01/2019 14:20:00.0009Z", "01/01/2019 14:20:00Z")] // there is no rounding up
+        [TestCase("01/01/2019 14:20:00.0019Z", "01/01/2019 14:20:00.001Z")] // there is no rounding up
         public void TestTimestampMillisecond(string s, string e)
         {
             var schema = (LogicalSchema)Schema.Parse("{\"type\": \"long\", \"logicalType\": \"timestamp-millis\"}");
@@ -124,6 +138,15 @@ namespace Avro.Test
         [TestCase("05/05/2019 14:20:00+01:00", "05/05/2019 13:20:00Z")]
         [TestCase("05/05/2019 00:00:00Z", "05/05/2019 00:00:00Z")]
         [TestCase("05/05/2019 00:00:00+01:00", "05/04/2019 23:00:00Z")] // adjusted to UTC
+        [TestCase("01/01/2019 14:20:00.1Z", "01/01/2019 14:20:00.1Z")]
+        [TestCase("01/01/2019 14:20:00.01Z", "01/01/2019 14:20:00.01Z")]
+        [TestCase("01/01/2019 14:20:00.001Z", "01/01/2019 14:20:00.001Z")]
+        [TestCase("01/01/2019 14:20:00.0001Z", "01/01/2019 14:20:00.0001Z")]
+        [TestCase("01/01/2019 14:20:00.00001Z", "01/01/2019 14:20:00.00001Z")]
+        [TestCase("01/01/2019 14:20:00.000001Z", "01/01/2019 14:20:00.000001Z")]
+        [TestCase("01/01/2019 14:20:00.0000001Z", "01/01/2019 14:20:00Z")]
+        [TestCase("01/01/2019 14:20:00.0000009Z", "01/01/2019 14:20:00Z")] // there is no rounding up
+        [TestCase("01/01/2019 14:20:00.0000019Z", "01/01/2019 14:20:00.000001Z")] // there is no rounding up
         public void TestTimestampMicrosecond(string s, string e)
         {
             var schema = (LogicalSchema)Schema.Parse("{\"type\": \"long\", \"logicalType\": \"timestamp-micros\"}");
@@ -144,26 +167,29 @@ namespace Avro.Test
 
         [TestCase("01:20:10", "01:20:10", false)]
         [TestCase("23:00:00", "23:00:00", false)]
+        [TestCase("23:59:00", "23:59:00", false)]
+        [TestCase("23:59:59", "23:59:59", false)]
+        [TestCase("01:20:10.1", "01:20:10.1", false)]
+        [TestCase("01:20:10.01", "01:20:10.01", false)]
+        [TestCase("01:20:10.001", "01:20:10.001", false)]
+        [TestCase("01:20:10.0001", "01:20:10", false)]
+        [TestCase("01:20:10.0009", "01:20:10", false)] // there is no rounding up
+        [TestCase("01:20:10.0019", "01:20:10.001", false)] // there is no rounding up
+        [TestCase("23:59:59.999", "23:59:59.999", false)]
         [TestCase("01:00:00:00", null, true)]
-        public void TestTime(string s, string e, bool expectRangeError)
+        public void TestTimeMillisecond(string s, string e, bool expectRangeError)
         {
             var timeMilliSchema = (LogicalSchema)Schema.Parse("{\"type\": \"int\", \"logicalType\": \"time-millis\"}");
-            var timeMicroSchema = (LogicalSchema)Schema.Parse("{\"type\": \"long\", \"logicalType\": \"time-micros\"}");
 
             var time = TimeSpan.Parse(s);
             
             var avroTimeMilli = new TimeMillisecond();
-            var avroTimeMicro = new TimeMicrosecond();
 
             if (expectRangeError)
             {
                 Assert.Throws<ArgumentOutOfRangeException>(() =>
                 {
                     avroTimeMilli.ConvertToLogicalValue(avroTimeMilli.ConvertToBaseValue(time, timeMilliSchema), timeMilliSchema);
-                });
-                Assert.Throws<ArgumentOutOfRangeException>(() =>
-                {
-                    avroTimeMicro.ConvertToLogicalValue(avroTimeMilli.ConvertToBaseValue(time, timeMicroSchema), timeMicroSchema);
                 });
             }
             else
@@ -172,8 +198,43 @@ namespace Avro.Test
 
                 var convertedTime = (TimeSpan)avroTimeMilli.ConvertToLogicalValue(avroTimeMilli.ConvertToBaseValue(time, timeMilliSchema), timeMilliSchema);
                 Assert.AreEqual(expectedTime, convertedTime);
+            }
+        }
 
-                convertedTime = (TimeSpan)avroTimeMicro.ConvertToLogicalValue(avroTimeMicro.ConvertToBaseValue(time, timeMicroSchema), timeMicroSchema);
+        [TestCase("01:20:10", "01:20:10", false)]
+        [TestCase("23:00:00", "23:00:00", false)]
+        [TestCase("23:59:00", "23:59:00", false)]
+        [TestCase("23:59:59", "23:59:59", false)]
+        [TestCase("01:20:10.1", "01:20:10.1", false)]
+        [TestCase("01:20:10.01", "01:20:10.01", false)]
+        [TestCase("01:20:10.001", "01:20:10.001", false)]
+        [TestCase("01:20:10.0001", "01:20:10.0001", false)]
+        [TestCase("01:20:10.00001", "01:20:10.00001", false)]
+        [TestCase("01:20:10.000001", "01:20:10.000001", false)]
+        [TestCase("01:20:10.0000001", "01:20:10", false)]
+        [TestCase("01:20:10.0000009", "01:20:10", false)]
+        [TestCase("23:59:59.999999", "23:59:59.999999", false)]
+        [TestCase("01:00:00:00", null, true)]
+        public void TestTimeMicrosecond(string s, string e, bool expectRangeError)
+        {
+            var timeMicroSchema = (LogicalSchema)Schema.Parse("{\"type\": \"long\", \"logicalType\": \"time-micros\"}");
+
+            var time = TimeSpan.Parse(s);
+            
+            var avroTimeMicro = new TimeMicrosecond();
+
+            if (expectRangeError)
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() =>
+                {
+                    avroTimeMicro.ConvertToLogicalValue(avroTimeMicro.ConvertToBaseValue(time, timeMicroSchema), timeMicroSchema);
+                });
+            }
+            else
+            {
+                var expectedTime = TimeSpan.Parse(e);
+
+                var convertedTime = (TimeSpan)avroTimeMicro.ConvertToLogicalValue(avroTimeMicro.ConvertToBaseValue(time, timeMicroSchema), timeMicroSchema);
                 Assert.AreEqual(expectedTime, convertedTime);
 
             }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO-3471
  - https://issues.apache.org/jira/browse/AVRO-3471
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
