### PR TITLE
AVRO-265: Protocol.toJson writes null namespace

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/Protocol.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Protocol.java
@@ -17,30 +17,29 @@
  */
 package org.apache.avro;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.avro.Schema.Field;
+import org.apache.avro.Schema.Field.Order;
+
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
-import java.io.IOException;
 import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.Set;
-import java.util.HashSet;
-
-import org.apache.avro.Schema.Field;
-import org.apache.avro.Schema.Field.Order;
-
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * A set of messages forming an application protocol.
@@ -417,7 +416,9 @@ public class Protocol extends JsonProperties {
 
     gen.writeStartObject();
     gen.writeStringField("protocol", name);
-    gen.writeStringField("namespace", namespace);
+    if (namespace != null) {
+      gen.writeStringField("namespace", namespace);
+    }
 
     if (doc != null)
       gen.writeStringField("doc", doc);

--- a/lang/java/compiler/src/test/idl/output/reservedwords.avpr
+++ b/lang/java/compiler/src/test/idl/output/reservedwords.avpr
@@ -1,6 +1,5 @@
 {
   "protocol" : "Foo",
-  "namespace" : null,
   "doc" : "Licensed to the Apache Software Foundation (ASF) under one\nor more contributor license agreements.  See the NOTICE file\ndistributed with this work for additional information\nregarding copyright ownership.  The ASF licenses this file\nto you under the Apache License, Version 2.0 (the\n\"License\"); you may not use this file except in compliance\nwith the License.  You may obtain a copy of the License at\n\n    https://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.",
   "types" : [ ],
   "messages" : {

--- a/lang/java/compiler/src/test/idl/output/unicode.avpr
+++ b/lang/java/compiler/src/test/idl/output/unicode.avpr
@@ -1,6 +1,5 @@
 {
   "protocol" : "Протоколы",
-  "namespace" : null,
   "doc" : "This is a test that UTF8 functions correctly.\nこのテストでは、UTF - 8で正しく機能している。\n这是一个测试，UTF - 8的正常运行。",
   "types" : [ {
     "type" : "record",


### PR DESCRIPTION
This change fixes this cosmetic bug.

Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-265
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR ~adds~ updates the following unit tests ~__OR__ does not need testing for this extremely good reason~:
    `reservedwords.avpr` and `unicode.avpr` (removed null namespaces from the expected output)

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
