### PR TITLE
[AVRO-3507] Implement Single Object reader

### DIFF
--- a/lang/rust/avro/examples/test_interop_single_object_encoding.rs
+++ b/lang/rust/avro/examples/test_interop_single_object_encoding.rs
@@ -48,7 +48,6 @@ impl From<InteropMessage> for Value {
     }
 }
 
-
 fn main() {
     let single_object = std::fs::read(format!("{}/test_message.bin", RESOURCES_FOLDER))
         .expect("File with single object not found or error occurred while reading it.");

--- a/lang/rust/avro/examples/test_interop_single_object_encoding.rs
+++ b/lang/rust/avro/examples/test_interop_single_object_encoding.rs
@@ -49,6 +49,11 @@ impl From<InteropMessage> for Value {
 }
 
 fn main() {
+    test_write();
+    test_read();
+}
+
+fn test_write() {
     let file_message = std::fs::read(format!("{}/test_message.bin", RESOURCES_FOLDER))
         .expect("File with single object not found or error occurred while reading");
     let mut generated_encoding: Vec<u8> = Vec::new();
@@ -57,4 +62,16 @@ fn main() {
         .write_value(InteropMessage, &mut generated_encoding)
         .expect("Should encode");
     assert_eq!(file_message, generated_encoding)
+}
+
+fn test_read() {
+    let file_message = std::fs::read(format!("{}/test_message.bin", RESOURCES_FOLDER))
+        .expect("File with single object not found or error occurred while reading");
+    let mut file_message = &file_message[..];
+    let read_message = apache_avro::GenericSingleObjectReader::new(InteropMessage::get_schema())
+        .expect("resolve expected")
+        .read_value(&mut file_message)
+        .expect("Should encode");
+    let expected_value: Value = InteropMessage.into();
+    assert_eq!(expected_value, read_message)
 }

--- a/lang/rust/avro/examples/test_interop_single_object_encoding.rs
+++ b/lang/rust/avro/examples/test_interop_single_object_encoding.rs
@@ -49,27 +49,27 @@ impl From<InteropMessage> for Value {
 }
 
 fn main() {
-    let file_message = std::fs::read(format!("{}/test_message.bin", RESOURCES_FOLDER))
-        .expect("File with single object not found or error occurred while reading");
-    test_write(&file_message);
-    test_read(file_message);
+    let single_object = std::fs::read(format!("{}/test_message.bin", RESOURCES_FOLDER))
+        .expect("File with single object not found or error occurred while reading it.");
+    test_write(&single_object);
+    test_read(&single_object[..]);
 }
 
-fn test_write(file_message: &[u8]) {
-    let mut generated_encoding: Vec<u8> = Vec::new();
+fn test_write(expected: &[u8]) {
+    let mut encoded: Vec<u8> = Vec::new();
     apache_avro::SingleObjectWriter::<InteropMessage>::with_capacity(1024)
-        .expect("resolve expected")
-        .write_value(InteropMessage, &mut generated_encoding)
-        .expect("Should encode");
-    assert_eq!(file_message, &generated_encoding)
+        .expect("Resolving failed")
+        .write_value(InteropMessage, &mut encoded)
+        .expect("Encoding failed");
+    assert_eq!(expected, &encoded)
 }
 
-fn test_read(file_message: Vec<u8>) {
-    let mut file_message = &file_message[..];
+fn test_read(encoded: &[u8]) {
+    let mut encoded = encoded;
     let read_message = apache_avro::GenericSingleObjectReader::new(InteropMessage::get_schema())
-        .expect("resolve expected")
-        .read_value(&mut file_message)
-        .expect("Should encode");
+        .expect("Resolving failed")
+        .read_value(&mut encoded)
+        .expect("Decoding failed");
     let expected_value: Value = InteropMessage.into();
     assert_eq!(expected_value, read_message)
 }

--- a/lang/rust/avro/examples/test_interop_single_object_encoding.rs
+++ b/lang/rust/avro/examples/test_interop_single_object_encoding.rs
@@ -49,24 +49,22 @@ impl From<InteropMessage> for Value {
 }
 
 fn main() {
-    test_write();
-    test_read();
-}
-
-fn test_write() {
     let file_message = std::fs::read(format!("{}/test_message.bin", RESOURCES_FOLDER))
         .expect("File with single object not found or error occurred while reading");
+    test_write(&file_message);
+    test_read(file_message);
+}
+
+fn test_write(file_message: &[u8]) {
     let mut generated_encoding: Vec<u8> = Vec::new();
     apache_avro::SingleObjectWriter::<InteropMessage>::with_capacity(1024)
         .expect("resolve expected")
         .write_value(InteropMessage, &mut generated_encoding)
         .expect("Should encode");
-    assert_eq!(file_message, generated_encoding)
+    assert_eq!(file_message, &generated_encoding)
 }
 
-fn test_read() {
-    let file_message = std::fs::read(format!("{}/test_message.bin", RESOURCES_FOLDER))
-        .expect("File with single object not found or error occurred while reading");
+fn test_read(file_message: Vec<u8>) {
     let mut file_message = &file_message[..];
     let read_message = apache_avro::GenericSingleObjectReader::new(InteropMessage::get_schema())
         .expect("resolve expected")

--- a/lang/rust/avro/src/error.rs
+++ b/lang/rust/avro/src/error.rs
@@ -337,6 +337,9 @@ pub enum Error {
     #[error("wrong magic in header")]
     HeaderMagic,
 
+    #[error("Message Header mismatch. Expected: {0:?}. Actual: {1:?}")]
+    MessageHeaderMismatch([u8; 10], [u8; 10]),
+
     #[error("Failed to get JSON from avro.schema key in map")]
     GetAvroSchemaFromMap,
 

--- a/lang/rust/avro/src/error.rs
+++ b/lang/rust/avro/src/error.rs
@@ -338,7 +338,7 @@ pub enum Error {
     HeaderMagic,
 
     #[error("Message Header mismatch. Expected: {0:?}. Actual: {1:?}")]
-    MessageHeaderMismatch([u8; 10], [u8; 10]),
+    SingleObjectHeaderMismatch([u8; 10], [u8; 10]),
 
     #[error("Failed to get JSON from avro.schema key in map")]
     GetAvroSchemaFromMap,

--- a/lang/rust/avro/src/lib.rs
+++ b/lang/rust/avro/src/lib.rs
@@ -742,7 +742,7 @@ pub use de::from_value;
 pub use decimal::Decimal;
 pub use duration::{Days, Duration, Millis, Months};
 pub use error::Error;
-pub use reader::{from_avro_datum, Reader};
+pub use reader::{from_avro_datum, Reader, GenericSingleObjectReader, SpecificSingleObjectReader};
 pub use schema::Schema;
 pub use ser::to_value;
 pub use util::max_allocation_bytes;

--- a/lang/rust/avro/src/lib.rs
+++ b/lang/rust/avro/src/lib.rs
@@ -742,7 +742,7 @@ pub use de::from_value;
 pub use decimal::Decimal;
 pub use duration::{Days, Duration, Millis, Months};
 pub use error::Error;
-pub use reader::{from_avro_datum, Reader, GenericSingleObjectReader, SpecificSingleObjectReader};
+pub use reader::{from_avro_datum, GenericSingleObjectReader, Reader, SpecificSingleObjectReader};
 pub use schema::Schema;
 pub use ser::to_value;
 pub use util::max_allocation_bytes;

--- a/lang/rust/avro/src/reader.rs
+++ b/lang/rust/avro/src/reader.rs
@@ -726,7 +726,7 @@ mod tests {
                     c,
                 }
             } else {
-                panic!("Should be record value")
+                panic!("Should be record value: {:?}", obj)
             }
         }
     }

--- a/lang/rust/avro/src/reader.rs
+++ b/lang/rust/avro/src/reader.rs
@@ -391,7 +391,10 @@ impl GenericSingleObjectReader {
                         reader,
                     )
                 } else {
-                    Err(Error::MessageHeaderMismatch(self.expected_header, header))
+                    Err(Error::SingleObjectHeaderMismatch(
+                        self.expected_header,
+                        header,
+                    ))
                 }
             }
             Err(io_error) => Err(Error::ReadHeader(io_error)),

--- a/lang/rust/avro/src/reader.rs
+++ b/lang/rust/avro/src/reader.rs
@@ -729,7 +729,7 @@ mod tests {
                     c,
                 }
             } else {
-                panic!("Should be record value: {:?}", obj)
+                panic!("Expected a Value::Record but was {:?}", obj)
             }
         }
     }

--- a/lang/rust/avro/src/reader.rs
+++ b/lang/rust/avro/src/reader.rs
@@ -717,7 +717,7 @@ mod tests {
                                 }
                             }
                         }
-                        _ => panic!("Unexpected pair"),
+                        (key, value) => panic!("Unexpected pair: {:?} -> {:?}", key, value),
                     }
                 }
                 TestSingleObjectReader {
@@ -745,7 +745,7 @@ mod tests {
     }
 
     #[test]
-    fn test_single_object_reader() {
+    fn test_avro_3507_single_object_reader() {
         let obj = TestSingleObjectReader {
             a: 42,
             b: 3.33,
@@ -775,7 +775,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reader_parity() {
+    fn test_avro_3507_reader_parity() {
         let obj = TestSingleObjectReader {
             a: 42,
             b: 3.33,

--- a/lang/rust/avro/src/reader.rs
+++ b/lang/rust/avro/src/reader.rs
@@ -802,9 +802,9 @@ mod tests {
             .expect("Schema should resolve");
         let specific_reader = SpecificSingleObjectReader::<TestSingleObjectReader>::new()
             .expect("schema should resolve");
-        let mut to_read1 = &to_read.clone()[..];
-        let mut to_read2 = &to_read.clone()[..];
-        let mut to_read3 = &to_read.clone()[..];
+        let mut to_read1 = &to_read[..];
+        let mut to_read2 = &to_read[..];
+        let mut to_read3 = &to_read[..];
 
         let val = generic_reader
             .read_value(&mut to_read1)

--- a/lang/rust/build.sh
+++ b/lang/rust/build.sh
@@ -63,7 +63,9 @@ do
 
     interop-data-test)
       prepare_build
+      echo "Running interop data tests"
       cargo run --all-features --example test_interop_data
+      echo -e "\nRunning single object encoding interop data tests"
       cargo run --all-features --example test_interop_single_object_encoding
       ;;
     *)


### PR DESCRIPTION
Single object encoding readers. Both generic interfacing only with value, and Specific that takes advantage of traits to deserialize directly to the user's type. 

### Jira

https://issues.apache.org/jira/browse/AVRO-3507

### Tests

- [x] Unit tests
- [x] Interop message test


### Documentation
https://issues.apache.org/jira/browse/AVRO-3513
