### PR TITLE
AVRO-3634: Implement AvroSchemaComponent for bool

### DIFF
--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -1860,6 +1860,7 @@ pub mod derive {
         );
     );
 
+    impl_schema!(bool, Schema::Boolean);
     impl_schema!(i8, Schema::Int);
     impl_schema!(i16, Schema::Int);
     impl_schema!(i32, Schema::Int);

--- a/lang/rust/avro_derive/src/lib.rs
+++ b/lang/rust/avro_derive/src/lib.rs
@@ -92,7 +92,6 @@ fn derive_avro_schema(input: &mut DeriveInput) -> Result<TokenStream, Vec<syn::E
             )])
         }
     };
-
     let ident = &input.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
     Ok(quote! {
@@ -237,7 +236,7 @@ fn type_to_schema_expr(ty: &Type) -> Result<TokenStream, Vec<syn::Error>> {
         let schema = match &type_string[..] {
             "bool" => quote! {apache_avro::schema::Schema::Boolean},
             "i8" | "i16" | "i32" | "u8" | "u16" => quote! {apache_avro::schema::Schema::Int},
-            "i64" => quote! {apache_avro::schema::Schema::Long},
+            "u32" | "i64" => quote! {apache_avro::schema::Schema::Long},
             "f32" => quote! {apache_avro::schema::Schema::Float},
             "f64" => quote! {apache_avro::schema::Schema::Double},
             "String" | "str" => quote! {apache_avro::schema::Schema::String},

--- a/lang/rust/avro_derive/tests/derive.rs
+++ b/lang/rust/avro_derive/tests/derive.rs
@@ -1043,11 +1043,12 @@ mod test_derive {
     #[derive(Debug, Serialize, Deserialize, AvroSchema, Clone, PartialEq)]
     struct TestBasicWithBool {
         a: bool,
+        b: Option<bool>,
     }
 
     proptest! {
     #[test]
-    fn test_basic_with_bool(a in any::<bool>()) {
+    fn avro_3634_test_basic_with_bool(a in any::<bool>(), b in any::<Option<bool>>()) {
         let schema = r#"
         {
             "type":"record",
@@ -1056,6 +1057,10 @@ mod test_derive {
                 {
                     "name":"a",
                     "type":"boolean"
+                },
+                {
+                    "name":"b",
+                    "type":["null","boolean"]
                 }
             ]
         }
@@ -1070,7 +1075,7 @@ mod test_derive {
         }
         assert_eq!(schema, TestBasicWithBool::get_schema());
 
-        serde_assert(TestBasicWithBool { a });
+        serde_assert(TestBasicWithBool { a, b });
     }}
 
     #[derive(Debug, Serialize, Deserialize, AvroSchema, Clone, PartialEq)]

--- a/lang/rust/avro_derive/tests/derive.rs
+++ b/lang/rust/avro_derive/tests/derive.rs
@@ -1041,6 +1041,39 @@ mod test_derive {
     }
 
     #[derive(Debug, Serialize, Deserialize, AvroSchema, Clone, PartialEq)]
+    struct TestBasicWithBool {
+        a: bool,
+    }
+
+    proptest! {
+    #[test]
+    fn test_basic_with_bool(a in any::<bool>()) {
+        let schema = r#"
+        {
+            "type":"record",
+            "name":"TestBasicWithBool",
+            "fields":[
+                {
+                    "name":"a",
+                    "type":"boolean"
+                }
+            ]
+        }
+        "#;
+        let schema = Schema::parse_str(schema).unwrap();
+        let derived_schema = TestBasicWithBool::get_schema();
+
+        if let Schema::Record { name, .. } = derived_schema {
+            assert_eq!("TestBasicWithBool", name.fullname(None))
+        } else {
+            panic!("TestBasicWithBool schema must be a record schema")
+        }
+        assert_eq!(schema, TestBasicWithBool::get_schema());
+
+        serde_assert(TestBasicWithBool { a });
+    }}
+
+    #[derive(Debug, Serialize, Deserialize, AvroSchema, Clone, PartialEq)]
     struct TestBasicWithU32 {
         a: u32,
     }


### PR DESCRIPTION
## What is the purpose of the change

* AVRO-3634: Add a test case for deriving an Avro schema for a struct with `bool`ean field

## Verifying this change

Run the unit tests

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable
