### PR TITLE
AVRO-3755: [Rust] Deserialization fails for reader schema with namespace

### DIFF
--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -4433,4 +4433,105 @@ mod tests {
         // schema validation happens here
         writer.append(avro_value).unwrap();
     }
+
+    #[test]
+    fn avro_3755_deserialize() {
+        #[derive(
+            Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, serde::Deserialize, serde::Serialize,
+        )]
+        pub enum Bar {
+            #[serde(rename = "bar0")]
+            Bar0,
+            #[serde(rename = "bar1")]
+            Bar1,
+            #[serde(rename = "bar2")]
+            Bar2,
+        }
+
+        #[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
+        pub struct Foo {
+            #[serde(rename = "barInit")]
+            pub bar_init: Bar,
+            #[serde(rename = "barUse")]
+            pub bar_use: Bar,
+        }
+
+        let writer_schema = r#"{
+            "type": "record",
+            "name": "Foo",
+            "fields":
+            [
+                {
+                    "name": "barInit",
+                    "type":
+                    {
+                        "type": "enum",
+                        "name": "Bar",
+                        "symbols":
+                        [
+                            "bar0",
+                            "bar1"
+                        ]
+                    }
+                },
+                {
+                    "name": "barUse",
+                    "type": "Bar"
+                }
+            ]
+            }"#;
+
+        let reader_schema = r#"{
+            "type": "record",
+            "name": "Foo",
+            "namespace": "name.space",
+            "fields":
+            [
+                {
+                    "name": "barInit",
+                    "type":
+                    {
+                        "type": "enum",
+                        "name": "Bar",
+                        "symbols":
+                        [
+                            "bar0",
+                            "bar1",
+                            "bar2"
+                        ]
+                    }
+                },
+                {
+                    "name": "barUse",
+                    "type": "Bar"
+                }
+            ]
+            }"#;
+
+        let writer_schema = Schema::parse_str(writer_schema).unwrap();
+        let foo = Foo {
+            bar_init: Bar::Bar0,
+            bar_use: Bar::Bar1,
+        };
+        let avro_value = crate::to_value(foo).unwrap();
+        assert!(
+            avro_value.validate(&writer_schema),
+            "value is valid for schema",
+        );
+        let datum = crate::to_avro_datum(&writer_schema, avro_value).unwrap();
+        let mut x = &datum[..];
+        let reader_schema = Schema::parse_str(reader_schema).unwrap();
+        let deser_value =
+            crate::from_avro_datum(&writer_schema, &mut x, Some(&reader_schema)).unwrap();
+        match deser_value {
+            types::Value::Record(fields) => {
+                assert_eq!(fields.len(), 2);
+                assert_eq!(fields[0].0, "barInit");
+                assert_eq!(fields[0].1, types::Value::Enum(0, "bar0".to_string()));
+                assert_eq!(fields[1].0, "barUse");
+                assert_eq!(fields[1].1, types::Value::Enum(1, "bar1".to_string()));
+            }
+            _ => panic!("Expected Value::Record"),
+        }
+    }
 }


### PR DESCRIPTION
AVRO-3755 

Add a unit test to prevent regressions.

The bug seems to be fixed earlier and most probably there is another test test for the same but it does not harm to have a second one.

## What is the purpose of the change

* Add a unit test to prevent regressions

## Verifying this change

* This change added tests and can be verified by executing the unit tests

## Documentation

- Does this pull request introduce a new feature? no
