### PR TITLE
AVRO-3517: Do not use the default features of the dependencies

### DIFF
--- a/lang/rust/avro/Cargo.toml
+++ b/lang/rust/avro/Cargo.toml
@@ -53,28 +53,28 @@ name = "single"
 harness = false
 
 [dependencies]
-byteorder = "1.4.3"
-bzip2 = { version = "0.4.3", optional = true }
-crc32fast = { version = "1.3.2", optional = true }
-digest = "0.10.3"
-libflate = "1.2.0"
-xz2 = { version = "0.1.6", optional = true }
-num-bigint = "0.4.3"
-rand = "0.8.5"
-regex = "1.5.5"
-serde_json = "1.0.79"
-serde = { version = "1.0.136", features = ["derive"] }
-snap = { version = "1.0.5", optional = true }
-strum = "0.24.0"
-strum_macros = "0.24.0"
-thiserror = "1.0.30"
-typed-builder = "0.10.0"
-uuid = { version = "1.0.0", features = ["serde", "v4"] }
-zerocopy = "0.6.1"
-lazy_static = "1.4.0"
-log = "0.4.16"
-zstd = { version = "0.11.1+zstd.1.5.2", optional = true }
-apache-avro-derive = { version= "0.14.0", path = "../avro_derive", optional = true }
+byteorder = { default-features = false, version = "1.4.3" }
+bzip2 = { default-features = false, version = "0.4.3", optional = true }
+crc32fast = { default-features = false, version = "1.3.2", optional = true }
+digest = { default-features = false, version="0.10.3", features = ["core-api"] }
+libflate = { default-features = false, version="1.2.0" }
+xz2 = { default-features = false, version = "0.1.6", optional = true }
+num-bigint = { default-features = false, version="0.4.3" }
+rand = { default-features = false, version="0.8.5", features = ["default"] }
+regex = { default-features = false, version="1.5.5", features = ["std"] }
+serde_json = { default-features = false, version="1.0.79", features = ["std"] }
+serde = { default-features = false, version = "1.0.136", features = ["derive"] }
+snap = { default-features = false, version = "1.0.5", optional = true }
+strum = { default-features = false, version="0.24.0" }
+strum_macros = { default-features = false, version="0.24.0" }
+thiserror = { default-features = false, version="1.0.30" }
+typed-builder = { default-features = false, version="0.10.0" }
+uuid = { default-features = false, version = "1.0.0", features = ["serde", "std", "v4"] }
+zerocopy = { default-features = false, version="0.6.1" }
+lazy_static = { default-features = false, version="1.4.0" }
+log = { default-features = false, version="0.4.16" }
+zstd = { default-features = false, version = "0.11.1+zstd.1.5.2", optional = true }
+apache-avro-derive = { default-features = false, version= "0.14.0", path = "../avro_derive", optional = true }
 
 [dev-dependencies]
 md-5 = "0.10.1"

--- a/lang/rust/avro_derive/Cargo.toml
+++ b/lang/rust/avro_derive/Cargo.toml
@@ -32,11 +32,11 @@ documentation = "https://docs.rs/apache-avro-derive"
 proc-macro = true
 
 [dependencies]
-darling = "0.14.0"
-quote = "1.0.18"
-syn = {version= "1.0.91", features=["full", "fold"]}
-proc-macro2 = "1.0.37"
-serde_json = "1.0.79"
+darling = { default-features = false, version="0.14.0" }
+quote = { default-features = false, version="1.0.18" }
+syn = { default-features = false, version="1.0.91", features=["full", "fold"]}
+proc-macro2 = { default-features = false, version="1.0.37" }
+serde_json = { default-features = false, version="1.0.79", features=["std"]}
 
 [dev-dependencies]
 apache-avro = { version = "0.14.0", path = "../avro", features = ["derive"] }


### PR DESCRIPTION
Explicitly list the features used/needed by Avro

Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3517

### Tests

- [X] Only Cargo.toml is changed. No need of new tests

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] No need