### PR TITLE
AVRO-3540 Support dictionaries keyed by types other than string 

### DIFF
--- a/lang/csharp/src/apache/main/Reflect/DotnetProperty.cs
+++ b/lang/csharp/src/apache/main/Reflect/DotnetProperty.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Reflection;
 using System.Collections;
+using System.Collections.Generic;
 
 namespace Avro.Reflect
 {
@@ -67,7 +68,8 @@ namespace Avro.Reflect
                 case Avro.Schema.Type.Array:
                     return typeof(IEnumerable).IsAssignableFrom(propType);
                 case Avro.Schema.Type.Map:
-                    return typeof(IDictionary).IsAssignableFrom(propType);
+                    var dictionaryType = typeof(IDictionary);
+                    return dictionaryType.IsAssignableFrom(propType) && propType.GenericTypeArguments[0] == typeof(string);
                 case Avro.Schema.Type.Union:
                     return true;
                 case Avro.Schema.Type.Fixed:

--- a/lang/csharp/src/apache/main/Specific/ObjectCreator.cs
+++ b/lang/csharp/src/apache/main/Specific/ObjectCreator.cs
@@ -125,6 +125,10 @@ namespace Avro.Specific
                                     break;
                                 }
                             }
+                            if (type != null)
+                            {
+                                break;
+                            }
                         }
                         catch
                         {

--- a/lang/csharp/src/apache/main/Specific/SpecificWriter.cs
+++ b/lang/csharp/src/apache/main/Specific/SpecificWriter.cs
@@ -154,7 +154,7 @@ namespace Avro.Specific
             foreach (System.Collections.DictionaryEntry de in map)
             {
                 encoder.StartItem();
-                encoder.WriteString(de.Key as string);
+                encoder.WriteString(de.Key.ToString());
                 Write(schema.ValueSchema, de.Value, encoder);
             }
             encoder.WriteMapEnd();

--- a/lang/csharp/src/apache/test/Generic/GenericRecordTests.cs
+++ b/lang/csharp/src/apache/test/Generic/GenericRecordTests.cs
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 using System;
 using System.Collections.Generic;
 using Avro.Generic;


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3540
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
- [ ] TestMapWithConverterSucceeds - tests new functionality
- [ ] TestMapWithoutConverterFails - covers maintain existing behavior as this is opt-in

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
