### PR TITLE
[ruby] Keep all union record errors and tag them accordingly

### DIFF
--- a/lang/ruby/lib/avro/schema_validator.rb
+++ b/lang/ruby/lib/avro/schema_validator.rb
@@ -196,9 +196,14 @@ module Avro
         compatible_type = first_compatible_type(datum, expected_schema, path, failures, options)
         return unless compatible_type.nil?
 
-        complex_type_failed = failures.detect { |r| COMPLEX_TYPES.include?(r[:type]) }
-        if complex_type_failed
-          complex_type_failed[:result].errors.each { |error| result << error }
+        complex_type_failed = failures.select { |r| COMPLEX_TYPES.include?(r[:type]) }
+        if complex_type_failed.any?
+          complex_type_failed.each do |type_failures|
+            type_failures[:result].errors.each do |error|
+              error_msg = type_failures[:schema] ? "#{type_failures[:schema]} #{error}" : error
+              result << error_msg
+            end
+          end
         else
           types = expected_schema.schemas.map { |s| "'#{s.type_sym}'" }.join(', ')
           result.add_error(path, "expected union of [#{types}], got #{actual_value_message(datum)}")
@@ -208,11 +213,16 @@ module Avro
       def first_compatible_type(datum, expected_schema, path, failures, options = {})
         expected_schema.schemas.find do |schema|
           # Avoid expensive validation if we're just validating a nil
-          next datum.nil? if schema.type_sym == :null
+          if schema.type_sym == :null
+            next datum.nil?
+          end
 
           result = Result.new
           validate_recursive(schema, datum, path, result, options)
-          failures << { type: schema.type_sym, result: result } if result.failure?
+
+          failure = { type: schema.type_sym, result: result }
+          failure[:schema] = schema.name if schema.is_a?(Avro::Schema::RecordSchema)
+          failures << failure if result.failure?
           !result.failure?
         end
       end

--- a/lang/ruby/test/test_schema_validator.rb
+++ b/lang/ruby/test/test_schema_validator.rb
@@ -556,7 +556,7 @@ class TestSchemaValidator < Test::Unit::TestCase
       validate!(schema, { 'name' => 'apple', 'color' => 'green' }, fail_on_extra_fields: true)
     end
     assert_equal(1, exception.result.errors.size)
-    assert_equal("at . extra field 'color' - not in schema", exception.to_s)
+    assert_equal("fruit at . extra field 'color' - not in schema", exception.to_s)
   end
 
   def test_validate_bytes_decimal


### PR DESCRIPTION
I wasn't able to create an issue in JIRA, since I don't seem to be able to request a user. I am a first time contributor, apologies  in case something is not precise enough

## What is the purpose of the change

Improving validation errors for unions of records
When no valid union is found, this line selects the **first** error that it finds. If there would be 3 different possible schemas, there are 3 `failures`, however only the first one will be considered.

https://github.com/apache/avro/blob/fc2a4e0e5d88755c776b97fa1872e70ffbe0d4bb/lang/ruby/lib/avro/schema_validator.rb#L199

The returned error also does not give any context of the error, only about the invalid fields.

As an example, consider we have 3 types of adresses `PersonalAddress`, `WorkAddress`, `SecondAddress` and we made a typo: We used the field `compan` instead of `company`, which belongs to `WorkAddress`. No type will work for the union.
`{ "compan" => "acme inc.", "some_other_field" => "something else" }`

Since `PersonalAddress` is the first type that fails, the errors of `PersonalAddress` are the ones that will be returned. Since `PersonalAddress` has different structure, all fields that aren't the same as in `WorkAddress` will be shown as errors. The error will be something like

```
at .address extra field 'compan' - not in schema
at .address extra field 'some_other_field' - not in schema
```

This gets very confusing because 1) The issue is that no union matched 2) It is not clear because only one of the error is displayed.

I'd be happy if this is fix in some other fashion, this is just an example. With we replace `detect` with `select` and we add the schema name to the error. Then the error will be like:

```
PersonalAddress at .address extra field 'compan' - not in schema
PersonalAddress at .address extra field 'some_other_field' - not in schema
WorkAddress at .address extra field 'compan' - not in schema
SecondAddress at .address extra field 'compan' - not in schema
SecondAddress at .address extra field 'some_other_field' - not in schema
```

## Verifying this change

This change added tests and can be verified as follows:

- Modified existing test, existing tests pass


## Documentation

- Does this pull request introduce a new feature?  no
