### PR TITLE
AVRO-3229: [py] Raise on invalid enum default only if validation enabled

### DIFF
--- a/lang/py/avro/schema.py
+++ b/lang/py/avro/schema.py
@@ -555,7 +555,7 @@ class EnumSchema(EqualByPropsMixin, NamedSchema):
         validate_names: bool = True,
     ) -> None:
         """
-        @arg validate_enum_symbols: If False, will allow enum symbols that are not valid Avro names.
+        @arg validate_enum_symbols: If False, will allow enum symbols that are not valid Avro names and default, which is not an enumerated symbol.
         """
         if validate_enum_symbols:
             for symbol in symbols:
@@ -575,7 +575,7 @@ class EnumSchema(EqualByPropsMixin, NamedSchema):
         if doc is not None:
             self.set_prop("doc", doc)
 
-        if other_props and "default" in other_props:
+        if validate_enum_symbols and other_props and "default" in other_props:
             default = other_props["default"]
             if default not in symbols:
                 raise avro.errors.InvalidDefault(f"Enum default '{default}' is not a valid member of symbols '{symbols}'")


### PR DESCRIPTION
## What is the purpose of the change

AVRO-3229 added validation for enum default raising an exception for invalid default.  Allow disabling validation, and parsing enums with enum default not defined using existing `validate_enum_symbols` flag.

## Verifying this change

This change is already covered by existing tests, such as lang/py/avro/test/test_schema.py expanded with #1433 .

## Documentation

Existing inline documentation is improved to cover this type of usage.
