### PR TITLE
AVRO-3649: reorder union types to match default

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/Schema.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Schema.java
@@ -1619,6 +1619,16 @@ public abstract class Schema extends JsonProperties implements Serializable {
     return defaultValue;
   }
 
+  /**
+   * Checks if a JSON value matches the schema.
+   *
+   * @param jsonValue a value to check against the schema
+   * @return true if the value is valid according to this schema
+   */
+  public boolean isValidValue(JsonNode jsonValue) {
+    return isValidDefault(this, jsonValue);
+  }
+
   private static boolean isValidDefault(Schema schema, JsonNode defaultValue) {
     if (defaultValue == null)
       return false;

--- a/lang/java/avro/src/test/java/org/apache/avro/reflect/TestReflect.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/reflect/TestReflect.java
@@ -1281,6 +1281,34 @@ public class TestReflect {
     check(ClassWithMultipleAliasesOnField.class, expectedSchema.toString());
   }
 
+  private static class NullableDefaultTest {
+    @Nullable
+    @AvroDefault("1")
+    int foo;
+  }
+
+  @Test
+  public void testAvroNullableDefault() {
+    check(NullableDefaultTest.class,
+        "{\"type\":\"record\",\"name\":\"NullableDefaultTest\","
+            + "\"namespace\":\"org.apache.avro.reflect.TestReflect\",\"fields\":["
+            + "{\"name\":\"foo\",\"type\":[\"int\",\"null\"],\"default\":1}]}");
+  }
+
+  private static class UnionDefaultTest {
+    @Union({String.class, Integer.class})
+    @AvroDefault("1")
+    Object foo;
+  }
+
+  @Test
+  public void testAvroUnionDefault() {
+    check(UnionDefaultTest.class,
+        "{\"type\":\"record\",\"name\":\"UnionDefaultTest\","
+            + "\"namespace\":\"org.apache.avro.reflect.TestReflect\",\"fields\":["
+            + "{\"name\":\"foo\",\"type\":[\"int\",\"string\"],\"default\":1}]}");
+  }
+
   private static class DefaultTest {
     @AvroDefault("1")
     int foo;


### PR DESCRIPTION
Why:
We want to use @AvroDefault with @Nullable.

How does it help with resolving the issue:
The schema generation automaticly picks the right order of the union type.

Side effects:
This change has no side effects, because:
- The order of union types is irrelevant for schema compability.
- This change enables definitions wich has been invalid.

## What is the purpose of the change
Implementing AVRO-3649.

## Verifying this change

- *Added test that validates that a correct schema is generated*

## Documentation

- **This is my big question. Is the reflection serialization documented anywhere?**
