### PR TITLE
AVRO-3775: [ruby] fix decoded default value of decimal logical type

### DIFF
--- a/lang/ruby/lib/avro/io.rb
+++ b/lang/ruby/lib/avro/io.rb
@@ -397,8 +397,10 @@ module Avro
           return Integer(default_value)
         when :float, :double
           return Float(default_value)
-        when :boolean, :enum, :fixed, :string, :bytes
+        when :boolean, :enum, :fixed, :string
           return default_value
+        when :bytes
+          return field_schema.type_adapter.decode(default_value)
         when :array
           read_array = []
           default_value.each do |json_val|

--- a/lang/ruby/lib/avro/io.rb
+++ b/lang/ruby/lib/avro/io.rb
@@ -400,8 +400,10 @@ module Avro
         when :boolean, :enum, :fixed, :string
           return default_value
         when :bytes
-          return default_value unless field_schema.type_adapter
-          return field_schema.type_adapter.decode(default_value)
+          if field_schema.logical_type == Schema::DECIMAL_LOGICAL_TYPE
+            return field_schema.type_adapter.decode(default_value)
+          end
+          return default_value
         when :array
           read_array = []
           default_value.each do |json_val|

--- a/lang/ruby/lib/avro/io.rb
+++ b/lang/ruby/lib/avro/io.rb
@@ -400,6 +400,7 @@ module Avro
         when :boolean, :enum, :fixed, :string
           return default_value
         when :bytes
+          return default_value unless field_schema.type_adapter
           return field_schema.type_adapter.decode(default_value)
         when :array
           read_array = []

--- a/lang/ruby/lib/avro/io.rb
+++ b/lang/ruby/lib/avro/io.rb
@@ -429,7 +429,7 @@ module Avro
           raise AvroError, fail_msg
         end
 
-        field_schema.logical_type ? field_schema.type_adapter.decode(datum) : datum
+        field_schema.type_adapter.decode(datum)
       end
 
       def skip_data(writers_schema, decoder)

--- a/lang/ruby/lib/avro/io.rb
+++ b/lang/ruby/lib/avro/io.rb
@@ -390,36 +390,31 @@ module Avro
 
       def read_default_value(field_schema, default_value)
         # Basically a JSON Decoder?
-        case field_schema.type_sym
+        datum = case field_schema.type_sym
         when :null
-          return nil
+          nil
         when :int, :long
-          return Integer(default_value)
+          Integer(default_value)
         when :float, :double
-          return Float(default_value)
-        when :boolean, :enum, :fixed, :string
-          return default_value
-        when :bytes
-          if field_schema.logical_type == Schema::DECIMAL_LOGICAL_TYPE
-            return field_schema.type_adapter.decode(default_value)
-          end
-          return default_value
+          Float(default_value)
+        when :boolean, :enum, :fixed, :string, :bytes
+          default_value
         when :array
           read_array = []
           default_value.each do |json_val|
             item_val = read_default_value(field_schema.items, json_val)
             read_array << item_val
           end
-          return read_array
+          read_array
         when :map
           read_map = {}
           default_value.each do |key, json_val|
             map_val = read_default_value(field_schema.values, json_val)
             read_map[key] = map_val
           end
-          return read_map
+          read_map
         when :union
-          return read_default_value(field_schema.schemas[0], default_value)
+          read_default_value(field_schema.schemas[0], default_value)
         when :record, :error
           read_record = {}
           field_schema.fields.each do |field|
@@ -428,11 +423,13 @@ module Avro
             field_val = read_default_value(field.type, json_val)
             read_record[field.name] = field_val
           end
-          return read_record
+          read_record
         else
           fail_msg = "Unknown type: #{field_schema.type}"
           raise AvroError, fail_msg
         end
+
+        field_schema.logical_type ? field_schema.type_adapter.decode(datum) : datum
       end
 
       def skip_data(writers_schema, decoder)

--- a/lang/ruby/test/test_logical_types.rb
+++ b/lang/ruby/test/test_logical_types.rb
@@ -273,7 +273,6 @@ class TestLogicalTypes < Test::Unit::TestCase
       end
 
       assert_equal 5, report.total_allocated
-      # Ruby 2.7 does not retain anything. Ruby 2.6 retains 1
       assert_operator 1, :>=, report.total_retained
     end
   end
@@ -294,7 +293,6 @@ class TestLogicalTypes < Test::Unit::TestCase
       end
 
       assert_equal 5, report.total_allocated
-      # Ruby 2.7 does not retain anything. Ruby 2.6 retains 1
       assert_operator 1, :>=, report.total_retained
     end
   end

--- a/lang/ruby/test/test_logical_types.rb
+++ b/lang/ruby/test/test_logical_types.rb
@@ -293,7 +293,7 @@ class TestLogicalTypes < Test::Unit::TestCase
       end
 
       assert_equal 5, report.total_allocated
-      assert_operator 1, :>=, report.total_retained
+      assert_equal 0, report.total_retained
     end
   end
 

--- a/lang/ruby/test/test_logical_types.rb
+++ b/lang/ruby/test/test_logical_types.rb
@@ -125,7 +125,6 @@ class TestLogicalTypes < Test::Unit::TestCase
   end
 
   def test_bytes_decimal_default
-    Avro.disable_field_default_validation = true
     sales_schema = Avro::Schema.parse('{
         "type": "record",
         "name": "Order",
@@ -190,7 +189,6 @@ class TestLogicalTypes < Test::Unit::TestCase
     encoded = encode(sales_record, sales_tax_schema)
     tax_nil_record = {"sales" => BigDecimal("12.34"), "tax" => nil}
     assert_equal tax_nil_record, decode(encoded, sales_tax_schema)
-    Avro.disable_field_default_validation = false
   end
 
   def test_bytes_decimal_range_errors

--- a/lang/ruby/test/test_logical_types.rb
+++ b/lang/ruby/test/test_logical_types.rb
@@ -183,8 +183,13 @@ class TestLogicalTypes < Test::Unit::TestCase
     sales_tax_record = {"sales" => BigDecimal("12.34"), "tax" => BigDecimal("0.000")}
     encoded = encode(sales_record, sales_schema)
     assert_equal sales_record, decode(encoded, sales_schema)
-
+    # decode with different schema applies default
     assert_equal sales_tax_record, decode(encoded, sales_tax_schema, writer_schema: sales_schema)
+
+    # decode with same schema does not apply default, since it is nullable during encode
+    encoded = encode(sales_record, sales_tax_schema)
+    tax_nil_record = {"sales" => BigDecimal("12.34"), "tax" => nil}
+    assert_equal tax_nil_record, decode(encoded, sales_tax_schema)
     Avro.disable_field_default_validation = false
   end
 


### PR DESCRIPTION
## What is the purpose of the change

fix https://issues.apache.org/jira/browse/AVRO-3775
when doing schema resolution, default value is being used. However, decimal default value was returned as string/bytes, however, should be BigDecimal


## Verifying this change

- New unit tests are added to reproduce (Expect CI is Red): https://github.com/jychen7/avro/actions/runs/5227583924/jobs/9439320277
- Fix are applied to make sure CI is Green

## Documentation

- Does this pull request introduce a new feature? `no`
- If yes, how is the feature documented? `not applicable`
