### PR TITLE
AVRO-3633: [Rust] Additional attributes for 'avro_derive' crate

### DIFF
--- a/lang/rust/Cargo.lock
+++ b/lang/rust/Cargo.lock
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "apache-avro-derive"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "apache-avro",
  "darling",
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "apache-avro-test-helper"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "color-backtrace",
  "ctor",

--- a/lang/rust/avro/Cargo.toml
+++ b/lang/rust/avro/Cargo.toml
@@ -53,7 +53,7 @@ harness = false
 name = "single"
 
 [dependencies]
-apache-avro-derive = { default-features = false, version = "0.14.0", path = "../avro_derive", optional = true }
+apache-avro-derive = { default-features = false, version = "0.15.0", path = "../avro_derive", optional = true }
 byteorder = { default-features = false, version = "1.4.3" }
 bzip2 = { default-features = false, version = "0.4.3", optional = true }
 crc32fast = { default-features = false, version = "1.3.2", optional = true }
@@ -83,7 +83,7 @@ rand = { default-features = false, version = "0.8.5", features = ["default"] }
 
 [dev-dependencies]
 anyhow = { default-features = false, version = "1.0.65", features = ["std"] }
-apache-avro-test-helper = { default-features = false, version = "0.14.0", path = "../avro_test_helper" }
+apache-avro-test-helper = { default-features = false, version = "0.15.0", path = "../avro_test_helper" }
 criterion = { default-features = false, version = "0.3.6" }
 hex-literal = { default-features = false, version = "0.3.4" }
 md-5 = { default-features = false, version = "0.10.5" }

--- a/lang/rust/avro_derive/Cargo.toml
+++ b/lang/rust/avro_derive/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "apache-avro-derive"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Apache Avro team <dev@avro.apache.org>"]
 description = "A library for deriving Avro schemata from Rust structs and enums"
 license = "Apache-2.0"

--- a/lang/rust/avro_derive/src/lib.rs
+++ b/lang/rust/avro_derive/src/lib.rs
@@ -127,12 +127,10 @@ fn get_data_struct_schema_def(
                 let field_attrs =
                     FieldOptions::from_attributes(&field.attrs[..]).map_err(darling_to_syn)?;
                 let doc = preserve_optional(field_attrs.doc);
-                let rename = field_attrs.rename;
-                if rename.is_some() {
-                    name = rename.unwrap();
+                if let Some(rename) = field_attrs.rename {
+                    name = rename
                 }
-                let skip = field_attrs.skip;
-                if skip.is_some() && skip.unwrap() {
+                if let Some(true) = field_attrs.skip {
                     continue;
                 }
                 let default_value = match field_attrs.default {

--- a/lang/rust/avro_derive/src/lib.rs
+++ b/lang/rust/avro_derive/src/lib.rs
@@ -33,6 +33,8 @@ struct FieldOptions {
     #[darling(default)]
     default: Option<String>,
     #[darling(default)]
+    rename: Option<String>,
+    #[darling(default)]
     skip: Option<bool>,
 }
 
@@ -121,10 +123,14 @@ fn get_data_struct_schema_def(
         syn::Fields::Named(ref a) => {
             let mut index: usize = 0;
             for field in a.named.iter() {
-                let name = field.ident.as_ref().unwrap().to_string(); // we know everything has a name
+                let mut name = field.ident.as_ref().unwrap().to_string(); // we know everything has a name
                 let field_attrs =
                     FieldOptions::from_attributes(&field.attrs[..]).map_err(darling_to_syn)?;
                 let doc = preserve_optional(field_attrs.doc);
+                let rename = field_attrs.rename;
+                if rename.is_some() {
+                    name = rename.unwrap();
+                }
                 let skip = field_attrs.skip;
                 if skip.is_some() && skip.unwrap() {
                     continue;

--- a/lang/rust/avro_derive/tests/derive.rs
+++ b/lang/rust/avro_derive/tests/derive.rs
@@ -1444,4 +1444,62 @@ mod test_derive {
             b: 321,
         });
     }
+
+    #[test]
+    fn test_basic_struct_with_rename_attribute() {
+        #[derive(Debug, Serialize, Deserialize, AvroSchema, Clone, PartialEq)]
+        struct TestBasicStructWithRenameAttribute {
+            #[avro(rename = "a1")]
+            #[serde(rename = "a1")]
+            a: bool,
+            b: i32,
+            #[avro(rename = "c1")]
+            #[serde(rename = "c1")]
+            c: f32,
+        }
+
+        let schema = r#"
+        {
+            "type":"record",
+            "name":"TestBasicStructWithRenameAttribute",
+            "fields": [
+                {
+                    "name":"a1",
+                    "type":"boolean"
+                },
+                {
+                    "name":"b",
+                    "type":"int"
+                },
+                {
+                    "name":"c1",
+                    "type":"float"
+                }
+            ]
+        }
+        "#;
+
+        let schema = Schema::parse_str(schema).unwrap();
+        if let Schema::Record { name, fields, .. } =
+            TestBasicStructWithRenameAttribute::get_schema()
+        {
+            assert_eq!("TestBasicStructWithRenameAttribute", name.fullname(None));
+            for field in fields {
+                match field.name.as_str() {
+                    "a" => panic!("Unexpected field name 'a': must be 'a1'"),
+                    "c" => panic!("Unexpected field name 'c': must be 'c1'"),
+                    _ => {}
+                }
+            }
+        } else {
+            panic!("TestBasicStructWithRenameAttribute schema must be a record schema")
+        }
+        assert_eq!(schema, TestBasicStructWithRenameAttribute::get_schema());
+
+        serde_assert(TestBasicStructWithRenameAttribute {
+            a: true,
+            b: 321,
+            c: 987.654,
+        });
+    }
 }

--- a/lang/rust/avro_derive/tests/derive.rs
+++ b/lang/rust/avro_derive/tests/derive.rs
@@ -1364,7 +1364,7 @@ mod test_derive {
     }
 
     #[test]
-    fn test_basic_struct_with_skip_attribute() {
+    fn avro_3633_test_basic_struct_with_skip_attribute() {
         // Note: If using the skip attribute together with serialization,
         // the serde's skip attribute needs also to be added
 
@@ -1415,8 +1415,8 @@ mod test_derive {
         "#;
 
         let schema = Schema::parse_str(schema).unwrap();
-        if let Schema::Record { name, fields, .. } = TestBasicStructWithSkipAttribute::get_schema()
-        {
+        let derived_schema = TestBasicStructWithSkipAttribute::get_schema();
+        if let Schema::Record { name, fields, .. } = &derived_schema {
             assert_eq!("TestBasicStructWithSkipAttribute", name.fullname(None));
             for field in fields {
                 match field.name.as_str() {
@@ -1427,11 +1427,14 @@ mod test_derive {
                 }
             }
         } else {
-            panic!("TestBasicStructWithSkipAttribute schema must be a record schema")
+            panic!(
+                "TestBasicStructWithSkipAttribute schema must be a record schema: {:?}",
+                derived_schema
+            )
         }
-        assert_eq!(schema, TestBasicStructWithSkipAttribute::get_schema());
+        assert_eq!(schema, derived_schema);
 
-        // Note: If serde its skip attribute is used on a field, the field its type
+        // Note: If serde's `skip` attribute is used on a field, the field's type
         // needs the trait 'Default' to be implemented, since it is skipping the serialization process.
         // Copied or cloned objects within 'serde_assert()' doesn't "copy" (serialize/deserialze)
         // these fields, so no values are initialized here for skipped fields.
@@ -1446,7 +1449,7 @@ mod test_derive {
     }
 
     #[test]
-    fn test_basic_struct_with_rename_attribute() {
+    fn avro_3633_test_basic_struct_with_rename_attribute() {
         #[derive(Debug, Serialize, Deserialize, AvroSchema, Clone, PartialEq)]
         struct TestBasicStructWithRenameAttribute {
             #[avro(rename = "a1")]
@@ -1480,9 +1483,8 @@ mod test_derive {
         "#;
 
         let schema = Schema::parse_str(schema).unwrap();
-        if let Schema::Record { name, fields, .. } =
-            TestBasicStructWithRenameAttribute::get_schema()
-        {
+        let derived_schema = TestBasicStructWithRenameAttribute::get_schema();
+        if let Schema::Record { name, fields, .. } = &derived_schema {
             assert_eq!("TestBasicStructWithRenameAttribute", name.fullname(None));
             for field in fields {
                 match field.name.as_str() {
@@ -1492,9 +1494,12 @@ mod test_derive {
                 }
             }
         } else {
-            panic!("TestBasicStructWithRenameAttribute schema must be a record schema")
+            panic!(
+                "TestBasicStructWithRenameAttribute schema must be a record schema: {:?}",
+                derived_schema
+            )
         }
-        assert_eq!(schema, TestBasicStructWithRenameAttribute::get_schema());
+        assert_eq!(schema, derived_schema);
 
         serde_assert(TestBasicStructWithRenameAttribute {
             a: true,

--- a/lang/rust/avro_test_helper/Cargo.toml
+++ b/lang/rust/avro_test_helper/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "apache-avro-test-helper"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2018"
 description = "Apache Avro tests helper."
 authors = ["Apache Avro team <dev@avro.apache.org>"]


### PR DESCRIPTION
## What is the purpose of the change

[AVRO-3633](https://issues.apache.org/jira/browse/AVRO-3633) *This pull request introduces additional macro attributes 'skip' and 'rename' to the 'avro_derive' crate.*


## Verifying this change

This change added tests and can be verified as follows:

- *Added test that validates correct behavior for skipping or renaming fields with derive macro 'AvroSchema'.*


## Documentation

- Does this pull request introduce a new feature? yes
- If yes, how is the feature documented? not documented
