### PR TITLE
AVRO-3748 [java] fix SeekableInputStream.skip

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/file/DataFileReader.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/file/DataFileReader.java
@@ -312,12 +312,11 @@ public class DataFileReader<D> extends DataFileStream<D> implements FileReader<D
       long length = in.length();
       long remaining = length - position;
       if (remaining > skip) {
-        in.seek(skip);
-        return in.tell() - position;
+        in.seek(position + skip);
       } else {
-        in.seek(remaining);
-        return in.tell() - position;
+        in.seek(length);
       }
+      return in.tell() - position;
     }
 
     @Override

--- a/lang/java/avro/src/test/java/org/apache/avro/file/TestSeekableInputStream.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/file/TestSeekableInputStream.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.avro.file;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Path;
+
+public class TestSeekableInputStream {
+    @Test
+    public void testSkip(@TempDir Path tempDir) throws IOException {
+        File f = tempDir.resolve("testSkip.avro").toFile();
+        try (FileWriter w = new FileWriter(f)) {
+            w.write("someContent");
+        }
+        try(SeekableFileInput in = new SeekableFileInput(f);
+            DataFileReader.SeekableInputStream stream = new DataFileReader.SeekableInputStream(in)
+        ) {
+            for (long i = 0; i < stream.length(); i++) {
+                Assertions.assertEquals(stream.length() - i, stream.available());
+                Assertions.assertEquals(1, stream.skip(1));
+            }
+        }
+    }
+}


### PR DESCRIPTION
The implementation of SeekableInputStream.skip had a longstantind issue that it did a seek to a wrong position.
This issue is rather difficult to hit in avro as it is only used in corner cases of for example the FastReader.

## What is the purpose of the change

* Fixes AVRO-3748 a longstanding issue in SeekableInputStream.skip


## Verifying this change

This change added a test to verify the new behavior 


## Documentation

- Does this pull request introduce a new feature? (yes / **no**)
