### PR TITLE
AVRO-3638: [Java] Support custom mapping of AVRO namespace to Java pa…

### DIFF
--- a/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/enum.vm
+++ b/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/enum.vm
@@ -16,8 +16,9 @@
 ## limitations under the License.
 ##
 #if ($schema.getNamespace())
-package $this.mangle($schema.getNamespace());
+package $this.mapNamespace($schema.getNamespace());
 #end
+
 #if ($schema.getDoc())
 /** $schema.getDoc() */
 #end

--- a/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/fixed.vm
+++ b/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/fixed.vm
@@ -16,8 +16,9 @@
 ## limitations under the License.
 ##
 #if ($schema.getNamespace())
-package $this.mangle($schema.getNamespace());
+package $this.mapNamespace($schema.getNamespace());
 #end
+
 #if ($schema.getDoc())
 /** $schema.getDoc() */
 #end

--- a/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/protocol.vm
+++ b/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/protocol.vm
@@ -16,7 +16,7 @@
 ## limitations under the License.
 ##
 #if ($protocol.getNamespace())
-package $this.mangle($protocol.getNamespace());
+package $this.mapNamespace($protocol.getNamespace());
 #end
 
 #if ($protocol.getDoc())
@@ -66,7 +66,7 @@ ${this.mangle($error.getFullName())}##
 #end
   @org.apache.avro.specific.AvroGenerated
   public interface Callback extends $this.mangleTypeIdentifier($protocol.getName()) {
-    public static final org.apache.avro.Protocol PROTOCOL = #if ($this.mangle($protocol.getNamespace()))$this.mangle($protocol.getNamespace()).#end${this.mangleTypeIdentifier($protocol.getName())}.PROTOCOL;
+    public static final org.apache.avro.Protocol PROTOCOL = #if ($this.mapNamespace($protocol.getNamespace()))$this.mapNamespace($protocol.getNamespace()).#end${this.mangleTypeIdentifier($protocol.getName())}.PROTOCOL;
 #foreach ($e in $protocol.getMessages().entrySet())
 #set ($name = $e.getKey())
 #set ($message = $e.getValue())

--- a/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/record.vm
+++ b/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/record.vm
@@ -16,7 +16,7 @@
 ## limitations under the License.
 ##
 #if ($schema.getNamespace())
-package $this.mangle($schema.getNamespace());
+package $this.mapNamespace($schema.getNamespace());
 #end
 
 import org.apache.avro.generic.GenericArray;
@@ -277,8 +277,8 @@ public class ${this.mangleTypeIdentifier($schema.getName())}#if ($schema.isError
    * Creates a new ${this.mangleTypeIdentifier($schema.getName())} RecordBuilder.
    * @return A new ${this.mangleTypeIdentifier($schema.getName())} RecordBuilder
    */
-  public static #if ($schema.getNamespace())$this.mangle($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())}.Builder newBuilder() {
-    return new #if ($schema.getNamespace())$this.mangle($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())}.Builder();
+  public static #if ($schema.getNamespace())$this.mapNamespace($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())}.Builder newBuilder() {
+    return new #if ($schema.getNamespace())$this.mapNamespace($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())}.Builder();
   }
 
   /**
@@ -286,11 +286,11 @@ public class ${this.mangleTypeIdentifier($schema.getName())}#if ($schema.isError
    * @param other The existing builder to copy.
    * @return A new ${this.mangleTypeIdentifier($schema.getName())} RecordBuilder
    */
-  public static #if ($schema.getNamespace())$this.mangle($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())}.Builder newBuilder(#if ($schema.getNamespace())$this.mangle($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())}.Builder other) {
+  public static #if ($schema.getNamespace())$this.mapNamespace($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())}.Builder newBuilder(#if ($schema.getNamespace())$this.mapNamespace($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())}.Builder other) {
     if (other == null) {
-      return new #if ($schema.getNamespace())$this.mangle($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())}.Builder();
+      return new #if ($schema.getNamespace())$this.mapNamespace($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())}.Builder();
     } else {
-      return new #if ($schema.getNamespace())$this.mangle($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())}.Builder(other);
+      return new #if ($schema.getNamespace())$this.mapNamespace($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())}.Builder(other);
     }
   }
 
@@ -299,11 +299,11 @@ public class ${this.mangleTypeIdentifier($schema.getName())}#if ($schema.isError
    * @param other The existing instance to copy.
    * @return A new ${this.mangleTypeIdentifier($schema.getName())} RecordBuilder
    */
-  public static #if ($schema.getNamespace())$this.mangle($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())}.Builder newBuilder(#if ($schema.getNamespace())$this.mangle($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())} other) {
+  public static #if ($schema.getNamespace())$this.mapNamespace($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())}.Builder newBuilder(#if ($schema.getNamespace())$this.mapNamespace($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())} other) {
     if (other == null) {
-      return new #if ($schema.getNamespace())$this.mangle($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())}.Builder();
+      return new #if ($schema.getNamespace())$this.mapNamespace($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())}.Builder();
     } else {
-      return new #if ($schema.getNamespace())$this.mangle($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())}.Builder(other);
+      return new #if ($schema.getNamespace())$this.mapNamespace($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())}.Builder(other);
     }
   }
 
@@ -334,7 +334,7 @@ public class ${this.mangleTypeIdentifier($schema.getName())}#if ($schema.isError
      * Creates a Builder by copying an existing Builder.
      * @param other The existing Builder to copy.
      */
-    private Builder(#if ($schema.getNamespace())$this.mangle($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())}.Builder other) {
+    private Builder(#if ($schema.getNamespace())$this.mapNamespace($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())}.Builder other) {
       super(other);
 #foreach ($field in $schema.getFields())
       if (isValidValue(fields()[$field.pos()], other.${this.mangle($field.name(), $schema.isError())})) {
@@ -353,7 +353,7 @@ public class ${this.mangleTypeIdentifier($schema.getName())}#if ($schema.isError
      * Creates a Builder by copying an existing $this.mangleTypeIdentifier($schema.getName()) instance
      * @param other The existing instance to copy.
      */
-    private Builder(#if ($schema.getNamespace())$this.mangle($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())} other) {
+    private Builder(#if ($schema.getNamespace())$this.mapNamespace($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())} other) {
 #if ($schema.isError())      super(other)#else
       super(SCHEMA$, MODEL$)#end;
 #foreach ($field in $schema.getFields())
@@ -369,25 +369,25 @@ public class ${this.mangleTypeIdentifier($schema.getName())}#if ($schema.isError
 #if ($schema.isError())
 
     @Override
-    public #if ($schema.getNamespace())$this.mangle($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())}.Builder setValue(Object value) {
+    public #if ($schema.getNamespace())$this.mapNamespace($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())}.Builder setValue(Object value) {
       super.setValue(value);
       return this;
     }
 
     @Override
-    public #if ($schema.getNamespace())$this.mangle($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())}.Builder clearValue() {
+    public #if ($schema.getNamespace())$this.mapNamespace($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())}.Builder clearValue() {
       super.clearValue();
       return this;
     }
 
     @Override
-    public #if ($schema.getNamespace())$this.mangle($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())}.Builder setCause(Throwable cause) {
+    public #if ($schema.getNamespace())$this.mapNamespace($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())}.Builder setCause(Throwable cause) {
       super.setCause(cause);
       return this;
     }
 
     @Override
-    public #if ($schema.getNamespace())$this.mangle($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())}.Builder clearCause() {
+    public #if ($schema.getNamespace())$this.mapNamespace($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())}.Builder clearCause() {
       super.clearCause();
       return this;
     }
@@ -423,7 +423,7 @@ public class ${this.mangleTypeIdentifier($schema.getName())}#if ($schema.isError
       * @param value The value of '${this.mangle($field.name(), $schema.isError())}'.
       * @return This builder.
       */
-    public #if ($schema.getNamespace())$this.mangle($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())}.Builder ${this.generateSetMethod($schema, $field)}(${this.javaUnbox($field.schema(), false)} value) {
+    public #if ($schema.getNamespace())$this.mapNamespace($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())}.Builder ${this.generateSetMethod($schema, $field)}(${this.javaUnbox($field.schema(), false)} value) {
       validate(fields()[$field.pos()], value);
 #if (${this.hasBuilder($field.schema())})
       this.${this.mangle($field.name(), $schema.isError())}Builder = null;
@@ -469,7 +469,7 @@ public class ${this.mangleTypeIdentifier($schema.getName())}#if ($schema.isError
      * @return This builder.
      */
 
-    public #if ($schema.getNamespace())$this.mangle($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())}.Builder ${this.generateSetBuilderMethod($schema, $field)}(${this.javaUnbox($field.schema(), false)}.Builder value) {
+    public #if ($schema.getNamespace())$this.mapNamespace($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())}.Builder ${this.generateSetBuilderMethod($schema, $field)}(${this.javaUnbox($field.schema(), false)}.Builder value) {
       ${this.generateClearMethod($schema, $field)}();
       ${this.mangle($field.name(), $schema.isError())}Builder = value;
       return this;
@@ -492,7 +492,7 @@ public class ${this.mangleTypeIdentifier($schema.getName())}#if ($schema.isError
 #end
       * @return This builder.
       */
-    public #if ($schema.getNamespace())$this.mangle($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())}.Builder ${this.generateClearMethod($schema, $field)}() {
+    public #if ($schema.getNamespace())$this.mapNamespace($schema.getNamespace()).#end${this.mangleTypeIdentifier($schema.getName())}.Builder ${this.generateClearMethod($schema, $field)}() {
 #if (${this.isUnboxedJavaTypeNullable($field.schema())})
       ${this.mangle($field.name(), $schema.isError())} = null;
 #end

--- a/lang/java/compiler/src/test/resources/simple_record_with_namespace.avsc
+++ b/lang/java/compiler/src/test/resources/simple_record_with_namespace.avsc
@@ -1,0 +1,9 @@
+{
+  "type": "record", 
+  "name": "SimpleRecordWithNamespace",
+  "namespace": "org.apache.avro.specific.test",
+  "fields" : [
+    {"name": "value", "type": "int"},
+    {"name": "nullableValue", "type": ["null","int"], "doc" : "doc"}
+  ]
+}

--- a/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/AbstractAvroMojo.java
+++ b/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/AbstractAvroMojo.java
@@ -193,6 +193,14 @@ public abstract class AbstractAvroMojo extends AbstractMojo {
   protected boolean enableDecimalLogicalType;
 
   /**
+   * Transformations to be applied when converting an Avro namespace to a Java
+   * package-name. Values are of format "namespacePrefix->packageName"
+   *
+   * @parameter property="namespaceMappings"
+   */
+  protected String[] namespaceMappings = new String[0];
+
+  /**
    * The current Maven project.
    *
    * @parameter default-value="${project}"

--- a/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/IDLProtocolMojo.java
+++ b/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/IDLProtocolMojo.java
@@ -94,6 +94,7 @@ public class IDLProtocolMojo extends AbstractAvroMojo {
         compiler.setStringType(GenericData.StringType.valueOf(stringType));
         compiler.setTemplateDir(templateDirectory);
         compiler.setFieldVisibility(getFieldVisibility());
+        compiler.setNamespaceMappings(namespaceMappings);
         compiler.setCreateOptionalGetters(createOptionalGetters);
         compiler.setGettersReturnOptional(gettersReturnOptional);
         compiler.setOptionalGettersForNullableFieldsOnly(optionalGettersForNullableFieldsOnly);


### PR DESCRIPTION
When Java code is generated from an avro schema, the default behaviour is to create classes in a "package" which is the namespace of the schema. However some users prefer to have the java classes placed under some specific base package, so make this possible.