### PR TITLE
AVRO-3631: [Rust] Add support for (de)serializing Rust byte arrays to Avro values

### DIFF
--- a/lang/rust/Cargo.lock
+++ b/lang/rust/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
 dependencies = [
  "gimli",
 ]
@@ -25,9 +25,9 @@ checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "ahash"
-version = "0.8.7"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -37,9 +37,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
@@ -58,9 +58,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstyle"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
 
 [[package]]
 name = "anyhow"
@@ -89,6 +89,7 @@ dependencies = [
  "pretty_assertions",
  "quad-rand",
  "rand",
+ "ref_thread_local",
  "regex-lite",
  "rstest",
  "serde",
@@ -132,15 +133,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
 dependencies = [
  "addr2line",
  "cc",
@@ -177,15 +178,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "block-buffer"
@@ -198,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bzip2"
@@ -231,9 +226,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "324c74f2155653c90b04f25b2a47a8a631360cb908f92a772695f430c7e31052"
 dependencies = [
  "jobserver",
  "libc",
@@ -274,18 +269,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.18"
+version = "4.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+checksum = "64acc1846d54c1fe936a78dc189c34e28d3f5afc348403f28ecf53660b9b8462"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.4.18"
+version = "4.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+checksum = "6fb8393d67ba2e7bfaf28a23458e4e2b543cc73a99595511eb207fdb8aede942"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -293,9 +288,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "console"
@@ -464,9 +459,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "encode_unicode"
@@ -481,16 +476,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
 dependencies = [
  "log",
-]
-
-[[package]]
-name = "errno"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
-dependencies = [
- "libc",
- "windows-sys",
 ]
 
 [[package]]
@@ -588,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -599,9 +584,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "glob"
@@ -611,9 +596,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "half"
-version = "2.3.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -648,9 +633,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.5"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex-literal"
@@ -666,12 +651,12 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
  "hermit-abi",
- "rustix",
+ "libc",
  "windows-sys",
 ]
 
@@ -686,15 +671,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
-version = "0.1.27"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
 dependencies = [
  "libc",
 ]
@@ -710,15 +695,15 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libflate"
@@ -751,16 +736,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
-
-[[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -795,15 +774,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]
@@ -840,9 +819,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.2"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
 dependencies = [
  "memchr",
 ]
@@ -855,15 +834,15 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "oorandom"
-version = "11.1.3"
+version = "11.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -871,15 +850,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -890,9 +869,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -902,9 +881,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "ppv-lite86"
@@ -937,7 +916,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags",
  "lazy_static",
  "num-traits",
  "rand",
@@ -1003,18 +982,24 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
 ]
 
 [[package]]
-name = "regex"
-version = "1.10.3"
+name = "ref_thread_local"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "a0d51660a68078997855ba5602f73ab3a5031bd7ad480a9d4c90fbbf04e1fff0"
+
+[[package]]
+name = "regex"
+version = "1.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1024,9 +1009,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1041,15 +1026,15 @@ checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "relative-path"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "rle-decode-fast"
@@ -1086,9 +1071,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc_version"
@@ -1100,29 +1085,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix"
-version = "0.38.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
-dependencies = [
- "bitflags 2.4.2",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys",
-]
-
-[[package]]
 name = "rustversion"
-version = "1.0.14"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "ryu"
-version = "1.0.16"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "same-file"
@@ -1135,9 +1107,9 @@ dependencies = [
 
 [[package]]
 name = "scc"
-version = "2.1.0"
+version = "2.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec96560eea317a9cc4e0bb1f6a2c93c09a19b8c4fc5cb3fcc0ec1c094cd783e2"
+checksum = "a4465c22496331e20eb047ff46e7366455bc01c0c02015c4a376de0b2cd3a1af"
 dependencies = [
  "sdd",
 ]
@@ -1156,15 +1128,15 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sdd"
-version = "0.2.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84345e4c9bd703274a082fb80caaa99b7612be48dfaa1dd9266577ec412309d"
+checksum = "8eb0dde0ccd15e337a3cf738a9a38115c6d8e74795d074e73973dad3d229a897"
 
 [[package]]
 name = "semver"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
@@ -1244,9 +1216,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "snap"
@@ -1369,9 +1341,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -1476,44 +1448,22 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "winapi",
+ "windows-sys",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
@@ -1521,122 +1471,72 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.52.0"
+name = "windows_i686_gnullvm"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "xz2"
@@ -1655,18 +1555,18 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.32"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.32"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1684,18 +1584,18 @@ dependencies = [
 
 [[package]]
 name = "zstd-safe"
-version = "7.1.0"
+version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd99b45c6bc03a018c8b8a86025678c87e55526064e38f9df301989dce7ec0a"
+checksum = "fa556e971e7b568dc775c136fc9de8c779b1c2fc3a63defaafadffdbd3181afa"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.10+zstd.1.5.6"
+version = "2.0.12+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c253a4914af5bafc8fa8c86ee400827e83cf6ec01195ec1f1ed8441bf00d65aa"
+checksum = "0a4e40c320c3cb459d9a9ff6de98cff88f4751ee9275d140e2be94a2b74e4c13"
 dependencies = [
  "cc",
  "pkg-config",

--- a/lang/rust/Cargo.lock
+++ b/lang/rust/Cargo.lock
@@ -194,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "bzip2"
@@ -270,18 +270,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.9"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64acc1846d54c1fe936a78dc189c34e28d3f5afc348403f28ecf53660b9b8462"
+checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.9"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8393d67ba2e7bfaf28a23458e4e2b543cc73a99595511eb207fdb8aede942"
+checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -289,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "console"

--- a/lang/rust/Cargo.lock
+++ b/lang/rust/Cargo.lock
@@ -93,7 +93,6 @@ dependencies = [
  "regex-lite",
  "rstest",
  "serde",
- "serde-byte-array",
  "serde_bytes",
  "serde_json",
  "serial_test",
@@ -1150,19 +1149,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-byte-array"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63213ee4ed648dbd87db6fa993d4275b46bfb4ddfd95b3756045007c2b28f742"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_bytes"
-version = "0.11.9"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
+checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
 dependencies = [
  "serde",
 ]

--- a/lang/rust/Cargo.lock
+++ b/lang/rust/Cargo.lock
@@ -93,6 +93,7 @@ dependencies = [
  "regex-lite",
  "rstest",
  "serde",
+ "serde_bytes",
  "serde_json",
  "serial_test",
  "sha2",
@@ -1145,6 +1146,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/lang/rust/Cargo.lock
+++ b/lang/rust/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
  "regex-lite",
  "rstest",
  "serde",
- "serde_bytes",
+ "serde-byte-array",
  "serde_json",
  "serial_test",
  "sha2",
@@ -1149,10 +1149,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_bytes"
-version = "0.11.9"
+name = "serde-byte-array"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
+checksum = "63213ee4ed648dbd87db6fa993d4275b46bfb4ddfd95b3756045007c2b28f742"
 dependencies = [
  "serde",
 ]

--- a/lang/rust/Cargo.lock
+++ b/lang/rust/Cargo.lock
@@ -94,6 +94,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde-byte-array",
+ "serde_bytes",
  "serde_json",
  "serial_test",
  "sha2",
@@ -1153,6 +1154,15 @@ name = "serde-byte-array"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63213ee4ed648dbd87db6fa993d4275b46bfb4ddfd95b3756045007c2b28f742"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
 dependencies = [
  "serde",
 ]

--- a/lang/rust/avro/Cargo.toml
+++ b/lang/rust/avro/Cargo.toml
@@ -30,11 +30,20 @@ categories.workspace = true
 documentation.workspace = true
 
 [features]
+<<<<<<< HEAD
 bzip = ["dep:bzip2"]
 derive = ["dep:apache-avro-derive"]
 snappy = ["dep:crc32fast", "dep:snap"]
 xz = ["dep:xz2"]
 zstandard = ["dep:zstd"]
+=======
+bzip = ["bzip2"]
+derive = ["apache-avro-derive"]
+snappy = ["crc32fast", "snap"]
+xz = ["xz2"]
+zstandard = ["zstd"]
+bytes = ["serde-byte-array"]
+>>>>>>> 16129448b (AVRO-3531: Code formatting)
 
 [lib]
 # disable benchmarks to allow passing criterion arguments to `cargo bench`

--- a/lang/rust/avro/Cargo.toml
+++ b/lang/rust/avro/Cargo.toml
@@ -69,11 +69,11 @@ snap = { default-features = false, version = "1.1.0", optional = true }
 strum = { default-features = false, version = "0.26.3" }
 strum_macros = { default-features = false, version = "0.26.4" }
 thiserror = { default-features = false, version = "1.0.62" }
+ref_thread_local = { default-features = false, version = "0.1.1" }
 typed-builder = { default-features = false, version = "0.19.1" }
 uuid = { default-features = false, version = "1.10.0", features = ["serde", "std"] }
 xz2 = { default-features = false, version = "0.1.7", optional = true }
 zstd = { default-features = false, version = "0.13.2", optional = true }
-
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 quad-rand = { default-features = false, version = "0.2.1" }

--- a/lang/rust/avro/Cargo.toml
+++ b/lang/rust/avro/Cargo.toml
@@ -35,7 +35,7 @@ derive = ["dep:apache-avro-derive"]
 snappy = ["dep:crc32fast", "dep:snap"]
 xz = ["dep:xz2"]
 zstandard = ["dep:zstd"]
-bytes = ["serde-bytes"]
+#bytes = ["serde_bytes"]
 
 [lib]
 # disable benchmarks to allow passing criterion arguments to `cargo bench`
@@ -65,7 +65,7 @@ log = { workspace = true }
 num-bigint = { default-features = false, version = "0.4.6", features = ["std", "serde"] }
 regex-lite = { default-features = false, version = "0.1.6", features = ["std", "string"] }
 serde = { workspace = true }
-serde_bytes = { default-features = false, version = "0.11", features = ["std"], optional = true }
+serde_bytes = { default-features = false, version = "0.11.14", features = ["std"] }
 serde_json = { workspace = true }
 snap = { default-features = false, version = "1.1.0", optional = true }
 strum = { default-features = false, version = "0.26.3" }

--- a/lang/rust/avro/Cargo.toml
+++ b/lang/rust/avro/Cargo.toml
@@ -64,6 +64,7 @@ log = { workspace = true }
 num-bigint = { default-features = false, version = "0.4.6", features = ["std", "serde"] }
 regex-lite = { default-features = false, version = "0.1.6", features = ["std", "string"] }
 serde = { workspace = true }
+serde_bytes = { default-features = false, version = "0.11" }
 serde_json = { workspace = true }
 snap = { default-features = false, version = "1.1.0", optional = true }
 strum = { default-features = false, version = "0.26.3" }

--- a/lang/rust/avro/Cargo.toml
+++ b/lang/rust/avro/Cargo.toml
@@ -65,7 +65,7 @@ log = { workspace = true }
 num-bigint = { default-features = false, version = "0.4.6", features = ["std", "serde"] }
 regex-lite = { default-features = false, version = "0.1.6", features = ["std", "string"] }
 serde = { workspace = true }
-serde_bytes = { default-features = false, version = "0.11", optional = true }
+serde_bytes = { default-features = false, version = "0.11", features = ["std"], optional = true }
 serde_json = { workspace = true }
 snap = { default-features = false, version = "1.1.0", optional = true }
 strum = { default-features = false, version = "0.26.3" }

--- a/lang/rust/avro/Cargo.toml
+++ b/lang/rust/avro/Cargo.toml
@@ -30,20 +30,12 @@ categories.workspace = true
 documentation.workspace = true
 
 [features]
-<<<<<<< HEAD
 bzip = ["dep:bzip2"]
 derive = ["dep:apache-avro-derive"]
 snappy = ["dep:crc32fast", "dep:snap"]
 xz = ["dep:xz2"]
 zstandard = ["dep:zstd"]
-=======
-bzip = ["bzip2"]
-derive = ["apache-avro-derive"]
-snappy = ["crc32fast", "snap"]
-xz = ["xz2"]
-zstandard = ["zstd"]
-bytes = ["serde-byte-array"]
->>>>>>> 16129448b (AVRO-3531: Code formatting)
+bytes = ["serde-bytes"]
 
 [lib]
 # disable benchmarks to allow passing criterion arguments to `cargo bench`
@@ -73,7 +65,7 @@ log = { workspace = true }
 num-bigint = { default-features = false, version = "0.4.6", features = ["std", "serde"] }
 regex-lite = { default-features = false, version = "0.1.6", features = ["std", "string"] }
 serde = { workspace = true }
-serde_bytes = { default-features = false, version = "0.11" }
+serde_bytes = { default-features = false, version = "0.11", optional = true }
 serde_json = { workspace = true }
 snap = { default-features = false, version = "1.1.0", optional = true }
 strum = { default-features = false, version = "0.26.3" }

--- a/lang/rust/avro/src/de.rs
+++ b/lang/rust/avro/src/de.rs
@@ -669,7 +669,6 @@ mod tests {
     use serial_test::serial;
     use std::sync::atomic::Ordering;
     use serde::Serialize;
-    use serde_bytes::ByteArray;
     use uuid::Uuid;
 
     use apache_avro_test_helper::TestResult;
@@ -1556,7 +1555,8 @@ mod tests {
     fn test_avro_3631_struct_fixed_field() {
         #[derive(Debug, Serialize, Deserialize)]
         struct TestStructFixedField {
-            field: ByteArray<6>,
+            #[serde(with = "serde_bytes")]
+            field: [u8; 6],
         }
 
         let value = Value::Record(vec![(

--- a/lang/rust/avro/src/de.rs
+++ b/lang/rust/avro/src/de.rs
@@ -355,20 +355,7 @@ impl<'a, 'de> de::Deserializer<'de> for &'a Deserializer<'de> {
         V: Visitor<'de>,
     {
         match *self.input {
-            Value::Array(ref values) => {
-                let bytes: Result<Vec<u8>, Self::Error> = values
-                    .iter()
-                    .map(|v| match v {
-                        Value::Int(i) if *i <= (u8::MAX as i32) && *i >= (u8::MIN as i32) => {
-                            Ok(*i as u8)
-                        }
-                        _ => Err(de::Error::custom(format!(
-                            "Byte array can be created only from Value::Int values which could be casted to u8: {v:?}"
-                        ))),
-                    })
-                    .collect();
-                visitor.visit_byte_buf(bytes?)
-            }
+            Value::Array(ref _values) => unimplemented!("Array of bytes"),
             Value::String(ref s) => visitor.visit_bytes(s.as_bytes()),
             Value::Bytes(ref bytes) | Value::Fixed(_, ref bytes) => visitor.visit_bytes(bytes),
             Value::Uuid(ref u) => visitor.visit_bytes(u.as_bytes()),
@@ -385,12 +372,26 @@ impl<'a, 'de> de::Deserializer<'de> for &'a Deserializer<'de> {
         V: Visitor<'de>,
     {
         match *self.input {
+            Value::Array(ref values) => {
+                let bytes: Result<Vec<u8>, Self::Error> = values
+                    .iter()
+                    .map(|v| match v {
+                        Value::Int(i) if *i <= (u8::MAX as i32) && *i >= (u8::MIN as i32) => {
+                            Ok(*i as u8)
+                        }
+                        _ => Err(de::Error::custom(format!(
+                            "Byte array can be created only from Value::Int values which could be casted to u8: {v:?}"
+                        ))),
+                    })
+                    .collect();
+                visitor.visit_byte_buf(bytes?)
+            },
             Value::String(ref s) => visitor.visit_byte_buf(s.clone().into_bytes()),
             Value::Bytes(ref bytes) | Value::Fixed(_, ref bytes) => {
                 visitor.visit_byte_buf(bytes.to_owned())
             }
             _ => Err(de::Error::custom(format!(
-                "Expected a String|Bytes|Fixed, but got {:?}",
+                "Expected a Array|String|Bytes|Fixed, but got {:?}",
                 self.input
             ))),
         }
@@ -684,65 +685,6 @@ pub fn from_value<'de, D: Deserialize<'de>>(value: &'de Value) -> Result<D, Erro
     let de = Deserializer::new(value);
     D::deserialize(&de)
 }
-
-/// A function that could be used by #[serde(deserialize_with = ...)] to give a
-/// hint to Avro's `Deserializer` how to deserialize a value like `Value::Fixed`
-/// to byte array like `[u8; N]`
-// #[allow(dead_code)]
-// pub fn avro_deserialize_bytes<'de, 'a: 'de, D>(deserializer: D) -> Result<&'a [u8], D::Error>
-// where
-//     D: de::Deserializer<'de>,
-// {
-//     struct BytesVisitor<'a> {
-//         marker: PhantomData<&'a [u8]>,
-//     }
-//
-//     impl<'de, 'a> Visitor<'de> for BytesVisitor<'a> {
-//         type Value = &'a [u8];
-//
-//         fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
-//             formatter.write_str("a byte array reference, e.g. &[u8]")
-//         }
-//
-//         fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-//         where
-//             E: de::Error,
-//         {
-//             Ok(v.clone())
-//         }
-//     }
-//
-//     deserializer.deserialize_bytes(BytesVisitor {
-//         marker: PhantomData,
-//     })
-// }
-//
-// #[allow(dead_code)]
-// pub fn avro_deserialize_fixed<'de, D, const N: usize>(deserializer: D) -> Result<[u8; N], D::Error>
-// where
-//     D: de::Deserializer<'de>,
-// {
-//     struct FixedVisitor<const N: usize>;
-//
-//     impl<'de, const N: usize> Visitor<'de> for FixedVisitor<N> {
-//         type Value = [u8; N];
-//
-//         fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
-//             formatter.write_str("a byte array with length, e.g. [u8; N]")
-//         }
-//
-//         fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-//         where
-//             E: de::Error,
-//         {
-//             let mut res = [0_u8; N];
-//             res.clone_from_slice(v);
-//             Ok(res)
-//         }
-//     }
-//
-//     deserializer.deserialize_bytes(FixedVisitor::<N>)
-// }
 
 #[cfg(test)]
 mod tests {
@@ -1637,79 +1579,60 @@ mod tests {
 
     #[test]
     fn avro_3631_deserialize_value_to_struct_with_byte_types() {
-        #[derive(Debug, Serialize, Deserialize)]
+        #[derive(Debug, Deserialize, PartialEq)]
         struct TestStructFixedField {
+            // borrowed byte arrays are not supported
+            // #[serde(with = "serde_bytes")]
+            // slice_field: &'a [u8],
+
+            // will be serialized as Value::Array<Vec<Value::Int>>
+            #[serde(with = "serde_bytes")]
+            vec_field: Vec<u8>,
+
+            // will be serialized as Value::Fixed
             #[serde(with = "serde_bytes")]
             fixed_field: [u8; 6],
-            // #[serde(serialize_with = "avro_serialize_fixed")]
-            // fixed_field2: &'a [u8],
-            // #[serde(serialize_with = "avro_serialize_fixed")]
-            // vec_field2: Vec<u8>,
 
-            // will be serialized as Value::Bytes
-            // #[serde(serialize_with = "avro_serialize_bytes")]
-            // bytes_field: &'a [u8],
-            // #[serde(serialize_with = "avro_serialize_bytes")]
-            // bytes_field2: [u8; 6],
-            // #[serde(serialize_with = "avro_serialize_bytes")]
-            // vec_field3: Vec<u8>,
+            // borrowed byte arrays are not supported
+            // #[serde(with = "serde_byte_array", borrow)]
+            // borrowed_fixed_field: &'a [u8; 16],
         }
 
         let expected = TestStructFixedField {
-            // array_field: &[1, 11, 111],
-            // bytes_field: &[2, 22, 222],
-            // bytes_field2: [2; 6],
+            // slice_field: &[1, 11, 111],
+            vec_field: vec![3, 33],
             fixed_field: [1; 6],
-            // fixed_field2: &[6, 66],
-            // vec_field: vec![3, 33],
-            // vec_field2: vec![4, 44],
-            // vec_field3: vec![5, 55],
+            // borrowed_fixed_field: &[2; 16],
         };
 
         let value = Value::Record(vec![
             // (
-            //     "array_field".to_owned(),
+            //     "slice_field".to_owned(),
             //     Value::Array(
             //         expected
-            //             .array_field
-            //             .iter()
-            //             .map(|i| Value::Int(*i as i32))
-            //             .collect(),
-            //     ),
-            // ),
-            // (
-            //     "vec_field".to_owned(),
-            //     Value::Array(
-            //         expected
-            //             .vec_field
+            //             .slice_field
             //             .iter()
             //             .map(|i| Value::Int(*i as i32))
             //             .collect(),
             //     ),
             // ),
             (
+                "vec_field".to_owned(),
+                Value::Array(
+                    expected
+                        .vec_field
+                        .iter()
+                        .map(|i| Value::Int(*i as i32))
+                        .collect(),
+                ),
+            ),
+            (
                 "fixed_field".to_owned(),
                 Value::Fixed(6, Vec::from(expected.fixed_field)),
             ),
             // (
-            //     "fixed_field2".to_owned(),
-            //     Value::Fixed(2, Vec::from(expected.fixed_field2)),
-            // ),
-            // (
-            //     "vec_field2".to_owned(),
-            //     Value::Fixed(2, expected.vec_field2.clone()),
-            // ),
-            // (
-            //     "bytes_field".to_owned(),
-            //     Value::Bytes(Vec::from(expected.bytes_field)),
-            // ),
-            // (
-            //     "bytes_field2".to_owned(),
-            //     Value::Bytes(Vec::from(expected.bytes_field2)),
-            // ),
-            // (
-            //     "vec_field3".to_owned(),
-            //     Value::Bytes(expected.vec_field3.clone()),
+            //     "borrowed_fixed_field".to_owned(),
+            //     Value::Fixed(16, expected.borrowed_fixed_field.iter().copied().collect()),
             // ),
         ]);
         assert_eq!(expected, from_value(&value).unwrap());

--- a/lang/rust/avro/src/de.rs
+++ b/lang/rust/avro/src/de.rs
@@ -385,7 +385,7 @@ impl<'a, 'de> de::Deserializer<'de> for &'a Deserializer<'de> {
                     })
                     .collect();
                 visitor.visit_byte_buf(bytes?)
-            },
+            }
             Value::String(ref s) => visitor.visit_byte_buf(s.clone().into_bytes()),
             Value::Bytes(ref bytes) | Value::Fixed(_, ref bytes) => {
                 visitor.visit_byte_buf(bytes.to_owned())
@@ -693,7 +693,6 @@ mod tests {
     use serde::{Deserialize, Serialize};
     use serial_test::serial;
     use std::sync::atomic::Ordering;
-    use serde::Serialize;
     use uuid::Uuid;
 
     use apache_avro_test_helper::TestResult;
@@ -1592,7 +1591,6 @@ mod tests {
             // will be serialized as Value::Fixed
             #[serde(with = "serde_bytes")]
             fixed_field: [u8; 6],
-
             // borrowed byte arrays are not supported
             // #[serde(with = "serde_byte_array", borrow)]
             // borrowed_fixed_field: &'a [u8; 16],

--- a/lang/rust/avro/src/de.rs
+++ b/lang/rust/avro/src/de.rs
@@ -21,8 +21,6 @@ use serde::{
     de::{self, DeserializeSeed, Visitor},
     forward_to_deserialize_any, Deserialize,
 };
-use std::fmt::Formatter;
-use std::marker::PhantomData;
 use std::{
     collections::{
         hash_map::{Keys, Values},
@@ -472,7 +470,7 @@ impl<'a, 'de> de::Deserializer<'de> for &'a Deserializer<'de> {
                     let mut arr = [0_u8; 6];
                     arr.clone_from_slice(items);
                     visitor.visit_bytes(&arr)
-                },
+                }
                 Value::Null => visitor.visit_seq(SeqDeserializer::new(&[])),
                 _ => Err(de::Error::custom(format!(
                     "Expected an Array, Fixed or Null, but got: {inner:?}"

--- a/lang/rust/avro/src/de.rs
+++ b/lang/rust/avro/src/de.rs
@@ -1550,4 +1550,18 @@ mod tests {
         assert_eq!(raw_bytes.unwrap().0, expected_bytes);
         Ok(())
     }
+
+    fn test_avro_3631_struct_fixed_field() {
+        #[derive(Debug, Serialize, Deserialize)]
+        struct TestStructFixedField {
+            field: [u8; 6],
+        }
+
+        let value = Value::Record(vec![(
+            "field".to_string(),
+            Value::Fixed(6, vec![0, 0, 0, 0, 0, 0]),
+        )]);
+        let _deserialized: TestStructFixedField = from_value(&value).unwrap();
+
+    }
 }

--- a/lang/rust/avro/src/de.rs
+++ b/lang/rust/avro/src/de.rs
@@ -668,6 +668,8 @@ mod tests {
     use serde::{Deserialize, Serialize};
     use serial_test::serial;
     use std::sync::atomic::Ordering;
+    use serde::Serialize;
+    use serde_bytes::ByteArray;
     use uuid::Uuid;
 
     use apache_avro_test_helper::TestResult;
@@ -1554,7 +1556,7 @@ mod tests {
     fn test_avro_3631_struct_fixed_field() {
         #[derive(Debug, Serialize, Deserialize)]
         struct TestStructFixedField {
-            field: [u8; 6],
+            field: ByteArray<6>,
         }
 
         let value = Value::Record(vec![(
@@ -1562,6 +1564,5 @@ mod tests {
             Value::Fixed(6, vec![0, 0, 0, 0, 0, 0]),
         )]);
         let _deserialized: TestStructFixedField = from_value(&value).unwrap();
-
     }
 }

--- a/lang/rust/avro/src/de.rs
+++ b/lang/rust/avro/src/de.rs
@@ -363,8 +363,7 @@ impl<'a, 'de> de::Deserializer<'de> for &'a Deserializer<'de> {
                             Ok(*i as u8)
                         }
                         _ => Err(de::Error::custom(format!(
-                            "Byte array can be created only from Value::Int values which could be casted to u8: {:?}",
-                            v
+                            "Byte array can be created only from Value::Int values which could be casted to u8: {v:?}"
                         ))),
                     })
                     .collect();

--- a/lang/rust/avro/src/lib.rs
+++ b/lang/rust/avro/src/lib.rs
@@ -871,9 +871,9 @@ pub use reader::{
     SpecificSingleObjectReader,
 };
 pub use schema::{AvroSchema, Schema};
-pub use ser::to_value;
 pub use util::{max_allocation_bytes, set_serde_human_readable};
 pub use uuid::Uuid;
+pub use ser::{avro_serialize_bytes, avro_serialize_fixed, to_value};
 pub use writer::{
     to_avro_datum, to_avro_datum_schemata, GenericSingleObjectWriter, SpecificSingleObjectWriter,
     Writer,

--- a/lang/rust/avro/src/lib.rs
+++ b/lang/rust/avro/src/lib.rs
@@ -871,9 +871,9 @@ pub use reader::{
     SpecificSingleObjectReader,
 };
 pub use schema::{AvroSchema, Schema};
+pub use ser::{avro_serialize_bytes, avro_serialize_fixed, to_value};
 pub use util::{max_allocation_bytes, set_serde_human_readable};
 pub use uuid::Uuid;
-pub use ser::{avro_serialize_bytes, avro_serialize_fixed, to_value};
 pub use writer::{
     to_avro_datum, to_avro_datum_schemata, GenericSingleObjectWriter, SpecificSingleObjectWriter,
     Writer,

--- a/lang/rust/avro/src/ser.rs
+++ b/lang/rust/avro/src/ser.rs
@@ -1151,7 +1151,7 @@ mod tests {
             ),
             (
                 "vec_field2".to_owned(),
-                Value::Fixed(2, Vec::from(test.vec_field2.clone())),
+                Value::Fixed(2, test.vec_field2.clone()),
             ),
             (
                 "bytes_field".to_owned(),
@@ -1163,7 +1163,7 @@ mod tests {
             ),
             (
                 "vec_field3".to_owned(),
-                Value::Bytes(Vec::from(test.vec_field3.clone())),
+                Value::Bytes(test.vec_field3.clone()),
             ),
         ]);
         assert_eq!(expected, to_value(test).unwrap());

--- a/lang/rust/avro/src/ser.rs
+++ b/lang/rust/avro/src/ser.rs
@@ -540,7 +540,6 @@ mod tests {
     use serde::{Deserialize, Serialize};
     use serial_test::serial;
     use std::sync::atomic::Ordering;
-    use serde_bytes::ByteArray;
 
     #[derive(Debug, Deserialize, Serialize, Clone)]
     struct Test {

--- a/lang/rust/avro/src/ser.rs
+++ b/lang/rust/avro/src/ser.rs
@@ -676,6 +676,11 @@ mod tests {
         Val2(f32, f32, f32),
     }
 
+    #[derive(Debug, Serialize, Deserialize)]
+    struct TestStructFixedField {
+        field: [u8; 6],
+    }
+
     #[test]
     fn test_to_value() -> TestResult {
         let test = Test {
@@ -1030,5 +1035,19 @@ mod tests {
         let ser = &mut Serializer {};
 
         assert!(ser.is_human_readable());
+    }
+
+    #[test]
+    fn test_to_value_fixed_field_avro_3631() {
+        let test = TestStructFixedField { field: [1; 6] };
+        let expected = Value::Record(vec![(
+            "field".to_owned(),
+            Value::Fixed(6, Vec::from(test.field.clone())),
+        )]);
+        assert_eq!(
+            to_value(test).unwrap(),
+            expected,
+            "error serializing fixed array"
+        );
     }
 }

--- a/lang/rust/avro/src/ser.rs
+++ b/lang/rust/avro/src/ser.rs
@@ -17,8 +17,7 @@
 
 //! Logic for serde-compatible serialization.
 use crate::{types::Value, Error};
-use ref_thread_local::ref_thread_local;
-use ref_thread_local::RefThreadLocal;
+use ref_thread_local::{ref_thread_local, RefThreadLocal};
 use serde::{ser, Serialize};
 use std::{collections::HashMap, iter::once};
 
@@ -1131,19 +1130,19 @@ mod tests {
             ),
             (
                 "fixed_field".to_owned(),
-                Value::Fixed(6, Vec::from(test.fixed_field.clone())),
+                Value::Fixed(6, Vec::from(test.fixed_field)),
             ),
             (
                 "fixed_field2".to_owned(),
-                Value::Fixed(2, Vec::from(test.fixed_field2.clone())),
+                Value::Fixed(2, Vec::from(test.fixed_field2)),
             ),
             (
                 "bytes_field".to_owned(),
-                Value::Bytes(Vec::from(test.bytes_field.clone())),
+                Value::Bytes(Vec::from(test.bytes_field)),
             ),
             (
                 "bytes_field2".to_owned(),
-                Value::Bytes(Vec::from(test.bytes_field2.clone())),
+                Value::Bytes(Vec::from(test.bytes_field2)),
             ),
             (
                 "vec_field".to_owned(),

--- a/lang/rust/avro/src/ser.rs
+++ b/lang/rust/avro/src/ser.rs
@@ -30,6 +30,7 @@ ref_thread_local! {
 }
 
 /// A hint helping in the serialization of a byte arrays (&[u8], [u8; N])
+#[derive(Debug)]
 enum BytesType {
     Bytes,
     Fixed,
@@ -1087,7 +1088,7 @@ mod tests {
     }
 
     #[test]
-    fn avro_3631_test_to_value_fixed_field() {
+    fn avro_3631_serialize_struct_to_value_with_byte_types() {
         #[derive(Debug, Serialize)]
         struct TestStructFixedField<'a> {
             // will be serialized as Value::Array<Vec<Value::Int>>
@@ -1104,10 +1105,15 @@ mod tests {
 
             // will be serialized as Value::Bytes
             #[serde(serialize_with = "avro_serialize_bytes")]
+            // #[serde(with = "serde_bytes")]
             bytes_field: &'a [u8],
-            #[serde(serialize_with = "avro_serialize_bytes")]
+
+            // #[serde(serialize_with = "avro_serialize_bytes")]
+            #[serde(with = "serde_bytes")]
             bytes_field2: [u8; 6],
+
             #[serde(serialize_with = "avro_serialize_bytes")]
+            // #[serde(with = "serde_bytes")]
             vec_field3: Vec<u8>,
         }
 

--- a/lang/rust/avro/src/ser.rs
+++ b/lang/rust/avro/src/ser.rs
@@ -677,11 +677,6 @@ mod tests {
         Val2(f32, f32, f32),
     }
 
-    #[derive(Debug, Serialize, Deserialize)]
-    struct TestStructFixedField {
-        field: ByteArray<6>,
-    }
-
     #[test]
     fn test_to_value() -> TestResult {
         let test = Test {
@@ -1040,12 +1035,16 @@ mod tests {
 
     #[test]
     fn avro_3631_test_to_value_fixed_field() {
-        let test = TestStructFixedField {
-            field: ByteArray::new([1; 6]),
-        };
+        #[derive(Debug, Serialize, Deserialize)]
+        struct TestStructFixedField {
+            #[serde(with = "serde_bytes")]
+            field: [u8; 6],
+        }
+
+        let test = TestStructFixedField { field: [1; 6] };
         let expected = Value::Record(vec![(
             "field".to_owned(),
-            Value::Fixed(6, Vec::from(test.field.clone().into_array())),
+            Value::Fixed(6, Vec::from(test.field.clone())),
         )]);
         assert_eq!(
             expected,

--- a/lang/rust/avro/src/ser.rs
+++ b/lang/rust/avro/src/ser.rs
@@ -1089,7 +1089,7 @@ mod tests {
 
     #[test]
     fn avro_3631_test_to_value_fixed_field() {
-        #[derive(Debug, Serialize, Deserialize)]
+        #[derive(Debug, Serialize)]
         struct TestStructFixedField<'a> {
             // will be serialized as Value::Array<Vec<Value::Int>>
             array_field: &'a [u8],

--- a/lang/rust/avro/src/ser.rs
+++ b/lang/rust/avro/src/ser.rs
@@ -174,7 +174,7 @@ impl<'b> ser::Serializer for &'b mut Serializer {
     }
 
     fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
-        Ok(Value::Bytes(v.to_owned()))
+        Ok(Value::Fixed(v.len(), v.to_owned()))
     }
 
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
@@ -486,6 +486,7 @@ mod tests {
     use serde::{Deserialize, Serialize};
     use serial_test::serial;
     use std::sync::atomic::Ordering;
+    use serde_bytes::ByteArray;
 
     #[derive(Debug, Deserialize, Serialize, Clone)]
     struct Test {
@@ -678,7 +679,7 @@ mod tests {
 
     #[derive(Debug, Serialize, Deserialize)]
     struct TestStructFixedField {
-        field: [u8; 6],
+        field: ByteArray<6>,
     }
 
     #[test]
@@ -1038,15 +1039,17 @@ mod tests {
     }
 
     #[test]
-    fn test_to_value_fixed_field_avro_3631() {
-        let test = TestStructFixedField { field: [1; 6] };
+    fn avro_3631_test_to_value_fixed_field() {
+        let test = TestStructFixedField {
+            field: ByteArray::new([1; 6]),
+        };
         let expected = Value::Record(vec![(
             "field".to_owned(),
-            Value::Fixed(6, Vec::from(test.field.clone())),
+            Value::Fixed(6, Vec::from(test.field.clone().into_array())),
         )]);
         assert_eq!(
-            to_value(test).unwrap(),
             expected,
+            to_value(test).unwrap(),
             "error serializing fixed array"
         );
     }

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -3128,12 +3128,11 @@ Field with name '"b"' is not a member of the map items"#,
     fn avro_3631_test_serialize_fixed_fields() {
         #[derive(Debug, Serialize, Deserialize)]
         struct TestStructFixedField {
-            field: ByteArray<6>,
+            #[serde(with = "serde_bytes")]
+            field: [u8; 6],
         }
 
-        let test = TestStructFixedField {
-            field: ByteArray::new([1; 6]),
-        };
+        let test = TestStructFixedField { field: [1; 6] };
         let value: Value = to_value(test).unwrap();
         let schema = Schema::parse_str(
             r#"

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -1164,7 +1164,6 @@ mod tests {
     use pretty_assertions::assert_eq;
     use serde::{Deserialize, Serialize};
     use serde_json::json;
-    use serde_bytes::ByteArray;
     use uuid::Uuid;
 
     #[test]

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -613,10 +613,7 @@ impl Value {
                     }
                 })
             }
-            (v, s) => Some(format!(
-                "Unsupported value-schema combination! Value: {:?}, schema: {:?}",
-                v, s
-            )),
+            (_v, _s) => Some("Unsupported value-schema combination".to_string()),
         }
     }
 
@@ -1231,7 +1228,7 @@ mod tests {
                 Value::Int(42),
                 Schema::Boolean,
                 false,
-                "Invalid value: Int(42) for schema: Boolean. Reason: Unsupported value-schema combination! Value: Int(42), schema: Boolean",
+                "Invalid value: Int(42) for schema: Boolean. Reason: Unsupported value-schema combination",
             ),
             (
                 Value::Union(0, Box::new(Value::Null)),
@@ -1249,7 +1246,7 @@ mod tests {
                 Value::Union(0, Box::new(Value::Null)),
                 Schema::Union(UnionSchema::new(vec![Schema::Double, Schema::Int])?),
                 false,
-                "Invalid value: Union(0, Null) for schema: Union(UnionSchema { schemas: [Double, Int], variant_index: {Int: 1, Double: 0} }). Reason: Unsupported value-schema combination! Value: Null, schema: Double",
+                "Invalid value: Union(0, Null) for schema: Union(UnionSchema { schemas: [Double, Int], variant_index: {Int: 1, Double: 0} }). Reason: Unsupported value-schema combination",
             ),
             (
                 Value::Union(3, Box::new(Value::Int(42))),
@@ -1289,9 +1286,9 @@ mod tests {
                 Value::Array(vec![Value::Boolean(true)]),
                 Schema::array(Schema::Long),
                 false,
-                "Invalid value: Array([Boolean(true)]) for schema: Array(ArraySchema { items: Long, attributes: {} }). Reason: Unsupported value-schema combination! Value: Boolean(true), schema: Long",
+                "Invalid value: Array([Boolean(true)]) for schema: Array(ArraySchema { items: Long, attributes: {} }). Reason: Unsupported value-schema combination",
             ),
-            (Value::Record(vec![]), Schema::Null, false, "Invalid value: Record([]) for schema: Null. Reason: Unsupported value-schema combination! Value: Record([]), schema: Null"),
+            (Value::Record(vec![]), Schema::Null, false, "Invalid value: Record([]) for schema: Null. Reason: Unsupported value-schema combination"),
             (
                 Value::Fixed(12, vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
                 Schema::Duration,
@@ -1377,7 +1374,6 @@ mod tests {
             name: Name::new("some_fixed").unwrap(),
             aliases: None,
             doc: None,
-            default: None,
             attributes: Default::default(),
         });
 
@@ -1561,7 +1557,7 @@ mod tests {
         ]);
         assert!(!value.validate(&schema));
         assert_logged(
-            r#"Invalid value: Record([("a", Boolean(false)), ("b", String("foo"))]) for schema: Record(RecordSchema { name: Name { name: "some_record", namespace: None }, aliases: None, doc: None, fields: [RecordField { name: "a", doc: None, aliases: None, default: None, schema: Long, order: Ascending, position: 0, custom_attributes: {} }, RecordField { name: "b", doc: None, aliases: None, default: None, schema: String, order: Ascending, position: 1, custom_attributes: {} }, RecordField { name: "c", doc: None, aliases: None, default: Some(Null), schema: Union(UnionSchema { schemas: [Null, Int], variant_index: {Null: 0, Int: 1} }), order: Ascending, position: 2, custom_attributes: {} }], lookup: {"a": 0, "b": 1, "c": 2}, attributes: {} }). Reason: Unsupported value-schema combination! Value: Boolean(false), schema: Long"#,
+            r#"Invalid value: Record([("a", Boolean(false)), ("b", String("foo"))]) for schema: Record(RecordSchema { name: Name { name: "some_record", namespace: None }, aliases: None, doc: None, fields: [RecordField { name: "a", doc: None, aliases: None, default: None, schema: Long, order: Ascending, position: 0, custom_attributes: {} }, RecordField { name: "b", doc: None, aliases: None, default: None, schema: String, order: Ascending, position: 1, custom_attributes: {} }, RecordField { name: "c", doc: None, aliases: None, default: Some(Null), schema: Union(UnionSchema { schemas: [Null, Int], variant_index: {Null: 0, Int: 1} }), order: Ascending, position: 2, custom_attributes: {} }], lookup: {"a": 0, "b": 1, "c": 2}, attributes: {} }). Reason: Unsupported value-schema combination"#,
         );
 
         let value = Value::Record(vec![
@@ -1733,7 +1729,6 @@ Field with name '"b"' is not a member of the map items"#,
                     aliases: None,
                     size: 20,
                     doc: None,
-                    default: None,
                     attributes: Default::default(),
                 }))
             }))
@@ -3046,7 +3041,6 @@ Field with name '"b"' is not a member of the map items"#,
                 aliases: None,
                 doc: None,
                 size: 3,
-                default: None,
                 attributes: Default::default()
             }))?,
             Value::Fixed(3, vec![97, 98, 99])
@@ -3059,7 +3053,6 @@ Field with name '"b"' is not a member of the map items"#,
                 aliases: None,
                 doc: None,
                 size: 3,
-                default: None,
                 attributes: Default::default()
             }))
             .is_err(),);
@@ -3071,7 +3064,6 @@ Field with name '"b"' is not a member of the map items"#,
                 aliases: None,
                 doc: None,
                 size: 3,
-                default: None,
                 attributes: Default::default()
             }))
             .is_err(),);

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -3118,6 +3118,8 @@ Field with name '"b"' is not a member of the map items"#,
 
     #[test]
     fn avro_3631_test_serialize_fixed_fields() {
+        use crate::{avro_serialize_bytes, avro_serialize_fixed};
+
         #[derive(Debug, Serialize, Deserialize)]
         struct TestStructFixedField {
             #[serde(with = "serde_bytes")]

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -1373,6 +1373,7 @@ mod tests {
             name: Name::new("some_fixed").unwrap(),
             aliases: None,
             doc: None,
+            default: None,
             attributes: Default::default(),
         });
 
@@ -1728,6 +1729,7 @@ Field with name '"b"' is not a member of the map items"#,
                     aliases: None,
                     size: 20,
                     doc: None,
+                    default: None,
                     attributes: Default::default(),
                 }))
             }))
@@ -3039,6 +3041,7 @@ Field with name '"b"' is not a member of the map items"#,
                 name: "test".into(),
                 aliases: None,
                 doc: None,
+                default: None,
                 size: 3,
                 attributes: Default::default()
             }))?,
@@ -3051,6 +3054,7 @@ Field with name '"b"' is not a member of the map items"#,
                 name: "test".into(),
                 aliases: None,
                 doc: None,
+                default: None,
                 size: 3,
                 attributes: Default::default()
             }))
@@ -3062,6 +3066,7 @@ Field with name '"b"' is not a member of the map items"#,
                 name: "test".into(),
                 aliases: None,
                 doc: None,
+                default: None,
                 size: 3,
                 attributes: Default::default()
             }))
@@ -3117,8 +3122,6 @@ Field with name '"b"' is not a member of the map items"#,
 
     #[test]
     fn avro_3631_test_serialize_fixed_fields() {
-        use crate::{avro_serialize_bytes, avro_serialize_fixed};
-
         #[derive(Debug, Serialize, Deserialize)]
         struct TestStructFixedField {
             #[serde(with = "serde_bytes")]

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -1167,6 +1167,7 @@ mod tests {
     use pretty_assertions::assert_eq;
     use serde::{Deserialize, Serialize};
     use serde_json::json;
+    use serde_bytes::ByteArray;
     use uuid::Uuid;
 
     #[test]
@@ -3123,14 +3124,16 @@ Field with name '"b"' is not a member of the map items"#,
         );
     }
 
-    #[derive(Debug, Serialize, Deserialize)]
-    struct TestStructFixedField {
-        field: [u8; 6],
-    }
-
     #[test]
-    fn test_avro_3631_serialize_fixed_fields() {
-        let test = TestStructFixedField { field: [1; 6] };
+    fn avro_3631_test_serialize_fixed_fields() {
+        #[derive(Debug, Serialize, Deserialize)]
+        struct TestStructFixedField {
+            field: ByteArray<6>,
+        }
+
+        let test = TestStructFixedField {
+            field: ByteArray::new([1; 6]),
+        };
         let value: Value = to_value(test).unwrap();
         let schema = Schema::parse_str(
             r#"

--- a/lang/rust/avro/src/writer.rs
+++ b/lang/rust/avro/src/writer.rs
@@ -1414,7 +1414,7 @@ mod tests {
             Err(e) => {
                 assert_eq!(
                     e.to_string(),
-                    r#"Value Record([("name", String("RustConf")), ("time", Union(1, Double(12345678.9)))]) does not match schema Record(RecordSchema { name: Name { name: "Conference", namespace: None }, aliases: None, doc: None, fields: [RecordField { name: "name", doc: None, aliases: None, default: None, schema: String, order: Ascending, position: 0, custom_attributes: {} }, RecordField { name: "date", doc: None, aliases: Some(["time2", "time"]), default: None, schema: Union(UnionSchema { schemas: [Null, Long], variant_index: {Null: 0, Long: 1} }), order: Ascending, position: 1, custom_attributes: {} }], lookup: {"date": 1, "name": 0, "time": 1, "time2": 1}, attributes: {} }): Reason: Unsupported value-schema combination! Value: Double(12345678.9), schema: Long"#
+                    r#"Value Record([("name", String("RustConf")), ("time", Union(1, Double(12345678.9)))]) does not match schema Record(RecordSchema { name: Name { name: "Conference", namespace: None }, aliases: None, doc: None, fields: [RecordField { name: "name", doc: None, aliases: None, default: None, schema: String, order: Ascending, position: 0, custom_attributes: {} }, RecordField { name: "date", doc: None, aliases: Some(["time2", "time"]), default: None, schema: Union(UnionSchema { schemas: [Null, Long], variant_index: {Null: 0, Long: 1} }), order: Ascending, position: 1, custom_attributes: {} }], lookup: {"date": 1, "name": 0, "time": 1, "time2": 1}, attributes: {} }): Reason: Unsupported value-schema combination"#
                 );
             }
         }

--- a/lang/rust/avro/tests/ser.rs
+++ b/lang/rust/avro/tests/ser.rs
@@ -1,5 +1,21 @@
-use apache_avro::to_value;
-use apache_avro::types::Value;
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use apache_avro::{to_value, types::Value};
 use serde::{Deserialize, Serialize};
 
 #[test]
@@ -25,11 +41,11 @@ fn avro_3631_visibility_of_avro_serialize_bytes_type() {
     let expected = Value::Record(vec![
         (
             "bytes_field".to_owned(),
-            Value::Bytes(Vec::from(test.bytes_field.clone())),
+            Value::Bytes(Vec::from(test.bytes_field)),
         ),
         (
             "fixed_field".to_owned(),
-            Value::Fixed(6, Vec::from(test.fixed_field.clone())),
+            Value::Fixed(6, Vec::from(test.fixed_field)),
         ),
     ]);
 

--- a/lang/rust/avro/tests/ser.rs
+++ b/lang/rust/avro/tests/ser.rs
@@ -1,0 +1,37 @@
+use apache_avro::to_value;
+use apache_avro::types::Value;
+use serde::{Deserialize, Serialize};
+
+#[test]
+fn avro_3631_visibility_of_avro_serialize_bytes_type() {
+    use apache_avro::{avro_serialize_bytes, avro_serialize_fixed};
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct TestStructFixedField<'a> {
+        // will be serialized as Value::Bytes
+        #[serde(serialize_with = "avro_serialize_bytes")]
+        bytes_field: &'a [u8],
+
+        // will be serialized as Value::Fixed
+        #[serde(serialize_with = "avro_serialize_fixed")]
+        fixed_field: [u8; 6],
+    }
+
+    let test = TestStructFixedField {
+        bytes_field: &[2, 22, 222],
+        fixed_field: [1; 6],
+    };
+
+    let expected = Value::Record(vec![
+        (
+            "bytes_field".to_owned(),
+            Value::Bytes(Vec::from(test.bytes_field.clone())),
+        ),
+        (
+            "fixed_field".to_owned(),
+            Value::Fixed(6, Vec::from(test.fixed_field.clone())),
+        ),
+    ]);
+
+    assert_eq!(expected, to_value(test).unwrap());
+}


### PR DESCRIPTION
## What is the purpose of the change

To make it possible to serialize Rust structs to Avro values (`types::Value`).

## Verifying this change

This change added tests and can be verified as follows:

* new unit and integration tests have been added

## Documentation

- Does this pull request introduce a new feature? yes
- If yes, how is the feature documented? Rustdoc
