### PR TITLE
AVRO-3664: [rust] Add Rust Avro Value conversion derive implementations

### DIFF
--- a/lang/rust/Cargo.lock
+++ b/lang/rust/Cargo.lock
@@ -77,6 +77,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
+ "uuid",
 ]
 
 [[package]]

--- a/lang/rust/avro/src/error.rs
+++ b/lang/rust/avro/src/error.rs
@@ -115,6 +115,12 @@ pub enum Error {
     #[error("expected UUID, got: {0:?}")]
     GetUuid(ValueKind),
 
+    #[error("expected Decimal, got: {0:?}")]
+    GetDecimal(ValueKind),
+
+    #[error("expected Duration, got: {0:?}")]
+    GetDuration(ValueKind),
+
     #[error("Fixed bytes of size 12 expected, got Fixed of size {0}")]
     GetDecimalFixedBytes(usize),
 

--- a/lang/rust/avro/src/error.rs
+++ b/lang/rust/avro/src/error.rs
@@ -238,6 +238,9 @@ pub enum Error {
     #[error("JSON value {0} claims to be i64 but cannot be converted")]
     GetI64FromJson(serde_json::Number),
 
+    #[error("Failed to convert from type to apache_avro::types::Value")]
+    ConvertFromValue(String),
+
     #[error("Cannot convert u64 to usize: {1}")]
     ConvertU64ToUsize(#[source] std::num::TryFromIntError, u64),
 

--- a/lang/rust/avro/src/lib.rs
+++ b/lang/rust/avro/src/lib.rs
@@ -745,7 +745,7 @@ pub use error::Error;
 pub use reader::{
     from_avro_datum, read_marker, GenericSingleObjectReader, Reader, SpecificSingleObjectReader,
 };
-pub use schema::{AvroSchema, Schema};
+pub use schema::{AvroSchema, AvroValue, Schema};
 pub use ser::to_value;
 pub use util::max_allocation_bytes;
 pub use writer::{to_avro_datum, GenericSingleObjectWriter, SpecificSingleObjectWriter, Writer};

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -1787,7 +1787,7 @@ pub trait AvroSchema {
 /// Trait for types that should be converted to or from an AvroValue. Derive implementation
 /// available through `derive` feature. To implement directly, use the `From<types::Value> for T`
 /// and `From<T> for types::Value` traits defined in std::convert::From
-pub trait AvroValue: From<types::Value> + Into<types::Value> {}
+pub trait AvroValue: TryFrom<types::Value> + Into<types::Value> {}
 
 #[cfg(feature = "derive")]
 pub mod derive {

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -1784,6 +1784,11 @@ pub trait AvroSchema {
     fn get_schema() -> Schema;
 }
 
+/// Trait for types that should be converted to or from an AvroValue. Derive implementation
+/// available through `derive` feature. To implement directly, use the `From<types::Value> for T`
+/// and `From<T> for types::Value` traits defined in std::convert::From
+pub trait AvroValue: From<types::Value> + Into<types::Value> {}
+
 #[cfg(feature = "derive")]
 pub mod derive {
     use super::*;

--- a/lang/rust/avro_derive/Cargo.toml
+++ b/lang/rust/avro_derive/Cargo.toml
@@ -42,3 +42,4 @@ syn = { default-features = false, version = "1.0.103", features = ["full", "fold
 apache-avro = { default-features = false, path = "../avro", features = ["derive"] }
 proptest = { default-features = false, version = "1.0.0", features = ["std"] }
 serde = { default-features = false, version = "1.0.147", features = ["derive"] }
+uuid = "1.2.1"

--- a/lang/rust/avro_derive/src/lib.rs
+++ b/lang/rust/avro_derive/src/lib.rs
@@ -21,9 +21,7 @@ use darling::FromAttributes;
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
 
-use syn::{
-    parse_macro_input, spanned::Spanned, AttrStyle, Attribute, DeriveInput, Error, Type, TypePath,
-};
+use syn::{parse_macro_input, spanned::Spanned, AttrStyle, Attribute, DeriveInput, Type, TypePath};
 
 #[derive(FromAttributes)]
 #[darling(attributes(avro))]
@@ -86,7 +84,7 @@ fn derive_avro_schema(input: &mut DeriveInput) -> Result<TokenStream, Vec<syn::E
             input.ident.span(),
         )?,
         _ => {
-            return Err(vec![Error::new(
+            return Err(vec![syn::Error::new(
                 input.ident.span(),
                 "AvroSchema derive only works for structs and simple enums ",
             )])
@@ -139,7 +137,7 @@ fn get_data_struct_schema_def(
                     Some(default_value) => {
                         let _: serde_json::Value = serde_json::from_str(&default_value[..])
                             .map_err(|e| {
-                                vec![Error::new(
+                                vec![syn::Error::new(
                                     field.ident.span(),
                                     format!("Invalid avro default json: \n{}", e),
                                 )]
@@ -167,13 +165,13 @@ fn get_data_struct_schema_def(
             }
         }
         syn::Fields::Unnamed(_) => {
-            return Err(vec![Error::new(
+            return Err(vec![syn::Error::new(
                 error_span,
                 "AvroSchema derive does not work for tuple structs",
             )])
         }
         syn::Fields::Unit => {
-            return Err(vec![Error::new(
+            return Err(vec![syn::Error::new(
                 error_span,
                 "AvroSchema derive does not work for unit structs",
             )])
@@ -224,7 +222,7 @@ fn get_data_enum_schema_def(
             }
         })
     } else {
-        Err(vec![Error::new(
+        Err(vec![syn::Error::new(
             error_span,
             "AvroSchema derive does not work for enums with non unit structs",
         )])

--- a/lang/rust/avro_derive/src/lib.rs
+++ b/lang/rust/avro_derive/src/lib.rs
@@ -20,7 +20,6 @@ extern crate darling;
 use darling::FromAttributes;
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
-
 use syn::{parse_macro_input, spanned::Spanned, AttrStyle, Attribute, DeriveInput, Type, TypePath};
 
 #[derive(FromAttributes)]
@@ -184,7 +183,7 @@ fn get_data_struct_schema_def(
                             .map_err(|e| {
                                 vec![syn::Error::new(
                                     field.ident.span(),
-                                    format!("Invalid avro default json: \n{}", e),
+                                    format!("Invalid avro default json: \n{e}"),
                                 )]
                             })?;
                         quote! {
@@ -336,7 +335,7 @@ fn type_to_schema_expr(ty: &Type) -> Result<TokenStream, Vec<syn::Error>> {
     } else {
         Err(vec![syn::Error::new_spanned(
             ty,
-            format!("Unable to generate schema for type: {:?}", ty),
+            format!("Unable to generate schema for type: {ty:?}"),
         )])
     }
 }
@@ -395,7 +394,7 @@ fn preserve_vec(op: Vec<impl quote::ToTokens>) -> TokenStream {
 }
 
 fn darling_to_syn(e: darling::Error) -> Vec<syn::Error> {
-    let msg = format!("{}", e);
+    let msg = format!("{e}");
     let token_errors = e.write_errors();
     vec![syn::Error::new(token_errors.span(), msg)]
 }

--- a/lang/rust/avro_derive/src/lib.rs
+++ b/lang/rust/avro_derive/src/lib.rs
@@ -145,7 +145,7 @@ fn derive_avro_value_struct(
                 ])
             }
         }
-        impl #impl_generics TryFrom<apache_avro::types::Value> for #ident #ty_generics #where_clause {
+        impl #impl_generics std::convert::TryFrom<apache_avro::types::Value> for #ident #ty_generics #where_clause {
             type Error = apache_avro::Error;
 
             fn try_from(value: apache_avro::types::Value) -> Result<Self, Self::Error> {
@@ -181,7 +181,7 @@ fn derive_avro_value_enum(
                 }
             }
         }
-        impl #impl_generics TryFrom<apache_avro::types::Value> for #ident #ty_generics #where_clause {
+        impl #impl_generics std::convert::TryFrom<apache_avro::types::Value> for #ident #ty_generics #where_clause {
             type Error = apache_avro::Error;
 
             fn try_from(value: apache_avro::types::Value) -> Result<Self, Self::Error> {

--- a/lang/rust/avro_derive/tests/derive.rs
+++ b/lang/rust/avro_derive/tests/derive.rs
@@ -17,7 +17,7 @@
 
 use apache_avro::{
     from_value,
-    schema::{derive::AvroSchemaComponent, AvroSchema},
+    schema::{derive::AvroSchemaComponent, AvroSchema, AvroValue},
     Reader, Schema, Writer,
 };
 use apache_avro_derive::*;
@@ -30,7 +30,7 @@ extern crate serde;
 
 #[cfg(test)]
 mod test_derive {
-    use apache_avro::schema::Alias;
+    use apache_avro::{schema::Alias, Decimal, Duration};
     use std::{
         borrow::{Borrow, Cow},
         sync::Mutex,
@@ -115,6 +115,15 @@ mod test_derive {
             b,
         };
         serde_assert(test);
+    }}
+
+    proptest! {
+    #[test]
+    fn test_value_smoke_test(a: i32, b: String) {
+        let test = TestBasic {
+            a,
+            b,
+        };
     }}
 
     #[derive(Debug, Serialize, Deserialize, AvroSchema, Clone, PartialEq, Eq)]
@@ -1560,5 +1569,28 @@ mod test_derive {
         } else {
             panic!("Unexpected schema type for {:?}", derived_schema)
         }
+    }
+
+    #[derive(Debug, Serialize, Deserialize, AvroValue, AvroSchema, Clone, PartialEq)]
+    enum TestValueEnum {
+        A,
+        B,
+        C,
+        D,
+    }
+
+    #[derive(Debug, Serialize, Deserialize, AvroSchema, AvroValue, Clone, PartialEq)]
+    struct TestValue {
+        f_boolean: bool,
+        f_int: i32,
+        f_long: i64,
+        f_float: f32,
+        f_double: f64,
+        f_string: String,
+        f_string_opt: Option<String>,
+        f_string_array_opt: Option<Vec<String>>,
+        f_enum: TestValueEnum,
+        f_array: Vec<String>,
+        f_map: HashMap<String, bool>,
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This change improves Avro rust library usability, adding type conversions directly to/from a user struct or enum into a `apache_avro::types::Value`. Specifically it adds the following elements:
* `AvroValue` trait to add `TryFrom<Value> for ...` and `From<X> for Value`
* A derive macro for `AvroValue` supporting both basic and complex field schemas

## Verifying this change

This change added tests and can be verified as follows:
- Added unit tests to check derive macro compilation in `rust/avro/derive` crate

## Documentation

- Does this pull request introduce a new feature? **yes**
- If yes, how is the feature documented? Doc comments added to `rust/avro/derive` crate
