### PR TITLE
AVRO-3659: Typo in python example

### DIFF
--- a/doc/content/en/docs/++version++/Getting started (Python)/_index.md
+++ b/doc/content/en/docs/++version++/Getting started (Python)/_index.md
@@ -128,7 +128,7 @@ We create a DataFileWriter, which we'll use to write serialized items to a data 
 writer.append({"name": "Alyssa", "favorite_number": 256})
 writer.append({"name": "Ben", "favorite_number": 7, "favorite_color": "red"})
         
-We use DataFileWriter.append to add items to our data file. Avro records are represented as Python dicts. Since the field favorite_color has type ["int", "null"], we are not required to specify this field, as shown in the first append. Were we to omit the required name field, an exception would be raised. Any extra entries not corresponding to a field are present in the dict are ignored.
+We use DataFileWriter.append to add items to our data file. Avro records are represented as Python dicts. Since the field favorite_color has type ["string", "null"], we are not required to specify this field, as shown in the first append. Were we to omit the required name field, an exception would be raised. Any extra entries not corresponding to a field are present in the dict are ignored.
 
 ```python
 reader = DataFileReader(open("users.avro", "rb"), DatumReader())


### PR DESCRIPTION
## What is the purpose of the change

* Fix the type of 'favorite_color' field in the docs, fixing AVRO-3659

## Verifying this change

This change is a trivial fix in Markdown documentation.

## Documentation

- Does this pull request introduce a new feature? no