### PR TITLE
AVRO-3698: SpecificData.getClassName must replace reserved words

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificData.java
@@ -91,6 +91,8 @@ public class SpecificData extends GenericData {
   public static final String KEY_CLASS_PROP = "java-key-class";
   public static final String ELEMENT_PROP = "java-element-class";
 
+  public static final char RESERVED_WORD_ESCAPE_CHAR = '$';
+
   /**
    * Reserved words from
    * https://docs.oracle.com/javase/specs/jls/se16/html/jls-3.html require
@@ -329,8 +331,26 @@ public class SpecificData extends GenericData {
     String name = schema.getName();
     if (namespace == null || "".equals(namespace))
       return name;
-    String dot = namespace.endsWith("$") ? "" : "."; // back-compatibly handle $
-    return namespace + dot + name;
+
+    StringBuilder classNameBuilder = new StringBuilder();
+    String[] words = namespace.split("\\.");
+
+    for (int i = 0; i < words.length; i++) {
+      String word = words[i];
+      classNameBuilder.append(word);
+
+      if (RESERVED_WORDS.contains(word)) {
+        classNameBuilder.append(RESERVED_WORD_ESCAPE_CHAR);
+      }
+
+      if (i != words.length - 1 || !word.endsWith("$")) { // back-compatibly handle $
+        classNameBuilder.append(".");
+      }
+    }
+
+    classNameBuilder.append(name);
+
+    return classNameBuilder.toString();
   }
 
   // cache for schemas created from Class objects. Use ClassValue to avoid

--- a/lang/java/avro/src/test/java/org/apache/avro/specific/TestSpecificData.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/specific/TestSpecificData.java
@@ -178,4 +178,11 @@ public class TestSpecificData {
       // Expected error
     }
   }
+
+  @Test
+  void classNameContainingReservedWords() {
+    final Schema schema = Schema.createRecord("AnyName", null, "db.public.table", false);
+
+    assertEquals("db.public$.table.AnyName", SpecificData.getClassName(schema));
+  }
 }

--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
@@ -61,6 +61,7 @@ import org.slf4j.LoggerFactory;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.avro.specific.SpecificData.RESERVED_WORDS;
+import static org.apache.avro.specific.SpecificData.RESERVED_WORD_ESCAPE_CHAR;
 
 /**
  * Generate specific Java interfaces and classes for protocols and schemas.
@@ -1126,7 +1127,7 @@ public class SpecificCompiler {
     }
     if (reservedWords.contains(word) || (isMethod && reservedWords
         .contains(Character.toLowerCase(word.charAt(0)) + ((word.length() > 1) ? word.substring(1) : "")))) {
-      return word + "$";
+      return word + RESERVED_WORD_ESCAPE_CHAR;
     }
     return word;
   }


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes AVRO-3698.

When makes Java Class, [SpecificCompiler](https://github.com/apache/avro/blob/master/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java#L1129) adds "$" after reserved words like public, new, etc...

For example, if the namespace of a schema is db.public.table, then the package name of the generated Java Class, made by SpecificCompiler, is db.public$.table. (Because public is a reserved word in java)

But when deserializes an Avro Record to a SpecificRecord, SpecificData.getClassName returns db.pulic.table.Name.

So, it can't find a class by name from SpecificData.getClassName.



## Verifying this change

This change added tests and can be verified as follows:
- Added ```@Test``` ```classNameContainingReservedWords``` on ```TestSpecificData```



## Documentation

- Does this pull request introduce a new feature? no