### PR TITLE
AVRO-3541: Unbump strum_macros

### DIFF
--- a/lang/rust/avro/Cargo.toml
+++ b/lang/rust/avro/Cargo.toml
@@ -66,7 +66,7 @@ serde_json = { default-features = false, version = "1.0.81", features = ["std"] 
 serde = { default-features = false, version = "1.0.137", features = ["derive"] }
 snap = { default-features = false, version = "1.0.5", optional = true }
 strum = { default-features = false, version = "0.24.1" }
-strum_macros = { default-features = false, version = "0.24.1" }
+strum_macros = { default-features = false, version = "0.24.0" }
 thiserror = { default-features = false, version = "1.0.31" }
 typed-builder = { default-features = false, version = "0.10.0" }
 uuid = { default-features = false, version = "1.1.1", features = ["serde", "std", "v4"] }


### PR DESCRIPTION
It looks like strum_macros is at 0.24.0 as opposed to 0.24.1 on [crates.io](https://crates.io/crates/strum_macros), causing the build to fail.

Alternatively, instead of fixing the version at 0.24.0 and 0.24.1, we could just use the semver prefix of 0.24.

### Jira

- [X] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3541
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
