### PR TITLE
AVRO-3700: Publish Java SBOM artifacts with CycloneDX

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,6 +248,19 @@
           <goalPrefix>avro</goalPrefix>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.cyclonedx</groupId>
+        <artifactId>cyclonedx-maven-plugin</artifactId>
+        <version>2.7.3</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>makeBom</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to publish SBOM artifacts.

Here is an article to give some context.
- https://www.activestate.com/blog/why-the-us-government-is-mandating-software-bill-of-materials-sbom/

Software Bill of Materials (SBOM) are additional artifacts containing the aggregate of all direct and transitive dependencies of a project. The US Government (based on NIST recommendations) currently accepts only the three most popular SBOM standards as valid, namely: [CycloneDX](https://cyclonedx.org/), [Software Identification (SWID) tag](https://csrc.nist.gov/projects/Software-Identification-SWID), [Software Package Data Exchange® (SPDX)](https://spdx.dev/).

This PR uses [CycloneDX maven plugin](https://github.com/CycloneDX/cyclonedx-maven-plugin), a lightweight software bill of materials (SBOM) standard designed for use in application security contexts and supply chain component analysis.

## Verifying this change

Manually verify with the following procedure. `avro-1.12.0-SNAPSHOT.jar` will have `avro-1.12.0-SNAPSHOT-cyclonedx.xml` and `avro-1.12.0-SNAPSHOT-cyclonedx.json` BOM files.
```
$ mvn install -DskipTests
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:04 min
[INFO] Finished at: 2023-01-05T10:15:49-08:00
[INFO] ------------------------------------------------------------------------

$ ls -al ~/.m2/repository/org/apache/avro/avro/1.12.0-SNAPSHOT/
total 2184
drwxr-xr-x  9 dongjoon  staff     288 Jan  5 10:14 .
drwxr-xr-x  5 dongjoon  staff     160 Jan  5 10:14 ..
-rw-r--r--  1 dongjoon  staff     302 Jan  5 10:14 _remote.repositories
-rw-r--r--  1 dongjoon  staff   17421 Jan  5 10:14 avro-1.12.0-SNAPSHOT-cyclonedx.json
-rw-r--r--  1 dongjoon  staff   15178 Jan  5 10:14 avro-1.12.0-SNAPSHOT-cyclonedx.xml
-rw-r--r--  1 dongjoon  staff  443402 Jan  5 10:14 avro-1.12.0-SNAPSHOT-tests.jar
-rw-r--r--  1 dongjoon  staff  612699 Jan  5 10:14 avro-1.12.0-SNAPSHOT.jar
-rw-r--r--  1 dongjoon  staff    9510 Jan  5 10:03 avro-1.12.0-SNAPSHOT.pom
-rw-r--r--  1 dongjoon  staff    1329 Jan  5 10:14 maven-metadata-local.xml
```

## Documentation

This is a build-only change.