### PR TITLE
AVRO-3783: Read LONG length for bytes, only allow INT sizes

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/io/BinaryDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/BinaryDecoder.java
@@ -329,9 +329,10 @@ public class BinaryDecoder extends Decoder {
 
   @Override
   public ByteBuffer readBytes(ByteBuffer old) throws IOException {
-    int length = readInt();
+    long length = readLong();
     if (length > MAX_ARRAY_SIZE) {
-      throw new UnsupportedOperationException("Cannot read arrays longer than " + MAX_ARRAY_SIZE + " bytes");
+      throw new UnsupportedOperationException(
+          "Cannot read arrays longer than " + MAX_ARRAY_SIZE + " bytes in Java library");
     }
     if (length > maxBytesLength) {
       throw new AvroRuntimeException("Bytes length " + length + " exceeds maximum allowed");
@@ -344,10 +345,10 @@ public class BinaryDecoder extends Decoder {
       result = old;
       ((Buffer) result).clear();
     } else {
-      result = ByteBuffer.allocate(length);
+      result = ByteBuffer.allocate((int) length);
     }
-    doReadBytes(result.array(), result.position(), length);
-    ((Buffer) result).limit(length);
+    doReadBytes(result.array(), result.position(), (int) length);
+    ((Buffer) result).limit((int) length);
     return result;
   }
 

--- a/lang/java/avro/src/main/java/org/apache/avro/io/DirectBinaryDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/DirectBinaryDecoder.java
@@ -39,26 +39,27 @@ class DirectBinaryDecoder extends BinaryDecoder {
   private InputStream in;
 
   private class ByteReader {
-    public ByteBuffer read(ByteBuffer old, int length) throws IOException {
+    public ByteBuffer read(ByteBuffer old, long length) throws IOException {
       this.checkLength(length);
       final ByteBuffer result;
       if (old != null && length <= old.capacity()) {
         result = old;
         result.clear();
       } else {
-        result = ByteBuffer.allocate(length);
+        result = ByteBuffer.allocate((int) length);
       }
-      doReadBytes(result.array(), result.position(), length);
-      result.limit(length);
+      doReadBytes(result.array(), result.position(), (int) length);
+      result.limit((int) length);
       return result;
     }
 
-    protected final void checkLength(int length) {
+    protected final void checkLength(long length) {
       if (length < 0L) {
         throw new AvroRuntimeException("Malformed data. Length is negative: " + length);
       }
       if (length > MAX_ARRAY_SIZE) {
-        throw new UnsupportedOperationException("Cannot read arrays longer than " + MAX_ARRAY_SIZE + " bytes");
+        throw new UnsupportedOperationException(
+            "Cannot read arrays longer than " + MAX_ARRAY_SIZE + " bytes in Java library");
       }
       if (length > maxBytesLength) {
         throw new AvroRuntimeException("Bytes length " + length + " exceeds maximum allowed");
@@ -74,12 +75,12 @@ class DirectBinaryDecoder extends BinaryDecoder {
     }
 
     @Override
-    public ByteBuffer read(ByteBuffer old, int length) throws IOException {
+    public ByteBuffer read(ByteBuffer old, long length) throws IOException {
       this.checkLength(length);
       if (old != null) {
         return super.read(old, length);
       } else {
-        return bbi.readBuffer(length);
+        return bbi.readBuffer((int) length);
       }
     }
 
@@ -170,7 +171,7 @@ class DirectBinaryDecoder extends BinaryDecoder {
 
   @Override
   public ByteBuffer readBytes(ByteBuffer old) throws IOException {
-    int length = readInt();
+    long length = readLong();
     return byteReader.read(old, length);
   }
 

--- a/lang/java/avro/src/test/java/org/apache/avro/io/TestBinaryData.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/io/TestBinaryData.java
@@ -18,6 +18,7 @@
 
 package org.apache.avro.io;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
@@ -39,4 +40,24 @@ public class TestBinaryData {
     assertEquals(nextIndex, 10);
   }
 
+  @Test
+  void testIntLongVleEquality() {
+    byte[] intResult = new byte[9];
+    byte[] longResult = new byte[9];
+    BinaryData.encodeInt(0, intResult, 0);
+    BinaryData.encodeLong(0, longResult, 0);
+    assertArrayEquals(intResult, longResult);
+    BinaryData.encodeInt(42, intResult, 0);
+    BinaryData.encodeLong(42, longResult, 0);
+    assertArrayEquals(intResult, longResult);
+    BinaryData.encodeInt(-24, intResult, 0);
+    BinaryData.encodeLong(-24, longResult, 0);
+    assertArrayEquals(intResult, longResult);
+    BinaryData.encodeInt(Integer.MAX_VALUE, intResult, 0);
+    BinaryData.encodeLong(Integer.MAX_VALUE, longResult, 0);
+    assertArrayEquals(intResult, longResult);
+    BinaryData.encodeInt(Integer.MIN_VALUE, intResult, 0);
+    BinaryData.encodeLong(Integer.MIN_VALUE, longResult, 0);
+    assertArrayEquals(intResult, longResult);
+  }
 }


### PR DESCRIPTION
***NEED HELP ACCESSING JIRA ACCOUNT TO FILE ISSUE FOR THIS***
## What is the purpose of the change

In the spec, the encoding for the bytes type is `bytes are encoded as a long followed by that many bytes of data.`. In the Java binary decoders they are read as ints this is not a correctness issue because the VLE of the long is the same as that of an equivalently valued int. The int is used (I assume) to enable easier interop with the ByteBuffer java class. But in the rare cases where validly encoded data of more than `MAX_ARRAY_SIZE` bytes is found, this change will cause an error of
```
throw new UnsupportedOperationException(
          "Cannot read arrays longer than " + MAX_ARRAY_SIZE + " bytes in Java library");
```
instead of 
```
throw new InvalidNumberEncodingException("Invalid int encoding");
```
This type of checking is consistent with what happens in `readString` which reads its size as a long. 

## Verifying this change

*(Please pick one of the following options)*


This change is already covered by existing tests, such as any test that decodes bytes from a static 


## Documentation

- Does this pull request introduce a new feature? no




