### PR TITLE
Avro-3313: [Java] use default enum when reading with old schema

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/Resolver.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Resolver.java
@@ -359,6 +359,7 @@ public class Resolver {
     public final int[] adjustments;
     public final Object[] values;
     public final boolean noAdjustmentsNeeded;
+    public final Integer readerDefault;
 
     private EnumAdjust(Schema w, Schema r, GenericData d, int[] adj, Object[] values) {
       super(w, r, d, Action.Type.ENUM);
@@ -366,6 +367,7 @@ public class Resolver {
       boolean noAdj;
       int rsymCount = r.getEnumSymbols().size();
       int count = Math.min(rsymCount, adj.length);
+      this.readerDefault = r.getEnumDefault() != null ? r.getEnumOrdinal(r.getEnumDefault()) : null;
       noAdj = (adj.length <= rsymCount);
       for (int i = 0; noAdj && i < count; i++) {
         noAdj &= (i == adj[i]);

--- a/lang/java/avro/src/main/java/org/apache/avro/generic/GenericDatumReader.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/generic/GenericDatumReader.java
@@ -268,7 +268,7 @@ public class GenericDatumReader<D> implements DatumReader<D> {
   protected Object readEnum(Schema expected, Decoder in) throws IOException {
     List<String> enumSymbols = expected.getEnumSymbols();
     int ordinal = in.readEnum();
-    if(ordinal >= enumSymbols.size()){
+    if(ordinal >= enumSymbols.size() && expected.getEnumDefault() != null){
       return createEnum(expected.getEnumDefault(), expected);
     }
 

--- a/lang/java/avro/src/main/java/org/apache/avro/generic/GenericDatumReader.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/generic/GenericDatumReader.java
@@ -269,7 +269,7 @@ public class GenericDatumReader<D> implements DatumReader<D> {
   protected Object readEnum(Schema expected, Decoder in) throws IOException {
     List<String> enumSymbols = expected.getEnumSymbols();
     int ordinal = in.readEnum();
-    if (ordinal >= enumSymbols.size()) {
+    if (ordinal < 0 || ordinal >= enumSymbols.size()) {
       if (expected.getEnumDefault() == null) {
         throw new AvroTypeException("Unknown Enum Ordinal " + ordinal);
       }

--- a/lang/java/avro/src/main/java/org/apache/avro/generic/GenericDatumReader.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/generic/GenericDatumReader.java
@@ -268,7 +268,7 @@ public class GenericDatumReader<D> implements DatumReader<D> {
   protected Object readEnum(Schema expected, Decoder in) throws IOException {
     List<String> enumSymbols = expected.getEnumSymbols();
     int ordinal = in.readEnum();
-    if(ordinal >= enumSymbols.size() && expected.getEnumDefault() != null){
+    if (ordinal >= enumSymbols.size() && expected.getEnumDefault() != null) {
       return createEnum(expected.getEnumDefault(), expected);
     }
 

--- a/lang/java/avro/src/main/java/org/apache/avro/generic/GenericDatumReader.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/generic/GenericDatumReader.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Constructor;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
@@ -265,7 +266,13 @@ public class GenericDatumReader<D> implements DatumReader<D> {
    * representations. By default, returns a GenericEnumSymbol.
    */
   protected Object readEnum(Schema expected, Decoder in) throws IOException {
-    return createEnum(expected.getEnumSymbols().get(in.readEnum()), expected);
+    List<String> enumSymbols = expected.getEnumSymbols();
+    int ordinal = in.readEnum();
+    if(ordinal >= enumSymbols.size()){
+      return createEnum(expected.getEnumDefault(), expected);
+    }
+
+    return createEnum(enumSymbols.get(ordinal), expected);
   }
 
   /**

--- a/lang/java/avro/src/main/java/org/apache/avro/generic/GenericDatumReader.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/generic/GenericDatumReader.java
@@ -33,6 +33,7 @@ import org.apache.avro.Conversions;
 import org.apache.avro.LogicalType;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field;
+import org.apache.avro.AvroTypeException;
 import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
@@ -268,7 +269,11 @@ public class GenericDatumReader<D> implements DatumReader<D> {
   protected Object readEnum(Schema expected, Decoder in) throws IOException {
     List<String> enumSymbols = expected.getEnumSymbols();
     int ordinal = in.readEnum();
-    if (ordinal >= enumSymbols.size() && expected.getEnumDefault() != null) {
+    if (ordinal >= enumSymbols.size()) {
+      if (expected.getEnumDefault() == null) {
+        throw new AvroTypeException("Unknown Enum Ordinal " + ordinal);
+      }
+
       return createEnum(expected.getEnumDefault(), expected);
     }
 

--- a/lang/java/avro/src/main/java/org/apache/avro/io/FastReaderBuilder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/FastReaderBuilder.java
@@ -490,7 +490,7 @@ public class FastReaderBuilder {
     return reusingReader((reuse, decoder) -> {
       Object resultObject;
       int index = decoder.readEnum();
-      if (index >= action.values.length) {
+      if (index < 0 || index >= action.values.length) {
         if (action.readerDefault == null) {
           throw new AvroTypeException("Unknown Enum Ordinal " + index);
         }

--- a/lang/java/avro/src/main/java/org/apache/avro/io/FastReaderBuilder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/FastReaderBuilder.java
@@ -488,8 +488,18 @@ public class FastReaderBuilder {
 
   private FieldReader createEnumReader(EnumAdjust action) {
     return reusingReader((reuse, decoder) -> {
+      Object resultObject;
       int index = decoder.readEnum();
-      Object resultObject = action.values[index];
+      if (index >= action.values.length) {
+        if (action.readerDefault == null) {
+          throw new AvroTypeException("Unknown Enum Ordinal " + index);
+        }
+
+        resultObject = action.values[action.readerDefault];
+      } else {
+        resultObject = action.values[index];
+      }
+
       if (resultObject == null) {
         throw new AvroTypeException("No match for " + action.writer.getEnumSymbols().get(index));
       }

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemaCompatibilityEnumDefaults.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemaCompatibilityEnumDefaults.java
@@ -106,10 +106,10 @@ public class TestSchemaCompatibilityEnumDefaults {
   @Test
   public void testEnumDefaultAppliedWhenFieldDefaultDefinedReadingWithOldSchema() throws Exception {
     Schema writerSchema = SchemaBuilder.record("Record1").fields().name("field1").type(ENUM_ABC_ENUM_DEFAULT_A_SCHEMA)
-      .noDefault().endRecord();
+        .noDefault().endRecord();
 
     Schema readerSchema = SchemaBuilder.record("Record1").fields().name("field1").type(ENUM_AB_ENUM_DEFAULT_A_SCHEMA)
-      .withDefault("B").endRecord();
+        .withDefault("B").endRecord();
 
     GenericRecord datum = new GenericData.Record(writerSchema);
     datum.put("field1", new GenericData.EnumSymbol(writerSchema, "C"));
@@ -139,9 +139,9 @@ public class TestSchemaCompatibilityEnumDefaults {
     expectedException.expectMessage("Index: 2, Size: 2");
 
     Schema writerSchema = SchemaBuilder.record("Record1").fields().name("field1").type(ENUM1_ABC_SCHEMA).noDefault()
-      .endRecord();
+        .endRecord();
     Schema readerSchema = SchemaBuilder.record("Record1").fields().name("field1").type(ENUM1_AB_SCHEMA).withDefault("A")
-      .endRecord();
+        .endRecord();
 
     GenericRecord datum = new GenericData.Record(writerSchema);
     datum.put("field1", new GenericData.EnumSymbol(writerSchema, "C"));
@@ -164,7 +164,7 @@ public class TestSchemaCompatibilityEnumDefaults {
   }
 
   private GenericRecord serializeWithNewSchemaThenDeserializeWithOldSchema(Schema writerSchema, GenericRecord datum,
-                                                                           Schema readerSchema) throws Exception {
+      Schema readerSchema) throws Exception {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     Encoder encoder = EncoderFactory.get().binaryEncoder(baos, null);
     DatumWriter<Object> datumWriter = new GenericDatumWriter<>(writerSchema);

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemaCompatibilityEnumDefaults.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemaCompatibilityEnumDefaults.java
@@ -135,8 +135,8 @@ public class TestSchemaCompatibilityEnumDefaults {
 
   @Test
   public void testFieldDefaultNotAppliedForUnknownSymbolReadingWithOldSchema() throws Exception {
-    expectedException.expect(IndexOutOfBoundsException.class);
-    expectedException.expectMessage("Index: 2, Size: 2");
+    expectedException.expect(AvroTypeException.class);
+    expectedException.expectMessage("Unknown Enum Ordinal 2");
 
     Schema writerSchema = SchemaBuilder.record("Record1").fields().name("field1").type(ENUM1_ABC_SCHEMA).noDefault()
         .endRecord();

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchemaCompatibilityEnumDefaults.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchemaCompatibilityEnumDefaults.java
@@ -133,6 +133,21 @@ public class TestSchemaCompatibilityEnumDefaults {
     serializeWithWriterThenDeserializeWithReader(writerSchema, datum, readerSchema);
   }
 
+  @Test
+  public void testFieldDefaultNotAppliedForUnknownSymbolReadingWithOldSchema() throws Exception {
+    expectedException.expect(IndexOutOfBoundsException.class);
+    expectedException.expectMessage("Index: 2, Size: 2");
+
+    Schema writerSchema = SchemaBuilder.record("Record1").fields().name("field1").type(ENUM1_ABC_SCHEMA).noDefault()
+      .endRecord();
+    Schema readerSchema = SchemaBuilder.record("Record1").fields().name("field1").type(ENUM1_AB_SCHEMA).withDefault("A")
+      .endRecord();
+
+    GenericRecord datum = new GenericData.Record(writerSchema);
+    datum.put("field1", new GenericData.EnumSymbol(writerSchema, "C"));
+    serializeWithNewSchemaThenDeserializeWithOldSchema(writerSchema, datum, readerSchema);
+  }
+
   private GenericRecord serializeWithWriterThenDeserializeWithReader(Schema writerSchema, GenericRecord datum,
       Schema readerSchema) throws Exception {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();


### PR DESCRIPTION
## What is the purpose of the change
According to [Avro documentation](https://avro.apache.org/docs/1.11.1/specification/#enums) for default value for Enums:
```
default: A default value for this enumeration, used during resolution when the reader encounters a symbol from the writer that isn’t defined in the reader’s schema (optional). The value provided here must be a JSON string that’s a member of the symbols array. See the documentation on schema resolution for how this gets used.
```
And in [Schema Resolution](https://avro.apache.org/docs/1.11.1/specification/#schema-resolution)
```
if both are enums: if the writer’s symbol is not present in the reader’s enum and the reader has a default value, then that value is used, otherwise an error is signalled.
```

This is not the case at the moment in Java implementation.
In the [TestSchemaCompatibilityEnumDefaults](https://github.com/apache/avro/blob/master/lang/java/avro/src/test/java/org/apache/avro/TestSchemaCompatibilityEnumDefaults.java), both writer and reader schemas are required for successful decoding object serialized with new schema into old schema. 
It should be possible, to decode Enums with just the old schema, without the new one present, as specified in the documentation.


## Verifying this change


This change added tests and can be verified as follows:
* New test is added to TestSchemaCompatibilityEnumDefaults to verify the change


## Documentation

- Does this pull request introduces a new feature? No

