### PR TITLE
AVRO-3484: Followup Check default json parsing at compile time for derive macro 

### DIFF
--- a/lang/rust/avro_derive/src/lib.rs
+++ b/lang/rust/avro_derive/src/lib.rs
@@ -124,6 +124,9 @@ fn get_data_struct_schema_def(
                 let doc = preserve_optional(field_attrs.doc);
                 let default_value = match field_attrs.default {
                     Some(default_value) => {
+                        let _: serde_json::Value = serde_json::from_str(&default_value[..]).map_err(|e| {
+                            vec![Error::new(field.ident.span(), format!("Invalid avro default json: \n{}",e))]
+                        })?;
                         quote! {
                             Some(serde_json::from_str(#default_value).expect(format!("Invalid JSON: {:?}", #default_value).as_str()))
                         }

--- a/lang/rust/avro_derive/src/lib.rs
+++ b/lang/rust/avro_derive/src/lib.rs
@@ -124,9 +124,13 @@ fn get_data_struct_schema_def(
                 let doc = preserve_optional(field_attrs.doc);
                 let default_value = match field_attrs.default {
                     Some(default_value) => {
-                        let _: serde_json::Value = serde_json::from_str(&default_value[..]).map_err(|e| {
-                            vec![Error::new(field.ident.span(), format!("Invalid avro default json: \n{}",e))]
-                        })?;
+                        let _: serde_json::Value = serde_json::from_str(&default_value[..])
+                            .map_err(|e| {
+                                vec![Error::new(
+                                    field.ident.span(),
+                                    format!("Invalid avro default json: \n{}", e),
+                                )]
+                            })?;
                         quote! {
                             Some(serde_json::from_str(#default_value).expect(format!("Invalid JSON: {:?}", #default_value).as_str()))
                         }


### PR DESCRIPTION
Checking the json before using in the macro with dummy command. 

