### PR TITLE
AVRO-3278: [ruby] Drop support for Ruby 2.6

### DIFF
--- a/.github/workflows/test-lang-ruby.yml
+++ b/.github/workflows/test-lang-ruby.yml
@@ -39,7 +39,6 @@ jobs:
     strategy:
       matrix:
         ruby:
-        - '2.6'
         - '2.7'
         - '3.0'
         - '3.1'
@@ -80,7 +79,6 @@ jobs:
     strategy:
       matrix:
         ruby:
-        - '2.6'
         - '2.7'
         - '3.0'
         - '3.1'

--- a/BUILD.md
+++ b/BUILD.md
@@ -11,7 +11,7 @@ The following packages must be installed before Avro can be built:
  - C++: cmake 3.7.2 or greater, g++, flex, bison, libboost-dev
  - C#: .NET Core 2.2 SDK
  - JavaScript: Node 12.x+, nodejs, npm
- - Ruby: Ruby 2.6 or greater, ruby-dev, gem, bundler, snappy
+ - Ruby: Ruby 2.7 or greater, ruby-dev, gem, bundler, snappy
  - Perl: Perl 5.24.1 or greater, gmake, Module::Install,
    Module::Install::ReadmeFromPod, Module::Install::Repository,
    Math::BigInt, JSON::XS, Try::Tiny, Regexp::Common, Encode,

--- a/lang/ruby/.rubocop.yml
+++ b/lang/ruby/.rubocop.yml
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
   NewCops: disable
   SuggestExtensions: false
 

--- a/lang/ruby/avro.gemspec
+++ b/lang/ruby/avro.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.description = "Avro is a data serialization and RPC format"
   s.homepage = "https://avro.apache.org/"
   s.license = "Apache-2.0"
-  s.required_ruby_version = ">= 2.6"
+  s.required_ruby_version = ">= 2.7"
 
   s.metadata["homepage_uri"] = s.homepage
   s.metadata["bug_tracker_uri"] = "https://issues.apache.org/jira/browse/AVRO"

--- a/lang/ruby/build.sh
+++ b/lang/ruby/build.sh
@@ -22,7 +22,7 @@ cd "$(dirname "$0")"
 
 # maintain our gems here
 export GEM_HOME="$PWD/.gem/"
-export PATH="/usr/local/rbenv/shims:$GEM_HOME/bin:$PATH"
+export PATH="$GEM_HOME/bin:$PATH"
 
 bundle install
 

--- a/lang/ruby/test/test_logical_types.rb
+++ b/lang/ruby/test/test_logical_types.rb
@@ -209,7 +209,6 @@ class TestLogicalTypes < Test::Unit::TestCase
       end
 
       assert_equal 5, report.total_allocated
-      # Ruby 2.7 does not retain anything. Ruby 2.6 retains 1
       assert_operator 1, :>=, report.total_retained
     end
   end
@@ -230,8 +229,7 @@ class TestLogicalTypes < Test::Unit::TestCase
       end
 
       assert_equal 5, report.total_allocated
-      # Ruby 2.7 does not retain anything. Ruby 2.6 retains 1 or 2
-      assert_operator 2, :>=, report.total_retained
+      assert_equal 0, report.total_retained
     end
   end
 


### PR DESCRIPTION
## What is the purpose of the change

https://issues.apache.org/jira/browse/AVRO-3278

Ruby 2.6 reached EOL on March 31, 2022.

## Verifying this change

This change is already covered by the existing Ruby tests.

## Documentation

- Does this pull request introduce a new feature? **no**
- Release notes for the next major release should note that Ruby 2.7 or later is required.