### PR TITLE
AVRO-3661: [Rust] Fix new clippy errors introduced with Rust 1.65

### DIFF
--- a/lang/rust/avro/benches/serde.rs
+++ b/lang/rust/avro/benches/serde.rs
@@ -231,23 +231,17 @@ fn bench_from_file(c: &mut Criterion, file_path: &str, name: &str) -> anyhow::Re
 }
 
 fn bench_small_schema_write_1_record(c: &mut Criterion) {
-    bench_write(c, &make_small_record, 1, "small schema, write 1 record").unwrap();
+    bench_write(c, make_small_record, 1, "small schema, write 1 record").unwrap();
 }
 
 fn bench_small_schema_write_100_record(c: &mut Criterion) {
-    bench_write(
-        c,
-        &make_small_record,
-        100,
-        "small schema, write 100 records",
-    )
-    .unwrap();
+    bench_write(c, make_small_record, 100, "small schema, write 100 records").unwrap();
 }
 
 fn bench_small_schema_write_10_000_record(c: &mut Criterion) {
     bench_write(
         c,
-        &make_small_record,
+        make_small_record,
         10_000,
         "small schema, write 10k records",
     )
@@ -255,17 +249,17 @@ fn bench_small_schema_write_10_000_record(c: &mut Criterion) {
 }
 
 fn bench_small_schema_read_1_record(c: &mut Criterion) {
-    bench_read(c, &make_small_record, 1, "small schema, read 1 record").unwrap();
+    bench_read(c, make_small_record, 1, "small schema, read 1 record").unwrap();
 }
 
 fn bench_small_schema_read_100_record(c: &mut Criterion) {
-    bench_read(c, &make_small_record, 100, "small schema, read 100 records").unwrap();
+    bench_read(c, make_small_record, 100, "small schema, read 100 records").unwrap();
 }
 
 fn bench_small_schema_read_10_000_record(c: &mut Criterion) {
     bench_read(
         c,
-        &make_small_record,
+        make_small_record,
         10_000,
         "small schema, read 10k records",
     )
@@ -273,37 +267,31 @@ fn bench_small_schema_read_10_000_record(c: &mut Criterion) {
 }
 
 fn bench_big_schema_write_1_record(c: &mut Criterion) {
-    bench_write(c, &make_big_record, 1, "big schema, write 1 record").unwrap();
+    bench_write(c, make_big_record, 1, "big schema, write 1 record").unwrap();
 }
 
 fn bench_big_schema_write_100_record(c: &mut Criterion) {
-    bench_write(c, &make_big_record, 100, "big schema, write 100 records").unwrap();
+    bench_write(c, make_big_record, 100, "big schema, write 100 records").unwrap();
 }
 
 fn bench_big_schema_write_10_000_record(c: &mut Criterion) {
-    bench_write(c, &make_big_record, 10_000, "big schema, write 10k records").unwrap();
+    bench_write(c, make_big_record, 10_000, "big schema, write 10k records").unwrap();
 }
 
 fn bench_big_schema_read_1_record(c: &mut Criterion) {
-    bench_read(c, &make_big_record, 1, "big schema, read 1 record").unwrap();
+    bench_read(c, make_big_record, 1, "big schema, read 1 record").unwrap();
 }
 
 fn bench_big_schema_read_100_record(c: &mut Criterion) {
-    bench_read(c, &make_big_record, 100, "big schema, read 100 records").unwrap();
+    bench_read(c, make_big_record, 100, "big schema, read 100 records").unwrap();
 }
 
 fn bench_big_schema_read_10_000_record(c: &mut Criterion) {
-    bench_read(c, &make_big_record, 10_000, "big schema, read 10k records").unwrap();
+    bench_read(c, make_big_record, 10_000, "big schema, read 10k records").unwrap();
 }
 
 fn bench_big_schema_read_100_000_record(c: &mut Criterion) {
-    bench_read(
-        c,
-        &make_big_record,
-        100_000,
-        "big schema, read 100k records",
-    )
-    .unwrap();
+    bench_read(c, make_big_record, 100_000, "big schema, read 100k records").unwrap();
 }
 
 // This benchmark reads from the `benches/quickstop-null.avro` file, which was pulled from

--- a/lang/rust/avro/benches/serde_json.rs
+++ b/lang/rust/avro/benches/serde_json.rs
@@ -65,7 +65,7 @@ fn bench_read_json(
 fn bench_big_schema_json_read_10_000_record(c: &mut Criterion) {
     bench_read_json(
         c,
-        &make_big_json_record,
+        make_big_json_record,
         10_000,
         "big schema, read 10k JSON records",
     );

--- a/lang/rust/avro/src/encode.rs
+++ b/lang/rust/avro/src/encode.rs
@@ -68,7 +68,7 @@ pub(crate) fn encode_internal<S: Borrow<Schema>>(
 
     match value {
         Value::Null => (),
-        Value::Boolean(b) => buffer.push(if *b { 1u8 } else { 0u8 }),
+        Value::Boolean(b) => buffer.push(u8::from(*b)),
         // Pattern | Pattern here to signify that these _must_ have the same encoding.
         Value::Int(i) | Value::Date(i) | Value::TimeMillis(i) => encode_int(*i, buffer),
         Value::Long(i)

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -1707,7 +1707,7 @@ fn pcf_map(schema: &Map<String, Value>) -> String {
                 _ => Cow::Borrowed(name),
             };
 
-            fields.push((k, format!("{}:{}", pcf_string(k), pcf_string(&*n))));
+            fields.push((k, format!("{}:{}", pcf_string(k), pcf_string(&n))));
             continue;
         }
 


### PR DESCRIPTION
## What is the purpose of the change

* Fix some minor Rust clippy errors introduced with Rust 1.65. AVRO-3661

## Verifying this change

* The Rust CI workflows should pass

This change is a trivial rework / code cleanup without any test coverage.

## Documentation

- Does this pull request introduce a new feature? no