### PR TITLE
[hotfix][java][test] RecordWithTimestamps#equals should compare its own localDateTime with that.localDateTime

### DIFF
--- a/lang/java/avro/src/test/java/org/apache/avro/reflect/TestReflectLogicalTypes.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/reflect/TestReflectLogicalTypes.java
@@ -768,6 +768,6 @@ class RecordWithTimestamps {
       return false;
     }
     RecordWithTimestamps that = (RecordWithTimestamps) obj;
-    return Objects.equals(that.localDateTime, that.localDateTime);
+    return Objects.equals(localDateTime, that.localDateTime);
   }
 }


### PR DESCRIPTION

## What is the purpose of the change

Currently `RecordWithTimestamps#equals` is invalid since it compares `that.localDateTime` vs `that.localDateTime`


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.
## Documentation

- Does this pull request introduce a new feature? ( no)
- If yes, how is the feature documented? (not applicable )