### PR TITLE
AVRO-3504: New method "skip_data" for DataFileReader

### DIFF
--- a/lang/py/avro/test/test_datafile.py
+++ b/lang/py/avro/test/test_datafile.py
@@ -175,7 +175,7 @@ class TestDataFile(unittest.TestCase):
 
             with reader(path) as dfr:
                 self.assertRaises(StopIteration, next, dfr)
-    
+
     def test_skip_data(self):
         """Skip data with method skip_data (DataFileReader)"""
         for codec in CODECS_TO_VALIDATE:

--- a/lang/py/avro/test/test_datafile.py
+++ b/lang/py/avro/test/test_datafile.py
@@ -175,3 +175,21 @@ class TestDataFile(unittest.TestCase):
 
             with reader(path) as dfr:
                 self.assertRaises(StopIteration, next, dfr)
+    
+    def test_skip_data(self):
+        """Skip data with method skip_data (DataFileReader)"""
+        for codec in CODECS_TO_VALIDATE:
+            for schema, datum in TEST_PAIRS:
+                # write data in binary to file 10 times
+                path = self.tempfile()
+                with writer(path, schema, codec) as dfw:
+                    for _ in range(10):
+                        dfw.append(datum)
+
+                # skip 5 elements and read 5 elements in binary from file
+                with reader(path) as dfr:
+                    dfr.skip_data(5)
+                    data = list(itertools.islice(dfr, 5))
+                    self.assertRaises(StopIteration, next, dfr)
+                self.assertEqual(len(data), 5)
+                self.assertEqual(data, [datum] * 5)


### PR DESCRIPTION
DatumReader has method "skip_data" which skips data with the help of a decoder. I suggest applying this method for DataFileReader to skip a lot of useless data.

New method "skip_data" for DataFileReader would accept the argument "number" which means number of datums that need skip.

Test for new fixture was written in "test_datafile.py". The test removes 50 misses from coverage.