### PR TITLE
AVRO-3543: Support wasm32 compilation target for Rust library

### DIFF
--- a/.github/workflows/test-lang-rust-ci.yml
+++ b/.github/workflows/test-lang-rust-ci.yml
@@ -44,6 +44,9 @@ jobs:
           - beta
           - nightly
           - 1.51.0  # MSRV
+        target:
+          - x86_64-unknown-linux-gnu
+          - wasm32-unknown-unknown
 
     steps:
       - name: Checkout
@@ -71,8 +74,10 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
           components: rustfmt
+          target: ${{ matrix.target }}
 
       - name: Rust Format
+        if: ${{ matrix.target }} != 'wasm32-unknown-unknown'
         uses: actions-rs/cargo@v1
         with:
           command: fmt
@@ -85,13 +90,15 @@ jobs:
           args: --manifest-path lang/rust/Cargo.toml --all-features --all-targets
 
       - name: Rust Test
+        if: ${{ matrix.target }} != 'wasm32-unknown-unknown'
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path lang/rust/Cargo.toml --all-features --all-targets
+          args: --manifest-path lang/rust/Cargo.toml --all-features --target ${{ matrix.target }}
 
       # because of https://github.com/rust-lang/cargo/issues/6669
       - name: Rust Test docs
+        if: ${{ matrix.target }} != 'wasm32-unknown-unknown'
         uses: actions-rs/cargo@v1
         with:
           command: test

--- a/.github/workflows/test-lang-rust-ci.yml
+++ b/.github/workflows/test-lang-rust-ci.yml
@@ -77,7 +77,7 @@ jobs:
           target: ${{ matrix.target }}
 
       - name: Rust Format
-        if: ${{ matrix.target }} != 'wasm32-unknown-unknown'
+        if: matrix.target != 'wasm32-unknown-unknown'
         uses: actions-rs/cargo@v1
         with:
           command: fmt
@@ -90,7 +90,7 @@ jobs:
           args: --manifest-path lang/rust/Cargo.toml --all-features --all-targets
 
       - name: Rust Test
-        if: ${{ matrix.target }} != 'wasm32-unknown-unknown'
+        if: matrix.target != 'wasm32-unknown-unknown'
         uses: actions-rs/cargo@v1
         with:
           command: test
@@ -98,7 +98,7 @@ jobs:
 
       # because of https://github.com/rust-lang/cargo/issues/6669
       - name: Rust Test docs
-        if: ${{ matrix.target }} != 'wasm32-unknown-unknown'
+        if: matrix.target != 'wasm32-unknown-unknown'
         uses: actions-rs/cargo@v1
         with:
           command: test

--- a/lang/rust/README.md
+++ b/lang/rust/README.md
@@ -526,7 +526,7 @@ fn main() -> Result<(), Error> {
     let mut record = Record::new(writer.schema()).unwrap();
     record.put("decimal_fixed", Decimal::from(9936.to_bigint().unwrap().to_signed_bytes_be()));
     record.put("decimal_var", Decimal::from((-32442.to_bigint().unwrap()).to_signed_bytes_be()));
-    record.put("uuid", uuid::Uuid::new_v4());
+    record.put("uuid", uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap());
     record.put("date", Value::Date(1));
     record.put("time_millis", Value::TimeMillis(2));
     record.put("time_micros", Value::TimeMicros(3));

--- a/lang/rust/README.md
+++ b/lang/rust/README.md
@@ -526,7 +526,7 @@ fn main() -> Result<(), Error> {
     let mut record = Record::new(writer.schema()).unwrap();
     record.put("decimal_fixed", Decimal::from(9936.to_bigint().unwrap().to_signed_bytes_be()));
     record.put("decimal_var", Decimal::from((-32442.to_bigint().unwrap()).to_signed_bytes_be()));
-    record.put("uuid", uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap());
+    record.put("uuid", uuid::Uuid::new_v4());
     record.put("date", Value::Date(1));
     record.put("time_millis", Value::TimeMillis(2));
     record.put("time_micros", Value::TimeMicros(3));

--- a/lang/rust/avro/Cargo.toml
+++ b/lang/rust/avro/Cargo.toml
@@ -60,6 +60,7 @@ digest = { default-features = false, version = "0.10.3", features = ["core-api"]
 libflate = { default-features = false, version = "1.2.0" }
 xz2 = { default-features = false, version = "0.1.7", optional = true }
 num-bigint = { default-features = false, version = "0.4.3" }
+rand = { default-features = false, version = "0.8.5", features = ["default"] }
 regex = { default-features = false, version = "1.5.6", features = ["std"] }
 serde_json = { default-features = false, version = "1.0.81", features = ["std"] }
 serde = { default-features = false, version = "1.0.137", features = ["derive"] }
@@ -68,18 +69,18 @@ strum = { default-features = false, version = "0.24.1" }
 strum_macros = { default-features = false, version = "0.24.0" }
 thiserror = { default-features = false, version = "1.0.31" }
 typed-builder = { default-features = false, version = "0.10.0" }
+uuid = { default-features = false, version = "1.1.1", features = ["serde", "std", "v4"] }
 zerocopy = { default-features = false, version = "0.6.1" }
 lazy_static = { default-features = false, version = "1.4.0" }
 log = { default-features = false, version = "0.4.17" }
 zstd = { default-features = false, version = "0.11.2+zstd.1.5.2", optional = true }
 apache-avro-derive = { default-features = false, version= "0.14.0", path = "../avro_derive", optional = true }
-uuid = { default-features = false, version = "1.1.1", features = ["std", "serde"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-quad-rand = "0.2.1"
+getrandom = { version = "0.2.7", default-features = false, features = ["std", "js"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-rand = { default-features = false, version = "0.8.5", features = ["default"] }
+getrandom = { version = "0.2.7", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 anyhow = { default-features = false, version = "1.0.57", features = ["std"] }

--- a/lang/rust/avro/Cargo.toml
+++ b/lang/rust/avro/Cargo.toml
@@ -60,7 +60,6 @@ digest = { default-features = false, version = "0.10.3", features = ["core-api"]
 libflate = { default-features = false, version = "1.2.0" }
 xz2 = { default-features = false, version = "0.1.7", optional = true }
 num-bigint = { default-features = false, version = "0.4.3" }
-rand = { default-features = false, version = "0.8.5", features = ["default"] }
 regex = { default-features = false, version = "1.5.6", features = ["std"] }
 serde_json = { default-features = false, version = "1.0.81", features = ["std"] }
 serde = { default-features = false, version = "1.0.137", features = ["derive"] }
@@ -69,12 +68,18 @@ strum = { default-features = false, version = "0.24.1" }
 strum_macros = { default-features = false, version = "0.24.0" }
 thiserror = { default-features = false, version = "1.0.31" }
 typed-builder = { default-features = false, version = "0.10.0" }
-uuid = { default-features = false, version = "1.1.1", features = ["serde", "std", "v4"] }
 zerocopy = { default-features = false, version = "0.6.1" }
 lazy_static = { default-features = false, version = "1.4.0" }
 log = { default-features = false, version = "0.4.17" }
 zstd = { default-features = false, version = "0.11.2+zstd.1.5.2", optional = true }
 apache-avro-derive = { default-features = false, version= "0.14.0", path = "../avro_derive", optional = true }
+uuid = { default-features = false, version = "1.1.1", features = ["std", "serde"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+quad-rand = "0.2.1"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+rand = { default-features = false, version = "0.8.5", features = ["default"] }
 
 [dev-dependencies]
 anyhow = { default-features = false, version = "1.0.57", features = ["std"] }

--- a/lang/rust/avro/Cargo.toml
+++ b/lang/rust/avro/Cargo.toml
@@ -60,7 +60,6 @@ digest = { default-features = false, version = "0.10.3", features = ["core-api"]
 libflate = { default-features = false, version = "1.2.0" }
 xz2 = { default-features = false, version = "0.1.7", optional = true }
 num-bigint = { default-features = false, version = "0.4.3" }
-rand = { default-features = false, version = "0.8.5", features = ["default"] }
 regex = { default-features = false, version = "1.5.6", features = ["std"] }
 serde_json = { default-features = false, version = "1.0.81", features = ["std"] }
 serde = { default-features = false, version = "1.0.137", features = ["derive"] }
@@ -77,10 +76,10 @@ zstd = { default-features = false, version = "0.11.2+zstd.1.5.2", optional = tru
 apache-avro-derive = { default-features = false, version= "0.14.0", path = "../avro_derive", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.2.7", default-features = false, features = ["std", "js"] }
+quad-rand = { default-features = false, version = "0.2.1" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-getrandom = { version = "0.2.7", default-features = false, features = ["std"] }
+rand = { default-features = false, version = "0.8.5", features = ["default"] }
 
 [dev-dependencies]
 anyhow = { default-features = false, version = "1.0.57", features = ["std"] }

--- a/lang/rust/avro/Cargo.toml
+++ b/lang/rust/avro/Cargo.toml
@@ -69,7 +69,7 @@ strum = { default-features = false, version = "0.24.1" }
 strum_macros = { default-features = false, version = "0.24.0" }
 thiserror = { default-features = false, version = "1.0.31" }
 typed-builder = { default-features = false, version = "0.10.0" }
-uuid = { default-features = false, version = "1.1.1", features = ["serde", "std", "v4"] }
+uuid = { default-features = false, version = "1.1.2", features = ["serde", "std"] }
 zerocopy = { default-features = false, version = "0.6.1" }
 lazy_static = { default-features = false, version = "1.4.0" }
 log = { default-features = false, version = "0.4.17" }

--- a/lang/rust/avro/src/lib.rs
+++ b/lang/rust/avro/src/lib.rs
@@ -604,7 +604,7 @@
 //!     let mut record = Record::new(writer.schema()).unwrap();
 //!     record.put("decimal_fixed", Decimal::from(9936.to_bigint().unwrap().to_signed_bytes_be()));
 //!     record.put("decimal_var", Decimal::from((-32442.to_bigint().unwrap()).to_signed_bytes_be()));
-//!     record.put("uuid", uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap());
+//!     record.put("uuid", uuid::Uuid::new_v4());
 //!     record.put("date", Value::Date(1));
 //!     record.put("time_millis", Value::TimeMillis(2));
 //!     record.put("time_micros", Value::TimeMicros(3));

--- a/lang/rust/avro/src/lib.rs
+++ b/lang/rust/avro/src/lib.rs
@@ -604,7 +604,7 @@
 //!     let mut record = Record::new(writer.schema()).unwrap();
 //!     record.put("decimal_fixed", Decimal::from(9936.to_bigint().unwrap().to_signed_bytes_be()));
 //!     record.put("decimal_var", Decimal::from((-32442.to_bigint().unwrap()).to_signed_bytes_be()));
-//!     record.put("uuid", uuid::Uuid::new_v4());
+//!     record.put("uuid", uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap());
 //!     record.put("date", Value::Date(1));
 //!     record.put("time_millis", Value::TimeMillis(2));
 //!     record.put("time_micros", Value::TimeMicros(3));

--- a/lang/rust/avro/src/writer.rs
+++ b/lang/rust/avro/src/writer.rs
@@ -513,17 +513,8 @@ pub fn to_avro_datum<T: Into<Value>>(schema: &Schema, value: T) -> AvroResult<Ve
     Ok(buffer)
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 fn generate_sync_marker() -> Vec<u8> {
     std::iter::repeat_with(rand::random).take(16).collect()
-}
-
-#[cfg(target_arch = "wasm32")]
-fn generate_sync_marker() -> Vec<u8> {
-    std::iter::repeat_with(quad_rand::rand)
-        .take(4)
-        .flat_map(|i| i.to_be_bytes())
-        .collect()
 }
 
 #[cfg(test)]

--- a/lang/rust/avro/src/writer.rs
+++ b/lang/rust/avro/src/writer.rs
@@ -513,8 +513,17 @@ pub fn to_avro_datum<T: Into<Value>>(schema: &Schema, value: T) -> AvroResult<Ve
     Ok(buffer)
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn generate_sync_marker() -> Vec<u8> {
     std::iter::repeat_with(rand::random).take(16).collect()
+}
+
+#[cfg(target_arch = "wasm32")]
+fn generate_sync_marker() -> Vec<u8> {
+    std::iter::repeat_with(quad_rand::rand)
+        .take(4)
+        .flat_map(|i| i.to_be_bytes())
+        .collect()
 }
 
 #[cfg(test)]

--- a/lang/rust/avro/src/writer.rs
+++ b/lang/rust/avro/src/writer.rs
@@ -24,7 +24,6 @@ use crate::{
     types::Value,
     AvroResult, Codec, Error,
 };
-use rand::random;
 use serde::Serialize;
 use std::{collections::HashMap, convert::TryFrom, io::Write, marker::PhantomData};
 
@@ -48,7 +47,7 @@ pub struct Writer<'a, W> {
     serializer: Serializer,
     #[builder(default = 0, setter(skip))]
     num_values: usize,
-    #[builder(default = std::iter::repeat_with(random).take(16).collect(), setter(skip))]
+    #[builder(default = generate_sync_marker(), setter(skip))]
     marker: Vec<u8>,
     #[builder(default = false, setter(skip))]
     has_header: bool,
@@ -512,6 +511,19 @@ pub fn to_avro_datum<T: Into<Value>>(schema: &Schema, value: T) -> AvroResult<Ve
     let mut buffer = Vec::new();
     write_avro_datum(schema, value, &mut buffer)?;
     Ok(buffer)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn generate_sync_marker() -> Vec<u8> {
+    std::iter::repeat_with(rand::random).take(16).collect()
+}
+
+#[cfg(target_arch = "wasm32")]
+fn generate_sync_marker() -> Vec<u8> {
+    std::iter::repeat_with(quad_rand::rand)
+        .take(4)
+        .flat_map(|i| i.to_be_bytes())
+        .collect()
 }
 
 #[cfg(test)]

--- a/lang/rust/avro_test_helper/src/lib.rs
+++ b/lang/rust/avro_test_helper/src/lib.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#[cfg(not(target_arch = "wasm32"))]
 use ctor::{ctor, dtor};
 
 use ref_thread_local::ref_thread_local;
@@ -28,6 +29,7 @@ ref_thread_local! {
 
 pub mod logger;
 
+#[cfg(not(target_arch = "wasm32"))]
 #[ctor]
 fn before_all() {
     // better stacktraces in tests
@@ -37,6 +39,7 @@ fn before_all() {
     logger::install();
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[dtor]
 fn after_all() {
     logger::clear_log_messages();

--- a/lang/rust/avro_test_helper/src/logger.rs
+++ b/lang/rust/avro_test_helper/src/logger.rs
@@ -59,6 +59,7 @@ pub fn assert_logged(expected_message: &str) {
     assert_eq!(LOG_MESSAGES.borrow_mut().pop().unwrap(), expected_message);
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn install() {
     log::set_logger(&*TEST_LOGGER)
         .map(|_| log::set_max_level(LevelFilter::Trace))


### PR DESCRIPTION
At this moment, due to dependency on `getrandom` crate, the Rust library can't compile for  WebAssembly (`wasm32-unknown-unknown` target). There is a workaround for environments containing JavaScript https://docs.rs/getrandom/0.2.7/getrandom/#webassembly-support but for others, it can't be used.
This PR replaces the usage of random generating for `wasm32` with the one that supports `wasm32`.

Jira
        https://issues.apache.org/jira/browse/AVRO-3543
