### PR TITLE
AVRO-3601: CustomAttributes#getAttribute() now returns boost::optional

### DIFF
--- a/lang/c++/api/CustomAttributes.hh
+++ b/lang/c++/api/CustomAttributes.hh
@@ -19,6 +19,7 @@
 #ifndef avro_CustomAttributes_hh__
 #define avro_CustomAttributes_hh__
 
+#include <boost/optional.hpp>
 #include <iostream>
 #include <map>
 #include <string>
@@ -33,7 +34,7 @@ class AVRO_DECL CustomAttributes {
   public:
     // Retrieves the custom attribute json entity for that attributeName, returns an
     // null if the attribute doesn't exist.
-    std::string getAttribute(const std::string &name) const;
+    boost::optional<std::string> getAttribute(const std::string &name) const;
 
     // Adds a custom attribute. If the attribute already exists, throw an exception.
     void addAttribute(const std::string &name, const std::string &value);

--- a/lang/c++/impl/CustomAttributes.cc
+++ b/lang/c++/impl/CustomAttributes.cc
@@ -23,13 +23,15 @@
 
 namespace avro {
 
-std::string CustomAttributes::getAttribute(const std::string &name) const {
+boost::optional<std::string> CustomAttributes::getAttribute(const std::string &name) const {
+    boost::optional<std::string> result;
     std::map<std::string, std::string>::const_iterator iter =
         attributes_.find(name);
     if (iter == attributes_.end()) {
-      return NULL;
+      return result;
     }
-    return iter->second;
+    result = iter->second;
+    return result;
 }
 
 void CustomAttributes::addAttribute(const std::string& name,

--- a/lang/c++/test/unittest.cc
+++ b/lang/c++/test/unittest.cc
@@ -467,8 +467,6 @@ struct TestSchema {
         concepts::MultiAttribute<NodePtr> fieldValues;
         std::vector<GenericDatum> defaultValues;
 
-        CustomAttributes cf;
-        cf.addAttribute("extra field", std::string("1"));
         fieldNames.add("f1");
         fieldValues.add(NodePtr( new NodePrimitive(Type::AVRO_LONG)));
 
@@ -479,6 +477,15 @@ struct TestSchema {
         "[{\"name\": \"f1\", \"type\": \"long\"}]}";
         testNodeRecord(nodeRecordWithoutCustomAttribute,
                     expectedJsonWithoutCustomAttribute);
+    }
+
+    void checkCustomAttributes_getAttribute()
+    {
+        CustomAttributes cf;
+        cf.addAttribute("field1", std::string("1"));
+
+        BOOST_CHECK_EQUAL(std::string("1"), *cf.getAttribute("field1"));
+        BOOST_CHECK_EQUAL(false, cf.getAttribute("not_existing").is_initialized());
     }
 
     void test() {
@@ -505,6 +512,7 @@ struct TestSchema {
 
         checkNodeRecordWithoutCustomAttribute();
         checkNodeRecordWithCustomAttribute();
+        checkCustomAttributes_getAttribute();
     }
 
     ValidSchema schema_;

--- a/lang/c++/test/unittest.cc
+++ b/lang/c++/test/unittest.cc
@@ -442,7 +442,12 @@ struct TestSchema {
         concepts::MultiAttribute<CustomAttributes> customAttributes;
 
         CustomAttributes cf;
-        cf.addAttribute("extra field", std::string("1"));
+        cf.addAttribute("stringField", std::string("\\\"field value with \\\"double quotes\\\"\\\""));
+        cf.addAttribute("booleanField", std::string("true"));
+        cf.addAttribute("numberField", std::string("1.23"));
+        cf.addAttribute("nullField", std::string("null"));
+        cf.addAttribute("arrayField", std::string("[1]"));
+        cf.addAttribute("mapField", std::string("{\\\"key1\\\":\\\"value1\\\", \\\"key2\\\":\\\"value2\\\"}"));
         fieldNames.add("f1");
         fieldValues.add(NodePtr( new NodePrimitive(Type::AVRO_LONG)));
         customAttributes.add(cf);
@@ -452,7 +457,14 @@ struct TestSchema {
                                             customAttributes);
         std::string expectedJsonWithCustomAttribute =
         "{\"type\": \"record\", \"name\": \"Test\",\"fields\": "
-        "[{\"name\": \"f1\", \"type\": \"long\",\"extra field\": \"1\"}]}";
+        "[{\"name\": \"f1\", \"type\": \"long\", "
+        "\"arrayField\": \"[1]\", "
+        "\"booleanField\": \"true\", "
+        "\"mapField\": \"{\\\"key1\\\":\\\"value1\\\", \\\"key2\\\":\\\"value2\\\"}\", "
+        "\"nullField\": \"null\", "
+        "\"numberField\": \"1.23\", "
+        "\"stringField\": \"\\\"field value with \\\"double quotes\\\"\\\"\""
+        "}]}";
         testNodeRecord(nodeRecordWithCustomAttribute,
                     expectedJsonWithCustomAttribute);
     }


### PR DESCRIPTION
Add unit tests for CustomAttributes#getAttribute(string)

### Jira

- [X] https://issues.apache.org/jira/browse/AVRO-3601

### Tests

- [X] My PR adds unit tests

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
