### PR TITLE
AVRO-3581: Fix Velocity configuration warnings

### DIFF
--- a/lang/java/ipc/src/main/java/org/apache/avro/ipc/stats/StatsServlet.java
+++ b/lang/java/ipc/src/main/java/org/apache/avro/ipc/stats/StatsServlet.java
@@ -56,11 +56,11 @@ public class StatsServlet extends HttpServlet {
     this.velocityEngine = new VelocityEngine();
 
     // These two properties tell Velocity to use its own classpath-based loader
-    velocityEngine.addProperty("resource.loader", "class");
-    velocityEngine.addProperty("class.resource.loader.class",
+    velocityEngine.addProperty("resource.loaders", "class");
+    velocityEngine.addProperty("resource.loader.class.class",
         "org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader");
 
-    velocityEngine.setProperty("runtime.references.strict", true);
+    velocityEngine.setProperty("runtime.strict_mode.enable", true);
     String logChuteName = "org.apache.velocity.runtime.log.NullLogChute";
     velocityEngine.setProperty("runtime.log.logsystem.class", logChuteName);
   }


### PR DESCRIPTION
Fix Velocity configuration warnings by changing to new configs since the old ones were deprecated.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-3581
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

It only changes Velocity configs and all the tests pass after the changes.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
