### PR TITLE
AVRO-3759: Add extra types for RecordSchema, EnumSchema, FixedSchema and DecimalSchema

### DIFF
--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -637,47 +637,72 @@ impl RecordField {
     }
 }
 
-/// The `lookup` table maps field names to their position in the `Vec`
-/// of `fields`.
+/// A description of an Enum schema.
 #[derive(Debug, Clone)]
 pub struct RecordSchema {
+    /// The name of the schema
     pub name: Name,
+    /// The aliases of the schema
     pub aliases: Aliases,
+    /// The documentation of the schema
     pub doc: Documentation,
+    /// The set of fields of the schema
     pub fields: Vec<RecordField>,
+    /// The `lookup` table maps field names to their position in the `Vec`
+    /// of `fields`.
     pub lookup: BTreeMap<String, usize>,
+    /// The custom attributes of the schema
     pub attributes: BTreeMap<String, Value>,
 }
 
+/// A description of an Enum schema.
 #[derive(Debug, Clone)]
 pub struct EnumSchema {
+    /// The name of the schema
     pub name: Name,
+    /// The aliases of the schema
     pub aliases: Aliases,
+    /// The documentation of the schema
     pub doc: Documentation,
+    /// The set of symbols of the schema
     pub symbols: Vec<String>,
+    /// The custom attributes of the schema
     pub attributes: BTreeMap<String, Value>,
 }
 
+/// A description of a Union schema.
 #[derive(Debug, Clone)]
 pub struct FixedSchema {
+    /// The name of the schema
     pub name: Name,
+    /// The aliases of the schema
     pub aliases: Aliases,
+    /// The documentation of the schema
     pub doc: Documentation,
+    /// The size of the fixed schema
     pub size: usize,
+    /// The custom attributes of the schema
     pub attributes: BTreeMap<String, Value>,
 }
 
+/// A description of a Union schema.
+///
 /// `scale` defaults to 0 and is an integer greater than or equal to 0 and `precision` is an
 /// integer greater than 0.
 #[derive(Debug, Clone)]
 pub struct DecimalSchema {
+    /// The number of digits in the unscaled value
     pub precision: DecimalMetadata,
+    /// The number of digits to the right of the decimal point
     pub scale: DecimalMetadata,
+    /// The inner schema of the decimal (fixed or bytes)
     pub inner: Box<Schema>,
 }
 
+/// A description of a Union schema
 #[derive(Debug, Clone)]
 pub struct UnionSchema {
+    /// The schemas that make up this union
     pub(crate) schemas: Vec<Schema>,
     // Used to ensure uniqueness of schema inputs, and provide constant time finding of the
     // schema index given a value.

--- a/lang/rust/avro/src/writer.rs
+++ b/lang/rust/avro/src/writer.rs
@@ -632,7 +632,7 @@ mod tests {
     use crate::{
         decimal::Decimal,
         duration::{Days, Duration, Millis, Months},
-        schema::Name,
+        schema::{DecimalSchema, FixedSchema, Name},
         types::Record,
         util::zig_i64,
     };
@@ -781,21 +781,21 @@ mod tests {
     #[test]
     fn decimal_fixed() -> TestResult<()> {
         let size = 30;
-        let inner = Schema::Fixed {
+        let inner = Schema::Fixed(FixedSchema {
             name: Name::new("decimal").unwrap(),
             aliases: None,
             doc: None,
             size,
             attributes: Default::default(),
-        };
+        });
         let value = vec![0u8; size];
         logical_type_test(
             r#"{"type": {"type": "fixed", "size": 30, "name": "decimal"}, "logicalType": "decimal", "precision": 20, "scale": 5}"#,
-            &Schema::Decimal {
+            &Schema::Decimal(DecimalSchema {
                 precision: 20,
                 scale: 5,
                 inner: Box::new(inner.clone()),
-            },
+            }),
             Value::Decimal(Decimal::from(value.clone())),
             &inner,
             Value::Fixed(size, value),
@@ -808,11 +808,11 @@ mod tests {
         let value = vec![0u8; 10];
         logical_type_test(
             r#"{"type": "bytes", "logicalType": "decimal", "precision": 4, "scale": 3}"#,
-            &Schema::Decimal {
+            &Schema::Decimal(DecimalSchema {
                 precision: 4,
                 scale: 3,
                 inner: Box::new(inner.clone()),
-            },
+            }),
             Value::Decimal(Decimal::from(value.clone())),
             &inner,
             value,
@@ -821,13 +821,13 @@ mod tests {
 
     #[test]
     fn duration() -> TestResult<()> {
-        let inner = Schema::Fixed {
+        let inner = Schema::Fixed(FixedSchema {
             name: Name::new("duration").unwrap(),
             aliases: None,
             doc: None,
             size: 12,
             attributes: Default::default(),
-        };
+        });
         let value = Value::Duration(Duration::new(
             Months::new(256),
             Days::new(512),

--- a/lang/rust/avro_derive/src/lib.rs
+++ b/lang/rust/avro_derive/src/lib.rs
@@ -190,14 +190,14 @@ fn get_data_struct_schema_def(
             .iter()
             .map(|field| (field.name.to_owned(), field.position))
             .collect();
-        apache_avro::schema::Schema::Record {
+        apache_avro::schema::Schema::Record(apache_avro::schema::RecordSchema {
             name,
             aliases: #record_aliases,
             doc: #record_doc,
             fields: schema_fields,
             lookup,
             attributes: Default::default(),
-        }
+        })
     })
 }
 
@@ -217,13 +217,13 @@ fn get_data_enum_schema_def(
             .map(|variant| variant.ident.to_string())
             .collect();
         Ok(quote! {
-            apache_avro::schema::Schema::Enum {
+            apache_avro::schema::Schema::Enum(apache_avro::schema::EnumSchema {
                 name: apache_avro::schema::Name::new(#full_schema_name).expect(&format!("Unable to parse enum name for schema {}", #full_schema_name)[..]),
                 aliases: #enum_aliases,
                 doc: #doc,
                 symbols: vec![#(#symbols.to_owned()),*],
                 attributes: Default::default(),
-            }
+            })
         })
     } else {
         Err(vec![syn::Error::new(

--- a/lang/rust/avro_derive/tests/derive.rs
+++ b/lang/rust/avro_derive/tests/derive.rs
@@ -30,7 +30,7 @@ extern crate serde;
 
 #[cfg(test)]
 mod test_derive {
-    use apache_avro::schema::Alias;
+    use apache_avro::schema::{Alias, EnumSchema, RecordSchema};
     use std::{
         borrow::{Borrow, Cow},
         sync::Mutex,
@@ -144,7 +144,7 @@ mod test_derive {
         "#;
         let schema = Schema::parse_str(schema).unwrap();
         assert_eq!(schema, TestBasicNamespace::get_schema());
-        if let Schema::Record { name, .. } = TestBasicNamespace::get_schema() {
+        if let Schema::Record(RecordSchema { name, .. }) = TestBasicNamespace::get_schema() {
             assert_eq!("com.testing.namespace".to_owned(), name.namespace.unwrap())
         } else {
             panic!("TestBasicNamespace schema must be a record schema")
@@ -191,7 +191,9 @@ mod test_derive {
         "#;
         let schema = Schema::parse_str(schema).unwrap();
         assert_eq!(schema, TestComplexNamespace::get_schema());
-        if let Schema::Record { name, fields, .. } = TestComplexNamespace::get_schema() {
+        if let Schema::Record(RecordSchema { name, fields, .. }) =
+            TestComplexNamespace::get_schema()
+        {
             assert_eq!(
                 "com.testing.complex.namespace".to_owned(),
                 name.namespace.unwrap()
@@ -201,7 +203,7 @@ mod test_derive {
                 .filter(|field| field.name == "a")
                 .map(|field| &field.schema)
                 .next();
-            if let Some(Schema::Record { name, .. }) = inner_schema {
+            if let Some(Schema::Record(RecordSchema { name, .. })) = inner_schema {
                 assert_eq!(
                     "com.testing.namespace".to_owned(),
                     name.namespace.clone().unwrap()
@@ -944,7 +946,9 @@ mod test_derive {
         }
         "#;
         let schema = Schema::parse_str(schema).unwrap();
-        if let Schema::Record { name, doc, .. } = TestBasicWithAttributes::get_schema() {
+        if let Schema::Record(RecordSchema { name, doc, .. }) =
+            TestBasicWithAttributes::get_schema()
+        {
             assert_eq!("com.testing.namespace".to_owned(), name.namespace.unwrap());
             assert_eq!("A Documented Record", doc.unwrap())
         } else {
@@ -987,7 +991,7 @@ mod test_derive {
         let schema = Schema::parse_str(schema).unwrap();
         let derived_schema = TestBasicWithOuterDocAttributes::get_schema();
         assert_eq!(&schema, &derived_schema);
-        if let Schema::Record { name, doc, .. } = derived_schema {
+        if let Schema::Record(RecordSchema { name, doc, .. }) = derived_schema {
             assert_eq!("com.testing.namespace".to_owned(), name.namespace.unwrap());
             assert_eq!("A Documented Record", doc.unwrap())
         } else {
@@ -1029,7 +1033,8 @@ mod test_derive {
         }
         "#;
         let schema = Schema::parse_str(schema).unwrap();
-        if let Schema::Record { name, doc, .. } = TestBasicWithLargeDoc::get_schema() {
+        if let Schema::Record(RecordSchema { name, doc, .. }) = TestBasicWithLargeDoc::get_schema()
+        {
             assert_eq!("com.testing.namespace".to_owned(), name.namespace.unwrap());
             assert_eq!(
                 "A Documented Record\nthat spans\nmultiple lines",
@@ -1069,7 +1074,7 @@ mod test_derive {
         let schema = Schema::parse_str(schema).unwrap();
         let derived_schema = TestBasicWithBool::get_schema();
 
-        if let Schema::Record { name, .. } = derived_schema {
+        if let Schema::Record(RecordSchema { name, .. }) = derived_schema {
             assert_eq!("TestBasicWithBool", name.fullname(None))
         } else {
             panic!("TestBasicWithBool schema must be a record schema")
@@ -1100,7 +1105,7 @@ mod test_derive {
         }
         "#;
         let schema = Schema::parse_str(schema).unwrap();
-        if let Schema::Record { name, .. } = TestBasicWithU32::get_schema() {
+        if let Schema::Record(RecordSchema { name, .. }) = TestBasicWithU32::get_schema() {
             assert_eq!("TestBasicWithU32", name.fullname(None))
         } else {
             panic!("TestBasicWithU32 schema must be a record schema")
@@ -1132,7 +1137,9 @@ mod test_derive {
         }
         "#;
         let schema = Schema::parse_str(schema).unwrap();
-        if let Schema::Record { name, aliases, .. } = TestBasicStructWithAliases::get_schema() {
+        if let Schema::Record(RecordSchema { name, aliases, .. }) =
+            TestBasicStructWithAliases::get_schema()
+        {
             assert_eq!("TestBasicStructWithAliases", name.fullname(None));
             assert_eq!(
                 Some(vec![
@@ -1174,7 +1181,9 @@ mod test_derive {
         }
         "#;
         let schema = Schema::parse_str(schema).unwrap();
-        if let Schema::Record { name, aliases, .. } = TestBasicStructWithAliases2::get_schema() {
+        if let Schema::Record(RecordSchema { name, aliases, .. }) =
+            TestBasicStructWithAliases2::get_schema()
+        {
             assert_eq!("TestBasicStructWithAliases2", name.fullname(None));
             assert_eq!(
                 Some(vec![
@@ -1213,7 +1222,9 @@ mod test_derive {
         }
         "#;
         let schema = Schema::parse_str(schema).unwrap();
-        if let Schema::Enum { name, aliases, .. } = TestBasicEnumWithAliases::get_schema() {
+        if let Schema::Enum(EnumSchema { name, aliases, .. }) =
+            TestBasicEnumWithAliases::get_schema()
+        {
             assert_eq!("TestBasicEnumWithAliases", name.fullname(None));
             assert_eq!(
                 Some(vec![
@@ -1254,7 +1265,9 @@ mod test_derive {
         }
         "#;
         let schema = Schema::parse_str(schema).unwrap();
-        if let Schema::Enum { name, aliases, .. } = TestBasicEnumWithAliases2::get_schema() {
+        if let Schema::Enum(EnumSchema { name, aliases, .. }) =
+            TestBasicEnumWithAliases2::get_schema()
+        {
             assert_eq!("TestBasicEnumWithAliases2", name.fullname(None));
             assert_eq!(
                 Some(vec![
@@ -1358,7 +1371,8 @@ mod test_derive {
         "#;
 
         let schema = Schema::parse_str(schema).unwrap();
-        if let Schema::Record { name, fields, .. } = TestBasicStructWithDefaultValues::get_schema()
+        if let Schema::Record(RecordSchema { name, fields, .. }) =
+            TestBasicStructWithDefaultValues::get_schema()
         {
             assert_eq!("TestBasicStructWithDefaultValues", name.fullname(None));
             use serde_json::json;
@@ -1455,7 +1469,7 @@ mod test_derive {
 
         let schema = Schema::parse_str(schema).unwrap();
         let derived_schema = TestBasicStructWithSkipAttribute::get_schema();
-        if let Schema::Record { name, fields, .. } = &derived_schema {
+        if let Schema::Record(RecordSchema { name, fields, .. }) = &derived_schema {
             assert_eq!("TestBasicStructWithSkipAttribute", name.fullname(None));
             for field in fields {
                 match field.name.as_str() {
@@ -1522,7 +1536,7 @@ mod test_derive {
 
         let schema = Schema::parse_str(schema).unwrap();
         let derived_schema = TestBasicStructWithRenameAttribute::get_schema();
-        if let Schema::Record { name, fields, .. } = &derived_schema {
+        if let Schema::Record(RecordSchema { name, fields, .. }) = &derived_schema {
             assert_eq!("TestBasicStructWithRenameAttribute", name.fullname(None));
             for field in fields {
                 match field.name.as_str() {
@@ -1553,7 +1567,7 @@ mod test_derive {
         }
 
         let derived_schema = TestRawIdent::get_schema();
-        if let Schema::Record { fields, .. } = derived_schema {
+        if let Schema::Record(RecordSchema { fields, .. }) = derived_schema {
             let field = fields.get(0).expect("TestRawIdent must contain a field");
             assert_eq!(field.name, "type");
         } else {


### PR DESCRIPTION
AVRO-3759

## What is the purpose of the change

* Adds extra types for RecordSchema, EnumSchema, FixedSchema and DecimalSchema

## Verifying this change

* Existing tests are updated to the API change

## Documentation

- Does this pull request introduce a new feature? no