### PR TITLE
AVRO-3679: [Rust] Enable 'perf' feature of regex dependency

### DIFF
--- a/lang/rust/Cargo.lock
+++ b/lang/rust/Cargo.lock
@@ -24,6 +24,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,6 +803,8 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 

--- a/lang/rust/avro/Cargo.toml
+++ b/lang/rust/avro/Cargo.toml
@@ -62,7 +62,7 @@ lazy_static = { default-features = false, version = "1.4.0" }
 libflate = { default-features = false, version = "1.2.0" }
 log = { default-features = false, version = "0.4.17" }
 num-bigint = { default-features = false, version = "0.4.3" }
-regex = { default-features = false, version = "1.7.0", features = ["std"] }
+regex = { default-features = false, version = "1.7.0", features = ["std", "perf"] }
 serde = { default-features = false, version = "1.0.148", features = ["derive"] }
 serde_json = { default-features = false, version = "1.0.89", features = ["std"] }
 snap = { default-features = false, version = "1.1.0", optional = true }


### PR DESCRIPTION
AVRO-3679

## What is the purpose of the change

* Enable better performance of regular expressions' evaluations

## Verifying this change

* All existing tests should pass

## Documentation

- Does this pull request introduce a new feature? no