### PR TITLE
Duplicate symbols

### DIFF
--- a/lang/py/avro/schema.py
+++ b/lang/py/avro/schema.py
@@ -573,9 +573,9 @@ class EnumSchema(EqualByPropsMixin, NamedSchema):
             duplicate_symbols = {symbol for symbol in symbols if symbols.count(symbol) > 1}
 
             if len(duplicate_symbols) == 1:
-                raise avro.errors.AvroException(f"Duplicate symbol: {duplicate_symbols}")
+                raise avro.errors.AvroException(f"Duplicate symbol: {list(duplicate_symbols)}")
             else:
-                raise avro.errors.AvroException(f"Duplicate symbols: {duplicate_symbols}")
+                raise avro.errors.AvroException(f"Duplicate symbols: {list(duplicate_symbols)}")
 
         # Call parent ctor
         NamedSchema.__init__(self, "enum", name, namespace, names, other_props)

--- a/lang/py/avro/schema.py
+++ b/lang/py/avro/schema.py
@@ -570,7 +570,12 @@ class EnumSchema(EqualByPropsMixin, NamedSchema):
                     raise avro.errors.InvalidName("An enum symbol must be a valid schema name.")
 
         if len(set(symbols)) < len(symbols):
-            raise avro.errors.AvroException(f"Duplicate symbol: {symbols}")
+            duplicate_symbols = {symbol for symbol in symbols if symbols.count(symbol) > 1}
+
+            if len(duplicate_symbols) == 1:
+                raise avro.errors.AvroException(f"Duplicate symbol: {duplicate_symbols}")
+            else:
+                raise avro.errors.AvroException(f"Duplicate symbols: {duplicate_symbols}")
 
         # Call parent ctor
         NamedSchema.__init__(self, "enum", name, namespace, names, other_props)


### PR DESCRIPTION
If EnumSchema has duplicate symbols, an error will raise. Instead of a list of duplicate symbols or a value of duplicate symbol, error shows all list of symbols. Improvement removes this defect and shows a message "Duplicate symbol" with the symbol, if it is one, or "Duplicates symbols" with the list of duplicate symbols, if there are more than one symbol.

P.S. Tests do not check error's message. Try to write a test for checking a message of an error can take a long time.

### Jira

- [ ] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
