### PR TITLE
AVRO-2404: Remove now obsolete Apache Rat workaround

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -345,17 +345,6 @@
               </execution>
             </executions>
             <configuration>
-              <licenses>
-                <!-- TODO (low prio): Remove this simple workaround when Apache Rat 0.14 has been released. -->
-                <!-- See also: https://issues.apache.org/jira/browse/RAT-212 -->
-                <!-- and       https://issues.apache.org/jira/browse/LEGAL-265 -->
-                <license implementation="org.apache.rat.analysis.license.ApacheSoftwareLicense20">
-                  <notes>Also allow the license url to be https.</notes>
-                  <patterns>
-                    <pattern>https://www.apache.org/licenses/LICENSE-2.0</pattern>
-                  </patterns>
-                </license>
-              </licenses>
               <consoleOutput>true</consoleOutput>
               <excludeSubProjects>false</excludeSubProjects>
               <excludes>


### PR DESCRIPTION
Remove a workaround that is no longer needed since we have a new enough Apache Rat.