### PR TITLE
AVRO-3559: Fix links to "Getting started ..." on the home page

### DIFF
--- a/doc/content/en/_index.html
+++ b/doc/content/en/_index.html
@@ -57,11 +57,11 @@ Rust, JavaScript, and even Perl.
 {{< blocks/section color="dark" type="features">}}
 <!-- Note: the number of feature blocks should be a multiple of 3 for optimal display -->
 
-{{% blocks/feature icon="fab fa-java" title="Getting started with Java" url="/docs/getting-started-java" %}}
+{{% blocks/feature icon="fab fa-java" title="Getting started with Java" url="/docs/++version++/getting-started-java" %}}
 For Java / JVM users, find out everything you need to know about specifying a schema, (de)serializing Avro data and code generation.
 {{% /blocks/feature %}}
 
-{{% blocks/feature icon="fab fa-python" title="Getting started with Python" url="/docs/getting-started-python" %}}
+{{% blocks/feature icon="fab fa-python" title="Getting started with Python" url="/docs/++version++/getting-started-python" %}}
 For Python users, find out everything you need to know about specifying a schema and (de)serializing Avro data.
 {{% /blocks/feature %}}
 


### PR DESCRIPTION

### Jira

- [X] https://issues.apache.org/jira/browse/AVRO-3559

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
