### PR TITLE
AVRO-3484: Add support for deriving a default value for a record field

### DIFF
--- a/lang/rust/avro_derive/Cargo.toml
+++ b/lang/rust/avro_derive/Cargo.toml
@@ -32,10 +32,11 @@ documentation = "https://docs.rs/apache-avro-derive"
 proc-macro = true
 
 [dependencies]
-syn = {version= "1.0.91", features=["full", "fold"]}
-quote = "1.0.18"
-proc-macro2 = "1.0.37"
 darling = "0.14.0"
+quote = "1.0.18"
+syn = {version= "1.0.91", features=["full", "fold"]}
+proc-macro2 = "1.0.37"
+serde_json = "1.0.79"
 
 [dev-dependencies]
 serde = { version = "1.0.136", features = ["derive"] }


### PR DESCRIPTION


### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3484

### Tests

- [X] My PR adds new unit tests

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
