### PR TITLE
AVRO-3845: avro-tools: Add log entry when an external schema is used

### DIFF
--- a/lang/java/tools/src/main/java/org/apache/avro/tool/DataFileReadTool.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/DataFileReadTool.java
@@ -18,6 +18,7 @@
 package org.apache.avro.tool;
 
 import java.io.BufferedInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.util.ArrayList;
@@ -35,9 +36,12 @@ import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.io.JsonEncoder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Reads a data file and dumps to JSON */
 public class DataFileReadTool implements Tool {
+  private static final Logger LOG = LoggerFactory.getLogger(DataFileReadTool.class);
   private static final long DEFAULT_HEAD_COUNT = 10;
 
   @Override
@@ -62,18 +66,13 @@ public class DataFileReadTool implements Tool {
         .ofType(String.class);
 
     OptionSet optionSet = optionParser.parse(args.toArray(new String[0]));
-    Boolean pretty = optionSet.has(prettyOption);
+    boolean pretty = optionSet.has(prettyOption);
     List<String> nargs = new ArrayList<>((List<String>) optionSet.nonOptionArguments());
 
     String readerSchemaStr = readerSchemaOption.value(optionSet);
     String readerSchemaFile = readerSchemaFileOption.value(optionSet);
 
-    Schema readerSchema = null;
-    if (readerSchemaFile != null) {
-      readerSchema = Util.parseSchemaFromFS(readerSchemaFile);
-    } else if (readerSchemaStr != null) {
-      readerSchema = new Schema.Parser().parse(readerSchemaStr);
-    }
+    Schema readerSchema = getSchema(readerSchemaStr, readerSchemaFile);
 
     long headCount = getHeadCount(optionSet, headOption, nargs);
 
@@ -92,7 +91,7 @@ public class DataFileReadTool implements Tool {
     }
     try (DataFileStream<Object> streamReader = new DataFileStream<>(inStream, reader)) {
       Schema schema = readerSchema != null ? readerSchema : streamReader.getSchema();
-      DatumWriter writer = new GenericDatumWriter<>(schema);
+      DatumWriter<Object> writer = new GenericDatumWriter<>(schema);
       JsonEncoder encoder = EncoderFactory.get().jsonEncoder(schema, out, pretty);
       for (long recordCount = 0; streamReader.hasNext() && recordCount < headCount; recordCount++) {
         Object datum = streamReader.next();
@@ -103,6 +102,18 @@ public class DataFileReadTool implements Tool {
       out.flush();
     }
     return 0;
+  }
+
+  private static Schema getSchema(String readerSchemaStr, String readerSchemaFile) throws IOException {
+    Schema readerSchema = null;
+    if (readerSchemaFile != null) {
+      LOG.info("Reading schema from file'{}'", readerSchemaFile);
+      readerSchema = Util.parseSchemaFromFS(readerSchemaFile);
+    } else if (readerSchemaStr != null) {
+      LOG.info("Reading schema from string '{}'", readerSchemaStr);
+      readerSchema = new Schema.Parser().parse(readerSchemaStr);
+    }
+    return readerSchema;
   }
 
   private static long getHeadCount(OptionSet optionSet, OptionSpec<String> headOption, List<String> nargs) {

--- a/lang/java/tools/src/main/java/org/apache/avro/tool/DataFileReadTool.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/DataFileReadTool.java
@@ -104,14 +104,14 @@ public class DataFileReadTool implements Tool {
     return 0;
   }
 
-  private static Schema getSchema(String readerSchemaStr, String readerSchemaFile) throws IOException {
+  static Schema getSchema(String schemaStr, String schemaFile) throws IOException {
     Schema readerSchema = null;
-    if (readerSchemaFile != null) {
-      LOG.info("Reading schema from file'{}'", readerSchemaFile);
-      readerSchema = Util.parseSchemaFromFS(readerSchemaFile);
-    } else if (readerSchemaStr != null) {
-      LOG.info("Reading schema from string '{}'", readerSchemaStr);
-      readerSchema = new Schema.Parser().parse(readerSchemaStr);
+    if (schemaFile != null) {
+      LOG.info("Reading schema from file '{}'", schemaFile);
+      readerSchema = Util.parseSchemaFromFS(schemaFile);
+    } else if (schemaStr != null) {
+      LOG.info("Reading schema from string '{}'", schemaStr);
+      readerSchema = new Schema.Parser().parse(schemaStr);
     }
     return readerSchema;
   }

--- a/lang/java/tools/src/main/java/org/apache/avro/tool/DataFileWriteTool.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/DataFileWriteTool.java
@@ -72,7 +72,7 @@ public class DataFileWriteTool implements Tool {
       p.printHelpOn(err);
       return 1;
     }
-    Schema schema = (schemafile != null) ? Util.parseSchemaFromFS(schemafile) : new Schema.Parser().parse(schemastr);
+    Schema schema = DataFileReadTool.getSchema(schemastr, schemafile);
 
     DatumReader<Object> reader = new GenericDatumReader<>(schema);
 

--- a/lang/java/tools/src/test/java/org/apache/avro/tool/TestDataFileRepairTool.java
+++ b/lang/java/tools/src/test/java/org/apache/avro/tool/TestDataFileRepairTool.java
@@ -180,7 +180,7 @@ public class TestDataFileRepairTool {
   }
 
   private void checkFileContains(File repairedFile, String... lines) throws IOException {
-    DataFileReader r = new DataFileReader<>(repairedFile, new GenericDatumReader<>(SCHEMA));
+    DataFileReader<Object> r = new DataFileReader<>(repairedFile, new GenericDatumReader<>(SCHEMA));
     for (String line : lines) {
       assertEquals(line, r.next().toString());
     }


### PR DESCRIPTION
## What is the purpose of the change
When `avro-tools fromjson` parameter `--schema-file` or `--schema` is used, it is unclear whether the tool actually picked up the provided schema.

## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

Also a couple of code style warnings are fixed.