### PR TITLE
AVRO-3657: Computation of initial buffer size in OutputBuffer makes no sense

### DIFF
--- a/lang/java/trevni/core/src/main/java/org/apache/trevni/OutputBuffer.java
+++ b/lang/java/trevni/core/src/main/java/org/apache/trevni/OutputBuffer.java
@@ -30,7 +30,11 @@ class OutputBuffer extends ByteArrayOutputStream {
   private int bitCount; // position in booleans
 
   public OutputBuffer() {
-    super((BLOCK_SIZE + BLOCK_SIZE) >> 2);
+    this(BLOCK_SIZE + (BLOCK_SIZE >> 2));
+  }
+
+  public OutputBuffer(int size) {
+    super(size);
   }
 
   public boolean isFull() {


### PR DESCRIPTION
## What is the purpose of the change

* Allocate 1.25x more space than the block size in the default constructor.
* Add a second constructor that allows the user to set the preferred size

AVRO-3657

## Verifying this change

* This change is already covered by existing tests

## Documentation

- Does this pull request introduce a new feature? no