### PR TITLE
doc: Fix invalid JSON in spec

### DIFF
--- a/doc/content/en/docs/++version++/Specification/_index.md
+++ b/doc/content/en/docs/++version++/Specification/_index.md
@@ -460,7 +460,7 @@ A file header is thus described by the following schema:
  "fields" : [
    {"name": "magic", "type": {"type": "fixed", "name": "Magic", "size": 4}},
    {"name": "meta", "type": {"type": "map", "values": "bytes"}},
-   {"name": "sync", "type": {"type": "fixed", "name": "Sync", "size": 16}},
+   {"name": "sync", "type": {"type": "fixed", "name": "Sync", "size": 16}}
   ]
 }
 ```


### PR DESCRIPTION

## What is the purpose of the change

Dangling commas are not permitted in JSON. This fixes that error in the Object Container Format header type definition.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Documentation

n/a