### PR TITLE
AVRO-3483: [Rust] Log error messages with a reason when the validation fails

### DIFF
--- a/lang/rust/avro/Cargo.toml
+++ b/lang/rust/avro/Cargo.toml
@@ -71,7 +71,7 @@ typed-builder = "0.10.0"
 uuid = { version = "0.8.2", features = ["serde", "v4"] }
 zerocopy = "0.6.1"
 lazy_static = "1.4.0"
-log = "0.4.14"
+log = "0.4.16"
 zstd = { version = "0.11.0+zstd.1.5.2", optional = true }
 
 [dev-dependencies]
@@ -81,3 +81,4 @@ criterion = "0.3.5"
 anyhow = "1.0.56"
 hex-literal = "0.3.4"
 env_logger = "0.9.0"
+ref_thread_local = "0.1.1"

--- a/lang/rust/avro/src/error.rs
+++ b/lang/rust/avro/src/error.rs
@@ -51,6 +51,10 @@ pub enum Error {
     #[error("Value does not match schema")]
     Validation,
 
+    /// Describes errors happened while validating Avro data.
+    #[error("Value does not match schema: Reason: {0}")]
+    ValidationWithReason(String),
+
     #[error("Unable to allocate {desired} bytes (maximum allowed: {maximum})")]
     MemoryAllocation { desired: usize, maximum: usize },
 

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -27,7 +27,7 @@ use serde::{
 use serde_json::{Map, Value};
 use std::{
     borrow::Cow,
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     convert::{TryFrom, TryInto},
     fmt,
     hash::Hash,
@@ -68,7 +68,7 @@ impl fmt::Display for SchemaFingerprint {
 /// More information about Avro schemas can be found in the
 /// [Avro Specification](https://avro.apache.org/docs/current/spec.html#schemas)
 #[derive(Clone, Debug, EnumDiscriminants)]
-#[strum_discriminants(name(SchemaKind), derive(Hash))]
+#[strum_discriminants(name(SchemaKind), derive(Hash, Ord, PartialOrd))]
 pub enum Schema {
     /// A `null` Avro schema.
     Null,
@@ -503,12 +503,12 @@ pub struct UnionSchema {
     // schema index given a value.
     // **NOTE** that this approach does not work for named types, and will have to be modified
     // to support that. A simple solution is to also keep a mapping of the names used.
-    variant_index: HashMap<SchemaKind, usize>,
+    variant_index: BTreeMap<SchemaKind, usize>,
 }
 
 impl UnionSchema {
     pub(crate) fn new(schemas: Vec<Schema>) -> AvroResult<Self> {
-        let mut vindex = HashMap::new();
+        let mut vindex = BTreeMap::new();
         for (i, schema) in schemas.iter().enumerate() {
             if let Schema::Union(_) = schema {
                 return Err(Error::GetNestedUnion);

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -349,8 +349,8 @@ impl Value {
     fn accumulate(accumulator: Option<String>, other: Option<String>) -> Option<String> {
         match (accumulator, other) {
             (None, None) => None,
-            (None, Some(reason)) => Some(reason),
-            (Some(reason), None) => Some(reason),
+            (None, s @ Some(_)) => s,
+            (s @ Some(_), None) => s,
             (Some(reason1), Some(reason2)) => Some(format!("{}\n{}", reason1, reason2)),
         }
     }

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -1287,6 +1287,14 @@ mod tests {
         )
         .validate(&schema));
 
+        assert!(!Value::Map(
+            vec![("c".to_string(), Value::Long(123_i64)),]
+                .into_iter()
+                .collect()
+        )
+        .validate(&schema));
+        assert_log_message("Invalid value: Map({\"c\": Long(123)}) for schema: Record { name: Name { name: \"some_record\", namespace: None }, aliases: None, doc: None, fields: [RecordField { name: \"a\", doc: None, default: None, schema: Long, order: Ascending, position: 0 }, RecordField { name: \"b\", doc: None, default: None, schema: String, order: Ascending, position: 1 }], lookup: {} }. Reason: Field with name '\"a\"' is not a member of the map items\nField with name '\"b\"' is not a member of the map items");
+
         let union_schema = Schema::Union(UnionSchema::new(vec![Schema::Null, schema]).unwrap());
 
         assert!(Value::Union(

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -334,8 +334,7 @@ impl Value {
     /// for the full set of rules of schema validation.
     pub fn validate(&self, schema: &Schema) -> bool {
         let rs = ResolvedSchema::try_from(schema).expect("Schema didn't successfully parse");
-        let res = self.validate_internal(schema, rs.get_names());
-        match res {
+        match self.validate_internal(schema, rs.get_names()) {
             Some(error_msg) => {
                 error!(
                     "Invalid value: {:?} for schema: {:?}. Reason: {}",
@@ -956,7 +955,6 @@ mod tests {
 
     #[test]
     fn validate() {
-        init();
         let value_schema_valid = vec![
             (Value::Int(42), Schema::Int, true, ""),
             (

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -1154,6 +1154,16 @@ mod tests {
             .as_str(),
         );
 
+        let value = Value::Enum(1000, "spades".to_string());
+        assert!(!value.validate(&schema));
+        assert_log_message(
+            format!(
+                "Invalid value: {:?} for schema: {:?}. Reason: {}",
+                value, schema, "No symbol at position '1000'"
+            )
+            .as_str(),
+        );
+
         let value = Value::String("lorem".to_string());
         assert!(!value.validate(&schema));
         assert_log_message(

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -929,7 +929,7 @@ mod tests {
 
     impl log::Log for TestLogger {
         fn enabled(&self, metadata: &Metadata) -> bool {
-            metadata.level() <= Level::Info
+            metadata.level() <= Level::Error
         }
 
         fn log(&self, record: &log::Record) {
@@ -938,10 +938,12 @@ mod tests {
                 msgs.push(format!("{}", record.args()));
             }
         }
+
         fn flush(&self) {}
     }
 
     static TEST_LOGGER: TestLogger = TestLogger;
+
     fn init() {
         let _ = log::set_logger(&TEST_LOGGER);
         log::set_max_level(LevelFilter::Info);

--- a/lang/rust/avro/src/writer.rs
+++ b/lang/rust/avro/src/writer.rs
@@ -357,11 +357,11 @@ fn write_value_ref_resolved(
     value: &Value,
     buffer: &mut Vec<u8>,
 ) -> AvroResult<()> {
-    if !value.validate_internal(
+    if let Some(err) = value.validate_internal(
         resolved_schema.get_root_schema(),
         resolved_schema.get_names(),
     ) {
-        return Err(Error::Validation);
+        return Err(Error::ValidationWithReason(err));
     }
     encode_internal(
         value,


### PR DESCRIPTION
Running `cargo test validate -- --nocapture` produces 

```
running 4 tests
[2022-04-08T21:50:28Z ERROR apache_avro::types] Invalid value: Int(42) for schema: Boolean. Reason: Unsupported value-schema combination
[2022-04-08T21:50:28Z ERROR apache_avro::types] Invalid value: Null for schema: Double. Reason: Unsupported value-schema combination
[2022-04-08T21:50:28Z ERROR apache_avro::types] Invalid value: Boolean(true) for schema: Long. Reason: Unsupported value-schema combination
[2022-04-08T21:50:28Z ERROR apache_avro::types] Invalid value: Fixed(5, [0, 0, 0, 0, 0]) for schema: Fixed { name: Name { name: "some_fixed", namespace: None }, aliases: None, doc: None, size: 4 }. Reason: The value's size (5) is different than the schema's size (4)
[2022-04-08T21:50:28Z ERROR apache_avro::types] Invalid value: Enum(1, "spades") for schema: Enum { name: Name { name: "some_enum", namespace: None }, aliases: None, doc: None, symbols: ["spades", "hearts", "diamonds", "clubs"] }. Reason: Symbol 'spades' is not at position '1'
[2022-04-08T21:50:28Z ERROR apache_avro::types] Invalid value: Record([]) for schema: Null. Reason: Unsupported value-schema combination
[2022-04-08T21:50:28Z ERROR apache_avro::types] Invalid value: Fixed(11, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) for schema: Duration. Reason: The value's size ('11') must be exactly 12 to be a Duration
[2022-04-08T21:50:28Z ERROR apache_avro::types] Invalid value: Record([("b", String("foo")), ("a", Long(42))]) for schema: Record { name: Name { name: "some_record", namespace: None }, aliases: None, doc: None, fields: [RecordField { name: "a", doc: None, default: None, schema: Long, order: Ascending, position: 0 }, RecordField { name: "b", doc: None, default: None, schema: String, order: Ascending, position: 1 }], lookup: {} }. Reason: Value's name 'b' does not match the expected field's name 'a'
[2022-04-08T21:50:28Z ERROR apache_avro::types] Invalid value: Bytes([0, 0, 0, 0, 0]) for schema: Fixed { name: Name { name: "some_fixed", namespace: None }, aliases: None, doc: None, size: 4 }. Reason: The bytes' length (5) is different than the schema's size (4)
[2022-04-08T21:50:28Z ERROR apache_avro::types] Invalid value: String("lorem") for schema: Enum { name: Name { name: "some_enum", namespace: None }, aliases: None, doc: None, symbols: ["spades", "hearts", "diamonds", "clubs"] }. Reason: 'lorem' is not a member of the possible symbols
[2022-04-08T21:50:28Z ERROR apache_avro::types] Invalid value: Boolean(false) for schema: Long. Reason: Unsupported value-schema combination
[2022-04-08T21:50:28Z ERROR apache_avro::types] Invalid value: Record([("unknown_field_name", Null)]) for schema: Record { name: Name { name: "record_name", namespace: None }, aliases: None, doc: None, fields: [RecordField { name: "field_name", doc: None, default: None, schema: Int, order: Ignore, position: 0 }], lookup: {} }. Reason: Value's name 'unknown_field_name' does not match the expected field's name 'field_name'
test types::tests::validate_fixed ... ok
[2022-04-08T21:50:28Z ERROR apache_avro::types] Invalid value: Null for schema: Ref { name: Name { name: "missing", namespace: None } }. Reason: Unresolved schema reference: 'missing'. Parsed names: []
test types::tests::validate ... ok
[2022-04-08T21:50:28Z ERROR apache_avro::types] Invalid value: Enum(0, "spades") for schema: Enum { name: Name { name: "some_other_enum", namespace: None }, aliases: None, doc: None, symbols: ["hearts", "diamonds", "clubs", "spades"] }. Reason: Symbol 'spades' is not at position '0'
[2022-04-08T21:50:28Z ERROR apache_avro::types] Invalid value: Record([("a", Long(42)), ("b", String("foo")), ("c", Null)]) for schema: Record { name: Name { name: "some_record", namespace: None }, aliases: None, doc: None, fields: [RecordField { name: "a", doc: None, default: None, schema: Long, order: Ascending, position: 0 }, RecordField { name: "b", doc: None, default: None, schema: String, order: Ascending, position: 1 }], lookup: {} }. Reason: The value's records length (3) is different than the schema's (2)
test types::tests::validate_enum ... ok
test types::tests::validate_record ... ok
```


### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3483

### Tests

- [X] My PR adds new unit tests

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] No need of new documentation