### PR TITLE
AVRO-3776: [ruby] fix encoding for decimal logical type

### DIFF
--- a/lang/ruby/test/test_logical_types.rb
+++ b/lang/ruby/test/test_logical_types.rb
@@ -100,6 +100,25 @@ class TestLogicalTypes < Test::Unit::TestCase
     assert_equal 'duration', schema.logical_type
   end
 
+  def test_bytes_decimal_field
+    schema = Avro::Schema.parse <<-SCHEMA
+        {
+            "type": "record",
+            "name": "Order",
+            "fields" : [
+                {
+                    "name": "sales",
+                    "type": "bytes",
+                    "logicalType": "decimal",
+                    "precision": 4,
+                    "scale": 2
+                }  
+            ]
+        }
+    SCHEMA
+    assert_encode_and_decode({"sales": BigDecimal("12.34")}, schema)
+  end
+
   def test_bytes_decimal
     schema = Avro::Schema.parse <<-SCHEMA
       { "type": "bytes", "logicalType": "decimal", "precision": 9, "scale": 6 }

--- a/lang/ruby/test/test_logical_types.rb
+++ b/lang/ruby/test/test_logical_types.rb
@@ -108,15 +108,17 @@ class TestLogicalTypes < Test::Unit::TestCase
             "fields" : [
                 {
                     "name": "sales",
-                    "type": "bytes",
-                    "logicalType": "decimal",
-                    "precision": 4,
-                    "scale": 2
+                    "type": {
+                        "type": "bytes",
+                        "logicalType": "decimal",
+                        "precision": 4,
+                        "scale": 2    
+                    }
                 }  
             ]
         }
     SCHEMA
-    assert_encode_and_decode({"sales": BigDecimal("12.34")}, schema)
+    assert_encode_and_decode({"sales" => BigDecimal("12.34")}, schema)
   end
 
   def test_bytes_decimal


### PR DESCRIPTION
## What is the purpose of the change

fix https://issues.apache.org/jira/browse/AVRO-3776


## Verifying this change

*(Please pick one of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
- *Extended interop tests to verify consistent valid schema names between SDKs*
- *Added test that validates that Java throws an AvroRuntimeException on invalid binary data*
- *Manually verified the change by building the website and checking the new redirect*


## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
