### PR TITLE
AVRO-3503 Fix usage of 'is' and 'as' in Equals

### DIFF
--- a/lang/csharp/src/apache/main/AvroDecimal.cs
+++ b/lang/csharp/src/apache/main/AvroDecimal.cs
@@ -19,12 +19,11 @@
 using System;
 using System.Globalization;
 using System.Numerics;
-
 namespace Avro
 {
-    /// <summary>
-    /// Represents a big decimal.
-    /// </summary>
+/// <summary>
+/// Represents a big decimal.
+/// </summary>
     public struct AvroDecimal : IConvertible, IFormattable, IComparable, IComparable<AvroDecimal>, IEquatable<AvroDecimal>
     {
         /// <summary>
@@ -880,7 +879,9 @@ namespace Avro
         /// </returns>
         public override bool Equals(object obj)
         {
-            return (obj is AvroDecimal @decimal) && Equals(@decimal);
+            return obj != null
+                && obj.GetType() == typeof(AvroDecimal)
+                && Equals((AvroDecimal)obj);
         }
 
         /// <summary>

--- a/lang/csharp/src/apache/main/File/DeflateCodec.cs
+++ b/lang/csharp/src/apache/main/File/DeflateCodec.cs
@@ -17,14 +17,13 @@
  */
 using System.IO;
 using System.IO.Compression;
-
 namespace Avro.File
 {
-    /// <summary>
-    /// Implements deflate compression and decompression.
-    /// </summary>
-    /// <seealso cref="Codec" />
-    /// <seealso cref="DeflateStream" />
+/// <summary>
+/// Implements deflate compression and decompression.
+/// </summary>
+/// <seealso cref="Codec" />
+/// <seealso cref="DeflateStream" />
     public class DeflateCodec : Codec
     {
         /// <inheritdoc/>
@@ -96,10 +95,16 @@ namespace Avro.File
         /// <inheritdoc/>
         public override bool Equals(object other)
         {
-            return this == other || GetType().Name == other.GetType().Name;
+            if (other == this)
+            {
+                return true;
+            }
+
+            return other != null
+                && other.GetType() == typeof(DeflateCodec);
         }
 
-        /// <inheritdoc/>
+/// <inheritdoc/>
         public override int GetHashCode()
         {
             return DataFileConstants.DeflateCodecHash;

--- a/lang/csharp/src/apache/main/File/NullCodec.cs
+++ b/lang/csharp/src/apache/main/File/NullCodec.cs
@@ -59,7 +59,13 @@ namespace Avro.File
         /// <inheritdoc/>
         public override bool Equals(object other)
         {
-            return this == other || GetType().Name == other.GetType().Name;
+            if (other == this)
+            {
+                return true;
+            }
+
+            return other != null
+                && other.GetType() == typeof(NullCodec);
         }
 
         /// <inheritdoc/>

--- a/lang/csharp/src/apache/main/Generic/GenericFixed.cs
+++ b/lang/csharp/src/apache/main/Generic/GenericFixed.cs
@@ -15,7 +15,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using System;
+using System.Linq;
 
 namespace Avro.Generic
 {
@@ -103,17 +105,19 @@ namespace Avro.Generic
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (this == obj) return true;
-            if (obj != null && obj is GenericFixed)
+            if (this == obj)
             {
-                GenericFixed that = obj as GenericFixed;
-                if (that.Schema.Equals(this.Schema))
-                {
-                    for (int i = 0; i < value.Length; i++) if (this.value[i] != that.value[i]) return false;
-                    return true;
-                }
+                return true;
             }
-            return false;
+
+            if (obj == null || obj.GetType() != typeof(GenericFixed))
+            {
+                return false;
+            }
+
+            GenericFixed that = (GenericFixed)obj;
+            return that.Schema.Equals(Schema)
+                && value.SequenceEqual(that.value);
         }
 
         /// <inheritdoc/>

--- a/lang/csharp/src/apache/main/Generic/GenericRecord.cs
+++ b/lang/csharp/src/apache/main/Generic/GenericRecord.cs
@@ -163,8 +163,13 @@ namespace Avro.Generic
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (this == obj) return true;
-            return obj is GenericRecord
+            if (this == obj)
+            {
+                return true;
+            }
+
+            return obj != null
+                && obj.GetType() == typeof(GenericRecord)
                 && Equals((GenericRecord)obj);
         }
 

--- a/lang/csharp/src/apache/main/Generic/PreresolvingDatumReader.cs
+++ b/lang/csharp/src/apache/main/Generic/PreresolvingDatumReader.cs
@@ -688,12 +688,16 @@ namespace Avro.Generic
                 return Equals( _writerSchema, other._writerSchema ) && Equals( _readerSchema, other._readerSchema );
             }
 
-            public override bool Equals( object obj )
+            public override bool Equals(object obj)
             {
-                if( ReferenceEquals( null, obj ) ) return false;
-                if( ReferenceEquals( this, obj ) ) return true;
-                if( obj.GetType() != this.GetType() ) return false;
-                return Equals( (SchemaPair) obj );
+                if (this == obj)
+                {
+                    return true;
+                }
+
+                return obj != null
+                    && obj.GetType() == typeof(SchemaPair)
+                    && Equals((SchemaPair)obj);
             }
 
             public override int GetHashCode()

--- a/lang/csharp/src/apache/main/Protocol/Message.cs
+++ b/lang/csharp/src/apache/main/Protocol/Message.cs
@@ -178,18 +178,27 @@ namespace Avro
         /// <summary>
         /// Tests equality of this Message object with the passed object
         /// </summary>
-        /// <param name="obj"></param>
-        /// <returns></returns>
+        /// <param name="obj">The object to compare with the current object.</param>
+        /// <returns>
+        /// true if the specified object  is equal to the current object; otherwise, false.
+        /// </returns>
         public override bool Equals(Object obj)
         {
-          if (obj == this) return true;
-          if (!(obj is Message)) return false;
+            if (obj == this)
+            {
+                return true;
+            }
 
-          Message that = obj as Message;
-          return this.Name.Equals(that.Name, StringComparison.Ordinal) &&
-                 this.Request.Equals(that.Request) &&
-                 areEqual(this.Response, that.Response) &&
-                 areEqual(this.Error, that.Error);
+            if (obj == null || obj.GetType() != typeof(Message))
+            {
+                return false;
+            }
+
+            Message that = (Message)obj;
+            return Name.Equals(that.Name, StringComparison.Ordinal)
+                && Request.Equals(that.Request)
+                && areEqual(Response, that.Response)
+                && areEqual(Error, that.Error);
         }
 
         /// <summary>

--- a/lang/csharp/src/apache/main/Protocol/Protocol.cs
+++ b/lang/csharp/src/apache/main/Protocol/Protocol.cs
@@ -213,17 +213,25 @@ namespace Avro
         /// <summary>
         /// Tests equality of this protocol object with the passed object
         /// </summary>
-        /// <param name="obj"></param>
-        /// <returns></returns>
+        /// <param name="obj">The <see cref="Object" /> to compare with this instance.</param>
+        /// <returns>
+        ///   <c>true</c> if the specified <see cref="Object" /> is equal to this instance; otherwise, <c>false</c>.
+        /// </returns>
         public override bool Equals(object obj)
         {
-            if (obj == this) return true;
-            if (!(obj is Protocol)) return false;
+            if (obj == this)
+            {
+                return true;
+            }
 
-            Protocol that = obj as Protocol;
+            if (obj == null || obj.GetType() != typeof(Protocol))
+            {
+                return false;
+            }
 
-            return this.Name.Equals(that.Name, StringComparison.Ordinal)
-                && this.Namespace.Equals(that.Namespace, StringComparison.Ordinal)
+            Protocol that = (Protocol)obj;
+            return Name.Equals(that.Name, StringComparison.Ordinal)
+                && Namespace.Equals(that.Namespace, StringComparison.Ordinal)
                 && TypesEquals(that.Types)
                 && MessagesEquals(that.Messages);
         }

--- a/lang/csharp/src/apache/main/Schema/ArraySchema.cs
+++ b/lang/csharp/src/apache/main/Schema/ArraySchema.cs
@@ -101,15 +101,19 @@ namespace Avro
         /// <returns>true two schemas are equal, false otherwise</returns>
         public override bool Equals(object obj)
         {
-            if (this == obj) return true;
-
-            if (obj != null && obj is ArraySchema)
+            if (obj == this)
             {
-                ArraySchema that = obj as ArraySchema;
-                if (ItemSchema.Equals(that.ItemSchema))
-                    return areEqual(that.Props, this.Props);
+                return true;
             }
-            return false;
+
+            if (obj == null || obj.GetType() != typeof(ArraySchema))
+            {
+                return false;
+            }
+
+            ArraySchema that = (ArraySchema)obj;
+            return ItemSchema.Equals(that.ItemSchema)
+                && areEqual(Props, that.Props);
         }
 
         /// <summary>

--- a/lang/csharp/src/apache/main/Schema/EnumSchema.cs
+++ b/lang/csharp/src/apache/main/Schema/EnumSchema.cs
@@ -258,28 +258,27 @@ namespace Avro
         /// <summary>
         /// Checks equality of two enum schema
         /// </summary>
-        /// <param name="obj"></param>
-        /// <returns></returns>
+        /// <param name="obj">The <see cref="Object" /> to compare with this instance.</param>
+        /// <returns>
+        ///   <c>true</c> if the specified <see cref="Object" /> is equal to this instance; otherwise, <c>false</c>.
+        /// </returns>
         public override bool Equals(object obj)
         {
-            if (obj == this) return true;
-            if (obj != null && obj is EnumSchema)
+            if (obj == this)
             {
-                EnumSchema that = obj as EnumSchema;
-                if (SchemaName.Equals(that.SchemaName) && Count == that.Count)
-                {
-                    for (int i = 0; i < Count; i++)
-                    {
-                        if (!Symbols[i].Equals(that.Symbols[i], StringComparison.Ordinal))
-                        {
-                            return false;
-                        }
-                    }
-
-                    return areEqual(that.Props, this.Props);
-                }
+                return true;
             }
-            return false;
+
+            if (obj == null || obj.GetType() != typeof(EnumSchema))
+            {
+                return false;
+            }
+
+            EnumSchema that = (EnumSchema)obj;
+            return SchemaName.Equals(that.SchemaName)
+                && Count == that.Count
+                && Symbols.SequenceEqual(that.Symbols)
+                && areEqual(Props, that.Props);
         }
 
         /// <summary>

--- a/lang/csharp/src/apache/main/Schema/Field.cs
+++ b/lang/csharp/src/apache/main/Schema/Field.cs
@@ -258,15 +258,24 @@ namespace Avro
         /// <returns>true if two fields are equal, false otherwise</returns>
         public override bool Equals(object obj)
         {
-            if (obj == this) return true;
-            if (obj != null && obj is Field)
+            if (obj == this)
             {
-                Field that = obj as Field;
-                return areEqual(that.Name, Name) && that.Pos == Pos && areEqual(that.Documentation, Documentation)
-                    && areEqual(that.Ordering, Ordering) && JtokenEqual.Equals(that.DefaultValue, DefaultValue)
-                    && that.Schema.Equals(Schema) && areEqual(that.Props, this.Props);
+                return true;
             }
-            return false;
+
+            if (obj == null || obj.GetType() != typeof(Field))
+            {
+                return false;
+            }
+
+            Field that = (Field)obj;
+            return string.Equals(Name, that.Name, StringComparison.Ordinal)
+                && Pos == that.Pos
+                && string.Equals(Documentation, that.Documentation, StringComparison.Ordinal)
+                && areEqual(that.Ordering, Ordering)
+                && JtokenEqual.Equals(that.DefaultValue, DefaultValue)
+                && that.Schema.Equals(Schema)
+                && areEqual(that.Props, Props);
         }
 
         /// <summary>

--- a/lang/csharp/src/apache/main/Schema/FixedSchema.cs
+++ b/lang/csharp/src/apache/main/Schema/FixedSchema.cs
@@ -107,14 +107,20 @@ namespace Avro
         /// <returns>true if two schemas are the same, false otherwise</returns>
         public override bool Equals(object obj)
         {
-            if (obj == this) return true;
-
-            if (obj != null && obj is FixedSchema)
+            if (obj == this)
             {
-                FixedSchema that = obj as FixedSchema;
-                return SchemaName.Equals(that.SchemaName) && Size == that.Size && areEqual(that.Props, this.Props);
+                return true;
             }
-            return false;
+
+            if (obj == null || obj.GetType() != typeof(FixedSchema))
+            {
+                return false;
+            }
+
+            FixedSchema that = (FixedSchema)obj;
+            return SchemaName.Equals(that.SchemaName)
+                && Size == that.Size
+                && areEqual(Props, that.Props);
         }
 
         /// <summary>

--- a/lang/csharp/src/apache/main/Schema/LogicalSchema.cs
+++ b/lang/csharp/src/apache/main/Schema/LogicalSchema.cs
@@ -95,14 +95,19 @@ namespace Avro
         /// <returns>true if two schemas are equal, false otherwise</returns>
         public override bool Equals(object obj)
         {
-            if (this == obj) return true;
-
-            if (obj != null && obj is LogicalSchema that)
+            if (this == obj)
             {
-                if (BaseSchema.Equals(that.BaseSchema))
-                    return areEqual(that.Props, Props);
+                return true;
             }
-            return false;
+
+            if (obj == null || obj.GetType() != typeof(LogicalSchema))
+            {
+                return false;
+            }
+
+            LogicalSchema that = (LogicalSchema)obj;
+            return BaseSchema.Equals(that.BaseSchema)
+                && areEqual(Props, that.Props);
         }
 
         /// <summary>

--- a/lang/csharp/src/apache/main/Schema/MapSchema.cs
+++ b/lang/csharp/src/apache/main/Schema/MapSchema.cs
@@ -15,9 +15,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using System;
-using System.Collections.Generic;
-using System.Text;
 using Newtonsoft.Json.Linq;
 
 namespace Avro
@@ -108,15 +107,19 @@ namespace Avro
         /// <returns>true if two schemas are equal, false otherwise</returns>
         public override bool Equals(object obj)
         {
-            if (this == obj) return true;
-
-            if (obj != null && obj is MapSchema)
+            if (this == obj)
             {
-                MapSchema that = obj as MapSchema;
-                if (ValueSchema.Equals(that.ValueSchema))
-                    return areEqual(that.Props, this.Props);
+                return true;
             }
-            return false;
+
+            if (obj == null || obj.GetType() != typeof(MapSchema))
+            {
+                return false;
+            }
+
+            MapSchema that = (MapSchema)obj;
+            return ValueSchema.Equals(that.ValueSchema)
+                && areEqual(that.Props, this.Props);
         }
 
         /// <summary>

--- a/lang/csharp/src/apache/main/Schema/NamedSchema.cs
+++ b/lang/csharp/src/apache/main/Schema/NamedSchema.cs
@@ -15,11 +15,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using System;
 using System.Collections.Generic;
-using System.Text;
 using Newtonsoft.Json.Linq;
-
 
 namespace Avro
 {

--- a/lang/csharp/src/apache/main/Schema/PrimitiveSchema.cs
+++ b/lang/csharp/src/apache/main/Schema/PrimitiveSchema.cs
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using System;
 using System.Linq;
 using Newtonsoft.Json;
@@ -140,15 +141,19 @@ namespace Avro
         /// <returns>true two schemas are equal, false otherwise</returns>
         public override bool Equals(object obj)
         {
-            if (this == obj) return true;
-
-            if (obj != null && obj is PrimitiveSchema)
+            if (this == obj)
             {
-                var that = obj as PrimitiveSchema;
-                if (this.Tag == that.Tag)
-                    return areEqual(that.Props, this.Props);
+                return true;
             }
-            return false;
+
+            if (obj == null || obj.GetType() != typeof(PrimitiveSchema))
+            {
+                return false;
+            }
+
+            PrimitiveSchema that = (PrimitiveSchema)obj;
+            return Tag == that.Tag
+                && areEqual(that.Props, this.Props);
         }
 
         /// <summary>

--- a/lang/csharp/src/apache/main/Schema/Property.cs
+++ b/lang/csharp/src/apache/main/Schema/Property.cs
@@ -15,8 +15,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -93,23 +95,19 @@ namespace Avro
         /// <returns>true if contents of the two maps are the same, false otherwise</returns>
         public override bool Equals(object obj)
         {
-            if (this == obj) return true;
-
-            if (obj != null && obj is PropertyMap)
+            if (this == obj)
             {
-                var that = obj as PropertyMap;
-                if (this.Count != that.Count)
-                    return false;
-                foreach (KeyValuePair<string, string> pair in this)
-                {
-                    if (!that.ContainsKey(pair.Key))
-                        return false;
-                    if (!pair.Value.Equals(that[pair.Key], StringComparison.Ordinal))
-                        return false;
-                }
                 return true;
             }
-            return false;
+
+            if (obj == null || obj.GetType() != typeof(PropertyMap))
+            {
+                return false;
+            }
+
+            PropertyMap that = (PropertyMap)obj;
+            return this.Count == that.Count
+                && this.OrderBy(pair => pair.Key).SequenceEqual(that.OrderBy(pair => pair.Key));
         }
 
         /// <summary>

--- a/lang/csharp/src/apache/main/Schema/RecordSchema.cs
+++ b/lang/csharp/src/apache/main/Schema/RecordSchema.cs
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -391,21 +392,25 @@ namespace Avro
         /// <returns>true if the two schemas are equal, false otherwise</returns>
         public override bool Equals(object obj)
         {
-            if (obj == this) return true;
-            if (obj != null && obj is RecordSchema)
+            if (obj == this)
             {
-                RecordSchema that = obj as RecordSchema;
+                return true;
+            }
+
+            if (obj == null || obj.GetType() != typeof(RecordSchema))
+            {
+                return false;
+            }
+
+                RecordSchema that = (RecordSchema)obj;
                 return protect(() => true, () =>
                 {
-                    if (this.SchemaName.Equals(that.SchemaName) && this.Count == that.Count)
-                    {
-                        for (int i = 0; i < Fields.Count; i++) if (!Fields[i].Equals(that.Fields[i])) return false;
-                        return areEqual(that.Props, this.Props);
-                    }
-                    return false;
+                    return SchemaName.Equals(that.SchemaName)
+                    && Count == that.Count
+                    && Fields.SequenceEqual(that.Fields)
+                    && areEqual(that.Props, this.Props);
+
                 }, that);
-            }
-            return false;
         }
 
         /// <summary>

--- a/lang/csharp/src/apache/main/Schema/SchemaName.cs
+++ b/lang/csharp/src/apache/main/Schema/SchemaName.cs
@@ -126,13 +126,19 @@ namespace Avro
         /// <returns>true or false</returns>
         public override bool Equals(Object obj)
         {
-            if (obj == this) return true;
-            if (obj != null && obj is SchemaName)
+            if (obj == this)
             {
-                SchemaName that = (SchemaName)obj;
-                return areEqual(that.Name, Name) && areEqual(that.Namespace, Namespace);
+                return true;
             }
-            return false;
+
+            if (obj == null || obj.GetType() != typeof(SchemaName))
+            {
+                return false;
+            }
+
+            SchemaName that = (SchemaName)obj;
+            return string.Equals(that.Name, Name, StringComparison.Ordinal)
+                && areEqual(that.Namespace, Namespace);
         }
 
         /// <summary>

--- a/lang/csharp/src/apache/main/Schema/UnionSchema.cs
+++ b/lang/csharp/src/apache/main/Schema/UnionSchema.cs
@@ -162,16 +162,30 @@ namespace Avro
         /// <returns>true if objects are equal, false otherwise</returns>
         public override bool Equals(object obj)
         {
-            if (obj == this) return true;
-            if (obj != null && obj is UnionSchema)
+            if (obj == this)
             {
-                UnionSchema that = obj as UnionSchema;
-                if (that.Count == Count)
-                {
-                    for (int i = 0; i < Count; i++) if (!that[i].Equals(this[i])) return false;
-                    return areEqual(that.Props, this.Props);
-                }
+                return true;
             }
+
+            if (obj == null || obj.GetType() != typeof(UnionSchema))
+            {
+                return false;
+            }
+
+            UnionSchema that = (UnionSchema)obj;
+            if (that.Count == Count)
+            {
+                for (int i = 0; i < Count; i++)
+                {
+                    if (!that[i].Equals(this[i]))
+                    {
+                        return false;
+                    }
+                }
+
+                return areEqual(that.Props, this.Props);
+            }
+
             return false;
         }
 

--- a/lang/csharp/src/apache/main/Specific/SpecificFixed.cs
+++ b/lang/csharp/src/apache/main/Specific/SpecificFixed.cs
@@ -15,10 +15,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Avro.Generic;
 
 namespace Avro.Specific
@@ -40,33 +39,34 @@ namespace Avro.Specific
         public abstract new Schema Schema { get; }
 
         /// <summary>
-        /// Determines whether the provided fixed is equivalent this this instance.
+        /// Determines whether the provided fixed is equivalent this instance.
         /// </summary>
-        /// <param name="obj">Fixed to compare.</param>
-        /// <returns>True if the fixed instances have equal values.</returns>
+        /// <param name="obj">Specific Fixed to compare.</param>
+        /// <returns>
+        /// True if the Specific Fixed instances have equal values.
+        /// </returns>
         protected bool Equals(SpecificFixed obj)
         {
-            if (this == obj) return true;
-            if (obj != null && obj is SpecificFixed)
+            if (this == obj)
             {
-                SpecificFixed that = obj as SpecificFixed;
-                if (that.Schema.Equals(this.Schema))
-                {
-                    for (int i = 0; i < value.Length; i++) if (this.value[i] != that.Value[i]) return false;
-                    return true;
-                }
+                return true;
             }
-            return false;
 
+            return obj.Schema.Equals(Schema)
+                && value.SequenceEqual(obj.value);
         }
 
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != this.GetType()) return false;
-            return Equals((SpecificFixed) obj);
+            if(obj == this)
+            {
+                return true;
+            }
+
+            return obj != null
+                && obj.GetType() == typeof(SpecificFixed)
+                && Equals((SpecificFixed)obj);
         }
 
         /// <inheritdoc/>

--- a/lang/csharp/src/apache/test/Generic/GenericEnumTests.cs
+++ b/lang/csharp/src/apache/test/Generic/GenericEnumTests.cs
@@ -62,11 +62,35 @@ namespace Avro.test.Generic
             Assert.IsFalse(genericEnum.Equals(null));
         }
 
+        [Test]
+        public void TestInheritanceEquals()
+        {
+            GenericEnum genericEnum = GetBaseGenericEnum();
+            TestGenericEnum testGenericEnum = new TestGenericEnum(Schema.Parse(baseSchema) as EnumSchema, "A");
+
+            Assert.False(genericEnum.Equals(testGenericEnum));
+            Assert.False(testGenericEnum.Equals(genericEnum));
+        }
+
         private GenericEnum GetBaseGenericEnum()
         {
             GenericEnum genericEnum = new GenericEnum(Schema.Parse(baseSchema) as EnumSchema, "A");
 
             return genericEnum;
+        }
+
+        public class TestGenericEnum : GenericEnum
+        {
+            public TestGenericEnum(EnumSchema schema, string value) : base(schema, value)
+            {
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj.GetType() == typeof(TestGenericEnum);
+            }
+
+            public override int GetHashCode() => base.GetHashCode();
         }
     }
 }

--- a/lang/csharp/src/apache/test/Generic/GenericFixedTests.cs
+++ b/lang/csharp/src/apache/test/Generic/GenericFixedTests.cs
@@ -1,0 +1,103 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Avro.Generic;
+using NUnit.Framework;
+
+namespace Avro.test.Generic
+{
+    [TestFixture]
+    public class GenericFixedTests
+    {
+        private const string baseSchema = "{\"type\": \"fixed\", \"size\": 2, \"name\": \"f\"}";
+
+        [Test]
+        public void TestEquals()
+        {
+            GenericFixed genericFixed = GetBaseGenericFixed();
+            GenericFixed genericFixed2 = GetBaseGenericFixed();
+
+            Assert.IsTrue(genericFixed.Equals(genericFixed2));
+        }
+
+        [Test]
+        public void TestEqualsNotEqual()
+        {
+            GenericFixed genericFixed = GetBaseGenericFixed();
+            GenericFixed genericFixed2 = new TestGenericFixed((FixedSchema)Schema.Parse(baseSchema), new byte[] { 1, 3 });
+
+            Assert.IsFalse(genericFixed.Equals(genericFixed2));
+        }
+
+        [Test]
+        public void TestEqualsObject()
+        {
+            GenericFixed genericFixed = GetBaseGenericFixed();
+            object genericFixed2 = genericFixed;
+
+            Assert.IsTrue(genericFixed.Equals(genericFixed2));
+        }
+
+        [Test]
+        public void TestEqualsObjectNullObject()
+        {
+            GenericFixed genericFixed = GetBaseGenericFixed();
+
+            Assert.IsFalse(genericFixed.Equals(null));
+        }
+
+        [Test]
+        public void TestInheritanceEquals()
+        {
+            GenericFixed genericFixed = GetBaseGenericFixed();
+            TestGenericFixed testGenericEnum = new TestGenericFixed((FixedSchema)Schema.Parse(baseSchema), new byte[] { 1, 2 });
+
+            Assert.False(genericFixed.Equals(testGenericEnum));
+            Assert.False(testGenericEnum.Equals(genericFixed));
+        }
+
+        private GenericFixed GetBaseGenericFixed()
+        {
+            GenericFixed genericFixed = new GenericFixed((FixedSchema)Schema.Parse(baseSchema), new byte[] { 1, 2 });
+
+            return genericFixed;
+        }
+
+        public class TestGenericFixed : GenericFixed
+        {
+            public TestGenericFixed(FixedSchema schema) : base(schema)
+            {
+            }
+
+            public TestGenericFixed(FixedSchema schema, byte[] value) : base(schema, value)
+            {
+            }
+
+            protected TestGenericFixed(uint size) : base(size)
+            {
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj.GetType() == typeof(TestGenericFixed);
+            }
+
+            public override int GetHashCode() => base.GetHashCode();
+        }
+    }
+}


### PR DESCRIPTION
### Jira

- [ ] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3503

### Tests

- [ ] My PR adds the following unit tests: Adding coverage for Equals changes

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
