### PR TITLE
Fix minor warnings from rust 1.66.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -85,7 +85,6 @@ updates:
       interval: "daily"
     open-pull-requests-limit: 20
     target-branch: master
-    labels: [auto-dependencies]
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/lang/rust/avro/src/writer.rs
+++ b/lang/rust/avro/src/writer.rs
@@ -456,7 +456,7 @@ impl<T> SpecificSingleObjectWriter<T>
 where
     T: AvroSchema + Into<Value>,
 {
-    /// Write the Into<Value> to the provided Write object. Returns a result with the number
+    /// Write the `Into<Value>` to the provided Write object. Returns a result with the number
     /// of bytes written including the header
     pub fn write_value<W: Write>(&mut self, data: T, writer: &mut W) -> AvroResult<usize> {
         let v: Value = data.into();

--- a/lang/rust/avro/tests/io.rs
+++ b/lang/rust/avro/tests/io.rs
@@ -132,7 +132,7 @@ fn test_binary_int_encoding() {
 #[test]
 fn test_binary_long_encoding() {
     for (number, hex_encoding) in BINARY_ENCODINGS.iter() {
-        let encoded = to_avro_datum(&Schema::Long, Value::Long(*number as i64)).unwrap();
+        let encoded = to_avro_datum(&Schema::Long, Value::Long(*number)).unwrap();
         assert_eq!(&encoded, hex_encoding);
     }
 }


### PR DESCRIPTION
No JIRA ticket!

## What is the purpose of the change

This PR fixes minor lint warnings produced by Rust 1.66.0.

## Verifying this change

CI should pass!

## Documentation

- Does this pull request introduce a new feature? no