### PR TITLE
AVRO-3701: Update maven-resources-plugin to 3.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
     <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
     <maven-javadoc-plugin.version>3.4.1</maven-javadoc-plugin.version>
     <maven-plugin-plugin.version>3.7.1</maven-plugin-plugin.version>
+    <maven-resources-plugin.version>3.3.0</maven-resources-plugin.version>
     <maven-shade-plugin.version>3.4.1</maven-shade-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <plugin-tools-javadoc.version>3.7.0</plugin-tools-javadoc.version>
@@ -152,6 +153,11 @@
           <groupId>org.apache.rat</groupId>
           <artifactId>apache-rat-plugin</artifactId>
           <version>${apache-rat-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>${maven-resources-plugin.version}</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
AVRO-3701

Signed-off-by: Martin Tzvetanov Grigorov <mgrigorov@apache.org>

## What is the purpose of the change

Maven 4.x (alpha) does not work with older versions of this plugin

## Verifying this change

CI must pass!

## Documentation

- Does this pull request introduce a new feature? no