### PR TITLE
AVRO-3542: Scale assignment optimization

### DIFF
--- a/lang/py/avro/schema.py
+++ b/lang/py/avro/schema.py
@@ -1132,7 +1132,7 @@ def make_avsc_object(json_data: object, names: Optional[avro.name.Names] = None,
                 size = json_data.get("size")
                 if logical_type == "decimal":
                     precision = json_data.get("precision")
-                    scale = 0 if json_data.get("scale") is None else json_data.get("scale")
+                    scale = json_data.get("scale", 0)
                     try:
                         return FixedDecimalSchema(size, name, precision, scale, namespace, names, other_props)
                     except avro.errors.IgnoredLogicalType as warning:


### PR DESCRIPTION
Changed string in the function: make_avsc_object (from the file "schema.py"):
scale = 0 if json_data.get("scale") is None else json_data.get("scale") -> scale = json_data.get("scale", 0)
 
By Python documentation:
get(self, key, default=None, /)
    Return the value for key if key is in the dictionary, else default.
 
It is more effective and readable than previous version.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3542
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).