### PR TITLE
AVRO-3670: Add NET 7.0 support

### DIFF
--- a/.github/workflows/codeql-csharp-analysis.yml
+++ b/.github/workflows/codeql-csharp-analysis.yml
@@ -61,7 +61,7 @@ jobs:
 
     # Install .NET SDKs
     - name: Install .NET SDKs
-      uses: actions/setup-dotnet@v3.0.3
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
           3.1.x

--- a/.github/workflows/codeql-csharp-analysis.yml
+++ b/.github/workflows/codeql-csharp-analysis.yml
@@ -61,12 +61,13 @@ jobs:
 
     # Install .NET SDKs
     - name: Install .NET SDKs
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v3.0.3
       with:
         dotnet-version: |
           3.1.x
           5.0.x
           6.0.x
+          7.0.x
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/test-lang-csharp.yml
+++ b/.github/workflows/test-lang-csharp.yml
@@ -43,7 +43,7 @@ jobs:
         run: sudo apt-get install -y libzstd-dev
 
       - name: Install .NET SDKs
-        uses: actions/setup-dotnet@v3.0.3
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
             3.1.x
@@ -74,7 +74,7 @@ jobs:
         run: sudo apt-get install -y libzstd-dev
 
       - name: Install .NET SDKs
-        uses: actions/setup-dotnet@v3.0.3
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
             3.1.x

--- a/.github/workflows/test-lang-csharp.yml
+++ b/.github/workflows/test-lang-csharp.yml
@@ -43,12 +43,13 @@ jobs:
         run: sudo apt-get install -y libzstd-dev
 
       - name: Install .NET SDKs
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v3.0.3
         with:
           dotnet-version: |
             3.1.x
             5.0.x
             6.0.x
+            7.0.x
 
       - uses: actions/cache@v3
         with:
@@ -63,19 +64,6 @@ jobs:
       - name: Test
         run: ./build.sh test
 
-      # Build and test against .NET 7
-      # .NET 7 is not released yet, however this is a good way to test if the project is ready for the release
-      # Once .NET 7 is officially released, this can be removed and 7.0.x can be used instead above
-      - name: Install .NET SDK 7.0 (pre-release)
-        uses: actions/setup-dotnet@v3
-        with:
-          include-prerelease: true
-          dotnet-version: |
-            7.0.x
-      
-      - name: Test .NET 7.0 (pre-release)
-        run: ./build.sh test
-
   interop:
     runs-on: ubuntu-latest
     steps:
@@ -86,12 +74,13 @@ jobs:
         run: sudo apt-get install -y libzstd-dev
 
       - name: Install .NET SDKs
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v3.0.3
         with:
           dotnet-version: |
             3.1.x
             5.0.x
             6.0.x
+            7.0.x
 
       - name: Cache Local Maven Repository
         uses: actions/cache@v3

--- a/.github/workflows/test-lang-java.yml
+++ b/.github/workflows/test-lang-java.yml
@@ -119,12 +119,13 @@ jobs:
           python3 -m pip install python-snappy zstandard
 
       - name: Setup C# for Generating Interop Data
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v3.0.3
         with:
           dotnet-version: |
             3.1.x
             5.0.x
             6.0.x
+            7.0.x
 
       - name: Install Java Avro for Interop Test
         working-directory: .

--- a/.github/workflows/test-lang-java.yml
+++ b/.github/workflows/test-lang-java.yml
@@ -119,7 +119,7 @@ jobs:
           python3 -m pip install python-snappy zstandard
 
       - name: Setup C# for Generating Interop Data
-        uses: actions/setup-dotnet@v3.0.3
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
             3.1.x

--- a/lang/csharp/README.md
+++ b/lang/csharp/README.md
@@ -17,20 +17,20 @@ Install-Package Apache.Avro
 
 ## Project Target Frameworks
 
-| Project             | Published to nuget.org     | Type       | .NET Standard 2.0  | .NET Standard 2.1 | .NET Core 3.1 | .NET 5.0  | .NET 6.0  |
-|:-------------------:|:--------------------------:|:----------:|:------------------:|:-----------------:|:-------------:|:---------:|:---------:|
-| Avro.main           | Apache.Avro                | Library    | ✔️                 | ✔️               |               |           |           |
-| Avro.File.Snappy    | Apache.Avro.File.Snappy    | Library    | ✔️                 | ✔️               |               |           |           |
-| Avro.File.BZip2     | Apache.Avro.File.BZip2     | Library    | ✔️                 | ✔️               |               |           |           |
-| Avro.File.XZ        | Apache.Avro.File.XZ        | Library    | ✔️                 | ✔️               |               |           |           |
-| Avro.File.Zstandard | Apache.Avro.File.Zstandard | Library    | ✔️                 | ✔️               |               |           |           |
-| Avro.codegen        | Apache.Avro.Tools          |  Exe        |                    |                   | ✔️            |✔️        |✔️        |
-| Avro.ipc            |                            | Library    | ✔️                 | ✔️               |               |           |           |
-| Avro.ipc.test       |                            | Unit Tests |                    |                   | ✔️            |✔️        |✔️        |
-| Avro.msbuild        |                            | Library    | ✔️                 | ✔️               |               |           |           |
-| Avro.perf           |                            | Exe        |                    |                   | ✔️            |✔️        |✔️        |
-| Avro.test           |                            | Unit Tests |                    |                   | ✔️            |✔️        |✔️        |
-| Avro.benchmark      |                            | Exe        |                    |                   | ✔️            |✔️        |✔️        |
+| Project             | Published to nuget.org     | Type       | .NET Standard 2.0  | .NET Standard 2.1 | .NET Core 3.1 | .NET 5.0  | .NET 6.0  | .NET 7.0  |
+|:-------------------:|:--------------------------:|:----------:|:------------------:|:-----------------:|:-------------:|:---------:|:---------:|:---------:|
+| Avro.main           | Apache.Avro                | Library    | ✔️                 | ✔️               |               |           |           |           |
+| Avro.File.Snappy    | Apache.Avro.File.Snappy    | Library    | ✔️                 | ✔️               |               |           |           |           |
+| Avro.File.BZip2     | Apache.Avro.File.BZip2     | Library    | ✔️                 | ✔️               |               |           |           |           |
+| Avro.File.XZ        | Apache.Avro.File.XZ        | Library    | ✔️                 | ✔️               |               |           |           |           |
+| Avro.File.Zstandard | Apache.Avro.File.Zstandard | Library    | ✔️                 | ✔️               |               |           |           |           |
+| Avro.codegen        | Apache.Avro.Tools          |  Exe        |                    |                   | ✔️            |✔️        |✔️        |✔️        |
+| Avro.ipc            |                            | Library    | ✔️                 | ✔️               |               |           |           |           |
+| Avro.ipc.test       |                            | Unit Tests |                    |                   | ✔️            |✔️        |✔️        |✔️        |
+| Avro.msbuild        |                            | Library    | ✔️                 | ✔️               |               |           |           |           |
+| Avro.perf           |                            | Exe        |                    |                   | ✔️            |✔️        |✔️        |✔️        |
+| Avro.test           |                            | Unit Tests |                    |                   | ✔️            |✔️        |✔️        |✔️        |
+| Avro.benchmark      |                            | Exe        |                    |                   | ✔️            |✔️        |✔️        |✔️        |
 
 ## Dependency package version strategy
 

--- a/lang/csharp/build.sh
+++ b/lang/csharp/build.sh
@@ -42,7 +42,7 @@ do
 
     perf)
       pushd ./src/apache/perf/
-      dotnet run --configuration Release --framework net6.0
+      dotnet run --configuration Release --framework net7.0
       ;;
 
     dist)
@@ -77,7 +77,7 @@ do
       ;;
 
     interop-data-generate)
-      dotnet run --project src/apache/test/Avro.test.csproj --framework net6.0 ../../share/test/schemas/interop.avsc ../../build/interop/data
+      dotnet run --project src/apache/test/Avro.test.csproj --framework net7.0 ../../share/test/schemas/interop.avsc ../../build/interop/data
       ;;
 
     interop-data-test)

--- a/lang/csharp/common.props
+++ b/lang/csharp/common.props
@@ -37,9 +37,7 @@
 
   <PropertyGroup Label="Target Frameworks">
     <!-- Exe -->
-    <!-- NOTE: .NET 7 is still in preview state, use it only if it is available to make sure the project is ready for it. When .NET 7 SDK is released preview, update this -->
-    <DefaultExeTargetFrameworks Condition="'$(NETCoreAppMaximumVersion)' != '7.0' or '$(_NETCoreSdkIsPreview)' == 'false'">netcoreapp3.1;net5.0;net6.0</DefaultExeTargetFrameworks>
-    <DefaultExeTargetFrameworks Condition="'$(NETCoreAppMaximumVersion)' == '7.0' and '$(_NETCoreSdkIsPreview)' == 'true'">net7.0</DefaultExeTargetFrameworks>
+    <DefaultExeTargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</DefaultExeTargetFrameworks>
     <!-- Library -->
     <DefaultLibraryTargetFrameworks>netstandard2.0;netstandard2.1</DefaultLibraryTargetFrameworks>
     <!-- Unit Tests -->
@@ -60,6 +58,12 @@
     <None Include="$(MSBuildThisFileDirectory)\LICENSE" Pack="true" Visible="false" PackagePath=""/>
     <None Include="$(MSBuildThisFileDirectory)\..\..\doc\assets\icons\logo.png" Pack="true" Visible="false" PackagePath=""/>
   </ItemGroup>
+
+  <PropertyGroup>
+    <!-- Disable warning for EOL target frameworks -->
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+  </PropertyGroup>
 
   <PropertyGroup>
     <IsTestProject Condition="'$(IsTestProject)' == ''">false</IsTestProject>

--- a/lang/csharp/src/apache/benchmark/Avro.benchmark.csproj
+++ b/lang/csharp/src/apache/benchmark/Avro.benchmark.csproj
@@ -31,6 +31,12 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- Some schemas use lower cased names, which causes some class names being lower case only -->
+    <!-- e.g. The type name 'test' only contains lower-cased ascii characters. Such names may become reserved for the language. -->
+    <NoWarn>$(NoWarn);CS8981</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
   </ItemGroup>

--- a/lang/csharp/src/apache/benchmark/Program.cs
+++ b/lang/csharp/src/apache/benchmark/Program.cs
@@ -21,8 +21,8 @@ namespace Avro.Benchmark
 {
     public class Program
     {
-        // dotnet run -c Release -f net6.0
-        // dotnet run -c Release -f net6.0 --runtimes netcoreapp3.1 net5.0 net6.0
+        // dotnet run -c Release -f net7.0
+        // dotnet run -c Release -f net7.0 --runtimes netcoreapp3.1 net5.0 net6.0 net7.0
         public static void Main(string[] args)
         {
             BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/lang/csharp/versions.props
+++ b/lang/csharp/versions.props
@@ -26,14 +26,14 @@
     !!! SHIPPED CLASS LIBRARIES SHOULD USE MINIMUMVERSIONs FOR SOME LIBRARIES. SEE BELOW !!!
   -->
   <PropertyGroup Label="Latest Package Versions">
-    <NewtonsoftJsonVersion>12.0.3</NewtonsoftJsonVersion>
-    <SystemCodeDomVersion>6.0.0</SystemCodeDomVersion>
+    <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
+    <SystemCodeDomVersion>7.0.0</SystemCodeDomVersion>
     <SystemReflectionVersion>4.3.0</SystemReflectionVersion>
     <SystemReflectionEmitILGenerationVersion>4.7.0</SystemReflectionEmitILGenerationVersion>
     <SystemReflectionEmitLightweightVersion>4.7.0</SystemReflectionEmitLightweightVersion>
 
     <!-- The following packages are required for the extra codec libraries. These are not direct dependencies of the Avro.main library. -->
-    <SharpZipLibVersion>1.3.3</SharpZipLibVersion>
+    <SharpZipLibVersion>1.4.1</SharpZipLibVersion>
     <IronSnappyVersion>1.3.0</IronSnappyVersion>
     <JovelerCompressionXZVersion>4.1.0</JovelerCompressionXZVersion>
     <ZstandardNetVersion>1.1.7</ZstandardNetVersion>
@@ -55,21 +55,19 @@
 	Please sort the packages alphabetically
   -->
   <PropertyGroup Label="Build, Test, Code Analysis, Benchmark Package Versions">
-    <BenchmarkDotNetVersion>0.13.1</BenchmarkDotNetVersion>
-    <CoverletCollectorVersion>3.1.2</CoverletCollectorVersion>
-    <CoverletMSBuildVersion>3.1.2</CoverletMSBuildVersion>
-    <MicrosoftBuildFrameworkVersion>17.1.0</MicrosoftBuildFrameworkVersion>
-    <MicrosoftBuildUtilitiesCoreVersion>17.1.0</MicrosoftBuildUtilitiesCoreVersion>
-    <MicrosoftCodeAnalysisVersion>4.1.0</MicrosoftCodeAnalysisVersion>
-    <MicrosoftCodeAnalysisCSharpVersion>4.1.0</MicrosoftCodeAnalysisCSharpVersion>
-    <MicrosoftCodeAnalysisCSharpCodeStyleVersion>4.1.0</MicrosoftCodeAnalysisCSharpCodeStyleVersion>
-    <!-- When .NET 7 SDK is released or the package is not in preview, update this version -->
-    <MicrosoftCodeAnalysisNetAnalyzersVersion Condition="'$(TargetFramework)' != 'net7.0'">6.0.0</MicrosoftCodeAnalysisNetAnalyzersVersion>
-    <MicrosoftCodeAnalysisNetAnalyzersVersion Condition="'$(TargetFramework)' == 'net7.0'">7.0.0-preview*</MicrosoftCodeAnalysisNetAnalyzersVersion>
-    <MicrosoftNETTestSdkVersion>17.1.0</MicrosoftNETTestSdkVersion>
-    <NUnitVersion>3.13.2</NUnitVersion>
-    <NUnitConsoleRunnerVersion>3.15.0</NUnitConsoleRunnerVersion>
-    <NUnit3TestAdapterVersion>4.2.1</NUnit3TestAdapterVersion>
+    <BenchmarkDotNetVersion>0.13.2</BenchmarkDotNetVersion>
+    <CoverletCollectorVersion>3.2.0</CoverletCollectorVersion>
+    <CoverletMSBuildVersion>3.2.0</CoverletMSBuildVersion>
+    <MicrosoftBuildFrameworkVersion>17.4.0</MicrosoftBuildFrameworkVersion>
+    <MicrosoftBuildUtilitiesCoreVersion>17.4.0</MicrosoftBuildUtilitiesCoreVersion>
+    <MicrosoftCodeAnalysisVersion>4.3.1</MicrosoftCodeAnalysisVersion>
+    <MicrosoftCodeAnalysisCSharpVersion>4.3.1</MicrosoftCodeAnalysisCSharpVersion>
+    <MicrosoftCodeAnalysisCSharpCodeStyleVersion>4.3.1</MicrosoftCodeAnalysisCSharpCodeStyleVersion>
+    <MicrosoftCodeAnalysisNetAnalyzersVersion>7.0.0-preview*</MicrosoftCodeAnalysisNetAnalyzersVersion>
+    <MicrosoftNETTestSdkVersion>17.4.0</MicrosoftNETTestSdkVersion>
+    <NUnitVersion>3.13.3</NUnitVersion>
+    <NUnitConsoleRunnerVersion>3.15.2</NUnitConsoleRunnerVersion>
+    <NUnit3TestAdapterVersion>4.3.0</NUnit3TestAdapterVersion>
     <StyleCopAnalyzersVersion>1.1.118</StyleCopAnalyzersVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## What is the purpose of the change

Add support for NET 7.0, AVRO-3670

## Verifying this change

This change just adds a new target framework, updates package versions and disables EOL SDK related warnings.

## Documentation

- Does this pull request introduce a new feature? (no)
