### PR TITLE
Fix possible heap-buffer-overflow in avro::DataFileReaderBase::readDataBlock()

### DIFF
--- a/lang/c++/impl/DataFile.cc
+++ b/lang/c++/impl/DataFile.cc
@@ -394,6 +394,9 @@ void DataFileReaderBase::readDataBlock() {
             compressed_.insert(compressed_.end(), data, data + len);
         }
         len = compressed_.size();
+        if (len < 4)
+            throw Exception("Cannot read compressed data, expected at least 4 bytes, got " + std::to_string(len));
+
         int b1 = compressed_[len - 4] & 0xFF;
         int b2 = compressed_[len - 3] & 0xFF;
         int b3 = compressed_[len - 2] & 0xFF;


### PR DESCRIPTION
Fix possible heap-buffer-overflow in avro::DataFileReaderBase::readDataBlock() while reading bad data.
This error was found by stress tests in ClickHouse under address sanitizer: https://github.com/ClickHouse/ClickHouse/issues/33652
Stacktrace:
```
==549==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60200037c8cc at pc 0x000034e6e371 bp 0x7fc5a2e97e50 sp 0x7fc5a2e97e48
READ of size 1 at 0x60200037c8cc thread T553 (QueryPipelineEx)
    #0 0x34e6e370 in avro::DataFileReaderBase::readDataBlock() obj-x86_64-linux-gnu/../contrib/avro/lang/c++/impl/DataFile.cc:418:18
    #1 0x34e70485 in avro::DataFileReaderBase::hasMore() obj-x86_64-linux-gnu/../contrib/avro/lang/c++/impl/DataFile.cc:338:9
    ...
```
You can find an example of corrupted file here: https://drive.google.com/file/d/1pEZk3cbWiPvFCbTnndTO5YbQameZ1Jt2/view?usp=sharing
Reading this corrupted file under address sanitizer leads to heap-buffer-overflow.