### PR TITLE
AVRO-2921 Additional Type Hints for avro.schema

### DIFF
--- a/lang/py/avro/protocol.py
+++ b/lang/py/avro/protocol.py
@@ -37,7 +37,7 @@ VALID_TYPE_SCHEMA_TYPES = ("enum", "record", "error", "fixed")
 
 
 class MessageObject(TypedDict, total=False):
-    request: Sequence[Mapping[str, object]]
+    request: Sequence[avro.schema.PropsType]
     response: Union[str, object]
     errors: Optional[Sequence[str]]
 
@@ -214,10 +214,10 @@ class Message:
             to_dump = MessageObject()
         except NameError:
             to_dump = {}
-        to_dump["request"] = self.request.to_json(names)
+        to_dump["request"] = cast(Sequence[avro.schema.PropsType], self.request.to_json(names))
         to_dump["response"] = self.response.to_json(names)
         if self.errors:
-            to_dump["errors"] = self.errors.to_json(names)
+            to_dump["errors"] = cast(Sequence[str], self.errors.to_json(names))
 
         return to_dump
 

--- a/lang/py/mypy.ini
+++ b/lang/py/mypy.ini
@@ -16,12 +16,12 @@
 [mypy]
 files =
     avro
-warn_return_any = True
-warn_unused_configs = True
-warn_unreachable = True
+warn_return_any = true
+warn_unused_configs = true
+warn_unreachable = true
 
 [mypy-snappy]
-ignore_missing_imports = True
+ignore_missing_imports = true
 
 [mypy-zstandard]
-ignore_missing_imports = True
+ignore_missing_imports = true


### PR DESCRIPTION
Adds strict type hints for avro.schema.

### Jira

- [x] My PR addresses [AVRO-2921](https://issues.apache.org/jira/browse/AVRO-2921) and references it in the PR title.
- [x] Adds no dependency

### Tests

- [x] My PR is covered by and passes existing tests.

### Commits

- [x] My commits all reference Jira issues in their subject lines.
- [x] In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  - [x] Subject is separated from body by a blank line
  - [x] Subject is limited to 50 characters (not including Jira issue reference)
  - [x] Subject does not end with a period
  - [x] Subject uses the imperative mood ("add", not "adding")
  - [x] Body wraps at 72 characters
  - [x] Body explains "what" and "why", not "how"

### Documentation

- [x] Type hints are a form of documentation as well as being a static analysis tool.
