### PR TITLE
AVRO-3674: [Rust] Pass the correct enclosing namespace when validating and resolving

### DIFF
--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -695,7 +695,9 @@ impl UnionSchema {
             self.schemas.iter().enumerate().find(|(_, schema)| {
                 let rs =
                     ResolvedSchema::try_from(*schema).expect("Schema didn't successfully parse");
-                value.validate_internal(schema, rs.get_names()).is_none()
+                value
+                    .validate_internal(schema, rs.get_names(), &None)
+                    .is_none()
             })
         }
     }

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -696,7 +696,7 @@ impl UnionSchema {
                 let rs =
                     ResolvedSchema::try_from(*schema).expect("Schema didn't successfully parse");
                 value
-                    .validate_internal(schema, rs.get_names(), &None)
+                    .validate_internal(schema, rs.get_names(), &schema.namespace())
                     .is_none()
             })
         }
@@ -822,6 +822,22 @@ impl Schema {
             | Schema::Fixed { attributes, .. } => Some(attributes),
             _ => None,
         }
+    }
+
+    /// Returns the name of the schema if it has one.
+    pub fn name(&self) -> Option<&Name> {
+        match self {
+            Schema::Ref { ref name, .. }
+            | Schema::Record { ref name, .. }
+            | Schema::Enum { ref name, .. }
+            | Schema::Fixed { ref name, .. } => Some(name),
+            _ => None,
+        }
+    }
+
+    /// Returns the namespace of the schema if it has one.
+    pub fn namespace(&self) -> Namespace {
+        self.name().and_then(|n| n.namespace.clone())
     }
 }
 

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -341,14 +341,9 @@ impl Value {
     pub fn validate(&self, schema: &Schema) -> bool {
         let rs = ResolvedSchema::try_from(schema).expect("Schema didn't successfully parse");
         let namespace = match schema {
-            Schema::Record {
-                name,
-                aliases: _,
-                doc: _,
-                fields: _,
-                lookup: _,
-                attributes: _,
-            } => &name.namespace,
+            Schema::Record { name, .. }
+            | Schema::Enum { name, .. }
+            | Schema::Fixed { name, .. } => &name.namespace,
             _ => &None,
         };
 
@@ -589,10 +584,10 @@ impl Value {
         match *schema {
             Schema::Ref { ref name } => {
                 if let Some(resolved) = names.get(name) {
-                    info!("Resolved {name:?}");
+                    info!("Resolved {:?}", name);
                     self.resolve_internal(resolved, names)
                 } else {
-                    info!("Failed to resolve schema {name:?}");
+                    error!("Failed to resolve schema {:?}", name);
                     Err(Error::SchemaResolutionError(name.clone()))
                 }
             }

--- a/lang/rust/avro/src/writer.rs
+++ b/lang/rust/avro/src/writer.rs
@@ -491,6 +491,7 @@ fn write_value_ref_resolved(
     if let Some(err) = value.validate_internal(
         resolved_schema.get_root_schema(),
         resolved_schema.get_names(),
+        &None,
     ) {
         return Err(Error::ValidationWithReason(err));
     }
@@ -512,6 +513,7 @@ fn write_value_ref_owned_resolved(
     if let Some(err) = value.validate_internal(
         resolved_schema.get_root_schema(),
         resolved_schema.get_names(),
+        &None,
     ) {
         return Err(Error::ValidationWithReason(err));
     }

--- a/lang/rust/avro/src/writer.rs
+++ b/lang/rust/avro/src/writer.rs
@@ -488,18 +488,19 @@ fn write_value_ref_resolved(
     value: &Value,
     buffer: &mut Vec<u8>,
 ) -> AvroResult<()> {
+    let root_schema = resolved_schema.get_root_schema();
     if let Some(err) = value.validate_internal(
-        resolved_schema.get_root_schema(),
+        root_schema,
         resolved_schema.get_names(),
-        &None,
+        &root_schema.namespace(),
     ) {
         return Err(Error::ValidationWithReason(err));
     }
     encode_internal(
         value,
-        resolved_schema.get_root_schema(),
+        root_schema,
         resolved_schema.get_names(),
-        &None,
+        &root_schema.namespace(),
         buffer,
     )?;
     Ok(())
@@ -510,18 +511,19 @@ fn write_value_ref_owned_resolved(
     value: &Value,
     buffer: &mut Vec<u8>,
 ) -> AvroResult<()> {
+    let root_schema = resolved_schema.get_root_schema();
     if let Some(err) = value.validate_internal(
-        resolved_schema.get_root_schema(),
+        root_schema,
         resolved_schema.get_names(),
-        &None,
+        &root_schema.namespace(),
     ) {
         return Err(Error::ValidationWithReason(err));
     }
     encode_internal(
         value,
-        resolved_schema.get_root_schema(),
+        root_schema,
         resolved_schema.get_names(),
-        &None,
+        &root_schema.namespace(),
         buffer,
     )?;
     Ok(())


### PR DESCRIPTION
AVRO-3674

## What is the purpose of the change

* Fix a bug in schema resolution and validation when processing an inner schema with and without its own namespace

## Verifying this change

* New unit tests are added

## Documentation

- Does this pull request introduce a new feature? yes

New public methods are added. Documented with Rustdoc
