### PR TITLE
AVRO-3563: Ensure docs/current/spec.html remains viable

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -184,6 +184,7 @@ do
       # If it was a SNAPSHOT, it was lowercased during the build.
       cp -R build/staging-web/public/docs/"${VERSION,,}"/* "build/$DOC_DIR/"
       cp -R "build/$DOC_DIR/api" build/staging-web/public/docs/"${VERSION,,}"/
+      ( cd "${VERSION,,}"; ln -s "${VERSION,,}" current )
       # add LICENSE and NOTICE for docs
       mkdir -p "build/$DOC_DIR"
       cp doc/LICENSE "build/$DOC_DIR"

--- a/doc/content/en/docs/++version++/Specification/_index.md
+++ b/doc/content/en/docs/++version++/Specification/_index.md
@@ -3,6 +3,8 @@ title: "Specification"
 linkTitle: "Specification"
 weight: 4
 date: 2021-10-25
+aliases:
+- spec.html
 ---
 
 <!--


### PR DESCRIPTION
This link is widely used. 

### Jira

- [X] My PR addresses the AVRO-3563

### Tests

- [X] My PR does not need testing for this extremely good reason: manual build of the website.

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

