### PR TITLE
Shifted integer and long constants to constants.py

### DIFF
--- a/lang/py/avro/codecs.py
+++ b/lang/py/avro/codecs.py
@@ -39,6 +39,7 @@ import avro.io
 #
 # Constants
 #
+
 STRUCT_CRC32 = struct.Struct(">I")  # big-endian unsigned int
 
 

--- a/lang/py/avro/compatibility.py
+++ b/lang/py/avro/compatibility.py
@@ -16,6 +16,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from copy import copy
 from enum import Enum
 from typing import Container, Iterable, List, Optional, Set, cast

--- a/lang/py/avro/constants.py
+++ b/lang/py/avro/constants.py
@@ -19,7 +19,6 @@
 
 """Contains Constants for Python Avro"""
 
-
 DATE = "date"
 DECIMAL = "decimal"
 TIMESTAMP_MICROS = "timestamp-micros"
@@ -57,3 +56,8 @@ NAMED_TYPES = (
 )
 
 VALID_TYPES = PRIMITIVE_TYPES + NAMED_TYPES + ("array", "map", "union", "request", "error_union")
+
+INT_MIN_VALUE = -(1 << 31)
+INT_MAX_VALUE = (1 << 31) - 1
+LONG_MIN_VALUE = -(1 << 63)
+LONG_MAX_VALUE = (1 << 63) - 1

--- a/lang/py/avro/datafile.py
+++ b/lang/py/avro/datafile.py
@@ -22,6 +22,7 @@ Read/Write Avro File Object Containers.
 
 https://avro.apache.org/docs/current/spec.html#Object+Container+Files
 """
+
 import io
 import json
 import warnings
@@ -293,7 +294,6 @@ class DataFileWriter(_DataFileMetadata):
 
 class DataFileReader(_DataFileMetadata):
     """Read files written by DataFileWriter."""
-
     __slots__ = (
         "_datum_decoder",
         "_datum_reader",

--- a/lang/py/avro/io.py
+++ b/lang/py/avro/io.py
@@ -158,9 +158,9 @@ def _iterate_node(node: ValidationNode) -> ValidationNodeGeneratorType:
         yield ValidationNode(*item)
 
 
-#############
-# Iteration #
-#############
+#
+# Iteration
+#
 
 
 def _default_iterator(_) -> ValidationNodeGeneratorType:
@@ -205,12 +205,11 @@ _ITERATORS["error"] = _ITERATORS["request"] = _ITERATORS["record"]
 
 class BinaryDecoder:
     """Read leaf values."""
-
     _reader: IO[bytes]
 
     def __init__(self, reader: IO[bytes]) -> None:
         """
-        reader is a Python object on which we can call read, seek, and tell.
+        Reader is a Python object on which we can call read, seek, and tell.
         """
         self._reader = reader
 
@@ -219,9 +218,7 @@ class BinaryDecoder:
         return self._reader
 
     def read(self, n: int) -> bytes:
-        """
-        Read n bytes.
-        """
+        """Read n bytes."""
         if n < 0:
             raise avro.errors.InvalidAvroBinaryEncoding(f"Requested {n} bytes to read, expected positive integer.")
         read_bytes = self.reader.read(n)
@@ -230,14 +227,12 @@ class BinaryDecoder:
         return read_bytes
 
     def read_null(self) -> None:
-        """
-        null is written as zero bytes
-        """
+        """Null is written as zero bytes"""
         return None
 
     def read_boolean(self) -> bool:
         """
-        a boolean is written as a single byte
+        A boolean is written as a single byte
         whose value is either 0 (false) or 1 (true).
         """
         return ord(self.read(1)) == 1
@@ -419,7 +414,7 @@ class BinaryEncoder:
 
     def __init__(self, writer: IO[bytes]) -> None:
         """
-        writer is a Python object on which we can call write.
+        Writer is a Python object on which we can call write.
         """
         self._writer = writer
 
@@ -432,14 +427,12 @@ class BinaryEncoder:
         self.writer.write(datum)
 
     def write_null(self, datum: None) -> None:
-        """
-        null is written as zero bytes
-        """
+        """Null is written as zero bytes"""
         pass
 
     def write_boolean(self, datum: bool) -> None:
         """
-        a boolean is written as a single byte
+        A boolean is written as a single byte
         whose value is either 0 (false) or 1 (true).
         """
         self.write(bytearray([bool(datum)]))
@@ -612,7 +605,6 @@ class BinaryEncoder:
 #
 class DatumReader:
     """Deserialize Avro-encoded data into a Python data structure."""
-
     _writers_schema: Optional[avro.schema.Schema]
     _readers_schema: Optional[avro.schema.Schema]
 
@@ -872,7 +864,7 @@ class DatumReader:
         the zero-based position within the union of the schema of its value.
         The value is then encoded per the indicated schema within the union.
         """
-        # schema resolution
+        # Schema resolution
         index_of_schema = int(decoder.read_long())
         if index_of_schema >= len(writers_schema.schemas):
             raise avro.errors.SchemaResolutionException(
@@ -880,7 +872,7 @@ class DatumReader:
             )
         selected_writers_schema = writers_schema.schemas[index_of_schema]
 
-        # read data
+        # Read data
         return self.read_data(selected_writers_schema, readers_schema, decoder)
 
     def skip_union(self, writers_schema: avro.schema.UnionSchema, decoder: BinaryDecoder) -> None:
@@ -913,7 +905,7 @@ class DatumReader:
            writer's schema does not have a field with the same name, then the
            field's value is unset.
         """
-        # schema resolution
+        # Schema resolution
         readers_fields_dict = readers_schema.fields_dict
         read_record = {}
         for field in writers_schema.fields:
@@ -924,7 +916,7 @@ class DatumReader:
             else:
                 self.skip_data(field.type, decoder)
 
-        # fill in default values
+        # Fill in default values
         if len(readers_fields_dict) > len(read_record):
             writers_fields_dict = writers_schema.fields_dict
             for field_name, field in readers_fields_dict.items():
@@ -940,9 +932,7 @@ class DatumReader:
             self.skip_data(field.type, decoder)
 
     def _read_default_value(self, field_schema: avro.schema.Schema, default_value: object) -> object:
-        """
-        Basically a JSON Decoder?
-        """
+        """Basically a JSON Decoder?"""
         if field_schema.type == "null":
             if default_value is None:
                 return None
@@ -993,7 +983,6 @@ class DatumReader:
 
 class DatumWriter:
     """DatumWriter for generic python objects."""
-
     _writers_schema: Optional[avro.schema.Schema]
 
     def __init__(self, writers_schema: Optional[avro.schema.Schema] = None) -> None:

--- a/lang/py/avro/schema.py
+++ b/lang/py/avro/schema.py
@@ -51,8 +51,16 @@ from typing import Mapping, MutableMapping, Optional, Sequence, Union, cast
 
 import avro.constants
 import avro.errors
-from avro.constants import NAMED_TYPES, PRIMITIVE_TYPES, VALID_TYPES
 from avro.name import Name, Names, validate_basename
+from avro.constants import (
+    NAMED_TYPES,
+    PRIMITIVE_TYPES, 
+    VALID_TYPES, 
+    INT_MAX_VALUE,
+    INT_MIN_VALUE,
+    LONG_MAX_VALUE,
+    LONG_MIN_VALUE,
+)
 
 #
 # Constants
@@ -93,11 +101,6 @@ CANONICAL_FIELD_ORDER = (
     "values",
     "size",
 )
-
-INT_MIN_VALUE = -(1 << 31)
-INT_MAX_VALUE = (1 << 31) - 1
-LONG_MIN_VALUE = -(1 << 63)
-LONG_MAX_VALUE = (1 << 63) - 1
 
 
 def _is_timezone_aware_datetime(dt: datetime.datetime) -> bool:


### PR DESCRIPTION
The changes made are:

- Code altered according to PEP 8 conventions. Files changed are: io.py, constants.py, schema.py, codecs.py, datafile.py and compatibility.py.
- General constants INT_MIN_VALUE, INT_MAX_VALUE, LONG_MIN_VALUE & LONG_MAX_VALUE shifted from schema.py to constants.py for clarity and better organization.

_(This is my first attempt to contribute to any open source project, not only this project. If I have made any errors or have misunderstood any step, please forgive me. I would be happy to adhere to any suggestions)_

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO-3571) issues and references them in the PR title. For example, "[AVRO-3571]: Python code refactor and rearrangement"
  - https://issues.apache.org/jira/browse/AVRO-3571
  - No dependencies are being added.

### Tests

- [x] My PR does not need testing because I have only moved certain constants from schema.py to constants.py and have refactored code to better adhere to the PEP 8 style guide.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] My commit doesn't add any functionality whatsoever.
