### PR TITLE
AVRO-3736: [Ruby] Preinstall gems in ubertool docker

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -56,6 +56,9 @@ DOCKER_BUILD_XTRA_ARGS=${DOCKER_BUILD_XTRA_ARGS-}
 # Override the docker image name used.
 DOCKER_IMAGE_NAME=${DOCKER_IMAGE_NAME-}
 
+# When building a docker container, these are the files that will sent and available.
+DOCKER_EXTRA_CONTEXT="lang/ruby/Gemfile lang/ruby/avro.gemspec lang/ruby/Manifest share/VERSION.txt"
+
 usage() {
   echo "Usage: $0 {lint|test|dist|sign|clean|veryclean|docker [--args \"docker-args\"]|rat|githooks|docker-test}"
   exit 1
@@ -302,7 +305,7 @@ do
       } > Dockerfile
       # Include the ruby gemspec for preinstallation.
       # shellcheck disable=SC2086
-      tar -cf- Dockerfile lang/ruby/Gemfile lang/ruby/avro.gemspec lang/ruby/Manifest | docker build $DOCKER_BUILD_XTRA_ARGS -t "$DOCKER_IMAGE_NAME" -
+      tar -cf- Dockerfile $DOCKER_EXTRA_CONTEXT | docker build $DOCKER_BUILD_XTRA_ARGS -t "$DOCKER_IMAGE_NAME" -
       rm Dockerfile
       # By mapping the .m2 directory you can do an mvn install from
       # within the container and use the result on your normal
@@ -337,7 +340,7 @@ do
       ;;
 
     docker-test)
-      tar -cf- share/docker/Dockerfile lang/ruby/Gemfile lang/ruby/avro.gemspec lang/ruby/Manifest |
+      tar -cf- share/docker/Dockerfile $DOCKER_EXTRA_CONTEXT |
         docker build -t avro-test -f share/docker/Dockerfile -
       docker run --rm -v "${PWD}:/avro${DOCKER_MOUNT_FLAG}" --env "JAVA=${JAVA:-8}" avro-test /avro/share/docker/run-tests.sh
       ;;

--- a/build.sh
+++ b/build.sh
@@ -300,8 +300,9 @@ do
         echo "RUN getent group $GROUP_ID || groupadd -g $GROUP_ID $USER_NAME"
         echo "RUN getent passwd $USER_ID || useradd -g $GROUP_ID -u $USER_ID -k /root -m $USER_NAME"
       } > Dockerfile
+      # Include the ruby gemspec for preinstallation.
       # shellcheck disable=SC2086
-      tar -cf- lang/ruby/Gemfile Dockerfile | docker build $DOCKER_BUILD_XTRA_ARGS -t "$DOCKER_IMAGE_NAME" -
+      tar -cf- Dockerfile lang/ruby/Gemfile lang/ruby/avro.gemspec lang/ruby/Manifest | docker build $DOCKER_BUILD_XTRA_ARGS -t "$DOCKER_IMAGE_NAME" -
       rm Dockerfile
       # By mapping the .m2 directory you can do an mvn install from
       # within the container and use the result on your normal
@@ -336,7 +337,7 @@ do
       ;;
 
     docker-test)
-      tar -cf- share/docker/Dockerfile lang/ruby/Gemfile |
+      tar -cf- share/docker/Dockerfile lang/ruby/Gemfile lang/ruby/avro.gemspec lang/ruby/Manifest |
         docker build -t avro-test -f share/docker/Dockerfile -
       docker run --rm -v "${PWD}:/avro${DOCKER_MOUNT_FLAG}" --env "JAVA=${JAVA:-8}" avro-test /avro/share/docker/run-tests.sh
       ;;

--- a/lang/ruby/Gemfile
+++ b/lang/ruby/Gemfile
@@ -16,8 +16,14 @@
 
 source 'https://rubygems.org'
 
-VERSION = File.open('../../share/VERSION.txt').read.sub('-SNAPSHOT', '.pre1').chomp
-File.write("lib/avro/VERSION.txt", VERSION)
+# Add the VERSION.txt if it exists, or use a fake one for preinstalling gems
+version_path = '../../share/VERSION.txt'
+if File.exist?(version_path)
+  VERSION = File.open(version_path).read.sub('-SNAPSHOT', '.pre1').chomp
+  File.write("lib/avro/VERSION.txt", VERSION)
+else
+  File.write("/tmp/lib/avro/VERSION.txt", "0.0.1-fake")
+end
 
 gemspec
 

--- a/lang/ruby/Gemfile
+++ b/lang/ruby/Gemfile
@@ -16,14 +16,8 @@
 
 source 'https://rubygems.org'
 
-# Add the VERSION.txt if it exists, or use a fake one for preinstalling gems
-version_path = '../../share/VERSION.txt'
-if File.exist?(version_path)
-  VERSION = File.open(version_path).read.sub('-SNAPSHOT', '.pre1').chomp
-  File.write("lib/avro/VERSION.txt", VERSION)
-else
-  File.write("/tmp/lib/avro/VERSION.txt", "0.0.1-fake")
-end
+VERSION = File.open('../../share/VERSION.txt').read.sub('-SNAPSHOT', '.pre1').chomp
+File.write("lib/avro/VERSION.txt", VERSION)
 
 gemspec
 

--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -179,6 +179,11 @@ RUN python3 -m pip install --upgrade pip setuptools wheel \
 # Install Ruby
 RUN apt-get -qqy install ruby-full \
  && apt-get -qqy clean
+COPY lang/ruby/* /tmp/
+RUN gem install bundler -v 1.17.3 --no-document && \
+    apt-get install -qqy libyaml-dev && \
+    mkdir -p /tmp/lib/avro/ && \
+    bundle install --gemfile=/tmp/Gemfile
 
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.60.0

--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -179,11 +179,12 @@ RUN python3 -m pip install --upgrade pip setuptools wheel \
 # Install Ruby
 RUN apt-get -qqy install ruby-full \
  && apt-get -qqy clean
-COPY lang/ruby/* /tmp/
-RUN gem install bundler -v 1.17.3 --no-document && \
+RUN mkdir -p /tmp/lang/ruby/lib/avro && mkdir -p /tmp/share
+COPY lang/ruby/* /tmp/lang/ruby/
+COPY share/VERSION.txt /tmp/share/
+RUN gem install bundler --no-document && \
     apt-get install -qqy libyaml-dev && \
-    mkdir -p /tmp/lib/avro/ && \
-    bundle install --gemfile=/tmp/Gemfile
+    cd /tmp/lang/ruby && bundle install
 
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.60.0


### PR DESCRIPTION
## What is the purpose of the change

This pull request preinstalls the gems that the Avro Ruby SDK depends on in the ubertool docker container.

## Verifying this change

This change was manually verified by building a clean docker and building the Avro Ruby SDK.

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable
