### PR TITLE
AVRO-3618: Test both directBinaryDecoder and binaryDecoder

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/io/BinaryDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/BinaryDecoder.java
@@ -59,7 +59,7 @@ public class BinaryDecoder extends Decoder {
   static final long MAX_ARRAY_SIZE = (long) Integer.MAX_VALUE - 8L;
 
   private static final String MAX_BYTES_LENGTH_PROPERTY = "org.apache.avro.limits.bytes.maxLength";
-  private final int maxBytesLength;
+  protected final int maxBytesLength;
 
   private ByteSource source = null;
   // we keep the buffer and its state variables in this class and not in a

--- a/lang/java/avro/src/test/java/org/apache/avro/io/TestBinaryDecoder.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/io/TestBinaryDecoder.java
@@ -239,7 +239,7 @@ public class TestBinaryDecoder {
   public void testInputStreamProxy() throws IOException {
     BinaryDecoder d = newDecoder(data);
     if (d != null) {
-      BinaryDecoder bd = (BinaryDecoder) d;
+      BinaryDecoder bd = d;
       InputStream test = bd.inputStream();
       InputStream check = new ByteArrayInputStream(data);
       validateInputStreamReads(test, check);
@@ -384,14 +384,7 @@ public class TestBinaryDecoder {
     byte[] bad = new byte[] { (byte) 1 };
     Decoder bd = this.newDecoder(bad);
 
-    final RuntimeException ex = Assert.assertThrows("Malformed data. Length is negative: -1", RuntimeException.class,
-        () -> bd.readBytes(null));
-    if (this.useDirect) {
-      Assert.assertTrue("Exception not IllegalArgumentException but " + ex.getClass(),
-          ex instanceof IllegalArgumentException);
-    } else {
-      Assert.assertTrue("Exception not AvroRuntimeException but " + ex.getClass(), ex instanceof AvroRuntimeException);
-    }
+    Assert.assertThrows("Malformed data. Length is negative: -1", AvroRuntimeException.class, () -> bd.readBytes(null));
   }
 
   @Test
@@ -400,14 +393,8 @@ public class TestBinaryDecoder {
     BinaryData.encodeLong(BinaryDecoder.MAX_ARRAY_SIZE + 1, bad, 0);
     Decoder bd = this.newDecoder(bad);
 
-    Throwable error = Assert.assertThrows("Cannot read arrays longer than " + BinaryDecoder.MAX_ARRAY_SIZE + " bytes",
-        Throwable.class, () -> bd.readBytes(null));
-    if (this.useDirect) {
-      Assert.assertTrue("Exception not OutOfMemoryError but " + error.getClass(), error instanceof OutOfMemoryError);
-    } else {
-      Assert.assertTrue("Exception not UnsupportedOperationException but " + error.getClass(),
-          error instanceof UnsupportedOperationException);
-    }
+    Assert.assertThrows("Cannot read arrays longer than " + BinaryDecoder.MAX_ARRAY_SIZE + " bytes",
+        UnsupportedOperationException.class, () -> bd.readBytes(null));
   }
 
   @Test
@@ -419,14 +406,8 @@ public class TestBinaryDecoder {
       System.setProperty("org.apache.avro.limits.bytes.maxLength", Long.toString(maxLength));
       Decoder bd = this.newDecoder(bad);
 
-      final Exception exception = Assert.assertThrows("Bytes length " + (maxLength + 1) + " exceeds maximum allowed",
-          Exception.class, () -> bd.readBytes(null));
-      if (this.useDirect) {
-        Assert.assertTrue("Exception not EOFException but " + exception.getClass(), exception instanceof EOFException);
-      } else {
-        Assert.assertTrue("Exception not AvroRuntimeException but " + exception.getClass(),
-            exception instanceof AvroRuntimeException);
-      }
+      Assert.assertThrows("Bytes length " + (maxLength + 1) + " exceeds maximum allowed", AvroRuntimeException.class,
+          () -> bd.readBytes(null));
     } finally {
       System.clearProperty("org.apache.avro.limits.bytes.maxLength");
     }


### PR DESCRIPTION
[AVRO-3618](https://issues.apache.org/jira/browse/AVRO-3618) : update unit test testBinaryDecoder to test directBinaryDecoder before moving it in JUnit5.

