### PR TITLE
 AVRO-3557: Trim whitespace from the avro_version shortcode 

### DIFF
--- a/doc/layouts/shortcodes/avro_version.html
+++ b/doc/layouts/shortcodes/avro_version.html
@@ -1,4 +1,4 @@
-<!--
+{{/*
 
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
@@ -17,6 +17,8 @@
  specific language governing permissions and limitations
  under the License.
 
--->
+*/}}{{/*
 
-{{ $.Site.Params.avroversion }}
+This file must not have a trailing newline.
+
+*/}}{{ $.Site.Params.avroversion }}


### PR DESCRIPTION
Use the Go template `{{/* comment */}}` instead of HTML comments to ensure that the avro_version shortcode doesn't add additional unwanted whitespace.

### Jira

- [X] My PR addresses AVRO-3557

### Tests

- [ ] My PR does not need testing for this extremely good reason: Manual testing with website build

