### PR TITLE
AVRO-3672: Add CI testing for Python 3.11

### DIFF
--- a/.github/workflows/test-lang-py.yml
+++ b/.github/workflows/test-lang-py.yml
@@ -40,6 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         python:
+        - '3.11'
         - '3.10'
         - '3.9'
         - '3.8'
@@ -86,6 +87,7 @@ jobs:
       fail-fast: false
       matrix:
         python:
+        - '3.11'
         - '3.10'
         - '3.9'
         - '3.8'

--- a/lang/py/avro/compatibility.py
+++ b/lang/py/avro/compatibility.py
@@ -50,6 +50,10 @@ class SchemaType(str, Enum):
     STRING = "string"
     UNION = "union"
 
+    def __str__(self):
+        return self.value
+
+
 
 class SchemaCompatibilityType(Enum):
     compatible = "compatible"

--- a/lang/py/avro/compatibility.py
+++ b/lang/py/avro/compatibility.py
@@ -54,7 +54,6 @@ class SchemaType(str, Enum):
         return self.value
 
 
-
 class SchemaCompatibilityType(Enum):
     compatible = "compatible"
     incompatible = "incompatible"

--- a/lang/py/setup.cfg
+++ b/lang/py/setup.cfg
@@ -38,6 +38,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Development Status :: 5 - Production/Stable
 
 [bdist_wheel]

--- a/lang/py/setup.cfg
+++ b/lang/py/setup.cfg
@@ -29,7 +29,7 @@ keywords =
 author = Apache Avro
 author_email = dev@avro.apache.org
 url = https://avro.apache.org/
-license_file = avro/LICENSE
+license_files = avro/LICENSE
 license = Apache License 2.0
 classifiers =
     License :: OSI Approved :: Apache Software License


### PR DESCRIPTION
AVRO-3672

## What is the purpose of the change

* Add Python 3.11 to the test matrix 

## Verifying this change

* Github Actions build should pass

## Documentation

- Does this pull request introduce a new feature? no