### PR TITLE
AVRO-3697: [ruby] Test against Ruby 3.2

### DIFF
--- a/.github/workflows/test-lang-ruby.yml
+++ b/.github/workflows/test-lang-ruby.yml
@@ -43,6 +43,7 @@ jobs:
         - '2.7'
         - '3.0'
         - '3.1'
+        - '3.2'
     steps:
       - uses: actions/checkout@v3
 
@@ -51,7 +52,7 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
 
       - name: Install Dependencies
-        run: sudo apt-get install -qqy bundler libsnappy-dev
+        run: sudo apt-get install -qqy libsnappy-dev
 
       - uses: actions/cache@v3
         with:
@@ -83,6 +84,7 @@ jobs:
         - '2.7'
         - '3.0'
         - '3.1'
+        - '3.2'
     steps:
       - uses: actions/checkout@v3
 
@@ -91,7 +93,7 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
 
       - name: Install Dependencies
-        run: sudo apt-get install -qqy bundler libsnappy-dev
+        run: sudo apt-get install -qqy libsnappy-dev
 
       - uses: actions/cache@v3
         with:

--- a/lang/ruby/build.sh
+++ b/lang/ruby/build.sh
@@ -24,11 +24,6 @@ cd "$(dirname "$0")"
 export GEM_HOME="$PWD/.gem/"
 export PATH="/usr/local/rbenv/shims:$GEM_HOME/bin:$PATH"
 
-# bootstrap bundler
-gem install --no-document -v 1.17.3 bundler
-
-# rbenv is used by the Dockerfile but not the Github action in CI
-rbenv rehash 2>/dev/null || echo "Not using rbenv"
 bundle install
 
 for target in "$@"


### PR DESCRIPTION
## What is the purpose of the change

* Test against the latest Ruby release, 3.2
    * bundler is already installed by the `setup-action` so skipping also installing it as a package saves some time in CI
    * bundler v1.17.3 is no longer needed
    * rbenv setup was previously removed from the Dockerfile: https://github.com/apache/avro/commit/cf7bfe7710febdc84e70fcc8ad21d859dbf1be1f#diff-9ad53a2cdd23436f405be61d20306403700f362287b3d86609319919176a6fb6L191-L203

## Verifying this change

This change is already covered by the existing Ruby test suite.

## Documentation

- Does this pull request introduce a new feature? **no**
