### PR TITLE
[Rust] Logging flood during validate method

### DIFF
--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -350,7 +350,7 @@ impl Value {
 
             match self.validate_internal(schema, rs.get_names(), &enclosing_namespace) {
                 Some(error_msg) => {
-                    error!(
+                    debug!(
                         "Invalid value: {:?} for schema: {:?}. Reason: {}",
                         self, schema, error_msg
                     );


### PR DESCRIPTION
Lowers logging level for validate with schemata method to debug level to avoid noisy logs.