### PR TITLE
AVRO-3533: Rust: Update dependencies

### DIFF
--- a/lang/rust/avro/Cargo.toml
+++ b/lang/rust/avro/Cargo.toml
@@ -56,31 +56,31 @@ harness = false
 byteorder = { default-features = false, version = "1.4.3" }
 bzip2 = { default-features = false, version = "0.4.3", optional = true }
 crc32fast = { default-features = false, version = "1.3.2", optional = true }
-digest = { default-features = false, version="0.10.3", features = ["core-api"] }
-libflate = { default-features = false, version="1.2.0" }
-xz2 = { default-features = false, version = "0.1.6", optional = true }
-num-bigint = { default-features = false, version="0.4.3" }
-rand = { default-features = false, version="0.8.5", features = ["default"] }
-regex = { default-features = false, version="1.5.5", features = ["std"] }
-serde_json = { default-features = false, version="1.0.79", features = ["std"] }
-serde = { default-features = false, version = "1.0.136", features = ["derive"] }
+digest = { default-features = false, version = "0.10.3", features = ["core-api"] }
+libflate = { default-features = false, version = "1.2.0" }
+xz2 = { default-features = false, version = "0.1.7", optional = true }
+num-bigint = { default-features = false, version = "0.4.3" }
+rand = { default-features = false, version = "0.8.5", features = ["default"] }
+regex = { default-features = false, version = "1.5.6", features = ["std"] }
+serde_json = { default-features = false, version = "1.0.81", features = ["std"] }
+serde = { default-features = false, version = "1.0.137", features = ["derive"] }
 snap = { default-features = false, version = "1.0.5", optional = true }
-strum = { default-features = false, version="0.24.0" }
-strum_macros = { default-features = false, version="0.24.0" }
-thiserror = { default-features = false, version="1.0.30" }
-typed-builder = { default-features = false, version="0.10.0" }
-uuid = { default-features = false, version = "1.0.0", features = ["serde", "std", "v4"] }
-zerocopy = { default-features = false, version="0.6.1" }
-lazy_static = { default-features = false, version="1.4.0" }
-log = { default-features = false, version="0.4.16" }
-zstd = { default-features = false, version = "0.11.1+zstd.1.5.2", optional = true }
+strum = { default-features = false, version = "0.24.0" }
+strum_macros = { default-features = false, version = "0.24.0" }
+thiserror = { default-features = false, version = "1.0.31" }
+typed-builder = { default-features = false, version = "0.10.0" }
+uuid = { default-features = false, version = "1.1.1", features = ["serde", "std", "v4"] }
+zerocopy = { default-features = false, version = "0.6.1" }
+lazy_static = { default-features = false, version = "1.4.0" }
+log = { default-features = false, version = "0.4.17" }
+zstd = { default-features = false, version = "0.11.2+zstd.1.5.2", optional = true }
 apache-avro-derive = { default-features = false, version= "0.14.0", path = "../avro_derive", optional = true }
 
 [dev-dependencies]
-anyhow = "1.0.56"
-apache-avro-test-helper = { version= "0.1.0", path = "../avro_test_helper" }
-criterion = "0.3.5"
-hex-literal = "0.3.4"
-md-5 = "0.10.1"
-pretty_assertions = "1.2.1"
-sha2 = "0.10.2"
+anyhow = { default-features = false, version = "1.0.57", features = ["std"] }
+apache-avro-test-helper = { default-features = false, version = "0.1.0", path = "../avro_test_helper" }
+criterion = { default-features = false, version = "0.3.5" }
+hex-literal = { default-features = false, version = "0.3.4" }
+md-5 = { default-features = false, version = "0.10.1" }
+pretty_assertions = { default-features = false, version = "1.2.1", features = ["std"] }
+sha2 = { default-features = false, version = "0.10.2" }

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -1694,8 +1694,9 @@ fn field_ordering_position(field: &str) -> Option<usize> {
 }
 
 /// Trait for types that serve as an Avro data model. Derive implementation available
-/// through `derive` feature. Do not implement directly, implement [`derive::AvroSchemaComponent`]
-/// to get this trait through a blanket implementation.
+/// through `derive` feature. Do not implement directly!
+/// Implement `apache_avro::schema::derive::AvroSchemaComponent` to get this trait
+/// through a blanket implementation.
 pub trait AvroSchema {
     fn get_schema() -> Schema;
 }

--- a/lang/rust/avro_derive/Cargo.toml
+++ b/lang/rust/avro_derive/Cargo.toml
@@ -32,13 +32,13 @@ documentation = "https://docs.rs/apache-avro-derive"
 proc-macro = true
 
 [dependencies]
-darling = { default-features = false, version="0.14.0" }
-quote = { default-features = false, version="1.0.18" }
-syn = { default-features = false, version="1.0.91", features=["full", "fold"]}
-proc-macro2 = { default-features = false, version="1.0.37" }
-serde_json = { default-features = false, version="1.0.79", features=["std"]}
+darling = { default-features = false, version = "0.14.1" }
+quote = { default-features = false, version = "1.0.18" }
+syn = { default-features = false, version = "1.0.96", features=["full", "fold"]}
+proc-macro2 = { default-features = false, version = "1.0.39" }
+serde_json = { default-features = false, version = "1.0.81", features=["std"]}
 
 [dev-dependencies]
-apache-avro = { path = "../avro", features = ["derive"] }
-proptest = "1.0.0"
-serde = { version = "1.0.136", features = ["derive"] }
+apache-avro = { default-features = false, path = "../avro", features = ["derive"] }
+proptest = { default-features = false, version = "1.0.0" }
+serde = { default-features = false, version = "1.0.137", features = ["derive"] }

--- a/lang/rust/avro_derive/Cargo.toml
+++ b/lang/rust/avro_derive/Cargo.toml
@@ -40,5 +40,5 @@ serde_json = { default-features = false, version = "1.0.81", features=["std"]}
 
 [dev-dependencies]
 apache-avro = { default-features = false, path = "../avro", features = ["derive"] }
-proptest = { default-features = false, version = "1.0.0" }
+proptest = { default-features = false, version = "1.0.0", features = ["std"] }
 serde = { default-features = false, version = "1.0.137", features = ["derive"] }

--- a/lang/rust/avro_test_helper/Cargo.toml
+++ b/lang/rust/avro_test_helper/Cargo.toml
@@ -22,9 +22,9 @@ edition = "2018"
 description = "Avro test helper. This crate is not supposed to be published!"
 
 [dependencies]
-ctor = "0.1.22"
-color-backtrace = { version = "0.5" }
-env_logger = "0.9.0"
-lazy_static = { default-features = false, version="1.4.0" }
-log = { default-features = false, version="0.4.16" }
-ref_thread_local = "0.1.1"
+ctor = { default-features = false, version = "0.1.22" }
+color-backtrace = { default-features = false, version = "0.5.1" }
+env_logger = { default-features = false, version = "0.9.0" }
+lazy_static = { default-features = false, version = "1.4.0" }
+log = { default-features = false, version = "0.4.17" }
+ref_thread_local = { default-features = false, version = "0.1.1" }


### PR DESCRIPTION
Add 'default-features = false' consistently for all [dev-]dependencies.
Fix Rustdoc warning.

### Jira

- [X] https://issues.apache.org/jira/browse/AVRO-3533

### Tests

- [X] No need of new unit tests

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] Rustdoc warning is fixed