### PR TITLE
AVRO-3518: Introduce a new type 'Alias'

### DIFF
--- a/lang/rust/avro/src/util.rs
+++ b/lang/rust/avro/src/util.rs
@@ -15,10 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::{
-    schema::{Aliases, Documentation},
-    AvroResult, Error,
-};
+use crate::{schema::Documentation, AvroResult, Error};
 use serde_json::{Map, Value};
 use std::{convert::TryFrom, i64, io::Read, sync::Once};
 
@@ -40,7 +37,7 @@ pub trait MapHelper {
         self.string("doc")
     }
 
-    fn aliases(&self) -> Aliases;
+    fn aliases(&self) -> Option<Vec<String>>;
 }
 
 impl MapHelper for Map<String, Value> {
@@ -50,7 +47,7 @@ impl MapHelper for Map<String, Value> {
             .map(|v| v.to_string())
     }
 
-    fn aliases(&self) -> Aliases {
+    fn aliases(&self) -> Option<Vec<String>> {
         // FIXME no warning when aliases aren't a json array of json strings
         self.get("aliases")
             .and_then(|aliases| aliases.as_array())

--- a/lang/rust/avro_derive/tests/derive.rs
+++ b/lang/rust/avro_derive/tests/derive.rs
@@ -30,6 +30,7 @@ extern crate serde;
 
 #[cfg(test)]
 mod test_derive {
+    use apache_avro::schema::Alias;
     use std::{
         borrow::{Borrow, Cow},
         sync::Mutex,
@@ -1097,7 +1098,11 @@ mod test_derive {
         if let Schema::Record { name, aliases, .. } = TestBasicStructWithAliases::get_schema() {
             assert_eq!("TestBasicStructWithAliases", name.fullname(None));
             assert_eq!(
-                Some(vec!["a".to_owned(), "b".to_owned(), "c".to_owned()]),
+                Some(vec![
+                    Alias::new("a").unwrap(),
+                    Alias::new("b").unwrap(),
+                    Alias::new("c").unwrap()
+                ]),
                 aliases
             );
         } else {
@@ -1135,7 +1140,11 @@ mod test_derive {
         if let Schema::Record { name, aliases, .. } = TestBasicStructWithAliases2::get_schema() {
             assert_eq!("TestBasicStructWithAliases2", name.fullname(None));
             assert_eq!(
-                Some(vec!["d".to_owned(), "e".to_owned(), "f".to_owned()]),
+                Some(vec![
+                    Alias::new("d").unwrap(),
+                    Alias::new("e").unwrap(),
+                    Alias::new("f").unwrap()
+                ]),
                 aliases
             );
         } else {
@@ -1170,7 +1179,11 @@ mod test_derive {
         if let Schema::Enum { name, aliases, .. } = TestBasicEnumWithAliases::get_schema() {
             assert_eq!("TestBasicEnumWithAliases", name.fullname(None));
             assert_eq!(
-                Some(vec!["a".to_owned(), "b".to_owned(), "c".to_owned()]),
+                Some(vec![
+                    Alias::new("a").unwrap(),
+                    Alias::new("b").unwrap(),
+                    Alias::new("c").unwrap()
+                ]),
                 aliases
             );
         } else {
@@ -1207,7 +1220,11 @@ mod test_derive {
         if let Schema::Enum { name, aliases, .. } = TestBasicEnumWithAliases2::get_schema() {
             assert_eq!("TestBasicEnumWithAliases2", name.fullname(None));
             assert_eq!(
-                Some(vec!["d".to_owned(), "e".to_owned(), "f".to_owned()]),
+                Some(vec![
+                    Alias::new("d").unwrap(),
+                    Alias::new("e").unwrap(),
+                    Alias::new("f").unwrap()
+                ]),
                 aliases
             );
         } else {


### PR DESCRIPTION
It uses Newtype pattern and wraps Name. This way it is easier to control
how it is being (de)serialized

Until now only Schema::Record serialized its aliases to JSON. Now this
is being done for all named schemata (Schema::Enum and Schema::Fixed)


### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3518

### Tests

- [X] My PR adds new unit tests

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] No need of new documentation