### PR TITLE
AVRO-3560: throw SchemaParseException on dangling content in avsc beyond end of schema

### DIFF
--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchema.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchema.java
@@ -21,10 +21,14 @@ import static org.junit.Assert.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -395,4 +399,36 @@ public class TestSchema {
     assertEquals("Int", nameInt.getQualified("space"));
   }
 
+  @Test(expected = SchemaParseException.class)
+  public void testContentAfterAvsc() throws Exception {
+    Schema.Parser parser = new Schema.Parser();
+    parser.setValidate(true);
+    parser.setValidateDefaults(true);
+    parser.parse("{\"type\": \"string\"}; DROP TABLE STUDENTS");
+  }
+
+  @Test
+  public void testContentAfterAvscInInputStream() throws Exception {
+    Schema.Parser parser = new Schema.Parser();
+    parser.setValidate(true);
+    parser.setValidateDefaults(true);
+    String avsc = "{\"type\": \"string\"}; DROP TABLE STUDENTS";
+    ByteArrayInputStream is = new ByteArrayInputStream(avsc.getBytes(StandardCharsets.UTF_8));
+    Schema schema = parser.parse(is);
+    assertNotNull(schema);
+  }
+
+  @Test(expected = SchemaParseException.class)
+  public void testContentAfterAvscInFile() throws Exception {
+    File avscFile = Files.createTempFile("testContentAfterAvscInFile", null).toFile();
+    try (FileWriter writer = new FileWriter(avscFile)) {
+      writer.write("{\"type\": \"string\"}; DROP TABLE STUDENTS");
+      writer.flush();
+    }
+
+    Schema.Parser parser = new Schema.Parser();
+    parser.setValidate(true);
+    parser.setValidateDefaults(true);
+    parser.parse(avscFile);
+  }
 }

--- a/lang/java/avro/src/test/java/org/apache/avro/io/TestResolvingIOResolving.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/io/TestResolvingIOResolving.java
@@ -101,7 +101,7 @@ public class TestResolvingIOResolving {
             "{\"type\":\"record\",\"name\":\"outer\",\"fields\":[" + "{\"name\": \"g1\", "
                 + "\"type\":{\"type\":\"record\",\"name\":\"inner\",\"fields\":["
                 + "{\"name\":\"f1\", \"type\":\"int\", \"default\": 101}," + "{\"name\":\"f2\", \"type\":\"int\"}]}}, "
-                + "{\"name\": \"g2\", \"type\": \"long\"}]}}",
+                + "{\"name\": \"g2\", \"type\": \"long\"}]}",
             "RRIIL", new Object[] { 10, 101, 11L } },
         // Default value for a record.
         { "{\"type\":\"record\",\"name\":\"outer\",\"fields\":[" + "{\"name\": \"g2\", \"type\": \"long\"}]}", "L",

--- a/lang/java/avro/src/test/java/org/apache/avro/io/parsing/TestResolvingGrammarGenerator.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/io/parsing/TestResolvingGrammarGenerator.java
@@ -103,9 +103,9 @@ public class TestResolvingGrammarGenerator {
   public static Collection<Object[]> data() {
     Collection<Object[]> ret = Arrays.asList(new Object[][] {
         { "{ \"type\": \"record\", \"name\": \"r\", \"fields\": [ " + " { \"name\" : \"f1\", \"type\": \"int\" }, "
-            + " { \"name\" : \"f2\", \"type\": \"float\" } " + "] } }", "{ \"f2\": 10.4, \"f1\": 10 } " },
-        { "{ \"type\": \"enum\", \"name\": \"e\", \"symbols\": " + "[ \"s1\", \"s2\"] } }", " \"s1\" " },
-        { "{ \"type\": \"enum\", \"name\": \"e\", \"symbols\": " + "[ \"s1\", \"s2\"] } }", " \"s2\" " },
+            + " { \"name\" : \"f2\", \"type\": \"float\" } " + "] }", "{ \"f2\": 10.4, \"f1\": 10 } " },
+        { "{ \"type\": \"enum\", \"name\": \"e\", \"symbols\": " + "[ \"s1\", \"s2\"] }", " \"s1\" " },
+        { "{ \"type\": \"enum\", \"name\": \"e\", \"symbols\": " + "[ \"s1\", \"s2\"] }", " \"s2\" " },
         { "{ \"type\": \"fixed\", \"name\": \"f\", \"size\": 10 }", "\"hello\"" },
         { "{ \"type\": \"array\", \"items\": \"int\" }", "[ 10, 20, 30 ]" },
         { "{ \"type\": \"map\", \"values\": \"int\" }", "{ \"k1\": 10, \"k3\": 20, \"k3\": 30 }" },


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3560

### Tests

- [x] My PR adds the following unit test:
  - TestSchema.testContentAfterAvsc()
  - TestSchema.testContentAfterAvscInInputStream()

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
