### PR TITLE
AVRO-3681: [Python] GitHub actions failing with python 3.6

### DIFF
--- a/.github/workflows/test-lang-py.yml
+++ b/.github/workflows/test-lang-py.yml
@@ -35,7 +35,7 @@ concurrency:
 jobs:
   test:
     name: Python ${{ matrix.python }} Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -82,7 +82,7 @@ jobs:
 
   interop:
     name: Python ${{ matrix.python }} Interop
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Use ubuntu-20.04 runners for Python workflow.
ubuntu-latest is now ubuntu-22.04 and it does not provide Python 3.6

AVRO-3681

## What is the purpose of the change

* Fix Python 3.6 CI on Github Actions

## Verifying this change

* CI must be green again

## Documentation

- Does this pull request introduce a new feature? no