### PR TITLE
AVRO-3558: Rust: Add a demo crate that shows usage as WebAssembly

### DIFF
--- a/.github/workflows/test-lang-rust-ci.yml
+++ b/.github/workflows/test-lang-rust-ci.yml
@@ -43,7 +43,10 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.51.0  # MSRV
+          - 1.54.0  # MSRV
+        target:
+          - x86_64-unknown-linux-gnu
+          - wasm32-unknown-unknown
 
     steps:
       - name: Checkout
@@ -71,8 +74,10 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
           components: rustfmt
+          target: ${{ matrix.target }}
 
       - name: Rust Format
+        if: matrix.target != 'wasm32-unknown-unknown'
         uses: actions-rs/cargo@v1
         with:
           command: fmt
@@ -85,19 +90,22 @@ jobs:
           args: --manifest-path lang/rust/Cargo.toml --all-features --all-targets
 
       - name: Rust Test
+        if: matrix.target != 'wasm32-unknown-unknown'
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path lang/rust/Cargo.toml --all-features
+          args: --manifest-path lang/rust/Cargo.toml --all-features --target ${{ matrix.target }}
 
       - name: Rust Test AVRO-3549
+        if: matrix.target != 'wasm32-unknown-unknown'
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path lang/rust/Cargo.toml test_avro_3549_read_not_enabled_codec
+          args: --manifest-path lang/rust/Cargo.toml --target ${{ matrix.target }} test_avro_3549_read_not_enabled_codec
 
       # because of https://github.com/rust-lang/cargo/issues/6669
       - name: Rust Test docs
+        if: matrix.target != 'wasm32-unknown-unknown'
         uses: actions-rs/cargo@v1
         with:
           command: test

--- a/.github/workflows/test-lang-rust-ci.yml
+++ b/.github/workflows/test-lang-rust-ci.yml
@@ -44,9 +44,6 @@ jobs:
           - beta
           - nightly
           - 1.51.0  # MSRV
-        target:
-          - x86_64-unknown-linux-gnu
-          - wasm32-unknown-unknown
 
     steps:
       - name: Checkout
@@ -74,10 +71,8 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
           components: rustfmt
-          target: ${{ matrix.target }}
 
       - name: Rust Format
-        if: matrix.target != 'wasm32-unknown-unknown'
         uses: actions-rs/cargo@v1
         with:
           command: fmt
@@ -90,22 +85,19 @@ jobs:
           args: --manifest-path lang/rust/Cargo.toml --all-features --all-targets
 
       - name: Rust Test
-        if: matrix.target != 'wasm32-unknown-unknown'
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path lang/rust/Cargo.toml --all-features --target ${{ matrix.target }}
+          args: --manifest-path lang/rust/Cargo.toml --all-features
 
       - name: Rust Test AVRO-3549
-        if: matrix.target != 'wasm32-unknown-unknown'
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path lang/rust/Cargo.toml --target ${{ matrix.target }} test_avro_3549_read_not_enabled_codec
+          args: --manifest-path lang/rust/Cargo.toml test_avro_3549_read_not_enabled_codec
 
       # because of https://github.com/rust-lang/cargo/issues/6669
       - name: Rust Test docs
-        if: matrix.target != 'wasm32-unknown-unknown'
         uses: actions-rs/cargo@v1
         with:
           command: test
@@ -230,9 +222,6 @@ jobs:
 
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-
-      - name: Install Firefox
-        run: sudo apt-get install firefox
 
       - name: Build the Web Assembly demo app
         run: wasm-pack build wasm-demo

--- a/.github/workflows/test-lang-rust-ci.yml
+++ b/.github/workflows/test-lang-rust-ci.yml
@@ -196,3 +196,46 @@ jobs:
       - name: Perl reads interop files created by Java and Rust
         working-directory: lang/perl
         run: ./build.sh interop-data-test
+
+  web-assembly:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          target: wasm32-unknown-unknown
+
+      - name: Cache Cargo
+        uses: actions/cache@v2
+        with:
+          # these represent dependencies downloaded by cargo
+          # and thus do not depend on the OS, arch nor rust version.
+          path: ~/.cargo
+          key: cargo-cache1-
+
+      - name: Cache Rust dependencies
+        uses: actions/cache@v2
+        with:
+          # these represent compiled steps of both dependencies and avro
+          # and thus are specific for a particular OS, arch and rust version.
+          path: ~/target
+          key: ${{ runner.os }}-target-cache1-stable-
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Install Firefox
+        run: apt install firefox
+
+      - name: Build the Web Assembly demo app
+        run: wasm-pack build wasm-demo
+
+      - name: Test the Web Assembly demo app
+        run: RUST_BACKTRACE=1 wasm-pack test --headless --firefox wasm-demo

--- a/.github/workflows/test-lang-rust-ci.yml
+++ b/.github/workflows/test-lang-rust-ci.yml
@@ -232,7 +232,7 @@ jobs:
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: Install Firefox
-        run: apt install firefox
+        run: sudo apt-get install firefox
 
       - name: Build the Web Assembly demo app
         run: wasm-pack build wasm-demo

--- a/lang/rust/Cargo.toml
+++ b/lang/rust/Cargo.toml
@@ -19,5 +19,6 @@
 members = [
     "avro_test_helper",
     "avro_derive",
-    "avro"
+    "avro",
+    "wasm-demo"
 ]

--- a/lang/rust/README.md
+++ b/lang/rust/README.md
@@ -642,6 +642,10 @@ let readers_schema = Schema::parse_str(r#"{"type": "array", "items":"int"}"#).un
 assert_eq!(false, SchemaCompatibility::can_read(&writers_schema, &readers_schema));
 ```
 
+## Minimal supported Rust version
+
+1.54.0
+
 ## License
 This project is licensed under [Apache License 2.0](https://github.com/apache/avro/blob/master/LICENSE.txt).
 

--- a/lang/rust/avro/src/encode.rs
+++ b/lang/rust/avro/src/encode.rs
@@ -107,6 +107,8 @@ pub(crate) fn encode_internal<S: Borrow<Schema>>(
         }
         Value::Uuid(uuid) => encode_bytes(
             // we need the call .to_string() to properly convert ASCII to UTF-8
+            #[allow(unknown_lints)] // for Rust 1.54.0
+            #[allow(clippy::unnecessary_to_owned)]
             &uuid.to_string(),
             buffer,
         ),

--- a/lang/rust/avro/src/encode.rs
+++ b/lang/rust/avro/src/encode.rs
@@ -106,8 +106,6 @@ pub(crate) fn encode_internal<S: Borrow<Schema>>(
             buffer.extend_from_slice(&slice);
         }
         Value::Uuid(uuid) => encode_bytes(
-            #[allow(unknown_lints)] // for Rust 1.51.0
-            #[allow(clippy::unnecessary_to_owned)]
             // we need the call .to_string() to properly convert ASCII to UTF-8
             &uuid.to_string(),
             buffer,

--- a/lang/rust/avro/src/ser.rs
+++ b/lang/rust/avro/src/ser.rs
@@ -285,7 +285,7 @@ impl<'b> ser::Serializer for &'b mut Serializer {
     }
 }
 
-impl<'a> ser::SerializeSeq for SeqSerializer {
+impl ser::SerializeSeq for SeqSerializer {
     type Ok = Value;
     type Error = Error;
 
@@ -303,7 +303,7 @@ impl<'a> ser::SerializeSeq for SeqSerializer {
     }
 }
 
-impl<'a> ser::SerializeTuple for SeqSerializer {
+impl ser::SerializeTuple for SeqSerializer {
     type Ok = Value;
     type Error = Error;
 

--- a/lang/rust/avro_derive/tests/derive.rs
+++ b/lang/rust/avro_derive/tests/derive.rs
@@ -824,7 +824,7 @@ mod test_derive {
 
     #[derive(Debug, Serialize, Deserialize, AvroSchema)]
     struct TestSmartPointers<'a> {
-        a: Box<String>,
+        a: String,
         b: Mutex<Vec<i64>>,
         c: Cow<'a, i32>,
     }
@@ -857,13 +857,13 @@ mod test_derive {
         let schema = Schema::parse_str(schema).unwrap();
         assert_eq!(schema, TestSmartPointers::get_schema());
         let test = TestSmartPointers {
-            a: Box::new("hey".into()),
+            a: "hey".into(),
             b: Mutex::new(vec![42]),
             c: Cow::Owned(32),
         };
         // test serde with manual equality for mutex
         let test = serde(test);
-        assert_eq!(Box::new("hey".into()), test.a);
+        assert_eq!("hey", test.a);
         assert_eq!(vec![42], *test.b.borrow().lock().unwrap());
         assert_eq!(Cow::Owned::<i32>(32), test.c);
     }

--- a/lang/rust/avro_derive/tests/derive.rs
+++ b/lang/rust/avro_derive/tests/derive.rs
@@ -823,8 +823,6 @@ mod test_derive {
     }}
 
     #[derive(Debug, Serialize, Deserialize, AvroSchema)]
-    #[allow(unknown_lints)] // Rust 1.51.0 (MSRV) does not support #[allow(clippy::box_collection)]
-    #[allow(clippy::box_collection)]
     struct TestSmartPointers<'a> {
         a: Box<String>,
         b: Mutex<Vec<i64>>,

--- a/lang/rust/wasm-demo/Cargo.toml
+++ b/lang/rust/wasm-demo/Cargo.toml
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[package]
+name = "hello-wasm"
+version = "0.1.0"
+authors = ["Apache Avro team <dev@avro.apache.org>"]
+description = "A demo project for testing apache_avro in WebAssembly"
+license = "Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/apache/avro"
+edition = "2018"
+keywords = ["avro", "data", "serialization", "wasm", "web assembly"]
+categories = ["encoding"]
+documentation = "https://docs.rs/apache-avro"
+
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+apache-avro = { path = "../avro" }
+serde = { default-features = false, version = "1.0.137", features = ["derive"] }
+wasm-bindgen = "0.2.63"
+
+[dev-dependencies]
+console_error_panic_hook = { version = "0.1.6" }
+wasm-bindgen-test = "0.3.13"
+
+[profile.release]
+# Tell `rustc` to optimize for small code size.
+opt-level = "s"

--- a/lang/rust/wasm-demo/README.md
+++ b/lang/rust/wasm-demo/README.md
@@ -1,0 +1,28 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# About
+
+An application that is used to test `apache_avro` crate as a web assembly.
+
+The project is created with `wasm-pack new wasm-demo` command and simplified to not use unrelated technologies (like Wee and a panic hook).
+
+# Code
+
+See [tests](./tests/demos.rs)

--- a/lang/rust/wasm-demo/src/lib.rs
+++ b/lang/rust/wasm-demo/src/lib.rs
@@ -14,4 +14,3 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-

--- a/lang/rust/wasm-demo/src/lib.rs
+++ b/lang/rust/wasm-demo/src/lib.rs
@@ -1,0 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+

--- a/lang/rust/wasm-demo/tests/demos.rs
+++ b/lang/rust/wasm-demo/tests/demos.rs
@@ -66,7 +66,11 @@ fn write_read() {
     record.put("a", 12_i32);
     record.put("b", "hello".to_owned());
 
-    let mut writer = Writer::with_codec(&schema, BufWriter::new(Vec::with_capacity(200)), Codec::Null);
+    let mut writer = Writer::with_codec(
+        &schema,
+        BufWriter::new(Vec::with_capacity(200)),
+        Codec::Null,
+    );
     writer.append(record).unwrap();
     writer.flush().unwrap();
     let bytes = writer.into_inner().unwrap().into_inner().unwrap();

--- a/lang/rust/wasm-demo/tests/demos.rs
+++ b/lang/rust/wasm-demo/tests/demos.rs
@@ -1,0 +1,82 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#![cfg(target_arch = "wasm32")]
+
+extern crate wasm_bindgen_test;
+
+use std::io::BufWriter;
+use wasm_bindgen_test::*;
+
+use apache_avro::{from_value, to_value, types::Record, Codec, Reader, Schema, Writer};
+use serde::{Deserialize, Serialize};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
+pub struct MyRecord {
+    b: String,
+    a: i64,
+}
+
+#[wasm_bindgen_test]
+fn serialization_roundtrip() {
+    console_error_panic_hook::set_once();
+
+    let record = MyRecord {
+        b: "hello".to_string(),
+        a: 1,
+    };
+
+    let serialized = to_value(&record).unwrap();
+    let deserialized = from_value::<MyRecord>(&serialized).unwrap();
+    assert_eq!(deserialized, record);
+}
+
+#[wasm_bindgen_test]
+fn write_read() {
+    console_error_panic_hook::set_once();
+
+    let schema_str = r#"
+    {
+      "type": "record",
+      "name": "my_record",
+      "fields": [
+        {"name": "a", "type": "long"},
+        {"name": "b", "type": "string"}
+      ]
+    }"#;
+    let schema = Schema::parse_str(schema_str).unwrap();
+
+    let mut record = Record::new(&schema).unwrap();
+    record.put("a", 12_i32);
+    record.put("b", "hello".to_owned());
+
+    let mut writer = Writer::with_codec(&schema, BufWriter::new(Vec::with_capacity(200)), Codec::Null);
+    writer.append(record).unwrap();
+    writer.flush().unwrap();
+    let bytes = writer.into_inner().unwrap().into_inner().unwrap();
+
+    let reader = Reader::new(&bytes[..]).unwrap();
+
+    for value in reader {
+        match value {
+            Ok(record) => println!("Successfully read {:?}", record),
+            Err(err) => panic!("An error occurred while reading: {:?}", err),
+        }
+    }
+}


### PR DESCRIPTION

### Jira

- [X] https://issues.apache.org/jira/browse/AVRO-3558

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
