### PR TITLE
AVRO-3628: [Java] JUnit 4.x tests are not executed

### DIFF
--- a/lang/java/archetypes/avro-service-archetype/src/main/pom/pom.xml
+++ b/lang/java/archetypes/avro-service-archetype/src/main/pom/pom.xml
@@ -79,8 +79,8 @@
       <version>\${logback.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <version>\${junit5.version}</version>
       <scope>test</scope>
     </dependency>

--- a/lang/java/archetypes/avro-service-archetype/src/main/pom/pom.xml
+++ b/lang/java/archetypes/avro-service-archetype/src/main/pom/pom.xml
@@ -35,7 +35,7 @@
   <properties>
     <avro.version>${project.version}</avro.version>
     <jackson-bom.version>${jackson-bom.version}</jackson-bom.version>
-    <junit.version>${junit.version}</junit.version>
+    <junit5.version>${junit5.version}</junit5.version>
     <logback.version>1.2.3</logback.version>
     <slf4j.version>${slf4j.version}</slf4j.version>
   </properties>
@@ -79,9 +79,9 @@
       <version>\${logback.version}</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>\${junit.version}</version>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>\${junit5.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/lang/java/archetypes/avro-service-archetype/src/main/resources/archetype-resources/src/test/java/integration/SimpleOrderServiceIntegrationTest.java
+++ b/lang/java/archetypes/avro-service-archetype/src/main/resources/archetype-resources/src/test/java/integration/SimpleOrderServiceIntegrationTest.java
@@ -21,8 +21,8 @@
 
 package ${package}.integration;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -30,9 +30,9 @@ import java.util.List;
 
 import ${package}.transport.SimpleOrderServiceEndpoint;
 import ${package}.transport.SimpleOrderServiceClient;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import ${package}.service.Confirmation;
 import ${package}.service.Item;
@@ -42,13 +42,13 @@ import ${package}.service.Order;
  * <code>SimpleOrderServiceIntegrationTest</code> runs as part of the Integration phase of the build and is
  * meant for end to end service testing.
  */
-public class SimpleOrderServiceIntegrationTest {
+class SimpleOrderServiceIntegrationTest {
 
   private static SimpleOrderServiceEndpoint service;
   private static SimpleOrderServiceClient client;
 
   @Test
-  public void simpleRoundTripTest() throws Exception {
+  void simpleRoundTripTest() throws Exception {
     Order simpleOrder = createOrder();
     Confirmation c = client.submitOrder(simpleOrder);
 
@@ -57,7 +57,7 @@ public class SimpleOrderServiceIntegrationTest {
     assertTrue(c.getEstimatedCompletion() > 0);
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setupTransport() throws Exception {
     InetSocketAddress endpointAddress = new InetSocketAddress("0.0.0.0", 12345);
     service = new SimpleOrderServiceEndpoint(endpointAddress);
@@ -67,7 +67,7 @@ public class SimpleOrderServiceIntegrationTest {
     client.start();
   }
 
-  @AfterClass
+  @AfterAll
   public static void shutdownTransport() throws Exception {
     client.stop();
     service.stop();

--- a/lang/java/maven-plugin/pom.xml
+++ b/lang/java/maven-plugin/pom.xml
@@ -24,7 +24,7 @@
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
     <version>1.12.0-SNAPSHOT</version>
-    <relativePath>../</relativePath>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>avro-maven-plugin</artifactId>
@@ -60,6 +60,7 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
       <version>${maven-core.version}</version>
+      <scope>provided</scope>
       <exclusions>
         <exclusion>
           <groupId>com.google.code.findbugs</groupId>

--- a/lang/java/maven-plugin/src/test/resources/unit/idl/pom-injecting-velocity-tools.xml
+++ b/lang/java/maven-plugin/src/test/resources/unit/idl/pom-injecting-velocity-tools.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.11.0-SNAPSHOT</version>
+    <version>1.12.0-SNAPSHOT</version>
     <relativePath>../../../../../../../../../</relativePath>
   </parent>
 

--- a/lang/java/maven-plugin/src/test/resources/unit/idl/pom.xml
+++ b/lang/java/maven-plugin/src/test/resources/unit/idl/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.11.0-SNAPSHOT</version>
+    <version>1.12.0-SNAPSHOT</version>
     <relativePath>../../../../../../../../../pom.xml</relativePath>
   </parent>
 

--- a/lang/java/maven-plugin/src/test/resources/unit/protocol/pom-injecting-velocity-tools.xml
+++ b/lang/java/maven-plugin/src/test/resources/unit/protocol/pom-injecting-velocity-tools.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.11.0-SNAPSHOT</version>
+    <version>1.12.0-SNAPSHOT</version>
     <relativePath>../../../../../../../../../</relativePath>
   </parent>
 

--- a/lang/java/maven-plugin/src/test/resources/unit/protocol/pom.xml
+++ b/lang/java/maven-plugin/src/test/resources/unit/protocol/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.11.0-SNAPSHOT</version>
+    <version>1.12.0-SNAPSHOT</version>
     <relativePath>../../../../../../../../../pom.xml</relativePath>
   </parent>
 

--- a/lang/java/maven-plugin/src/test/resources/unit/schema/pom.xml
+++ b/lang/java/maven-plugin/src/test/resources/unit/schema/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.11.0-SNAPSHOT</version>
+    <version>1.12.0-SNAPSHOT</version>
     <relativePath>../../../../../../../../../pom.xml</relativePath>
   </parent>
 

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -42,7 +42,6 @@
     <servlet-api.version>4.0.1</servlet-api.version>
     <jetty.version>9.4.48.v20220622</jetty.version>
     <jopt-simple.version>5.0.4</jopt-simple.version>
-    <junit.version>4.13.2</junit.version>
     <junit5.version>5.9.0</junit5.version>
     <netty.version>4.1.81.Final</netty.version>
     <protobuf.version>3.21.5</protobuf.version>
@@ -157,13 +156,14 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
+          <version>3.0.0-M7</version>
           <configuration>
             <includes>
               <!-- Avro naming convention for JUnit tests -->
               <include>**/Test**</include>
             </includes>
             <excludes>
-              <!-- A few innner classes are not to be tested -->
+              <!-- A few inner classes are not to be tested -->
               <exclude>**/*$*</exclude>
               <!-- exclude the generated classes under apache.avro.test, some of
                 these match **/Test** and are not JUnit tests -->
@@ -592,9 +592,9 @@
     will inherit these dependencies directly, and can opt out if necessary with <excludes> -->
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>${junit5.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Use JUnit 5.x Vintage engine instead of JUnit 4.x

## What is the purpose of the change

* Fix the execution of JUnit 4.x unit tests by using JUnit 5.x Vintage engine. Fixes AVRO-3628


## Verifying this change

Check the stdout of the Maven build and make sure that JUnit 4.x tests are executed, e.g. avro-maven-plugin module should execute 11 tests.

## Documentation

- Does this pull request introduce a new feature? no