### PR TITLE
AVRO-3662: It seems Ruby 2.6 sometimes retains '2'

### DIFF
--- a/lang/ruby/test/test_logical_types.rb
+++ b/lang/ruby/test/test_logical_types.rb
@@ -230,8 +230,8 @@ class TestLogicalTypes < Test::Unit::TestCase
       end
 
       assert_equal 5, report.total_allocated
-      # Ruby 2.7 does not retain anything. Ruby 2.6 retains 1
-      assert_operator 1, :>=, report.total_retained
+      # Ruby 2.7 does not retain anything. Ruby 2.6 retains 1 or 2
+      assert_operator 2, :>=, report.total_retained
     end
   end
 


### PR DESCRIPTION
AVRO-3662 

## What is the purpose of the change

* Test `test_bytes_decimal_object_allocations_decode` is flaky on Ruby 2.6


## Verifying this change

* Tests should pass on CI 

## Documentation

- Does this pull request introduce a new feature? no