### PR TITLE
AVRO-3544: Fix projects print template for website

### DIFF
--- a/doc/layouts/project/list.print.html
+++ b/doc/layouts/project/list.print.html
@@ -1,3 +1,4 @@
+{{ define "main" }}
 <!--
 
  Licensed to the Apache Software Foundation (ASF) under one
@@ -18,7 +19,5 @@
  under the License.
 
 -->
-
-{{ define "main" }}
 {{ partial "print/render"  . }}
 {{ end }}


### PR DESCRIPTION
This turns out to be the same problem also experienced in AVRO-3378, which needs to be applied to the `print` template.

### Jira

- [X] My PR addresses AVRO-3544

