### PR TITLE
docs: Fix a few typos

### DIFF
--- a/doc/content/en/docs/++version++/Specification/_index.md
+++ b/doc/content/en/docs/++version++/Specification/_index.md
@@ -564,7 +564,7 @@ A transport is a system that supports:
 
 * **transmission of request messages**
 * **receipt of corresponding response messages**
-Servers may send a response message back to the client corresponding to a request message. The mechanism of correspondance is transport-specific. For example, in HTTP it is implicit, since HTTP directly supports requests and responses. But a transport that multiplexes many client threads over a single socket would need to tag messages with unique identifiers.
+Servers may send a response message back to the client corresponding to a request message. The mechanism of correspondence is transport-specific. For example, in HTTP it is implicit, since HTTP directly supports requests and responses. But a transport that multiplexes many client threads over a single socket would need to tag messages with unique identifiers.
 
 Transports may be either stateless or stateful. In a stateless transport, messaging assumes no established connection state, while stateful transports establish connections that may be used for multiple messages. This distinction is discussed further in the [handshake](#handshake) section below.
 

--- a/lang/py/avro/tether/tether_task.py
+++ b/lang/py/avro/tether/tether_task.py
@@ -318,7 +318,7 @@ class TetherTask(abc.ABC):
 
         Parameters
         ------------------------------------------------------
-        data - Sould containg the bytes encoding the serialized data
+        data - Sould containing the bytes encoding the serialized data
               - I think this gets represented as a tring
         count - how many input records are provided in the binary stream
         """

--- a/lang/py/avro/tether/tether_task.py
+++ b/lang/py/avro/tether/tether_task.py
@@ -318,8 +318,8 @@ class TetherTask(abc.ABC):
 
         Parameters
         ------------------------------------------------------
-        data - Sould containing the bytes encoding the serialized data
-              - I think this gets represented as a tring
+        data - Should contain the bytes encoding the serialized data
+              - I think this gets represented as a string
         count - how many input records are provided in the binary stream
         """
         try:


### PR DESCRIPTION
There are small typos in:
- doc/content/en/docs/++version++/Specification/_index.md
- lang/py/avro/tether/tether_task.py

Fixes:
- Should read `correspondence` rather than `correspondance`.
- Should read `contain` rather than `containg`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md