### PR TITLE
[AVRO-3590] fix Snappy CodecFactory is null

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/file/CodecFactory.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/file/CodecFactory.java
@@ -66,7 +66,7 @@ public abstract class CodecFactory {
   /** Snappy codec. */
   public static CodecFactory snappyCodec() {
     try {
-      return new SnappyCodec.Option();
+      return SnappyCodec.OPTION;
     } catch (Throwable t) {
       LOG.debug("Snappy was not available", t);
       return null;

--- a/lang/java/avro/src/main/java/org/apache/avro/file/SnappyCodec.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/file/SnappyCodec.java
@@ -28,6 +28,9 @@ import org.xerial.snappy.Snappy;
 public class SnappyCodec extends Codec {
   private CRC32 crc32 = new CRC32();
 
+  private static final SnappyCodec INSTANCE = new SnappyCodec();
+  public static final CodecFactory OPTION = new SnappyCodec.Option();
+
   static class Option extends CodecFactory {
     static {
       // if snappy isn't available, this will throw an exception which we
@@ -37,7 +40,7 @@ public class SnappyCodec extends Codec {
 
     @Override
     protected Codec createInstance() {
-      return new SnappyCodec();
+      return SnappyCodec.INSTANCE;
     }
   }
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

Related to [AVRO-3590](https://issues.apache.org/jira/browse/AVRO-3590)

### Tests

```TestAllCodec#testCodec```

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
