### PR TITLE
AVRO-3511: Fix the parsing canonical form for Decimal schema

### DIFF
--- a/lang/rust/avro/src/error.rs
+++ b/lang/rust/avro/src/error.rs
@@ -256,11 +256,17 @@ pub enum Error {
     #[error("Unknown primitive type: {0}")]
     ParsePrimitive(String),
 
-    #[error("invalid JSON for {key:?}: {precision:?}")]
-    GetDecimalPrecisionFromJson {
+    #[error("invalid JSON for {key:?}: {value:?}")]
+    GetDecimalMetadataValueFromJson {
         key: String,
-        precision: serde_json::Value,
+        value: serde_json::Value,
     },
+
+    #[error("The decimal precision ({precision}) must be bigger or equal to the scale ({scale})")]
+    DecimalPrecisionLessThanScale { precision: usize, scale: usize },
+
+    #[error("The decimal precision ({precision}) must be a positive number")]
+    DecimalPrecisionMuBePositive { precision: usize },
 
     #[error("Unexpected `type` {0} variant for `logicalType`")]
     GetLogicalTypeVariant(serde_json::Value),

--- a/lang/rust/avro/tests/schema.rs
+++ b/lang/rust/avro/tests/schema.rs
@@ -368,21 +368,13 @@ const OTHER_ATTRIBUTES_EXAMPLES: &[(&str, bool)] = &[
 ];
 
 const DECIMAL_LOGICAL_TYPE: &[(&str, bool)] = &[
-  /*
     (
         r#"{
-            "type": "fixed",
-            "logicalType": "decimal",
-            "name": "TestDecimal",
-            "precision": 4,
-            "size": 10,
-            "scale": 2
-        }"#,
-        true,
-    ),
-    (
-        r#"{
-            "type": "bytes",
+            "type": {
+                "type": "fixed",
+                "name": "TestDecimal",
+                "size": 10
+            },
             "logicalType": "decimal",
             "precision": 4,
             "scale": 2
@@ -391,65 +383,97 @@ const DECIMAL_LOGICAL_TYPE: &[(&str, bool)] = &[
     ),
     (
         r#"{
-            "type": "bytes",
+            "type": {
+                "type": "fixed",
+                "name": "ScaleIsImplicitlyZero",
+                "size": 10
+            },
             "logicalType": "decimal",
-            "precision": 2,
-            "scale": -2
+            "precision": 4
+        }"#,
+        true,
+    ),
+    (
+        r#"{
+            "type": {
+                "type": "fixed",
+                "name": "PrecisionMustBeGreaterThanZero",
+                "size": 10
+            },
+            "logicalType": "decimal",
+            "precision": 0
         }"#,
         false,
     ),
     (
         r#"{
-            "type": "bytes",
-            "logicalType": "decimal",
-            "precision": -2,
-            "scale": 2
-        }"#,
+             "type": "bytes",
+             "logicalType": "decimal",
+             "precision": 4,
+             "scale": 2
+         }"#,
+        true,
+    ),
+    (
+        r#"{
+             "type": "bytes",
+             "logicalType": "decimal",
+             "precision": 2,
+             "scale": -2
+         }"#,
         false,
     ),
     (
         r#"{
-            "type": "bytes",
-            "logicalType": "decimal",
-            "precision": 2,
-            "scale": 3
-        }"#,
+             "type": "bytes",
+             "logicalType": "decimal",
+             "precision": -2,
+             "scale": 2
+         }"#,
         false,
     ),
     (
         r#"{
-            "type": "fixed",
-            "logicalType": "decimal",
-            "name": "TestDecimal",
-            "precision": -10,
-            "scale": 2,
-            "size": 5
-        }"#,
+             "type": "bytes",
+             "logicalType": "decimal",
+             "precision": 2,
+             "scale": 3
+         }"#,
         false,
     ),
     (
         r#"{
-            "type": "fixed",
-            "logicalType": "decimal",
-            "name": "TestDecimal",
-            "precision": 2,
-            "scale": 3,
-            "size": 2
-        }"#,
+             "type": "fixed",
+             "logicalType": "decimal",
+             "name": "TestDecimal",
+             "precision": -10,
+             "scale": 2,
+             "size": 5
+         }"#,
         false,
     ),
     (
         r#"{
-            "type": "fixed",
-            "logicalType": "decimal",
-            "name": "TestDecimal",
-            "precision": 2,
-            "scale": 2,
-            "size": -2
-        }"#,
+             "type": "fixed",
+             "logicalType": "decimal",
+             "name": "TestDecimal",
+             "precision": 2,
+             "scale": 3,
+             "size": 2
+         }"#,
         false,
     ),
-   */
+    (
+        r#"{
+             "type": "fixed",
+             "logicalType": "decimal",
+             "name": "TestDecimal",
+             "precision": 2,
+             "scale": 2,
+             "size": -2
+         }"#,
+        false,
+    ),
 ];
 
 const DECIMAL_LOGICAL_TYPE_ATTRIBUTES: &[(&str, bool)] = &[


### PR DESCRIPTION
### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3511

### Tests

- [X] My PR enables many IT tests

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] No need of new documentation