### PR TITLE
AVRO-2771: Refactor custom codable check

### DIFF
--- a/lang/java/compiler/pom.xml
+++ b/lang/java/compiler/pom.xml
@@ -137,6 +137,7 @@
                 <argument>org.apache.avro.compiler.specific.SchemaTask</argument>
                 <argument>${project.basedir}/src/test/resources/full_record_v1.avsc</argument>
                 <argument>${project.basedir}/src/test/resources/full_record_v2.avsc</argument>
+                <argument>${project.basedir}/src/test/resources/regression_error_field_in_record.avsc</argument>
                 <argument>${project.basedir}/target/generated-test-sources/javacc</argument>
               </arguments>
             </configuration>

--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
@@ -943,19 +943,21 @@ public class SpecificCompiler {
    * record.vm can handle the schema being presented.
    */
   public boolean isCustomCodable(Schema schema) {
-    if (schema.isError())
-      return false;
     return isCustomCodable(schema, new HashSet<>());
   }
 
   private boolean isCustomCodable(Schema schema, Set<Schema> seen) {
     if (!seen.add(schema))
+      // Recursive call: assume custom codable until a caller on the call stack proves
+      // otherwise.
       return true;
     if (schema.getLogicalType() != null)
       return false;
     boolean result = true;
     switch (schema.getType()) {
     case RECORD:
+      if (schema.isError())
+        return false;
       for (Schema.Field f : schema.getFields())
         result &= isCustomCodable(f.schema(), seen);
       break;

--- a/lang/java/compiler/src/test/resources/regression_error_field_in_record.avsc
+++ b/lang/java/compiler/src/test/resources/regression_error_field_in_record.avsc
@@ -1,0 +1,23 @@
+{
+    "type" : "record",
+    "name" : "RecordWithErrorField",
+    "doc" : "With custom coders in Avro 1.9, previously successful records with error fields now fail to compile.",
+    "namespace" : "org.apache.avro.specific.test",
+    "fields" : [ {
+        "name" : "s",
+        "type" : [ "null", "string" ],
+        "default" : null
+    }, {
+        "name": "e",
+        "type": [ "null", {
+            "type" : "error",
+            "name" : "TestError",
+            "fields" : [ {
+                "name" : "message",
+                "type" : "string"
+            } ]
+        } ],
+        "default": null
+    } ]
+}
+

--- a/lang/java/compiler/src/test/resources/regression_error_field_in_record.avsc
+++ b/lang/java/compiler/src/test/resources/regression_error_field_in_record.avsc
@@ -20,4 +20,3 @@
         "default": null
     } ]
 }
-


### PR DESCRIPTION
Moved the isError check for the "custom codable" check to fix a
backwards compatibility issue between versions 1.8.x & 1.9.x.

Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-2771
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests ~__OR__ does not need testing for this extremely good reason~:
   `org.apache.avro.specific.TestGeneratedCode#withErrorField`

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
