### PR TITLE
Oracle JDK 18 no longer exists

### DIFF
--- a/.github/workflows/test-lang-java.yml
+++ b/.github/workflows/test-lang-java.yml
@@ -43,7 +43,6 @@ jobs:
         - '8'
         - '11'
         - '17'
-        - '18'
         - '19'
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Just about all pull requests fail over a missing Java 18.