### PR TITLE
AVRO-3757: [rust] Update syn to 2.x

### DIFF
--- a/lang/rust/Cargo.lock
+++ b/lang/rust/Cargo.lock
@@ -91,7 +91,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -350,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.4"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+checksum = "0558d22a7b463ed0241e993f76f09f30b126687447751a8638587b864e4b3944"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -360,26 +360,26 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.14.4"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+checksum = "ab8bfa2e259f8ee1ce5e97824a3c55ec4404a0d772ca7fa96bf19f0752a046eb"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.14.4"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
 dependencies = [
  "darling_core",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -884,7 +884,7 @@ checksum = "a2a0814352fd64b58489904a44ea8d90cb1a91dcb6b4f5ebabc32c8318e93cb6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.3",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -947,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.3"
+version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8234ae35e70582bfa0f1fedffa6daa248e41dd045310b19800c4a36382c8f60"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1000,7 +1000,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.3",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1101,7 +1101,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.3",
+ "syn 2.0.15",
  "wasm-bindgen-shared",
 ]
 
@@ -1135,7 +1135,7 @@ checksum = "4783ce29f09b9d93134d41297aded3a712b7b979e9c6f28c32cb88c973a94869"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.3",
+ "syn 2.0.15",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/lang/rust/avro/src/de.rs
+++ b/lang/rust/avro/src/de.rs
@@ -1006,7 +1006,7 @@ mod tests {
         );
     }
 
-    type TestResult<T> = Result<T, Box<dyn std::error::Error>>;
+    type TestResult<T> = anyhow::Result<T, Box<dyn std::error::Error>>;
 
     #[test]
     fn test_date() -> TestResult<()> {

--- a/lang/rust/avro/src/writer.rs
+++ b/lang/rust/avro/src/writer.rs
@@ -698,7 +698,7 @@ mod tests {
         assert_eq!(to_avro_datum(&schema, union).unwrap(), expected);
     }
 
-    type TestResult<T> = Result<T, Box<dyn std::error::Error>>;
+    type TestResult<T> = anyhow::Result<T, Box<dyn std::error::Error>>;
 
     fn logical_type_test<T: Into<Value> + Clone>(
         schema_str: &'static str,

--- a/lang/rust/avro_derive/Cargo.toml
+++ b/lang/rust/avro_derive/Cargo.toml
@@ -33,11 +33,11 @@ documentation = "https://docs.rs/apache-avro-derive"
 proc-macro = true
 
 [dependencies]
-darling = { default-features = false, version = "0.14.4" }
+darling = { default-features = false, version = "0.20.1" }
 proc-macro2 = { default-features = false, version = "1.0.56" }
 quote = { default-features = false, version = "1.0.27" }
 serde_json = { default-features = false, version = "1.0.96", features = ["std"] }
-syn = { default-features = false, version = "1.0.109", features = ["full", "fold"] }
+syn = { default-features = false, version = "2.0.15", features = ["full", "fold"] }
 
 [dev-dependencies]
 apache-avro = { default-features = false, path = "../avro", features = ["derive"] }

--- a/lang/rust/avro_derive/src/lib.rs
+++ b/lang/rust/avro_derive/src/lib.rs
@@ -293,17 +293,24 @@ fn to_compile_errors(errors: Vec<syn::Error>) -> proc_macro2::TokenStream {
 fn extract_outer_doc(attributes: &[Attribute]) -> Option<String> {
     let doc = attributes
         .iter()
-        .filter(|attr| attr.style == AttrStyle::Outer && attr.path.is_ident("doc"))
-        .map(|attr| {
-            let mut tokens = attr.tokens.clone().into_iter();
-            tokens.next(); // skip the Punct
-            let to_trim: &[char] = &['"', ' '];
-            tokens
-                .next() // use the Literal
-                .unwrap()
-                .to_string()
-                .trim_matches(to_trim)
-                .to_string()
+        .filter(|attr| attr.style == AttrStyle::Outer && attr.path().is_ident("doc"))
+        .filter_map(|attr| {
+            let meta_list = attr.meta.require_list();
+            match meta_list {
+                Ok(list) => {
+                    let mut tokens = list.tokens.clone().into_iter();
+                    tokens.next(); // skip the Punct
+                    let to_trim: &[char] = &['"', ' '];
+                    let result = tokens
+                        .next() // use the Literal
+                        .unwrap()
+                        .to_string()
+                        .trim_matches(to_trim)
+                        .to_string();
+                    Some(result)
+                }
+                Err(_) => None,
+            }
         })
         .collect::<Vec<String>>()
         .join("\n");

--- a/lang/rust/avro_derive/tests/derive.rs
+++ b/lang/rust/avro_derive/tests/derive.rs
@@ -985,13 +985,14 @@ mod test_derive {
         }
         "#;
         let schema = Schema::parse_str(schema).unwrap();
-        if let Schema::Record { name, doc, .. } = TestBasicWithOuterDocAttributes::get_schema() {
+        let derived_schema = TestBasicWithOuterDocAttributes::get_schema();
+        assert_eq!(&schema, &derived_schema);
+        if let Schema::Record { name, doc, .. } = derived_schema {
             assert_eq!("com.testing.namespace".to_owned(), name.namespace.unwrap());
             assert_eq!("A Documented Record", doc.unwrap())
         } else {
             panic!("TestBasicWithOuterDocAttributes schema must be a record schema")
         }
-        assert_eq!(schema, TestBasicWithOuterDocAttributes::get_schema());
     }
 
     #[derive(Debug, Serialize, Deserialize, AvroSchema, Clone, PartialEq, Eq)]


### PR DESCRIPTION
AVRO-3757

Fix compilation errors in avro_derive.
Use anyhow for test results for better error reporting.


## What is the purpose of the change

* Update a dependency that is used by other dependencies for auto derivation (serde, strum, darling, ...)

## Verifying this change

* Run the test suite

## Documentation

- Does this pull request introduce a new feature? no
