### PR TITLE
[AVRO-3460] [rust] Follow up: reusing NameRef

### DIFF
--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -337,7 +337,7 @@ impl Value {
         self.validate_internal(schema, rs.get_names())
     }
 
-    fn validate_internal(&self, schema: &Schema, names: &NamesRef) -> bool {
+    pub(crate) fn validate_internal(&self, schema: &Schema, names: &NamesRef) -> bool {
         match (self, schema) {
             (_, &Schema::Ref { ref name }) => names
                 .get(name)

--- a/lang/rust/avro/src/writer.rs
+++ b/lang/rust/avro/src/writer.rs
@@ -357,7 +357,10 @@ fn write_value_ref_resolved(
     value: &Value,
     buffer: &mut Vec<u8>,
 ) -> AvroResult<()> {
-    if !value.validate(resolved_schema.get_root_schema()) {
+    if !value.validate_internal(
+        resolved_schema.get_root_schema(),
+        resolved_schema.get_names(),
+    ) {
         return Err(Error::Validation);
     }
     encode_internal(


### PR DESCRIPTION
Reuses the namesRef from the writer in the same way the encoder does

### Jira

- [ ] AVRO-3460 follow up

### Tests

- All unit tests pass 

### Commits

### Documentation
nothing new 
