### PR TITLE
AVRO-3696: [py] Replace tox-wheel with standard tox

### DIFF
--- a/.github/workflows/test-lang-java.yml
+++ b/.github/workflows/test-lang-java.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Install Python Dependencies
         run: |
-          python3 -m pip install --upgrade pip setuptools tox-wheel
+          python3 -m pip install --upgrade pip setuptools tox
           python3 -m pip install python-snappy zstandard
 
       - name: Setup C# for Generating Interop Data

--- a/.github/workflows/test-lang-js.yml
+++ b/.github/workflows/test-lang-js.yml
@@ -96,7 +96,7 @@ jobs:
                                                             libzstd-dev
       - name: Install Python Dependencies
         run: |
-          python3 -m pip install --upgrade pip setuptools tox-wheel
+          python3 -m pip install --upgrade pip setuptools tox
           python3 -m pip install python-snappy zstandard
 
       - name: Create Interop Data Directory

--- a/.github/workflows/test-lang-py.yml
+++ b/.github/workflows/test-lang-py.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          python3 -m pip install --upgrade pip setuptools tox-wheel
+          python3 -m pip install --upgrade pip setuptools tox
 
       - name: Lint
         if: ${{ matrix.python == '3.10' }}
@@ -114,7 +114,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          python3 -m pip install --upgrade pip setuptools tox-wheel
+          python3 -m pip install --upgrade pip setuptools tox
           python3 -m pip install python-snappy zstandard
 
       - name: Cache Local Maven Repository

--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -173,7 +173,7 @@ ENV PIP_NO_CACHE_DIR=off
 
 # Install Python3 packages
 RUN python3 -m pip install --upgrade pip setuptools wheel \
- && python3 -m pip install tox-wheel zstandard
+ && python3 -m pip install tox zstandard
 
 
 # Install Ruby


### PR DESCRIPTION
## What is the purpose of the change

Replace tox-wheel with standard tox

Usage of third party tox-wheel package started failing since tox released version 4 with native wheel. Any usage of tox-wheel is replaced with standard tox package to fix Python tests.

## Verifying this change

This change is already covered by existing tests, and now CI pipeline should work with Python.


## Documentation

- Does this pull request introduce a new feature?: no
