### PR TITLE
AVRO-3712: Fix C++ build by initializing union

### DIFF
--- a/lang/c++/api/Reader.hh
+++ b/lang/c++/api/Reader.hh
@@ -84,7 +84,7 @@ public:
         union {
             double d;
             uint64_t i;
-        } v;
+        } v = { 0 };
         reader_.read(v.i);
         val = v.d;
     }


### PR DESCRIPTION
AVRO-3712

## What is the purpose of the change

Fix build. (I'm guessing adding 'pedantic' to build.sh broke this a while back.)

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Documentation

No documentation required.