### PR TITLE
AVRO-3492: Add support for deriving Schema::Record aliases

### DIFF
--- a/lang/rust/avro_derive/tests/derive.rs
+++ b/lang/rust/avro_derive/tests/derive.rs
@@ -1063,4 +1063,40 @@ mod test_derive {
         serde_assert(TestBasicWithU32 { a: u32::MIN });
         serde_assert(TestBasicWithU32 { a: 1_u32 });
     }
+
+    #[derive(Debug, Serialize, Deserialize, AvroSchema, Clone, PartialEq)]
+    #[avro(alias = "a", alias = "b", alias = "c")]
+    struct TestBasicWithAliases {
+        a: i32,
+    }
+
+    #[test]
+    fn test_basic_with_aliases() {
+        let schema = r#"
+        {
+            "type":"record",
+            "name":"TestBasicWithAliases",
+            "aliases":["a", "b", "c"],
+            "fields":[
+                {
+                    "name":"a",
+                    "type":"int"
+                }
+            ]
+        }
+        "#;
+        let schema = Schema::parse_str(schema).unwrap();
+        if let Schema::Record { name, aliases, .. } = TestBasicWithAliases::get_schema() {
+            assert_eq!("TestBasicWithAliases", name.fullname(None));
+            assert_eq!(
+                Some(vec!["a".to_owned(), "b".to_owned(), "c".to_owned()]),
+                aliases
+            );
+        } else {
+            panic!("TestBasicWithAliases schema must be a record schema")
+        }
+        assert_eq!(schema, TestBasicWithAliases::get_schema());
+
+        serde_assert(TestBasicWithAliases { a: i32::MAX });
+    }
 }

--- a/lang/rust/avro_derive/tests/derive.rs
+++ b/lang/rust/avro_derive/tests/derive.rs
@@ -1099,4 +1099,42 @@ mod test_derive {
 
         serde_assert(TestBasicWithAliases { a: i32::MAX });
     }
+
+    #[derive(Debug, Serialize, Deserialize, AvroSchema, Clone, PartialEq)]
+    #[avro(alias = "d")]
+    #[avro(alias = "e")]
+    #[avro(alias = "f")]
+    struct TestBasicWithAliases2 {
+        a: i32,
+    }
+
+    #[test]
+    fn test_basic_with_aliases2() {
+        let schema = r#"
+        {
+            "type":"record",
+            "name":"TestBasicWithAliases2",
+            "aliases":["d", "e", "f"],
+            "fields":[
+                {
+                    "name":"a",
+                    "type":"int"
+                }
+            ]
+        }
+        "#;
+        let schema = Schema::parse_str(schema).unwrap();
+        if let Schema::Record { name, aliases, .. } = TestBasicWithAliases2::get_schema() {
+            assert_eq!("TestBasicWithAliases2", name.fullname(None));
+            assert_eq!(
+                Some(vec!["d".to_owned(), "e".to_owned(), "f".to_owned()]),
+                aliases
+            );
+        } else {
+            panic!("TestBasicWithAliases2 schema must be a record schema")
+        }
+        assert_eq!(schema, TestBasicWithAliases2::get_schema());
+
+        serde_assert(TestBasicWithAliases2 { a: i32::MAX });
+    }
 }


### PR DESCRIPTION
Uses Darling's 'multiple' attribute feature - https://github.com/TedDriggs/darling/blob/master/tests/multiple.rs.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3492

### Tests

- [X] My PR adds a new unit test
- 
### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] TODO