### PR TITLE
AVRO-3722 [ruby] Eagerly Initialize Instance Variables in Ruby Implementation

### DIFF
--- a/lang/ruby/lib/avro/schema.rb
+++ b/lang/ruby/lib/avro/schema.rb
@@ -126,6 +126,7 @@ module Avro
     def initialize(type, logical_type=nil)
       @type_sym = type.is_a?(Symbol) ? type : type.to_sym
       @logical_type = logical_type
+      @type_adapter = nil
     end
 
     attr_reader :type_sym
@@ -571,6 +572,7 @@ module Avro
         @order = order
         @doc = doc
         @aliases = aliases
+        @type_adapter = nil
         validate_aliases! if aliases
         validate_default! if default? && !Avro.disable_field_default_validation
       end


### PR DESCRIPTION
This commit eagerly initializes the `@type_adapter` instance variable to `nil` so that implementations can see better inline cache hits

## What is the purpose of the change

Improving inline cache performance with the Ruby AVRO gem.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

[Here is the JIRA ticket](https://issues.apache.org/jira/browse/AVRO-3722)

Thanks!
