### PR TITLE
AVRO-3758: [Rust] use atomic types instead of static mut

### DIFF
--- a/lang/rust/avro/src/de.rs
+++ b/lang/rust/avro/src/de.rs
@@ -649,9 +649,9 @@ pub fn from_value<'de, D: Deserialize<'de>>(value: &'de Value) -> Result<D, Erro
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::Ordering;
     use pretty_assertions::assert_eq;
     use serde::Serialize;
+    use std::sync::atomic::Ordering;
     use uuid::Uuid;
 
     use super::*;

--- a/lang/rust/avro/src/de.rs
+++ b/lang/rust/avro/src/de.rs
@@ -649,6 +649,7 @@ pub fn from_value<'de, D: Deserialize<'de>>(value: &'de Value) -> Result<D, Erro
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::Ordering;
     use pretty_assertions::assert_eq;
     use serde::Serialize;
     use uuid::Uuid;
@@ -1227,32 +1228,27 @@ mod tests {
 
     #[test]
     fn avro_3747_human_readable_false() -> TestResult<()> {
-        // AVRO-3747: set serde's is_human_readable to false
         use serde::de::Deserializer as SerdeDeserializer;
 
-        unsafe {
-            crate::util::SERDE_HUMAN_READABLE = false;
-        }
+        let is_human_readable = false;
+        crate::util::SERDE_HUMAN_READABLE.store(is_human_readable, Ordering::Release);
 
-        let deser = Deserializer::new(&Value::Null);
+        let deser = &Deserializer::new(&Value::Null);
 
-        assert_eq!((&deser).is_human_readable(), false);
+        assert_eq!(deser.is_human_readable(), is_human_readable);
 
         Ok(())
     }
 
     #[test]
     fn avro_3747_human_readable_true() -> TestResult<()> {
-        // AVRO-3747: set serde's is_human_readable to true
         use serde::de::Deserializer as SerdeDeserializer;
 
-        unsafe {
-            crate::util::SERDE_HUMAN_READABLE = true;
-        }
+        crate::util::SERDE_HUMAN_READABLE.store(true, Ordering::Release);
 
-        let deser = Deserializer::new(&Value::Null);
+        let deser = &Deserializer::new(&Value::Null);
 
-        assert!((&deser).is_human_readable());
+        assert!(deser.is_human_readable());
 
         Ok(())
     }

--- a/lang/rust/avro/src/ser.rs
+++ b/lang/rust/avro/src/ser.rs
@@ -488,6 +488,7 @@ pub fn to_value<S: Serialize>(value: S) -> Result<Value, Error> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::Ordering;
     use super::*;
     use pretty_assertions::assert_eq;
     use serde::{Deserialize, Serialize};
@@ -1007,9 +1008,7 @@ mod tests {
     fn avro_3747_human_readable_false() {
         use serde::ser::Serializer as SerdeSerializer;
 
-        unsafe {
-            crate::util::SERDE_HUMAN_READABLE = false;
-        }
+        crate::util::SERDE_HUMAN_READABLE.store(false, Ordering::Release);
 
         let ser = &mut Serializer {};
 
@@ -1020,9 +1019,7 @@ mod tests {
     fn avro_3747_human_readable_true() {
         use serde::ser::Serializer as SerdeSerializer;
 
-        unsafe {
-            crate::util::SERDE_HUMAN_READABLE = true;
-        }
+        crate::util::SERDE_HUMAN_READABLE.store(true, Ordering::Release);
 
         let ser = &mut Serializer {};
 

--- a/lang/rust/avro/src/ser.rs
+++ b/lang/rust/avro/src/ser.rs
@@ -488,10 +488,10 @@ pub fn to_value<S: Serialize>(value: S) -> Result<Value, Error> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::Ordering;
     use super::*;
     use pretty_assertions::assert_eq;
     use serde::{Deserialize, Serialize};
+    use std::sync::atomic::Ordering;
 
     #[derive(Debug, Deserialize, Serialize, Clone)]
     struct Test {


### PR DESCRIPTION
AVRO-3758

## What is the purpose of the change

* Simplification and removal of `unsafe {}` block usages

## Verifying this change

*  This change is a trivial rework
* The relevant tests are updated

## Documentation

- Does this pull request introduce a new feature? no