### PR TITLE
AVRO-3540 Support dictionaries keyed by types other than string

### DIFF
--- a/doc/assets/scss/_styles_project.scss
+++ b/doc/assets/scss/_styles_project.scss
@@ -1,0 +1,23 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Disable all github editing links for now
+.td-page-meta--view { display: none !important; }
+.td-page-meta--edit { display: none !important; }
+.td-page-meta--child { display: none !important; }
+.td-page-meta--issue { display: none !important; }
+.td-page-meta--project-issue { display: none !important; }

--- a/doc/content/en/docs/next/Specification/_index.md
+++ b/doc/content/en/docs/next/Specification/_index.md
@@ -367,7 +367,7 @@ For example, the union schema `["null","string"]` would encode:
 
 * _null_ as zero (the index of "null" in the union):
 `00`
-* the string "a" as one (the index of "string" in the union, encoded as hex 02), followed by the serialized string:
+* the string "a" as one (the index of "string" in the union, 1, encoded as hex 02), followed by the serialized string:
 `02 02 61`
 NOTE: Currently for C/C++ implementations, the positions are practically an int, but theoretically a long. In reality, we don't expect unions with 215M members
 

--- a/doc/content/en/project/How to contribute/_index.md
+++ b/doc/content/en/project/How to contribute/_index.md
@@ -1,0 +1,282 @@
+---
+title: "How to contribute"
+linkTitle: "How to contribute"
+weight: 3
+---
+
+<!--
+
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+-->
+
+## Getting the source code
+
+First of all, you need the Avro source code.
+
+The easiest way is to clone or fork the GitHub mirror:
+
+```shell
+git clone https://github.com/apache/avro.git -o github
+```
+
+
+## Making Changes
+
+Before you start, file an issue in [JIRA](https://issues.apache.org/jira/browse/AVRO) or discuss your ideas on the [Avro developer mailing list](http://avro.apache.org/mailing_lists.html). Describe your proposed changes and check that they fit in with what others are doing and have planned for the project. Be patient, it may take folks a while to understand your requirements.
+
+Modify the source code and add some (very) nice features using your favorite IDE.
+
+But take care about the following points
+
+**All Languages**
+- Contributions should pass existing unit tests.
+- Contributions should document public facing APIs.
+- Contributions should add new tests to demonstrate bug fixes or test new features.
+
+**Java**
+
+- All public classes and methods should have informative [Javadoc comments](https://www.oracle.com/fr/technical-resources/articles/java/javadoc-tool.html).
+- Do not use @author tags.
+- Java code should be formatted according to [Oracle's conventions](https://www.oracle.com/java/technologies/javase/codeconventions-introduction.html), with one exception:
+  - Indent two spaces per level, not four.
+- [JUnit](http://www.junit.org/) is our test framework:
+- You must implement a class whose class name starts with Test.
+- Define methods within your class and tag them with the @Test annotation. Call JUnit's many assert methods to verify conditions; these methods will be executed when you run mvn test.
+- By default, do not let tests write any temporary files to /tmp. Instead, the tests should write to the location specified by the test.dir system property.
+- Place your class in the src/test/java/ tree.
+- You can run all the unit tests with the command mvn test, or you can run a specific unit test with the command mvn -Dtest=<class name, fully qualified or short name> test (for example mvn -Dtest=TestFoo test)
+
+
+## Code Style (Autoformatting)
+
+For Java code we use [Spotless](https://github.com/diffplug/spotless/) to format the code to comply with Avro's code style conventions (see above). Automatic formatting relies on [Avro's Eclipse JDT formatter definition](https://github.com/apache/avro/blob/master/lang/java/eclipse-java-formatter.xml). You can use the same definition to auto format from Eclipse or from IntelliJ configuring the Eclipse formatter plugin.
+
+If you use maven code styles issues are checked at the compile phase. If your code breaks because of bad formatting, you can format it automatically by running the command:
+```shell
+mvn spotless:apply
+```
+
+## Unit Tests
+
+Please make sure that all unit tests succeed before constructing your patch and that no new compiler warnings are introduced by your patch. Each language has its own directory and test process.
+
+<details><summary>Java</summary>
+
+```shell
+cd avro-trunk/lang/java
+mvn clean test
+```
+</details>
+
+<details><summary>Python</summary>
+
+```shell
+cd avro-trunk/lang/py
+./setup.py build test
+```
+</details>
+
+<details><summary><a href="https://www.rust-lang.org/">Rust</a></summary>
+
+```shell
+cd avro-trunk/lang/rust
+./build.sh clean test
+```
+</details>
+
+<details><summary>C#</summary>
+
+```shell
+cd avro-trunk/lang/csharp
+./build.sh clean test
+```
+</details>
+
+<details><summary>C</summary>
+
+```shell
+cd avro-trunk/lang/c
+./build.sh clean
+./build.sh test
+```
+</details>
+
+<details><summary>C++</summary>
+
+```shell
+cd avro-trunk/lang/c++
+./build.sh clean test
+```
+</details>
+
+<details><summary>Ruby</summary>
+
+```shell
+cd avro-trunk/lang/ruby
+gem install echoe
+rake clean test
+```
+</details>
+
+<details><summary>PHP</summary>
+
+```shell
+cd avro-trunk/lang/php
+./build.sh clean
+./build.sh test
+```
+</details>
+
+
+## Contributing your code
+
+Contribution can be made directly via github with a Pull Request, or via a patch.
+
+**Via Github**
+
+Method is to create a [pull request](https://help.github.com/articles/using-pull-requests/).
+
+On your fork, create a branch named with JIRA (avro-1234_fixNpe for example) 
+On source, go to it
+```shell
+git pull
+git switch avro-1234_fixNpe
+```
+
+code your changes (following preceding recommendations)
+
+check and add updated sources
+```shell
+git status
+
+# Add any new or changed files with:
+git add src/.../MyNewClass.java
+git add src/.../TestMyNewClass.java
+```
+
+Finally, create a commit with your changes and a good log message, and push it:
+```shell
+git commit -m "AVRO-1234: Fix NPE by adding check to ..."
+git push
+```
+On your github fork site, a button will propose you to build the Pull Request.
+Click on it, fill Conversation form, and create it.
+Link this PR to the corresponding JIRA ticket (on JIRA ticket, add PR to "Issue Links" chapter, and add label 'pull-request-available' to it .
+
+<!--  TODO: Fix formatting and decide whether this should be included in this section, moved to another section
+<details><summary><b>Via Patch</b> (if you don't have github account)</summary>
+<blockquote>
+<details><summary><b>Clone avro repository</b></summary> 
+
+```shell
+git clone https://github.com/apache/avro.git -o github
+```
+</details>
+code your changes (following preceding recommendations)
+<details><summary><b>Creating a patch</b></summary>
+
+In order to create a patch, type:
+git diff > AVRO-1234.patch
+
+This will report all modifications done on Avro sources on your local disk and save them into the AVRO-1234.patch file. Read the patch file.
+Make sure it includes ONLY the modifications required to fix a single issue.
+
+Please do not:
+```
+reformat code unrelated to the bug being fixed: formatting changes should be separate patches/commits.
+comment out code that is now obsolete: just remove it.
+insert comments around each change, marking the change: folks can use subversion to figure out what's changed and by whom.
+make things public which are not required by end users.
+```
+Please do:
+```
+try to adhere to the coding style of files you edit;
+comment code whose function or rationale is not obvious;
+update documentation (e.g., package.html files, this wiki, etc.)
+name the patch file after the JIRA – AVRO-<JIRA#>.patch
+```
+</details>
+
+<details><summary><b>Applying a patch</b></summary>
+
+To apply a patch either you generated or found from JIRA, you can issue
+
+patch -p0 < AVRO-<JIRA#>.patch
+
+if you just want to check whether the patch applies you can run patch with --dry-run option
+
+patch -p0 --dry-run < AVRO-<JIRA#>.patch
+
+If you are an Eclipse user, you can apply a patch by:
+
+    Right click project name in Package Explorer
+    Team -> Apply Patch
+
+Finally, patches should be ''attached'' to an issue report in JIRA via the '''Attach File''' link on the issue's Jira. Please add a comment that asks for a code review following our code review checklist.
+</details>
+<details><summary><b>Contributing your patch</b></summary>
+
+When you believe that your patch is ready to be committed, select the '''Submit Patch''' link on the issue's Jira.
+
+Folks should run tests before selecting '''Submit Patch'''. Tests should all pass. Javadoc should report '''no''' warnings or errors. Submitting patches that fail tests is frowned on (unless the failure is not actually due to the patch).
+
+If your patch involves performance optimizations, they should be validated by benchmarks that demonstrate an improvement.
+
+If your patch creates an incompatibility with the latest major release, then you must set the '''Incompatible change''' flag on the issue's Jira 'and' fill in the '''Release Note''' field with an explanation of the impact of the incompatibility and the necessary steps users must take.
+
+If your patch implements a major feature or improvement, then you must fill in the '''Release Note''' field on the issue's Jira with an explanation of the feature that will be comprehensible by the end user.
+
+Once you have submitted your patch, a committer should evaluate it within a few days and either: commit it; or reject it with an explanation.
+
+Please be patient. Committers are busy people too. If no one responds to your patch after a few days, please make friendly reminders. Please incorporate other's suggestions into your patch if you think they're reasonable. Finally, remember that even a patch that is not committed is useful to the community.
+
+Should your patch be rejected, select the '''Resume Progress''' on the issue's Jira, upload a new patch with necessary fixes, and then select the **Submit Patch** link again.
+
+In many cases a patch may need to be updated based on review comments. In this case the updated patch should be re-attached to the Jira with the name name. Jira will archive the older version of the patch and make the new patch the active patch. This will enable a history of patches on the Jira. As stated above patch naming is generally AVRO-#.patch where AVRO-# is the id of the Jira issue.
+
+Committers: for non-trivial changes, it is best to get another committer to review your patches before commit. Use Submit Patch link like other contributors, and then wait for a "+1" from another committer before committing. Please also try to frequently review things in the patch queue.
+
+</details>
+
+<details><summary><b>Committing Guidelines for committers</b></summary>
+
+Apply the patch uploaded by the user or check out their pull request. Edit the CHANGES.txt file, adding a description of the change, including the bug number it fixes. Add it to the appropriate section - BUGFIXES, IMPROVEMENTS, NEW FEATURES. Please follow the format in CHANGES.txt file. While adding an entry please add it to the end of a section. Use the same entry for the first line of the git commit message.
+
+Changes are normally committed to master first, then, if they're backward-compatible, cherry-picked to a branch.
+
+When you commit a change, resolve the issue in Jira. When resolving, always set the fix version and assign the issue. Set the fix version to either to the next minor release if the change is compatible and will be merged to that branch, or to the next major release if the change is incompatible and will only be committed to trunk. Assign the issue to the primary author of the patch. If the author is not in the list of project contributors, edit their Jira roles and make them an Avro contributor.
+</details>
+</blockquote>
+</details>
+-->
+
+## Jira Guidelines
+
+Please comment on issues in [Jira](https://issues.apache.org/jira/projects/AVRO/issues), making your concerns known. Please also vote for issues that are a high priority for you.
+
+Please refrain from editing descriptions and comments if possible, as edits spam the mailing list and clutter Jira's "All" display, which is otherwise very useful. Instead, preview descriptions and comments using the preview button (on the right) before posting them. Keep descriptions brief and save more elaborate proposals for comments, since descriptions are included in Jira's automatically sent messages. If you change your mind, note this in a new comment, rather than editing an older comment. The issue should preserve this history of the discussion.
+
+## Stay involved
+
+Contributors should join the Avro mailing lists. In particular, the commit list (to see changes as they are made), the dev list (to join discussions of changes) and the user list (to help others).
+
+## See Also
+
+- [Apache contributor documentation](http://www.apache.org/dev/contributors.html)
+- [Apache voting documentation](http://www.apache.org/foundation/voting.html)

--- a/lang/csharp/src/apache/main/Reflect/ClassCache.cs
+++ b/lang/csharp/src/apache/main/Reflect/ClassCache.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 
 namespace Avro.Reflect
 {
@@ -112,7 +113,13 @@ namespace Avro.Reflect
                 case Avro.Schema.Type.Array:
                     return null;
                 case Avro.Schema.Type.Map:
-                    return null;
+                    if (!propType.IsGenericType)
+                    {
+                        return null;
+                    }
+                    Type valueType = propType.GenericTypeArguments[1];
+                    avroType = typeof(IDictionary<,>).MakeGenericType(typeof(string), valueType);
+                    break;
                 case Avro.Schema.Type.Union:
                     return null;
                 case Avro.Schema.Type.Fixed:
@@ -242,7 +249,7 @@ namespace Avro.Reflect
                     LoadClassCache(objType.GenericTypeArguments[0], ars.ItemSchema);
                     break;
                 case MapSchema ms:
-                    if (!typeof(IDictionary).IsAssignableFrom(objType))
+                    if (!objType.IsGenericType && !typeof(IDictionary).IsAssignableFrom(objType))
                     {
                         throw new AvroException($"Cant map type {objType.Name} to map {ms.Name}");
                     }
@@ -252,7 +259,16 @@ namespace Avro.Reflect
                         throw new AvroException($"Cant map non-generic type {objType.Name} to map {ms.Name}");
                     }
 
-                    if (!typeof(string).IsAssignableFrom(objType.GenericTypeArguments[0]))
+                    if(!objType.IsInstanceOfType(typeof(IDictionary))
+                        && objType.IsGenericType
+                        && objType.GetGenericTypeDefinition() != typeof(IDictionary<,>))
+                    {
+                        throw new AvroException($"Cant map type {objType.Name} to map {ms.Name}");
+                    }
+
+                    
+                    var keyType = objType.GenericTypeArguments[0];
+                    if (!(keyType.IsPrimitive || keyType.IsEnum || typeof(string).IsAssignableFrom(keyType)))
                     {
                         throw new AvroException($"First type parameter of {objType.Name} must be assignable to string");
                     }

--- a/lang/csharp/src/apache/main/Reflect/DotnetProperty.cs
+++ b/lang/csharp/src/apache/main/Reflect/DotnetProperty.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Reflection;
 using System.Collections;
+using System.Collections.Generic;
 
 namespace Avro.Reflect
 {
@@ -67,7 +68,8 @@ namespace Avro.Reflect
                 case Avro.Schema.Type.Array:
                     return typeof(IEnumerable).IsAssignableFrom(propType);
                 case Avro.Schema.Type.Map:
-                    return typeof(IDictionary).IsAssignableFrom(propType);
+                    var dictionaryType = typeof(IDictionary);
+                    return dictionaryType.IsAssignableFrom(propType) && propType.GenericTypeArguments[0] == typeof(string);
                 case Avro.Schema.Type.Union:
                     return true;
                 case Avro.Schema.Type.Fixed:

--- a/lang/csharp/src/apache/main/Specific/ObjectCreator.cs
+++ b/lang/csharp/src/apache/main/Specific/ObjectCreator.cs
@@ -125,6 +125,10 @@ namespace Avro.Specific
                                     break;
                                 }
                             }
+                            if (type != null)
+                            {
+                                break;
+                            }
                         }
                         catch
                         {

--- a/lang/csharp/src/apache/main/Specific/SpecificWriter.cs
+++ b/lang/csharp/src/apache/main/Specific/SpecificWriter.cs
@@ -154,7 +154,7 @@ namespace Avro.Specific
             foreach (System.Collections.DictionaryEntry de in map)
             {
                 encoder.StartItem();
-                encoder.WriteString(de.Key as string);
+                encoder.WriteString(de.Key.ToString());
                 Write(schema.ValueSchema, de.Value, encoder);
             }
             encoder.WriteMapEnd();

--- a/lang/csharp/src/apache/test/Generic/GenericRecordTests.cs
+++ b/lang/csharp/src/apache/test/Generic/GenericRecordTests.cs
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 using System;
 using System.Collections.Generic;
 using Avro.Generic;

--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectData.java
@@ -71,6 +71,9 @@ public class ReflectData extends SpecificData {
 
   private static final String STRING_OUTER_PARENT_REFERENCE = "this$0";
 
+  /**
+   * Always false since custom coders are not available for {@link ReflectData}.
+   */
   @Override
   public boolean useCustomCoders() {
     return false;

--- a/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificData.java
@@ -191,7 +191,7 @@ public class SpecificData extends GenericData {
 
   /**
    * Retrieve the current value of the custom-coders feature flag. Defaults to
-   * <code>true</code>, but this default can be overridden using the system
+   * <code>false</code>, but this default can be overridden using the system
    * property <code>org.apache.avro.specific.use_custom_coders</code>, and can be
    * set dynamically by {@link SpecificData#useCustomCoders()}. See <a
    * href="https://avro.apache.org/docs/current/gettingstartedjava.html#Beta+feature:+Generating+faster+code"Getting

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -43,7 +43,7 @@
     <jetty.version>9.4.46.v20220331</jetty.version>
     <jopt-simple.version>5.0.4</jopt-simple.version>
     <junit.version>4.13.2</junit.version>
-    <netty.version>4.1.77.Final</netty.version>
+    <netty.version>4.1.78.Final</netty.version>
     <protobuf.version>3.21.1</protobuf.version>
     <thrift.version>0.16.0</thrift.version>
     <slf4j.version>1.7.36</slf4j.version>

--- a/lang/py/avro/io.py
+++ b/lang/py/avro/io.py
@@ -699,8 +699,8 @@ class DatumReader:
                     warnings.warn(avro.errors.IgnoredLogicalType(f"Invalid decimal precision {precision}. Must be a positive integer."))
                     return decoder.read_bytes()
                 scale = writers_schema.get_prop("scale")
-                if not (isinstance(scale, int) and scale > 0):
-                    warnings.warn(avro.errors.IgnoredLogicalType(f"Invalid decimal scale {scale}. Must be a positive integer."))
+                if not (isinstance(scale, int) and scale >= 0):
+                    warnings.warn(avro.errors.IgnoredLogicalType(f"Invalid decimal scale {scale}. Must be a non-negative integer."))
                     return decoder.read_bytes()
                 return decoder.read_decimal_from_bytes(precision, scale)
             return decoder.read_bytes()
@@ -711,8 +711,8 @@ class DatumReader:
                     warnings.warn(avro.errors.IgnoredLogicalType(f"Invalid decimal precision {precision}. Must be a positive integer."))
                     return self.read_fixed(writers_schema, readers_schema, decoder)
                 scale = writers_schema.get_prop("scale")
-                if not (isinstance(scale, int) and scale > 0):
-                    warnings.warn(avro.errors.IgnoredLogicalType(f"Invalid decimal scale {scale}. Must be a positive integer."))
+                if not (isinstance(scale, int) and scale >= 0):
+                    warnings.warn(avro.errors.IgnoredLogicalType(f"Invalid decimal scale {scale}. Must be a non-negative integer."))
                     return self.read_fixed(writers_schema, readers_schema, decoder)
                 return decoder.read_decimal_from_fixed(precision, scale, writers_schema.size)
             return self.read_fixed(writers_schema, readers_schema, decoder)
@@ -1067,8 +1067,8 @@ class DatumWriter:
         if writers_schema.type == "bytes":
             if logical_type == "decimal":
                 scale = writers_schema.get_prop("scale")
-                if not (isinstance(scale, int) and scale > 0):
-                    warnings.warn(avro.errors.IgnoredLogicalType(f"Invalid decimal scale {scale}. Must be a positive integer."))
+                if not (isinstance(scale, int) and scale >= 0):
+                    warnings.warn(avro.errors.IgnoredLogicalType(f"Invalid decimal scale {scale}. Must be a non-negative integer."))
                 elif not isinstance(datum, decimal.Decimal):
                     warnings.warn(avro.errors.IgnoredLogicalType(f"{datum} is not a decimal type"))
                 else:
@@ -1080,8 +1080,8 @@ class DatumWriter:
             if logical_type == "decimal":
                 scale = writers_schema.get_prop("scale")
                 size = writers_schema.size
-                if not (isinstance(scale, int) and scale > 0):
-                    warnings.warn(avro.errors.IgnoredLogicalType(f"Invalid decimal scale {scale}. Must be a positive integer."))
+                if not (isinstance(scale, int) and scale >= 0):
+                    warnings.warn(avro.errors.IgnoredLogicalType(f"Invalid decimal scale {scale}. Must be a non-negative integer."))
                 elif not isinstance(datum, decimal.Decimal):
                     warnings.warn(avro.errors.IgnoredLogicalType(f"{datum} is not a decimal type"))
                 else:

--- a/lang/py/avro/schema.py
+++ b/lang/py/avro/schema.py
@@ -303,7 +303,7 @@ class DecimalLogicalSchema(LogicalSchema):
             raise avro.errors.IgnoredLogicalType(f"Invalid decimal precision {precision}. Max is {max_precision}.")
 
         if not isinstance(scale, int) or scale < 0:
-            raise avro.errors.IgnoredLogicalType(f"Invalid decimal scale {scale}. Must be a positive integer.")
+            raise avro.errors.IgnoredLogicalType(f"Invalid decimal scale {scale}. Must be a non-negative integer.")
 
         if scale > precision:
             raise avro.errors.IgnoredLogicalType(f"Invalid decimal scale {scale}. Cannot be greater than precision {precision}.")

--- a/lang/py/avro/test/test_io.py
+++ b/lang/py/avro/test/test_io.py
@@ -72,12 +72,26 @@ SCHEMAS_TO_VALIDATE = tuple(
             decimal.Decimal("-3.1415"),
         ),
         (
+            {
+                "type": "fixed",
+                "logicalType": "decimal",
+                "name": "Test",
+                "size": 8,
+                "precision": 1,
+            },
+            decimal.Decimal("3"),
+        ),
+        (
             {"type": "bytes", "logicalType": "decimal", "precision": 5, "scale": 4},
             decimal.Decimal("3.1415"),
         ),
         (
             {"type": "bytes", "logicalType": "decimal", "precision": 5, "scale": 4},
             decimal.Decimal("-3.1415"),
+        ),
+        (
+            {"type": "bytes", "logicalType": "decimal", "precision": 1},
+            decimal.Decimal("3"),
         ),
         ({"type": "enum", "name": "Test", "symbols": ["A", "B"]}, "B"),
         ({"type": "array", "items": "long"}, [1, 3, 2]),

--- a/lang/py/avro/test/test_schema.py
+++ b/lang/py/avro/test/test_schema.py
@@ -421,7 +421,7 @@ IGNORED_LOGICAL_TYPE = [
     ),
     ValidTestSchema(
         {"type": "bytes", "logicalType": "decimal", "precision": 2, "scale": -2},
-        warnings=[avro.errors.IgnoredLogicalType("Invalid decimal scale -2. Must be a positive integer.")],
+        warnings=[avro.errors.IgnoredLogicalType("Invalid decimal scale -2. Must be a non-negative integer.")],
     ),
     ValidTestSchema(
         {"type": "bytes", "logicalType": "decimal", "precision": -2, "scale": 2},

--- a/lang/rust/avro/Cargo.toml
+++ b/lang/rust/avro/Cargo.toml
@@ -65,8 +65,8 @@ regex = { default-features = false, version = "1.5.6", features = ["std"] }
 serde_json = { default-features = false, version = "1.0.81", features = ["std"] }
 serde = { default-features = false, version = "1.0.137", features = ["derive"] }
 snap = { default-features = false, version = "1.0.5", optional = true }
-strum = { default-features = false, version = "0.24.0" }
-strum_macros = { default-features = false, version = "0.24.0" }
+strum = { default-features = false, version = "0.24.1" }
+strum_macros = { default-features = false, version = "0.24.1" }
 thiserror = { default-features = false, version = "1.0.31" }
 typed-builder = { default-features = false, version = "0.10.0" }
 uuid = { default-features = false, version = "1.1.1", features = ["serde", "std", "v4"] }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3540
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
- [ ] TestMapWithConverterSucceeds - tests new functionality
- [ ] TestMapWithoutConverterFails - covers maintain existing behavior as this is opt-in

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
