### PR TITLE
AVRO-3592: Add the codec packages to the tar

### DIFF
--- a/lang/csharp/build.sh
+++ b/lang/csharp/build.sh
@@ -68,7 +68,7 @@ do
 
       # build the tarball
       mkdir -p ${ROOT}/dist/csharp
-      (cd build; tar czf ${ROOT}/../dist/csharp/avro-csharp-${VERSION}.tar.gz main codegen LICENSE NOTICE)
+      (cd build; tar czf ${ROOT}/../dist/csharp/avro-csharp-${VERSION}.tar.gz main codegen codec LICENSE NOTICE)
 
       # build documentation
       doxygen Avro.dox


### PR DESCRIPTION
Add the `codec/` packages to the C# distribution.  Note that these are missing from the Avro 1.11.1 binary release but uploaded to nuget.org from the same build. 

### Jira

- [X] My PR addresses AVRO-3592

### Tests

- [X] My PR does not need testing for this extremely good reason: manually building

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

