### PR TITLE
Rust non unit enum

### DIFF
--- a/lang/rust/Cargo.lock
+++ b/lang/rust/Cargo.lock
@@ -77,6 +77,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
+ "uuid",
 ]
 
 [[package]]

--- a/lang/rust/avro/src/error.rs
+++ b/lang/rust/avro/src/error.rs
@@ -115,6 +115,12 @@ pub enum Error {
     #[error("expected UUID, got: {0:?}")]
     GetUuid(ValueKind),
 
+    #[error("expected Decimal, got: {0:?}")]
+    GetDecimal(ValueKind),
+
+    #[error("expected Duration, got: {0:?}")]
+    GetDuration(ValueKind),
+
     #[error("Fixed bytes of size 12 expected, got Fixed of size {0}")]
     GetDecimalFixedBytes(usize),
 
@@ -237,6 +243,9 @@ pub enum Error {
 
     #[error("JSON value {0} claims to be i64 but cannot be converted")]
     GetI64FromJson(serde_json::Number),
+
+    #[error("Failed to convert from type to apache_avro::types::Value")]
+    ConvertFromValue(String),
 
     #[error("Cannot convert u64 to usize: {1}")]
     ConvertU64ToUsize(#[source] std::num::TryFromIntError, u64),

--- a/lang/rust/avro/src/lib.rs
+++ b/lang/rust/avro/src/lib.rs
@@ -745,7 +745,7 @@ pub use error::Error;
 pub use reader::{
     from_avro_datum, read_marker, GenericSingleObjectReader, Reader, SpecificSingleObjectReader,
 };
-pub use schema::{AvroSchema, Schema};
+pub use schema::{AvroSchema, AvroValue, Schema};
 pub use ser::to_value;
 pub use util::max_allocation_bytes;
 pub use writer::{to_avro_datum, GenericSingleObjectWriter, SpecificSingleObjectWriter, Writer};

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -1784,6 +1784,11 @@ pub trait AvroSchema {
     fn get_schema() -> Schema;
 }
 
+/// Trait for types that should be converted to or from an AvroValue. Derive implementation
+/// available through `derive` feature. To implement directly, use the `From<types::Value> for T`
+/// and `From<T> for types::Value` traits defined in std::convert::From
+pub trait AvroValue: TryFrom<types::Value> + Into<types::Value> {}
+
 #[cfg(feature = "derive")]
 pub mod derive {
     use super::*;

--- a/lang/rust/avro_derive/Cargo.toml
+++ b/lang/rust/avro_derive/Cargo.toml
@@ -42,3 +42,4 @@ syn = { default-features = false, version = "1.0.103", features = ["full", "fold
 apache-avro = { default-features = false, path = "../avro", features = ["derive"] }
 proptest = { default-features = false, version = "1.0.0", features = ["std"] }
 serde = { default-features = false, version = "1.0.147", features = ["derive"] }
+uuid = "1.2.1"

--- a/lang/rust/avro_derive/src/lib.rs
+++ b/lang/rust/avro_derive/src/lib.rs
@@ -15,14 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
+extern crate core;
 extern crate darling;
 
 use darling::FromAttributes;
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
-
 use syn::{
-    parse_macro_input, spanned::Spanned, AttrStyle, Attribute, DeriveInput, Error, Type, TypePath,
+    parse_macro_input, spanned::Spanned, AttrStyle, Attribute, DeriveInput, Field, GenericArgument,
+    PathSegment, Type, TypePath,
 };
 
 #[derive(FromAttributes)]
@@ -58,6 +59,14 @@ pub fn proc_macro_derive_avro_schema(input: proc_macro::TokenStream) -> proc_mac
         .into()
 }
 
+#[proc_macro_derive(AvroValue)]
+pub fn proc_macro_derive_avro_value(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    derive_avro_value(&input)
+        .unwrap_or_else(to_compile_errors)
+        .into()
+}
+
 fn derive_avro_schema(input: &mut DeriveInput) -> Result<TokenStream, Vec<syn::Error>> {
     let named_type_options =
         NamedTypeOptions::from_attributes(&input.attrs[..]).map_err(darling_to_syn)?;
@@ -86,7 +95,7 @@ fn derive_avro_schema(input: &mut DeriveInput) -> Result<TokenStream, Vec<syn::E
             input.ident.span(),
         )?,
         _ => {
-            return Err(vec![Error::new(
+            return Err(vec![syn::Error::new(
                 input.ident.span(),
                 "AvroSchema derive only works for structs and simple enums ",
             )])
@@ -104,6 +113,84 @@ fn derive_avro_schema(input: &mut DeriveInput) -> Result<TokenStream, Vec<syn::E
                 } else {
                     named_schemas.insert(name.clone(), apache_avro::schema::Schema::Ref{name: name.clone()});
                     #schema_def
+                }
+            }
+        }
+    })
+}
+
+fn derive_avro_value(input: &DeriveInput) -> Result<TokenStream, Vec<syn::Error>> {
+    match &input.data {
+        syn::Data::Struct(data_struct) => derive_avro_value_struct(input, data_struct),
+        syn::Data::Enum(data_enum) => derive_avro_value_enum(input, data_enum),
+        _ => Err(vec![syn::Error::new(
+            input.ident.span(),
+            "AvroValue derive only works for structs and simple enums ",
+        )]),
+    }
+}
+
+fn derive_avro_value_struct(
+    input: &DeriveInput,
+    data_struct: &syn::DataStruct,
+) -> Result<TokenStream, Vec<syn::Error>> {
+    let ident = &input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    let (from_field_assigns, into_fields) = get_data_struct_value_defs(data_struct, ident.span())?;
+    Ok(quote! {
+        impl #impl_generics From<#ident #ty_generics> for apache_avro::types::Value #where_clause {
+            fn from(value: #ident #ty_generics) -> Self {
+                apache_avro::types::Value::Record(vec![
+                    #(#into_fields)*
+                ])
+            }
+        }
+        impl #impl_generics std::convert::TryFrom<apache_avro::types::Value> for #ident #ty_generics #where_clause {
+            type Error = apache_avro::Error;
+
+            fn try_from(value: apache_avro::types::Value) -> Result<Self, Self::Error> {
+                let record_fields = match value {
+                        apache_avro::types::Value::Record(fields)  => fields,
+                        other_value => Err(Self::Error::GetRecord{
+                            expected: vec![],
+                            other: other_value.into(),
+                        })?
+                    };
+                Ok(Self {
+                    #(#from_field_assigns)*
+                })
+            }
+        }
+    })
+}
+
+fn derive_avro_value_enum(
+    input: &DeriveInput,
+    data_enum: &syn::DataEnum,
+) -> Result<TokenStream, Vec<syn::Error>> {
+    let ident = &input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    let (into_matches, from_matches) =
+        get_data_enum_value_defs(ident, data_enum, input.ident.span())?;
+    let nsymbols = data_enum.variants.len();
+    Ok(quote! {
+        impl #impl_generics From<#ident #ty_generics> for apache_avro::types::Value #where_clause {
+            fn from(value: #ident #ty_generics) -> Self {
+                match value {
+                    #(#into_matches),*,
+                }
+            }
+        }
+        impl #impl_generics std::convert::TryFrom<apache_avro::types::Value> for #ident #ty_generics #where_clause {
+            type Error = apache_avro::Error;
+
+            fn try_from(value: apache_avro::types::Value) -> Result<Self, Self::Error> {
+                match value {
+                    #(#from_matches),*,
+                    apache_avro::types::Value::Enum(index, _) => {
+                        Err(Self::Error::GetEnumValue{index: index as usize, nsymbols: #nsymbols})
+                    },
+                    other => Err(Self::Error::GetEnum(other.into()))
                 }
             }
         }
@@ -139,9 +226,9 @@ fn get_data_struct_schema_def(
                     Some(default_value) => {
                         let _: serde_json::Value = serde_json::from_str(&default_value[..])
                             .map_err(|e| {
-                                vec![Error::new(
+                                vec![syn::Error::new(
                                     field.ident.span(),
-                                    format!("Invalid avro default json: \n{}", e),
+                                    format!("Invalid avro default json: \n{e}"),
                                 )]
                             })?;
                         quote! {
@@ -167,13 +254,13 @@ fn get_data_struct_schema_def(
             }
         }
         syn::Fields::Unnamed(_) => {
-            return Err(vec![Error::new(
+            return Err(vec![syn::Error::new(
                 error_span,
                 "AvroSchema derive does not work for tuple structs",
             )])
         }
         syn::Fields::Unit => {
-            return Err(vec![Error::new(
+            return Err(vec![syn::Error::new(
                 error_span,
                 "AvroSchema derive does not work for unit structs",
             )])
@@ -197,6 +284,221 @@ fn get_data_struct_schema_def(
             attributes: Default::default(),
         }
     })
+}
+
+fn get_data_struct_value_defs(
+    data_struct: &syn::DataStruct,
+    error_span: Span,
+) -> Result<(Vec<TokenStream>, Vec<TokenStream>), Vec<syn::Error>> {
+    let fields = match data_struct.fields {
+        syn::Fields::Named(ref named_fields) => named_fields,
+        syn::Fields::Unnamed(_) => {
+            return Err(vec![syn::Error::new(
+                error_span,
+                "AvroValue derive does not work for tuple structs",
+            )])
+        }
+        syn::Fields::Unit => {
+            return Err(vec![syn::Error::new(
+                error_span,
+                "AvroValue derive does not work for unit structs",
+            )])
+        }
+    };
+    let mut into_fields = vec![];
+    let mut from_field_assigns = vec![];
+    let mut index = 0_usize;
+    for field in fields.named.iter() {
+        let field_attrs =
+            FieldOptions::from_attributes(&field.attrs[..]).map_err(darling_to_syn)?;
+        let field_ident = field
+            .ident
+            .clone()
+            .expect("AvroValue requires only named struct fields");
+        let name = match field_attrs.rename {
+            Some(name_attr) => name_attr,
+            None => field_ident.to_string(),
+        };
+        let value_expr = type_to_value_expr(&field.ty)?;
+        // for cases in which the field was skipped, we must have a field-value, so we assume that
+        // the field implements default, and assign a default value to it. We skip incrementing
+        // the index, here, since it is not included in the record field
+        from_field_assigns.push(match field_attrs.skip {
+            Some(true) => {
+                quote!(#field_ident: Default::default(),);
+                continue;
+            }
+            _ => data_struct_value_assignment(field, index)?,
+        });
+        into_fields.push(data_struct_value_record_field(
+            name,
+            &field_ident,
+            value_expr,
+        ));
+        index += 1;
+    }
+    Ok((from_field_assigns, into_fields))
+}
+
+fn data_struct_value_record_field(
+    name: String,
+    field_ident: &proc_macro2::Ident,
+    value_expr: ValueExpr,
+) -> TokenStream {
+    let value_ident = Some(proc_macro2::Ident::new("value", field_ident.span()));
+    let record_value = data_struct_value_field_as_value(
+        field_ident.clone(),
+        value_ident,
+        value_expr,
+        field_ident.span(),
+    );
+    quote!((#name.to_string(), #record_value),)
+}
+
+fn data_struct_value_field_as_value(
+    ident: proc_macro2::Ident,
+    receiver_ident: Option<proc_macro2::Ident>,
+    value_expr: ValueExpr,
+    span: proc_macro2::Span,
+) -> TokenStream {
+    let ident = match receiver_ident {
+        Some(receiver_ident) => quote!(#receiver_ident.#ident),
+        None => quote!(#ident),
+    };
+    match value_expr {
+        ValueExpr::Convertable(_) => quote!(apache_avro::types::Value::from(#ident)),
+        ValueExpr::Option(value_variant) => {
+            let inner_expr = data_struct_value_field_as_value(
+                proc_macro2::Ident::new("item", span),
+                None,
+                *value_variant,
+                span,
+            );
+            quote!(match #ident {
+                Some(item) => apache_avro::types::Value::Union(1, Box::new(#inner_expr)),
+                None => apache_avro::types::Value::Union(0, Box::new(apache_avro::types::Value::Null)),
+            })
+        }
+        ValueExpr::Array(value_variant) => {
+            let inner_expr = data_struct_value_field_as_value(
+                proc_macro2::Ident::new("item", span),
+                None,
+                *value_variant,
+                span,
+            );
+            quote!(apache_avro::types::Value::Array(#ident.into_iter().map(|item| {
+                #inner_expr
+            }).collect::<Vec<apache_avro::types::Value>>()))
+        }
+        ValueExpr::Map(value_variant) => {
+            let inner_expr = data_struct_value_field_as_value(
+                proc_macro2::Ident::new("value", span),
+                None,
+                *value_variant,
+                span,
+            );
+            quote!(apache_avro::types::Value::Map(#ident.into_iter().map(|(key, value)| {
+                    (key, #inner_expr)
+            }).collect::<HashMap<String, apache_avro::types::Value>>()))
+        }
+    }
+}
+
+fn data_struct_value_assignment(
+    field: &Field,
+    index: usize,
+) -> Result<TokenStream, Vec<syn::Error>> {
+    let field_ident = field.clone().ident.unwrap();
+    let ident = proc_macro2::Ident::new("value", field.span());
+    let value_expr = type_to_value_expr(&field.ty)?;
+    let value_assignment =
+        data_struct_value_field_as_assigned(quote!(#ident), None, value_expr, ident.span());
+    Ok(quote!(#field_ident: match record_fields.get(#index) {
+        Some((_, value)) => {
+            #value_assignment
+        }?,
+        _ => return Err(Self::Error::GetField(stringify!(#field_ident).to_string())),
+    },))
+}
+
+fn data_struct_value_field_as_assigned(
+    ident: TokenStream,
+    receiver_ident: Option<proc_macro2::Ident>,
+    value_expr: ValueExpr,
+    span: proc_macro2::Span,
+) -> TokenStream {
+    let ident = match receiver_ident {
+        Some(receiver_ident) => quote!(#receiver_ident.#ident),
+        None => quote!(#ident),
+    };
+    match value_expr {
+        ValueExpr::Convertable(field_type) => quote!(#field_type::try_from(#ident.clone())),
+        ValueExpr::Option(value_variant) => {
+            let union_ident = proc_macro2::Ident::new("union_value", span);
+            let value_expr = data_struct_value_field_as_assigned(
+                quote!(*#union_ident),
+                None,
+                *value_variant,
+                ident.span(),
+            );
+            quote!(match #ident.clone() {
+                apache_avro::types::Value::Union(0, _) => None,
+                apache_avro::types::Value::Union(1, union_value) => Some(#value_expr),
+                apache_avro::types::Value::Union(union_index, _) => {
+                    Err(Self::Error::GetUnionVariant{
+                        index: union_index as i64,
+                        num_variants: 2,
+                    })?
+                },
+                _ => Err(Self::Error::GetUnionVariant{
+                    index: -1,
+                    num_variants: 2,
+                })?,
+            }
+            .transpose())
+        }
+        ValueExpr::Array(value_variant) => {
+            let var_ident = proc_macro2::Ident::new("item_value", span);
+            let value_expr = data_struct_value_field_as_assigned(
+                quote!(#var_ident),
+                None,
+                *value_variant,
+                ident.span(),
+            );
+            quote!(match #ident {
+                apache_avro::types::Value::Array(item_values) => item_values
+                    .iter()
+                    .map(|#var_ident| { #value_expr })
+                    .collect::<Result<Vec<_>, Self::Error>>(),
+                other_value => {
+                    Err(Self::Error::GetArray{
+                        expected: apache_avro::schema::SchemaKind::Array,
+                        other: other_value.into()
+                    })
+                }
+            })
+        }
+        ValueExpr::Map(value_variant) => {
+            let var_ident = proc_macro2::Ident::new("item_value", span);
+            let value_expr = data_struct_value_field_as_assigned(
+                quote!(#var_ident),
+                None,
+                *value_variant,
+                ident.span(),
+            );
+            quote!(match #ident {
+                apache_avro::types::Value::Map(field_value_pairs) => field_value_pairs
+                    .iter()
+                    .map(|(item_key, item_value)| (
+                        #value_expr.map(|value| (item_key.clone(), value))
+                    )).collect::<Result<HashMap<_, _>, Self::Error>>(),
+                other_value => Err(Self::Error::GetMap{
+                    expected: apache_avro::schema::SchemaKind::Map,
+                    other: other_value.into()
+                }),
+            })
+        }
+    }
 }
 
 fn get_data_enum_schema_def(
@@ -224,11 +526,40 @@ fn get_data_enum_schema_def(
             }
         })
     } else {
-        Err(vec![Error::new(
+        Err(vec![syn::Error::new(
             error_span,
             "AvroSchema derive does not work for enums with non unit structs",
         )])
     }
+}
+
+fn get_data_enum_value_defs(
+    ident: &syn::Ident,
+    e: &syn::DataEnum,
+    error_span: Span,
+) -> Result<(Vec<TokenStream>, Vec<TokenStream>), Vec<syn::Error>> {
+    if !e.variants.iter().all(|v| syn::Fields::Unit == v.fields) {
+        return Err(vec![syn::Error::new(
+            error_span,
+            "AvroValue derive does not work for enums with non unit structs",
+        )]);
+    }
+    Ok(e.variants.iter().enumerate().fold(
+        (vec![], vec![]),
+        |(mut into_matches, mut from_matches), (index, variant)| {
+            let index = index as u32;
+            let variant_string = variant.ident.to_string();
+            into_matches.push(quote!(
+                #ident::#variant => {
+                    apache_avro::types::Value::Enum(#index, #variant_string.to_string())
+                }
+            ));
+            from_matches.push(quote!(
+                apache_avro::types::Value::Enum(#index, _) => Ok(#ident::#variant)
+            ));
+            (into_matches, from_matches)
+        },
+    ))
 }
 
 /// Takes in the Tokens of a type and returns the tokens of an expression with return type `Schema`
@@ -270,8 +601,62 @@ fn type_to_schema_expr(ty: &Type) -> Result<TokenStream, Vec<syn::Error>> {
     } else {
         Err(vec![syn::Error::new_spanned(
             ty,
-            format!("Unable to generate schema for type: {:?}", ty),
+            format!("Unable to generate schema for type: {ty:?}"),
         )])
+    }
+}
+
+/// A parsed union of the Avro value expressions to create the required serialization/deserializaion
+/// patterns required for converting simple & complex field values
+#[derive(Clone)]
+enum ValueExpr {
+    Convertable(syn::Type),
+    Option(Box<ValueExpr>),
+    Array(Box<ValueExpr>),
+    Map(Box<ValueExpr>),
+}
+
+/// Takes in the Tokens of a type and returns the tokens of an expression with return type `Schema`
+fn type_to_value_expr(ty: &Type) -> Result<ValueExpr, Vec<syn::Error>> {
+    match ty {
+        Type::Path(p) => {
+            let path_segment = p.path.segments.last().unwrap();
+            let type_string = &path_segment.ident.to_string()[..];
+            let value = match type_string {
+                "Option" => {
+                    let inner_ty = get_path_inner_type(ty, path_segment, 0)?;
+                    ValueExpr::Option(Box::new(type_to_value_expr(&inner_ty)?))
+                }
+                "Vec" => {
+                    let inner_ty = get_path_inner_type(ty, path_segment, 0)?;
+                    ValueExpr::Array(Box::new(type_to_value_expr(&inner_ty)?))
+                }
+                "HashMap" => {
+                    let inner_ty = get_path_inner_type(ty, path_segment, 1)?;
+                    ValueExpr::Map(Box::new(type_to_value_expr(&inner_ty)?))
+                }
+                "char" => {
+                    return Err(vec![syn::Error::new_spanned(
+                        ty,
+                        "AvroValue: Cannot guarantee successful deserialization of this type",
+                    )])
+                }
+                "u64" => {
+                    return Err(vec![syn::Error::new_spanned(
+                        ty,
+                        "Cannot guarantee successful serialization of this type due to overflow concerns",
+                    )])
+                }
+                _ => {
+                    ValueExpr::Convertable(ty.clone())
+                }
+            };
+            Ok(value)
+        }
+        _ => Err(vec![syn::Error::new_spanned(
+            ty,
+            format!("Unable to generate value for type: {ty:?}"),
+        )]),
     }
 }
 
@@ -280,6 +665,35 @@ fn type_to_schema_expr(ty: &Type) -> Result<TokenStream, Vec<syn::Error>> {
 /// - `A<T> -> <A<T> as apache_avro::schema::derive::AvroSchemaComponent>::get_schema_in_ctxt()`
 fn type_path_schema_expr(p: &TypePath) -> TokenStream {
     quote! {<#p as apache_avro::schema::derive::AvroSchemaComponent>::get_schema_in_ctxt(named_schemas, enclosing_namespace)}
+}
+
+/// Returns the generic type argument from a PathType at the specified index
+fn get_path_inner_type(
+    ty: &Type,
+    path_segment: &PathSegment,
+    index: usize,
+) -> Result<Type, Vec<syn::Error>> {
+    match path_segment.clone().arguments {
+        syn::PathArguments::AngleBracketed(angle_bracket) => {
+            let gen_args: Vec<GenericArgument> = angle_bracket
+                .args
+                .iter()
+                .cloned()
+                .filter(|arg| matches!(arg, syn::GenericArgument::Type(_)))
+                .collect();
+            match gen_args.get(index) {
+                Some(syn::GenericArgument::Type(ty)) => Ok(ty.clone()),
+                _ => Err(vec![syn::Error::new_spanned(
+                    ty,
+                    "TypePath has unexpected type arguments",
+                )]),
+            }
+        }
+        _ => Err(vec![syn::Error::new_spanned(
+            ty,
+            "AvroValue Option type has unexpected type arguments",
+        )]),
+    }
 }
 
 /// Stolen from serde
@@ -329,7 +743,7 @@ fn preserve_vec(op: Vec<impl quote::ToTokens>) -> TokenStream {
 }
 
 fn darling_to_syn(e: darling::Error) -> Vec<syn::Error> {
-    let msg = format!("{}", e);
+    let msg = format!("{e}");
     let token_errors = e.write_errors();
     vec![syn::Error::new(token_errors.span(), msg)]
 }
@@ -337,6 +751,7 @@ fn darling_to_syn(e: darling::Error) -> Vec<syn::Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
     #[test]
     fn basic_case() {
         let test_struct = quote! {
@@ -349,6 +764,26 @@ mod tests {
         match syn::parse2::<DeriveInput>(test_struct) {
             Ok(mut input) => {
                 assert!(derive_avro_schema(&mut input).is_ok())
+            }
+            Err(error) => panic!(
+                "Failed to parse as derive input when it should be able to. Error: {:?}",
+                error
+            ),
+        };
+    }
+
+    #[test]
+    fn basic_case_value() {
+        let test_struct = quote! {
+            struct A {
+                a: i32,
+                b: String
+            }
+        };
+
+        match syn::parse2::<DeriveInput>(test_struct) {
+            Ok(input) => {
+                assert!(derive_avro_value(&input).is_ok())
             }
             Err(error) => panic!(
                 "Failed to parse as derive input when it should be able to. Error: {:?}",
@@ -422,6 +857,27 @@ mod tests {
         match syn::parse2::<DeriveInput>(basic_enum) {
             Ok(mut input) => {
                 assert!(derive_avro_schema(&mut input).is_ok())
+            }
+            Err(error) => panic!(
+                "Failed to parse as derive input when it should be able to. Error: {:?}",
+                error
+            ),
+        };
+    }
+
+    #[test]
+    fn test_basic_enum_value() {
+        let basic_enum = quote! {
+            enum Basic {
+                A,
+                B,
+                C,
+                D
+            }
+        };
+        match syn::parse2::<DeriveInput>(basic_enum) {
+            Ok(input) => {
+                assert!(derive_avro_value(&input).is_ok())
             }
             Err(error) => panic!(
                 "Failed to parse as derive input when it should be able to. Error: {:?}",


### PR DESCRIPTION
## What is the purpose of the change

Add Rust AvroSchema derive support for non-unit enums supporting only single, unnamed fields. This is the Rust idiomatic way to create union types.

## Verifying this change

- Add unit tests to match new derive behavior


## Documentation

- Does this pull request introduce a new feature? yes
- Added Rust documentation comments
