### PR TITLE
AVRO-3646: integration tests for (de)serializing of enum with mixed variants

### DIFF
--- a/.github/workflows/test-lang-rust-audit.yml
+++ b/.github/workflows/test-lang-rust-audit.yml
@@ -21,7 +21,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches:
     paths:
       - .github/workflows/test-lang-rust-audit.yml
       - lang/rust/Cargo.toml

--- a/.github/workflows/test-lang-rust-ci.yml
+++ b/.github/workflows/test-lang-rust-ci.yml
@@ -21,7 +21,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches:
     paths:
       - .github/workflows/test-lang-rust-ci.yml
       - lang/rust/**

--- a/.github/workflows/test-lang-rust-clippy.yml
+++ b/.github/workflows/test-lang-rust-clippy.yml
@@ -21,7 +21,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches:
     paths:
       - .github/workflows/test-lang-rust-clippy.yml
       - lang/rust/**

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -366,6 +366,7 @@ impl Value {
         schema: &Schema,
         names: &HashMap<Name, S>,
     ) -> Option<String> {
+        dbg!(&self, &schema);
         match (self, schema) {
             (_, &Schema::Ref { ref name }) => names.get(name).map_or_else(
                 || {

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -366,7 +366,6 @@ impl Value {
         schema: &Schema,
         names: &HashMap<Name, S>,
     ) -> Option<String> {
-        dbg!(&self, &schema);
         match (self, schema) {
             (_, &Schema::Ref { ref name }) => names.get(name).map_or_else(
                 || {

--- a/lang/rust/avro/tests/serde_enum.rs
+++ b/lang/rust/avro/tests/serde_enum.rs
@@ -36,10 +36,10 @@ const SCHEMA_STR: &str = r#"
                                     "type": "enum",
                                     "name": "TestEnumType",
                                     "symbols": [
-                                        "Nullvariant",
-                                        "IntVariant",
-                                        "TupleVariant",
-                                        "StructVariant"
+                                        "Null",
+                                        "Int",
+                                        "Tuple",
+                                        "Struct"
                                     ]
                                 }
                             },
@@ -54,7 +54,7 @@ const SCHEMA_STR: &str = r#"
                                     },
                                     {
                                         "type": "record",
-                                        "name": "StructVariant",
+                                        "name": "Struct",
                                         "fields": [
                                             {
                                                 "name": "b",
@@ -78,10 +78,10 @@ struct TestExternalEnum {
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
 enum TestEnum {
-    NullVariant,
-    IntVariant(i64),
-    TupleVariant(i64, i64),
-    StructVariant { b: i64 },
+    Null,
+    Int(i64),
+    Tuple(i64, i64),
+    Struct { b: i64 },
 }
 
 #[test]
@@ -90,25 +90,23 @@ fn avro_3646_test_to_value_mixed_enum() {
 
     let data = vec![
         (
-            TestExternalEnum {
-                a: TestEnum::NullVariant,
-            },
+            TestExternalEnum { a: TestEnum::Null },
             Value::Record(vec![(
                 "a".to_owned(),
                 Value::Record(vec![
-                    ("type".to_owned(), Value::Enum(0, "NullVariant".to_owned())),
+                    ("type".to_owned(), Value::Enum(0, "Null".to_owned())),
                     ("value".to_owned(), Value::Union(0, Box::new(Value::Null))),
                 ]),
             )]),
         ),
         (
             TestExternalEnum {
-                a: TestEnum::IntVariant(1),
+                a: TestEnum::Int(1),
             },
             Value::Record(vec![(
                 "a".to_owned(),
                 Value::Record(vec![
-                    ("type".to_owned(), Value::Enum(1, "IntVariant".to_owned())),
+                    ("type".to_owned(), Value::Enum(1, "Int".to_owned())),
                     (
                         "value".to_owned(),
                         Value::Union(1, Box::new(Value::Long(1))),
@@ -118,12 +116,12 @@ fn avro_3646_test_to_value_mixed_enum() {
         ),
         (
             TestExternalEnum {
-                a: TestEnum::TupleVariant(1, 2),
+                a: TestEnum::Tuple(1, 2),
             },
             Value::Record(vec![(
                 "a".to_owned(),
                 Value::Record(vec![
-                    ("type".to_owned(), Value::Enum(2, "TupleVariant".to_owned())),
+                    ("type".to_owned(), Value::Enum(2, "Tuple".to_owned())),
                     (
                         "value".to_owned(),
                         Value::Union(
@@ -136,15 +134,12 @@ fn avro_3646_test_to_value_mixed_enum() {
         ),
         (
             TestExternalEnum {
-                a: TestEnum::StructVariant { b: 1 },
+                a: TestEnum::Struct { b: 1 },
             },
             Value::Record(vec![(
                 "a".to_owned(),
                 Value::Record(vec![
-                    (
-                        "type".to_owned(),
-                        Value::Enum(3, "StructVariant".to_owned()),
-                    ),
+                    ("type".to_owned(), Value::Enum(3, "Struct".to_owned())),
                     (
                         "value".to_owned(),
                         Value::Union(

--- a/lang/rust/avro/tests/serde_enum.rs
+++ b/lang/rust/avro/tests/serde_enum.rs
@@ -1,0 +1,169 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use apache_avro::{from_value, to_value, types::Value, Schema};
+use pretty_assertions::assert_eq;
+use serde::{Deserialize, Serialize};
+
+const SCHEMA_STR: &str = r#"
+        {
+            "type": "record",
+            "name": "serde_enum",
+            "fields": [
+                {
+                    "name": "a",
+                    "type": {
+                        "type": "record",
+                        "name": "TestEnum",
+                        "fields": [
+                            {
+                                "name": "type",
+                                "type": {
+                                    "type": "enum",
+                                    "name": "TestEnumType",
+                                    "symbols": [
+                                        "Nullvariant",
+                                        "IntVariant",
+                                        "TupleVariant",
+                                        "StructVariant"
+                                    ]
+                                }
+                            },
+                            {
+                                "name": "value",
+                                "type": [
+                                    "null",
+                                    "long",
+                                    {
+                                        "type": "array",
+                                        "items": "long"
+                                    },
+                                    {
+                                        "type": "record",
+                                        "name": "StructVariant",
+                                        "fields": [
+                                            {
+                                                "name": "b",
+                                                "type": "long"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+        "#;
+
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+struct TestExternalEnum {
+    a: TestEnum,
+}
+
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+enum TestEnum {
+    NullVariant,
+    IntVariant(i64),
+    TupleVariant(i64, i64),
+    StructVariant { b: i64 },
+}
+
+#[test]
+fn avro_3646_test_to_value_mixed_enum() {
+    let schema = Schema::parse_str(SCHEMA_STR).unwrap();
+
+    let data = vec![
+        (
+            TestExternalEnum {
+                a: TestEnum::NullVariant,
+            },
+            Value::Record(vec![(
+                "a".to_owned(),
+                Value::Record(vec![
+                    ("type".to_owned(), Value::Enum(0, "NullVariant".to_owned())),
+                    ("value".to_owned(), Value::Union(0, Box::new(Value::Null))),
+                ]),
+            )]),
+        ),
+        (
+            TestExternalEnum {
+                a: TestEnum::IntVariant(1),
+            },
+            Value::Record(vec![(
+                "a".to_owned(),
+                Value::Record(vec![
+                    ("type".to_owned(), Value::Enum(1, "IntVariant".to_owned())),
+                    (
+                        "value".to_owned(),
+                        Value::Union(1, Box::new(Value::Long(1))),
+                    ),
+                ]),
+            )]),
+        ),
+        (
+            TestExternalEnum {
+                a: TestEnum::TupleVariant(1, 2),
+            },
+            Value::Record(vec![(
+                "a".to_owned(),
+                Value::Record(vec![
+                    ("type".to_owned(), Value::Enum(2, "TupleVariant".to_owned())),
+                    (
+                        "value".to_owned(),
+                        Value::Union(
+                            2,
+                            Box::new(Value::Array(vec![Value::Long(1), Value::Long(2)])),
+                        ),
+                    ),
+                ]),
+            )]),
+        ),
+        (
+            TestExternalEnum {
+                a: TestEnum::StructVariant { b: 1 },
+            },
+            Value::Record(vec![(
+                "a".to_owned(),
+                Value::Record(vec![
+                    (
+                        "type".to_owned(),
+                        Value::Enum(3, "StructVariant".to_owned()),
+                    ),
+                    (
+                        "value".to_owned(),
+                        Value::Union(
+                            3,
+                            Box::new(Value::Record(vec![("b".to_owned(), Value::Long(1))])),
+                        ),
+                    ),
+                ]),
+            )]),
+        ),
+    ];
+
+    for (test, expected) in &data {
+        let actual = to_value(test).unwrap();
+        assert_eq!(actual, *expected, "Cannot serialize");
+        if !actual.validate(&schema) {
+            panic!("Cannot validate value: {:?}", actual);
+        }
+        let deserialized: TestExternalEnum = from_value(&actual).unwrap();
+        assert_eq!(deserialized, *test, "Cannot deserialize");
+    }
+}

--- a/lang/rust/avro/tests/serde_enum_with_duplicates.rs
+++ b/lang/rust/avro/tests/serde_enum_with_duplicates.rs
@@ -36,8 +36,8 @@ const SCHEMA_STR: &str = r#"
                                     "type": "enum",
                                     "name": "TestEnumType",
                                     "symbols": [
-                                        "Nullvariant1",
-                                        "Nullvariant2",
+                                        "NullVariant1",
+                                        "NullVariant2",
                                         "NullTupleVariant",
                                         "NullNewTypeVariant",
                                         "NullStructVariant",
@@ -102,7 +102,7 @@ enum TestEnum {
 }
 
 #[test]
-fn avro_3646_test_to_value_mixed_enum() {
+fn avro_3646_test_to_value_mixed_enum_with_duplicates() {
     let schema = Schema::parse_str(SCHEMA_STR).unwrap();
 
     let data = vec![

--- a/lang/rust/avro/tests/serde_enum_with_duplicates.rs
+++ b/lang/rust/avro/tests/serde_enum_with_duplicates.rs
@@ -36,13 +36,8 @@ const SCHEMA_STR: &str = r#"
                                     "type": "enum",
                                     "name": "TestEnumType",
                                     "symbols": [
-                                        "NullVariant1",
-                                        "NullVariant2",
-                                        "NullTupleVariant",
-                                        "NullNewTypeVariant",
-                                        "NullStructVariant",
-                                        "IntVariant1",
-                                        "IntVariant2",
+                                        "NullVariant",
+                                        "IntVariant",
                                         "TupleVariant",
                                         "StructVariant",
                                         "NameStructVariant"
@@ -61,6 +56,16 @@ const SCHEMA_STR: &str = r#"
                                     {
                                         "type": "record",
                                         "name": "StructVariant",
+                                        "fields": [
+                                            {
+                                                "name": "b",
+                                                "type": "long"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "type": "record",
+                                        "name": "NameStructVariant",
                                         "fields": [
                                             {
                                                 "name": "b",
@@ -89,13 +94,8 @@ struct TestStruct {
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
 enum TestEnum {
-    NullVariant1,
-    NullVariant2,
-    NullTupleVariant(),
-    NullNewTypeVariant(()),
-    NullStructVariant {},
-    IntVariant1(i64),
-    IntVariant2(i64),
+    NullVariant,
+    IntVariant(i64),
     TupleVariant(i64, i64),
     StructVariant { b: i64 },
     NameStructVariant(TestStruct),
@@ -108,96 +108,24 @@ fn avro_3646_test_to_value_mixed_enum_with_duplicates() {
     let data = vec![
         (
             TestExternalEnum {
-                a: TestEnum::NullVariant1,
+                a: TestEnum::NullVariant,
             },
             Value::Record(vec![(
                 "a".to_owned(),
                 Value::Record(vec![
-                    ("type".to_owned(), Value::Enum(0, "NullVariant1".to_owned())),
+                    ("type".to_owned(), Value::Enum(0, "NullVariant".to_owned())),
                     ("value".to_owned(), Value::Union(0, Box::new(Value::Null))),
                 ]),
             )]),
         ),
         (
             TestExternalEnum {
-                a: TestEnum::NullVariant2,
+                a: TestEnum::IntVariant(1),
             },
             Value::Record(vec![(
                 "a".to_owned(),
                 Value::Record(vec![
-                    ("type".to_owned(), Value::Enum(1, "NullVariant2".to_owned())),
-                    ("value".to_owned(), Value::Union(0, Box::new(Value::Null))),
-                ]),
-            )]),
-        ),
-        (
-            TestExternalEnum {
-                a: TestEnum::NullTupleVariant(),
-            },
-            Value::Record(vec![(
-                "a".to_owned(),
-                Value::Record(vec![
-                    (
-                        "type".to_owned(),
-                        Value::Enum(2, "NullTupleVariant".to_owned()),
-                    ),
-                    ("value".to_owned(), Value::Union(0, Box::new(Value::Null))),
-                ]),
-            )]),
-        ),
-        (
-            TestExternalEnum {
-                a: TestEnum::NullNewTypeVariant(()),
-            },
-            Value::Record(vec![(
-                "a".to_owned(),
-                Value::Record(vec![
-                    (
-                        "type".to_owned(),
-                        Value::Enum(3, "NullNewTypeVariant".to_owned()),
-                    ),
-                    ("value".to_owned(), Value::Union(0, Box::new(Value::Null))),
-                ]),
-            )]),
-        ),
-        (
-            TestExternalEnum {
-                a: TestEnum::NullStructVariant {},
-            },
-            Value::Record(vec![(
-                "a".to_owned(),
-                Value::Record(vec![
-                    (
-                        "type".to_owned(),
-                        Value::Enum(4, "NullStructVariant".to_owned()),
-                    ),
-                    ("value".to_owned(), Value::Union(0, Box::new(Value::Null))),
-                ]),
-            )]),
-        ),
-        (
-            TestExternalEnum {
-                a: TestEnum::IntVariant1(1),
-            },
-            Value::Record(vec![(
-                "a".to_owned(),
-                Value::Record(vec![
-                    ("type".to_owned(), Value::Enum(5, "IntVariant1".to_owned())),
-                    (
-                        "value".to_owned(),
-                        Value::Union(1, Box::new(Value::Long(1))),
-                    ),
-                ]),
-            )]),
-        ),
-        (
-            TestExternalEnum {
-                a: TestEnum::IntVariant2(1),
-            },
-            Value::Record(vec![(
-                "a".to_owned(),
-                Value::Record(vec![
-                    ("type".to_owned(), Value::Enum(6, "IntVariant2".to_owned())),
+                    ("type".to_owned(), Value::Enum(1, "IntVariant".to_owned())),
                     (
                         "value".to_owned(),
                         Value::Union(1, Box::new(Value::Long(1))),
@@ -212,7 +140,7 @@ fn avro_3646_test_to_value_mixed_enum_with_duplicates() {
             Value::Record(vec![(
                 "a".to_owned(),
                 Value::Record(vec![
-                    ("type".to_owned(), Value::Enum(7, "TupleVariant".to_owned())),
+                    ("type".to_owned(), Value::Enum(2, "TupleVariant".to_owned())),
                     (
                         "value".to_owned(),
                         Value::Union(
@@ -232,7 +160,7 @@ fn avro_3646_test_to_value_mixed_enum_with_duplicates() {
                 Value::Record(vec![
                     (
                         "type".to_owned(),
-                        Value::Enum(8, "StructVariant".to_owned()),
+                        Value::Enum(3, "StructVariant".to_owned()),
                     ),
                     (
                         "value".to_owned(),
@@ -253,12 +181,12 @@ fn avro_3646_test_to_value_mixed_enum_with_duplicates() {
                 Value::Record(vec![
                     (
                         "type".to_owned(),
-                        Value::Enum(9, "NameStructVariant".to_owned()),
+                        Value::Enum(4, "NameStructVariant".to_owned()),
                     ),
                     (
                         "value".to_owned(),
                         Value::Union(
-                            3,
+                            4,
                             Box::new(Value::Record(vec![("b".to_owned(), Value::Long(1))])),
                         ),
                     ),

--- a/lang/rust/avro/tests/serde_enum_with_duplicates.rs
+++ b/lang/rust/avro/tests/serde_enum_with_duplicates.rs
@@ -36,11 +36,11 @@ const SCHEMA_STR: &str = r#"
                                     "type": "enum",
                                     "name": "TestEnumType",
                                     "symbols": [
-                                        "NullVariant",
-                                        "IntVariant",
-                                        "TupleVariant",
-                                        "StructVariant",
-                                        "NameStructVariant"
+                                        "Null",
+                                        "Int",
+                                        "Tuple",
+                                        "Struct",
+                                        "NameStruct"
                                     ]
                                 }
                             },
@@ -55,7 +55,7 @@ const SCHEMA_STR: &str = r#"
                                     },
                                     {
                                         "type": "record",
-                                        "name": "StructVariant",
+                                        "name": "Struct",
                                         "fields": [
                                             {
                                                 "name": "b",
@@ -65,7 +65,7 @@ const SCHEMA_STR: &str = r#"
                                     },
                                     {
                                         "type": "record",
-                                        "name": "NameStructVariant",
+                                        "name": "NameStruct",
                                         "fields": [
                                             {
                                                 "name": "b",
@@ -94,11 +94,11 @@ struct TestStruct {
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
 enum TestEnum {
-    NullVariant,
-    IntVariant(i64),
-    TupleVariant(i64, i64),
-    StructVariant { b: i64 },
-    NameStructVariant(TestStruct),
+    Null,
+    Int(i64),
+    Tuple(i64, i64),
+    Struct { b: i64 },
+    NameStruct(TestStruct),
 }
 
 #[test]
@@ -107,25 +107,23 @@ fn avro_3646_test_to_value_mixed_enum_with_duplicates() {
 
     let data = vec![
         (
-            TestExternalEnum {
-                a: TestEnum::NullVariant,
-            },
+            TestExternalEnum { a: TestEnum::Null },
             Value::Record(vec![(
                 "a".to_owned(),
                 Value::Record(vec![
-                    ("type".to_owned(), Value::Enum(0, "NullVariant".to_owned())),
+                    ("type".to_owned(), Value::Enum(0, "Null".to_owned())),
                     ("value".to_owned(), Value::Union(0, Box::new(Value::Null))),
                 ]),
             )]),
         ),
         (
             TestExternalEnum {
-                a: TestEnum::IntVariant(1),
+                a: TestEnum::Int(1),
             },
             Value::Record(vec![(
                 "a".to_owned(),
                 Value::Record(vec![
-                    ("type".to_owned(), Value::Enum(1, "IntVariant".to_owned())),
+                    ("type".to_owned(), Value::Enum(1, "Int".to_owned())),
                     (
                         "value".to_owned(),
                         Value::Union(1, Box::new(Value::Long(1))),
@@ -135,12 +133,12 @@ fn avro_3646_test_to_value_mixed_enum_with_duplicates() {
         ),
         (
             TestExternalEnum {
-                a: TestEnum::TupleVariant(1, 2),
+                a: TestEnum::Tuple(1, 2),
             },
             Value::Record(vec![(
                 "a".to_owned(),
                 Value::Record(vec![
-                    ("type".to_owned(), Value::Enum(2, "TupleVariant".to_owned())),
+                    ("type".to_owned(), Value::Enum(2, "Tuple".to_owned())),
                     (
                         "value".to_owned(),
                         Value::Union(
@@ -153,15 +151,12 @@ fn avro_3646_test_to_value_mixed_enum_with_duplicates() {
         ),
         (
             TestExternalEnum {
-                a: TestEnum::StructVariant { b: 1 },
+                a: TestEnum::Struct { b: 1 },
             },
             Value::Record(vec![(
                 "a".to_owned(),
                 Value::Record(vec![
-                    (
-                        "type".to_owned(),
-                        Value::Enum(3, "StructVariant".to_owned()),
-                    ),
+                    ("type".to_owned(), Value::Enum(3, "Struct".to_owned())),
                     (
                         "value".to_owned(),
                         Value::Union(
@@ -174,15 +169,12 @@ fn avro_3646_test_to_value_mixed_enum_with_duplicates() {
         ),
         (
             TestExternalEnum {
-                a: TestEnum::NameStructVariant(TestStruct { b: 1 }),
+                a: TestEnum::NameStruct(TestStruct { b: 1 }),
             },
             Value::Record(vec![(
                 "a".to_owned(),
                 Value::Record(vec![
-                    (
-                        "type".to_owned(),
-                        Value::Enum(4, "NameStructVariant".to_owned()),
-                    ),
+                    ("type".to_owned(), Value::Enum(4, "NameStruct".to_owned())),
                     (
                         "value".to_owned(),
                         Value::Union(

--- a/lang/rust/avro/tests/serde_enum_with_duplicates.rs
+++ b/lang/rust/avro/tests/serde_enum_with_duplicates.rs
@@ -1,0 +1,279 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use apache_avro::{from_value, to_value, types::Value, Schema};
+use pretty_assertions::assert_eq;
+use serde::{Deserialize, Serialize};
+
+const SCHEMA_STR: &str = r#"
+        {
+            "type": "record",
+            "name": "serde_enum",
+            "fields": [
+                {
+                    "name": "a",
+                    "type": {
+                        "type": "record",
+                        "name": "TestEnum",
+                        "fields": [
+                            {
+                                "name": "type",
+                                "type": {
+                                    "type": "enum",
+                                    "name": "TestEnumType",
+                                    "symbols": [
+                                        "Nullvariant1",
+                                        "Nullvariant2",
+                                        "NullTupleVariant",
+                                        "NullNewTypeVariant",
+                                        "NullStructVariant",
+                                        "IntVariant1",
+                                        "IntVariant2",
+                                        "TupleVariant",
+                                        "StructVariant",
+                                        "NameStructVariant"
+                                    ]
+                                }
+                            },
+                            {
+                                "name": "value",
+                                "type": [
+                                    "null",
+                                    "long",
+                                    {
+                                        "type": "array",
+                                        "items": "long"
+                                    },
+                                    {
+                                        "type": "record",
+                                        "name": "StructVariant",
+                                        "fields": [
+                                            {
+                                                "name": "b",
+                                                "type": "long"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+        "#;
+
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+struct TestExternalEnum {
+    a: TestEnum,
+}
+
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+struct TestStruct {
+    b: i64,
+}
+
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+enum TestEnum {
+    NullVariant1,
+    NullVariant2,
+    NullTupleVariant(),
+    NullNewTypeVariant(()),
+    NullStructVariant {},
+    IntVariant1(i64),
+    IntVariant2(i64),
+    TupleVariant(i64, i64),
+    StructVariant { b: i64 },
+    NameStructVariant(TestStruct),
+}
+
+#[test]
+fn avro_3646_test_to_value_mixed_enum() {
+    let schema = Schema::parse_str(SCHEMA_STR).unwrap();
+
+    let data = vec![
+        (
+            TestExternalEnum {
+                a: TestEnum::NullVariant1,
+            },
+            Value::Record(vec![(
+                "a".to_owned(),
+                Value::Record(vec![
+                    ("type".to_owned(), Value::Enum(0, "NullVariant1".to_owned())),
+                    ("value".to_owned(), Value::Union(0, Box::new(Value::Null))),
+                ]),
+            )]),
+        ),
+        (
+            TestExternalEnum {
+                a: TestEnum::NullVariant2,
+            },
+            Value::Record(vec![(
+                "a".to_owned(),
+                Value::Record(vec![
+                    ("type".to_owned(), Value::Enum(1, "NullVariant2".to_owned())),
+                    ("value".to_owned(), Value::Union(0, Box::new(Value::Null))),
+                ]),
+            )]),
+        ),
+        (
+            TestExternalEnum {
+                a: TestEnum::NullTupleVariant(),
+            },
+            Value::Record(vec![(
+                "a".to_owned(),
+                Value::Record(vec![
+                    (
+                        "type".to_owned(),
+                        Value::Enum(2, "NullTupleVariant".to_owned()),
+                    ),
+                    ("value".to_owned(), Value::Union(0, Box::new(Value::Null))),
+                ]),
+            )]),
+        ),
+        (
+            TestExternalEnum {
+                a: TestEnum::NullNewTypeVariant(()),
+            },
+            Value::Record(vec![(
+                "a".to_owned(),
+                Value::Record(vec![
+                    (
+                        "type".to_owned(),
+                        Value::Enum(3, "NullNewTypeVariant".to_owned()),
+                    ),
+                    ("value".to_owned(), Value::Union(0, Box::new(Value::Null))),
+                ]),
+            )]),
+        ),
+        (
+            TestExternalEnum {
+                a: TestEnum::NullStructVariant {},
+            },
+            Value::Record(vec![(
+                "a".to_owned(),
+                Value::Record(vec![
+                    (
+                        "type".to_owned(),
+                        Value::Enum(4, "NullStructVariant".to_owned()),
+                    ),
+                    ("value".to_owned(), Value::Union(0, Box::new(Value::Null))),
+                ]),
+            )]),
+        ),
+        (
+            TestExternalEnum {
+                a: TestEnum::IntVariant1(1),
+            },
+            Value::Record(vec![(
+                "a".to_owned(),
+                Value::Record(vec![
+                    ("type".to_owned(), Value::Enum(5, "IntVariant1".to_owned())),
+                    (
+                        "value".to_owned(),
+                        Value::Union(1, Box::new(Value::Long(1))),
+                    ),
+                ]),
+            )]),
+        ),
+        (
+            TestExternalEnum {
+                a: TestEnum::IntVariant2(1),
+            },
+            Value::Record(vec![(
+                "a".to_owned(),
+                Value::Record(vec![
+                    ("type".to_owned(), Value::Enum(6, "IntVariant2".to_owned())),
+                    (
+                        "value".to_owned(),
+                        Value::Union(1, Box::new(Value::Long(1))),
+                    ),
+                ]),
+            )]),
+        ),
+        (
+            TestExternalEnum {
+                a: TestEnum::TupleVariant(1, 2),
+            },
+            Value::Record(vec![(
+                "a".to_owned(),
+                Value::Record(vec![
+                    ("type".to_owned(), Value::Enum(7, "TupleVariant".to_owned())),
+                    (
+                        "value".to_owned(),
+                        Value::Union(
+                            2,
+                            Box::new(Value::Array(vec![Value::Long(1), Value::Long(2)])),
+                        ),
+                    ),
+                ]),
+            )]),
+        ),
+        (
+            TestExternalEnum {
+                a: TestEnum::StructVariant { b: 1 },
+            },
+            Value::Record(vec![(
+                "a".to_owned(),
+                Value::Record(vec![
+                    (
+                        "type".to_owned(),
+                        Value::Enum(8, "StructVariant".to_owned()),
+                    ),
+                    (
+                        "value".to_owned(),
+                        Value::Union(
+                            3,
+                            Box::new(Value::Record(vec![("b".to_owned(), Value::Long(1))])),
+                        ),
+                    ),
+                ]),
+            )]),
+        ),
+        (
+            TestExternalEnum {
+                a: TestEnum::NameStructVariant(TestStruct { b: 1 }),
+            },
+            Value::Record(vec![(
+                "a".to_owned(),
+                Value::Record(vec![
+                    (
+                        "type".to_owned(),
+                        Value::Enum(9, "NameStructVariant".to_owned()),
+                    ),
+                    (
+                        "value".to_owned(),
+                        Value::Union(
+                            3,
+                            Box::new(Value::Record(vec![("b".to_owned(), Value::Long(1))])),
+                        ),
+                    ),
+                ]),
+            )]),
+        ),
+    ];
+
+    for (test, expected) in &data {
+        let actual = to_value(test).unwrap();
+        assert_eq!(actual, *expected, "Cannot serialize");
+        if !actual.validate(&schema) {
+            panic!("Cannot validate value: {:?}", actual);
+        }
+        let deserialized: TestExternalEnum = from_value(&actual).unwrap();
+        assert_eq!(deserialized, *test, "Cannot deserialize");
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds two integration tests to assess the changes of #1921:

- (De)serialization of an enum with mixed variants (Null, new type, tuple and struct): `serde_enum`.
- (De)serialization of an enum with mixed and duplicate variants: `serde_enum_with_duplicates`.

## Verifying this change

The two integration tests **do not pass** for multiple reasons:

- The serialized values do not validate the defined schema.
- The `type` value for the tuple variant is serialized as an `Array` of `Union` instead as an `Union` of `Array`.
- With duplicate variants, the index in the `type` union is not valid (because there is no duplicate in the union defined by the schema).

## Documentation

- Does this pull request introduce a new feature? no
