### PR TITLE
AVRO-3640: [Java] Correctly handle symbolic links as source directory for Maven plugin

### DIFF
--- a/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/AbstractAvroMojo.java
+++ b/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/AbstractAvroMojo.java
@@ -24,6 +24,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -202,6 +203,13 @@ public abstract class AbstractAvroMojo extends AbstractMojo {
 
   @Override
   public void execute() throws MojoExecutionException {
+    if (Files.isSymbolicLink(sourceDirectory.toPath())) {
+      try {
+        sourceDirectory = Files.readSymbolicLink(sourceDirectory.toPath()).toFile();
+      } catch (IOException e) {
+        throw new MojoExecutionException("Could not resolve symbolic link " + sourceDirectory.getPath());
+      }
+    }
     boolean hasSourceDir = null != sourceDirectory && sourceDirectory.isDirectory();
     boolean hasImports = null != imports;
     boolean hasTestDir = null != testSourceDirectory && testSourceDirectory.isDirectory();

--- a/lang/java/maven-plugin/src/test/java/org/apache/avro/mojo/TestSchemaMojo.java
+++ b/lang/java/maven-plugin/src/test/java/org/apache/avro/mojo/TestSchemaMojo.java
@@ -21,6 +21,8 @@ import org.codehaus.plexus.util.FileUtils;
 import org.junit.Test;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -66,5 +68,22 @@ public class TestSchemaMojo extends AbstractAvroMojoTest {
 
     final String schemaUserContent = FileUtils.fileRead(new File(outputDir, "SchemaUser.java"));
     assertTrue("Got " + schemaUserContent + " instead", schemaUserContent.contains("It works!"));
+  }
+
+  @Test
+  public void testSymbolicLinkValidInputDirectoryMojo() throws Exception {
+    Path sourcePath = new File(getBasedir(), "src/test/avro").toPath();
+    Path symbolicLinkPath = new File(getBasedir(), "target/test-harness/symbolic-link-directory").toPath();
+    File outputDirectory = new File(getBasedir(), "target/test-harness/symbolic-link-schema-output/test");
+    File symbolicLinkPom = new File(getBasedir(), "src/test/resources/unit/schema/symbolic-link-pom.xml");
+    Files.createSymbolicLink(symbolicLinkPath, sourcePath);
+    final SchemaMojo mojo = (SchemaMojo) lookupMojo("schema", symbolicLinkPom);
+    assertNotNull(mojo);
+    mojo.execute();
+
+    final Set<String> generatedFiles = new HashSet<>(
+        Arrays.asList("PrivacyDirectImport.java", "PrivacyImport.java", "SchemaPrivacy.java", "SchemaUser.java"));
+
+    assertFilesExist(outputDirectory, generatedFiles);
   }
 }

--- a/lang/java/maven-plugin/src/test/resources/unit/schema/symbolic-link-pom.xml
+++ b/lang/java/maven-plugin/src/test/resources/unit/schema/symbolic-link-pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>avro-parent</artifactId>
+    <groupId>org.apache.avro</groupId>
+    <version>1.12.0-SNAPSHOT</version>
+    <relativePath>../../../../../../../../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>avro-maven-plugin-test</artifactId>
+  <packaging>jar</packaging>
+
+  <name>testproject</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>avro-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>schema</id>
+            <goals>
+              <goal>schema</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <sourceDirectory>${basedir}/target/test-harness/symbolic-link-directory</sourceDirectory>
+          <outputDirectory>${basedir}/target/test-harness/symbolic-link-schema-output</outputDirectory>
+          <imports>
+            <import>${basedir}/src/test/avro/imports</import>
+            <import>${basedir}/src/test/avro/directImport/PrivacyDirectImport.avsc</import>
+          </imports>
+          <project implementation="org.apache.maven.plugin.testing.stubs.MavenProjectStub"/>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+      <version>${parent.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+  </dependencies>
+</project>


### PR DESCRIPTION
This PR provides a fix for situations where a user provides the Maven plugin with a symbolic link instead of an actual directory as the source directory, and the plugin fails to detect the source files referred to by the link. To fix this, the plugin will first check if the provided directory is a symbolic link, and resolve it to the actual directory if necessary.

In order to verify this, a unit test has been added which creates a symbolic link, and this link is referred to in the provided POM's `sourceDirectory` field. When the test completes, files will be written to the output directory similarly to the non-symbolic test cases.