### PR TITLE
AVRO-3262: Include Avro record class name in toString

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificRecordBase.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificRecordBase.java
@@ -91,7 +91,7 @@ public abstract class SpecificRecordBase
 
   @Override
   public String toString() {
-    return getSpecificData().toString(this);
+    return getClass().getName() + " " + getSpecificData().toString(this);
   }
 
   @Override

--- a/lang/java/ipc/src/test/java/org/apache/avro/specific/TestSpecificData.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/specific/TestSpecificData.java
@@ -118,6 +118,12 @@ public class TestSpecificData {
         .build();
 
     String json = foo.toString();
+    int startIndex = json.indexOf("{"); // Since package names and class names cannot contain '{'
+    if (startIndex != -1) {
+      json = json.substring(startIndex);
+    } else {
+      json = "";
+    }
     JsonFactory factory = new JsonFactory();
     JsonParser parser = factory.createParser(json);
     ObjectMapper mapper = new ObjectMapper();


### PR DESCRIPTION
## What is the purpose of the change
This pull request improves the toString method output by including class name to the output, fixing [AVRO-3262](https://issues.apache.org/jira/browse/AVRO-3262)

## Verifying this change
My PR modifies the following unit test
   org.apache.avro.specific.TestSpecificData.java#specificRecordToString

## Documentation
- Does this pull request introduce a new feature?
   No
