### PR TITLE
AVRO-3678: [Rust] Support writing float value to field defined as double

### DIFF
--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -403,6 +403,7 @@ impl Value {
             (&Value::Duration(_), &Schema::Duration) => None,
             (&Value::Uuid(_), &Schema::Uuid) => None,
             (&Value::Float(_), &Schema::Float) => None,
+            (&Value::Float(_), &Schema::Double) => None,
             (&Value::Double(_), &Schema::Double) => None,
             (&Value::Bytes(_), &Schema::Bytes) => None,
             (&Value::Bytes(_), &Schema::Decimal { .. }) => None,
@@ -1011,6 +1012,9 @@ mod tests {
     fn validate() {
         let value_schema_valid = vec![
             (Value::Int(42), Schema::Int, true, ""),
+            (Value::Int(43), Schema::Long, true, ""),
+            (Value::Float(43.2), Schema::Float, true, ""),
+            (Value::Float(45.9), Schema::Double, true, ""),
             (
                 Value::Int(42),
                 Schema::Boolean,
@@ -1563,6 +1567,12 @@ Field with name '"b"' is not a member of the map items"#,
         let value = Value::Uuid(Uuid::parse_str("1481531d-ccc9-46d9-a56f-5b67459c0537").unwrap());
         assert!(value.clone().resolve(&Schema::Uuid).is_ok());
         assert!(value.resolve(&Schema::TimestampMicros).is_err());
+    }
+
+    #[test]
+    fn avro_3678_resolve_float_to_double() {
+        let value = Value::Float(2345.1);
+        assert!(value.resolve(&Schema::Double).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
Originally contributed by @shaeqahmed with #1985

<!--

*Thank you very much for contributing to Apache Avro - we are happy that you want to help us improve Avro. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Avro a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/AVRO/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "AVRO-XXXX: [component] Title of the pull request", where *AVRO-XXXX* should be replaced by the actual issue number. 
    The *component* is optional, but can help identify the correct reviewers faster: either the language ("java", "python") or subsystem such as "build" or "doc" are good candidates.  

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests. You can [build the entire project](https://github.com/apache/avro/blob/master/BUILD.md) or just the [language-specific SDK](https://avro.apache.org/project/how-to-contribute/#unit-tests).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Every commit message references Jira issues in their subject lines. In addition, commits follow the guidelines from [How to write a good git commit message](https://chris.beams.io/posts/git-commit/)
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

-->

## What is the purpose of the change

This pull request adds support for validating/resolving a float value against a destination schema where the corresponding field is defined as a double, fixing AVRO-3678. This makes the behavior similar to how we currently support other lossless upcasting of numeric types, such as int -> long, which should be expected behavior.

https://issues.apache.org/jira/browse/AVRO-3678

## Verifying this change

This change added tests and can be verified as follows:
- Added tests that validates that a float value can be resolved & validated against a schema double field.


## Documentation

- Does this pull request introduce a new feature? **no**
