### PR TITLE
AVRO-3773: [ruby] fix validator for decimal default

### DIFF
--- a/lang/ruby/test/test_schema.rb
+++ b/lang/ruby/test/test_schema.rb
@@ -618,7 +618,7 @@ class TestSchema < Test::Unit::TestCase
         type: 'record',
         name: 'account',
         fields: [
-          { name: 'balance', type: 'bytes', "logicalType": "decimal", "precision": 9, "scale": 2 }
+          { name: 'balance', type: 'bytes', logicalType: 'decimal', precision: 9, scale: 2 }
         ]
       )
     end
@@ -633,10 +633,10 @@ class TestSchema < Test::Unit::TestCase
           {
             name: 'balance',
             type: [
-              { type: 'bytes', "logicalType": "decimal", "precision": 9, "scale": 2 },
-              "null"
+              { type: 'bytes', logicalType: 'decimal', precision: 9, scale: 2 },
+              'null'
             ],
-            default: "\u00ff"
+            default: '\u00ff'
           }
         ]
       )

--- a/lang/ruby/test/test_schema.rb
+++ b/lang/ruby/test/test_schema.rb
@@ -612,6 +612,37 @@ class TestSchema < Test::Unit::TestCase
     assert_equal schema_hash, schema.to_avro
   end
 
+  def test_bytes_decimal_in_record
+    assert_nothing_raised do
+      hash_to_schema(
+        type: 'record',
+        name: 'account',
+        fields: [
+          { name: 'balance', type: 'bytes', "logicalType": "decimal", "precision": 9, "scale": 2 }
+        ]
+      )
+    end
+  end
+
+  def test_bytes_decimal_with_default_in_record
+    assert_nothing_raised do
+      hash_to_schema(
+        type: 'record',
+        name: 'account',
+        fields: [
+          {
+            name: 'balance',
+            type: [
+              { type: 'bytes', "logicalType": "decimal", "precision": 9, "scale": 2 },
+              "null"
+            ],
+            default: "\u00ff"
+          }
+        ]
+      )
+    end
+  end
+  
   def test_bytes_decimal_to_include_precision_scale
     schema = Avro::Schema.parse <<-SCHEMA
       {


### PR DESCRIPTION
## What is the purpose of the change

fixing validator for https://issues.apache.org/jira/browse/AVRO-3773


## Verifying this change

- New unit tests are added to reproduce, refer to [first Github Action](https://github.com/jychen7/avro/actions/runs/5207444823/jobs/9394998133) (Expect failure)
- Adding the fix pass all tests, including both old and new ones

## Documentation

- Does this pull request introduce a new feature? `no`
- If yes, how is the feature documented? `not applicable`
