### PR TITLE
AVRO-3727: Add RollForward option to avrogen

### DIFF
--- a/lang/csharp/src/apache/codegen/Avro.codegen.csproj
+++ b/lang/csharp/src/apache/codegen/Avro.codegen.csproj
@@ -49,6 +49,14 @@
     </Description>
   </PropertyGroup>
 
+  <!--
+    Roll-forward to the next available higher major version, and lowest minor version, if requested major version is missing. If the requested major version is present, then the Minor policy is used.
+    https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#rollforward
+  -->
+  <PropertyGroup>
+    <RollForward>Major</RollForward>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />


### PR DESCRIPTION
## What is the purpose of the change

Add RollForward -> Major to avrogen, to make sure it will run even if the required NET SDK is not installed (AVRO-3727)*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
