### PR TITLE
AVRO-2397: [c++] Add support for type and field aliases

### DIFF
--- a/lang/c++/api/Node.hh
+++ b/lang/c++/api/Node.hh
@@ -59,7 +59,7 @@ public:
     std::string fullname() const;
     const std::string &ns() const { return ns_; }
     const std::string &simpleName() const { return simpleName_; }
-    const std::vector<std::string>& aliases() const;
+    const std::vector<std::string> &aliases() const;
 
     void ns(std::string n) { ns_ = std::move(n); }
     void simpleName(std::string n) { simpleName_ = std::move(n); }

--- a/lang/c++/api/Node.hh
+++ b/lang/c++/api/Node.hh
@@ -40,30 +40,38 @@ class GenericDatum;
 using NodePtr = std::shared_ptr<Node>;
 
 class AVRO_DECL Name {
+    struct Aliases;
+
     std::string ns_;
     std::string simpleName_;
+    std::unique_ptr<Aliases> aliases_;
 
 public:
-    Name() = default;
-    explicit Name(const std::string &fullname);
-    Name(std::string simpleName, std::string ns) : ns_(std::move(ns)), simpleName_(std::move(simpleName)) { check(); }
+    Name();
+    explicit Name(const std::string &name);
+    Name(std::string simpleName, std::string ns);
+    Name(const Name& other);
+    Name& operator=(const Name& other);
+    Name(Name&& other);
+    Name& operator=(Name&& other);
+    ~Name();
 
     std::string fullname() const;
     const std::string &ns() const { return ns_; }
     const std::string &simpleName() const { return simpleName_; }
+    const std::vector<std::string>& aliases() const;
 
     void ns(std::string n) { ns_ = std::move(n); }
     void simpleName(std::string n) { simpleName_ = std::move(n); }
     void fullname(const std::string &n);
+    void addAlias(const std::string &alias);
 
     bool operator<(const Name &n) const;
     void check() const;
     bool operator==(const Name &n) const;
     bool operator!=(const Name &n) const { return !((*this) == n); }
-    void clear() {
-        ns_.clear();
-        simpleName_.clear();
-    }
+    bool equalOrAliasedBy(const Name &n) const;
+    void clear();
     explicit operator std::string() const {
         return fullname();
     }

--- a/lang/c++/api/NodeImpl.hh
+++ b/lang/c++/api/NodeImpl.hh
@@ -294,42 +294,30 @@ protected:
 };
 
 class AVRO_DECL NodeRecord : public NodeImplRecord {
-    std::vector<GenericDatum> defaultValues;
+    std::vector<std::vector<std::string>> fieldsAliases_;
+    std::vector<GenericDatum> fieldsDefaultValues_;
 
 public:
     NodeRecord() : NodeImplRecord(AVRO_RECORD) {}
-    NodeRecord(const HasName &name, const MultiLeaves &fields,
-               const LeafNames &fieldsNames,
-               std::vector<GenericDatum> dv);
-
-    NodeRecord(const HasName &name, const HasDoc &doc, const MultiLeaves &fields,
-               const LeafNames &fieldsNames,
-               std::vector<GenericDatum> dv) : NodeImplRecord(AVRO_RECORD, name, doc, fields, fieldsNames, MultiAttributes(), NoSize()),
-                                               defaultValues(std::move(dv)) {
-        leafNameCheck();
-    }
 
     NodeRecord(const HasName &name, const MultiLeaves &fields,
-               const LeafNames &fieldsNames,
-               const std::vector<GenericDatum>& dv,
-               const MultiAttributes &customAttributes) :
-        NodeImplRecord(AVRO_RECORD, name, fields, fieldsNames, customAttributes, NoSize()),
-        defaultValues(dv) {
-        leafNameCheck();
-    }
+               const LeafNames &fieldsNames, std::vector<GenericDatum> dv);
 
     NodeRecord(const HasName &name, const HasDoc &doc, const MultiLeaves &fields,
-               const LeafNames &fieldsNames,
-               const std::vector<GenericDatum>& dv,
-               const MultiAttributes &customAttributes) :
-        NodeImplRecord(AVRO_RECORD, name, doc, fields, fieldsNames, customAttributes, NoSize()),
-        defaultValues(dv) {
-        leafNameCheck();
-    }
+               const LeafNames &fieldsNames, std::vector<GenericDatum> dv);
+
+    NodeRecord(const HasName &name, const MultiLeaves &fields,
+               const LeafNames &fieldsNames, std::vector<std::vector<std::string>> fieldsAliases,
+               std::vector<GenericDatum> dv, const MultiAttributes &customAttributes);
+
+    NodeRecord(const HasName &name, const HasDoc &doc, const MultiLeaves &fields,
+               const LeafNames &fieldsNames, std::vector<std::vector<std::string>> fieldsAliases,
+               std::vector<GenericDatum> dv, const MultiAttributes &customAttributes);
 
     void swap(NodeRecord &r) {
         NodeImplRecord::swap(r);
-        defaultValues.swap(r.defaultValues);
+        fieldsAliases_.swap(r.fieldsAliases_);
+        fieldsDefaultValues_.swap(r.fieldsDefaultValues_);
     }
 
     SchemaResolution resolve(const Node &reader) const override;
@@ -344,22 +332,10 @@ public:
     }
 
     const GenericDatum &defaultValueAt(size_t index) override {
-        return defaultValues[index];
+        return fieldsDefaultValues_[index];
     }
 
     void printDefaultToJson(const GenericDatum &g, std::ostream &os, size_t depth) const override;
-
-private:
-    // check if leaf name is valid Name and is not duplicate
-    void leafNameCheck() {
-        for (size_t i = 0; i < leafNameAttributes_.size(); ++i) {
-            if (!nameIndex_.add(leafNameAttributes_.get(i), i)) {
-                throw Exception(boost::format(
-                                    "Cannot add duplicate field: %1%")
-                                % leafNameAttributes_.get(i));
-            }
-        }
-    }
 };
 
 class AVRO_DECL NodeEnum : public NodeImplEnum {

--- a/lang/c++/test/CodecTests.cc
+++ b/lang/c++/test/CodecTests.cc
@@ -1264,6 +1264,46 @@ static const TestData3 data3[] = {
 
     {R"(["boolean", "int"])", "U1I", R"(["boolean", "long"])", "U1L", 1},
     {R"(["boolean", "int"])", "U1I", R"(["long", "boolean"])", "U0L", 1},
+
+    // Aliases
+    {"{\"type\":\"record\", \"name\":\"r\", \"fields\":["
+     "{\"name\":\"f0\", \"type\":\"int\"},"
+     "{\"name\":\"f1\", \"type\":\"boolean\"},"
+     "{\"name\":\"f2\", \"type\":\"double\"}]}",
+     "IBD",
+     "{\"type\":\"record\", \"name\":\"s\", \"aliases\":[\"r\"], \"fields\":["
+     "{\"name\":\"g0\", \"type\":\"int\", \"aliases\":[\"f0\"]},"
+     "{\"name\":\"g1\", \"type\":\"boolean\", \"aliases\":[\"f1\"]},"
+     "{\"name\":\"f2\", \"type\":\"double\", \"aliases\":[\"g2\"]}]}",
+     "IBD",
+     1},
+    {"{\"type\":\"record\", \"name\":\"r\", \"namespace\":\"n\", \"fields\":["
+     "{\"name\":\"f0\", \"type\":\"int\"}]}",
+     "I",
+     "{\"type\":\"record\", \"name\":\"s\", \"namespace\":\"n2\", \"aliases\":[\"t\", \"n.r\"], \"fields\":["
+     " {\"name\":\"f0\", \"type\":\"int\"}]}",
+     "I",
+     1},
+    {"{\"type\":\"enum\", \"name\":\"e\", \"symbols\":[\"a\", \"b\"]}",
+     "e1",
+     "{\"type\":\"enum\", \"name\":\"f\", \"aliases\":[\"e\"], \"symbols\":[\"a\", \"b\", \"c\"]}",
+     "e1",
+     1},
+    {"{\"type\":\"enum\", \"name\":\"e\", \"namespace\":\"n\", \"symbols\":[\"a\", \"b\"]}",
+     "e1",
+     "{\"type\":\"enum\", \"name\":\"f\", \"namespace\":\"n2\", \"aliases\":[\"g\", \"n.e\"], \"symbols\":[\"a\", \"b\"]}",
+     "e1",
+     1},
+    {"{\"type\":\"fixed\", \"name\":\"f\", \"size\":8}",
+     "f8",
+     "{\"type\":\"fixed\", \"name\":\"g\", \"aliases\":[\"f\"], \"size\":8}",
+     "f8",
+     1},
+    {"{\"type\":\"fixed\", \"name\":\"f\", \"namespace\":\"n\", \"size\":8}",
+     "f8",
+     "{\"type\":\"fixed\", \"name\":\"g\", \"namespace\":\"n2\", \"aliases\":[\"h\", \"n.f\"], \"size\":8}",
+     "f8",
+     1},
 };
 
 static const TestData4 data4[] = {

--- a/lang/c++/test/unittest.cc
+++ b/lang/c++/test/unittest.cc
@@ -437,6 +437,7 @@ struct TestSchema {
         Name recordName("Test");
         HasName nameConcept(recordName);
         concepts::MultiAttribute<std::string> fieldNames;
+        std::vector<std::vector<std::string>> fieldAliases;
         concepts::MultiAttribute<NodePtr> fieldValues;
         std::vector<GenericDatum> defaultValues;
         concepts::MultiAttribute<CustomAttributes> customAttributes;
@@ -453,7 +454,7 @@ struct TestSchema {
         customAttributes.add(cf);
 
         NodeRecord nodeRecordWithCustomAttribute(nameConcept, fieldValues,
-                                            fieldNames, defaultValues,
+                                            fieldNames, fieldAliases, defaultValues,
                                             customAttributes);
         std::string expectedJsonWithCustomAttribute =
         "{\"type\": \"record\", \"name\": \"Test\",\"fields\": "


### PR DESCRIPTION
## What is the purpose of the change
This adds support to the C++ library for type and field aliases. It addresses AVRO-2397 and also AVRO-1496.

It is an evolution of the old PR #522. That sought to handle support by overriding the `Name` equality operator and also using `Name` for field names too. This struck me as too broad a change (do we want that notion of equality everywhere?) and not really appropriate for field aliases (where there is no namespace).

The handling is now in two places:
1) In `ResolvingGrammarGenerator`, writer types are now matched via the new `equalOrAliasedBy()` method
2) Field aliases are handled simply by allowing them to be looked up via `nameIndex()` - i.e. aliases are added there too, as well as the original names.

## Verifying this change
This change added tests and can be verified by running the C++ unit tests, specifically `CodecTests`.

## Documentation
- Does this pull request introduce a new feature? Yes.
- If yes, how is the feature documented? Currently, I have made no documentation changes, as I'm not sure that it's stated anywhere that aliases are _not_ supported. If that's the case, it should be removed / reversed.
