### PR TITLE
Bump Maven plugin versions and maven version for the docker based build

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+    <extension>
+        <groupId>org.apache.maven.extensions</groupId>
+        <artifactId>maven-build-cache-extension</artifactId>
+        <version>1.0.0</version>
+    </extension>
+</extensions>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -156,7 +156,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M7</version>
+          <version>${maven-surefire-plugin.version}</version>
           <configuration>
             <includes>
               <!-- Avro naming convention for JUnit tests -->

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>27</version>
+    <version>28</version>
   </parent>
 
   <groupId>org.apache.avro</groupId>
@@ -47,20 +47,20 @@
     <avro.docDir>build/avro-doc-${project.version}/api</avro.docDir>
 
     <!-- plugin versions -->
-    <apache-rat-plugin.version>0.14</apache-rat-plugin.version>
-    <checkstyle-plugin.version>3.1.2</checkstyle-plugin.version>
+    <apache-rat-plugin.version>0.15</apache-rat-plugin.version>
+    <checkstyle-plugin.version>3.2.0</checkstyle-plugin.version>
     <checkstyle.version>9.3</checkstyle.version>
     <enforcer-plugin.version>3.1.0</enforcer-plugin.version>
     <extra-enforcer-rules.version>1.6.1</extra-enforcer-rules.version>
     <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
     <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
-    <maven-javadoc-plugin.version>3.4.0</maven-javadoc-plugin.version>
+    <maven-javadoc-plugin.version>3.4.1</maven-javadoc-plugin.version>
     <maven-plugin-plugin.version>3.6.4</maven-plugin-plugin.version>
-    <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
+    <maven-shade-plugin.version>3.4.1</maven-shade-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
-    <plugin-tools-javadoc.version>3.5</plugin-tools-javadoc.version>
-    <spotless-maven-plugin.version>2.23.0</spotless-maven-plugin.version>
-    <surefire.version>3.0.0-M5</surefire.version>
+    <plugin-tools-javadoc.version>3.7.0</plugin-tools-javadoc.version>
+    <spotless-maven-plugin.version>2.27.2</spotless-maven-plugin.version>
+    <maven-surefire-plugin.version>3.0.0-M7</maven-surefire-plugin.version>
 
     <!-- Pin output timestamp to make the Java build reproducible -->
     <project.build.outputTimestamp>10</project.build.outputTimestamp>
@@ -359,11 +359,13 @@
                 <exclude>**/.gitattributes</exclude>
                 <exclude>**/.gitignore</exclude>
                 <exclude>**/.gitmodules</exclude>
-                <!-- Docsy -->
+                <!-- Hugo / Docsy -->
                 <exclude>doc/build/**</exclude>
                 <exclude>doc/themes/docsy/**</exclude>
                 <exclude>doc/examples/java-example/target/**</exclude>
                 <exclude>doc/examples/mr-example/target/**</exclude>
+                <exclude>doc/node_modules/**</exclude>
+                <exclude>**/.hugo_build.lock</exclude>
                 <!-- build or test files (some are generated files that we commit as-is for testing purposes) -->
                 <exclude>**/*.log</exclude>
                 <exclude>**/*.rej</exclude>

--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -86,7 +86,7 @@ RUN apt-get -qqy install --no-install-recommends libzstd-dev \
 
 # Install a maven release  -------------------------------------------
 # Inspired from https://github.com/apache/accumulo-docker/blob/master/Dockerfile#L53
-ENV MAVEN_VERSION 3.8.4
+ENV MAVEN_VERSION 3.8.6
 ENV APACHE_DIST_URLS \
   https://www.apache.org/dyn/closer.cgi?action=download&filename= \
   # if the version is outdated (or we're grabbing the .asc file), we might have to pull from the dist/archive :/


### PR DESCRIPTION
I was playing today with maven 4 and noticed that Avro was not building yet with it. This PR updates some dependencies so we can run it and enables the new cache plugin to speed up builds for users on Maven 4.