### PR TITLE
AVRO-3772: [Rust] Deserialize Errors for an Unknown Enum Symbol instead of Returning Default

### DIFF
--- a/lang/rust/avro/src/lib.rs
+++ b/lang/rust/avro/src/lib.rs
@@ -868,61 +868,6 @@ mod tests {
 
     //TODO: move where it fits better
     #[test]
-    fn test_enum_resolution() {
-        let writer_raw_schema = r#"
-            {
-                "type": "record",
-                "name": "test",
-                "fields": [
-                    {"name": "a", "type": "long", "default": 42},
-                    {"name": "b", "type": "string"},
-                    {
-                        "name": "c",
-                        "type": {
-                            "type": "enum",
-                            "name": "suit",
-                            "symbols": ["diamonds", "spades", "clubs", "hearts"]
-                        },
-                        "default": "spades"
-                    }
-                ]
-            }
-        "#;
-        let reader_raw_schema = r#"
-            {
-                "type": "record",
-                "name": "test",
-                "fields": [
-                    {"name": "a", "type": "long", "default": 42},
-                    {"name": "b", "type": "string"},
-                    {
-                        "name": "c",
-                        "type": {
-                            "type": "enum",
-                            "name": "suit",
-                            "symbols": ["diamonds", "spades", "ninja", "hearts"]
-                        },
-                        "default": "spades"
-                    }
-                ]
-            }
-        "#;
-        let writer_schema = Schema::parse_str(writer_raw_schema).unwrap();
-        let reader_schema = Schema::parse_str(reader_raw_schema).unwrap();
-        let mut writer = Writer::with_codec(&writer_schema, Vec::new(), Codec::Null);
-        let mut record = Record::new(writer.schema()).unwrap();
-        record.put("a", 27i64);
-        record.put("b", "foo");
-        record.put("c", "clubs");
-        writer.append(record).unwrap();
-        let input = writer.into_inner().unwrap();
-        let mut reader = Reader::with_schema(&reader_schema, &input[..]).unwrap();
-        assert!(reader.next().unwrap().is_err());
-        assert!(reader.next().is_none());
-    }
-
-    //TODO: move where it fits better
-    #[test]
     fn test_enum_no_reader_schema() {
         let writer_raw_schema = r#"
             {

--- a/lang/rust/avro/src/schema_compatibility.rs
+++ b/lang/rust/avro/src/schema_compatibility.rs
@@ -974,4 +974,68 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn avro_3772_enum_default_less_symbols() -> TestResult {
+        let writer_raw_schema = r#"
+        {
+          "type": "record",
+          "name": "test",
+          "fields": [
+            {"name": "a", "type": "long", "default": 42},
+            {"name": "b", "type": "string"},
+            {
+              "name": "c",
+              "type": {
+                "type": "enum",
+                "name": "suit",
+                "symbols": ["diamonds", "spades", "clubs", "hearts"]
+              },
+              "default": "spades"
+            }
+          ]
+        }
+        "#;
+
+        let reader_raw_schema = r#"
+        {
+          "type": "record",
+          "name": "test",
+          "fields": [
+            {"name": "a", "type": "long", "default": 42},
+            {"name": "b", "type": "string"},
+            {
+              "name": "c",
+              "type": {
+                 "type": "enum",
+                "name": "suit",
+                  "symbols": ["hearts", "spades"]
+              },
+              "default": "spades"
+            }
+          ]
+        }
+      "#;
+        let writer_schema = Schema::parse_str(writer_raw_schema)?;
+        let reader_schema = Schema::parse_str(reader_raw_schema)?;
+        let mut writer = Writer::with_codec(&writer_schema, Vec::new(), Codec::Null);
+        let mut record = Record::new(writer.schema()).unwrap();
+        record.put("a", 27i64);
+        record.put("b", "foo");
+        record.put("c", "hearts");
+        writer.append(record).unwrap();
+        let input = writer.into_inner()?;
+        let mut reader = Reader::with_schema(&reader_schema, &input[..])?;
+        assert_eq!(
+            reader.next().unwrap().unwrap(),
+            Value::Record(vec![
+                ("a".to_string(), Value::Long(27)),
+                ("b".to_string(), Value::String("foo".to_string())),
+                ("c".to_string(), Value::Enum(0, "hearts".to_string())),
+            ])
+        );
+        assert!(reader.next().is_none());
+
+        Ok(())
+    }
 }

--- a/lang/rust/avro/src/schema_compatibility.rs
+++ b/lang/rust/avro/src/schema_compatibility.rs
@@ -327,6 +327,10 @@ impl SchemaCompatibility {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{
+        types::{Record, Value},
+        Codec, Reader, Writer,
+    };
     use apache_avro_test_helper::TestResult;
 
     fn int_array_schema() -> Schema {
@@ -905,5 +909,69 @@ mod tests {
             &point_2d_fullname_schema(),
             &read_schema
         ));
+    }
+
+    #[test]
+    fn avro_3772_enum_default() -> TestResult {
+        let writer_raw_schema = r#"
+        {
+          "type": "record",
+          "name": "test",
+          "fields": [
+            {"name": "a", "type": "long", "default": 42},
+            {"name": "b", "type": "string"},
+            {
+              "name": "c",
+              "type": {
+                "type": "enum",
+                "name": "suit",
+                "symbols": ["diamonds", "spades", "clubs", "hearts"]
+              },
+              "default": "spades"
+            }
+          ]
+        }
+        "#;
+
+        let reader_raw_schema = r#"
+        {
+          "type": "record",
+          "name": "test",
+          "fields": [
+            {"name": "a", "type": "long", "default": 42},
+            {"name": "b", "type": "string"},
+            {
+              "name": "c",
+              "type": {
+                 "type": "enum",
+                "name": "suit",
+                  "symbols": ["diamonds", "spades", "ninja", "hearts"]
+              },
+              "default": "spades"
+            }
+          ]
+        }
+      "#;
+        let writer_schema = Schema::parse_str(writer_raw_schema)?;
+        let reader_schema = Schema::parse_str(reader_raw_schema)?;
+        let mut writer = Writer::with_codec(&writer_schema, Vec::new(), Codec::Null);
+        let mut record = Record::new(writer.schema()).unwrap();
+        record.put("a", 27i64);
+        record.put("b", "foo");
+        record.put("c", "clubs");
+        writer.append(record).unwrap();
+        let input = writer.into_inner()?;
+        let mut reader = Reader::with_schema(&reader_schema, &input[..])?;
+        assert_eq!(
+            reader.next().unwrap().unwrap(),
+            Value::Record(vec![
+                ("a".to_string(), Value::Long(27)),
+                ("b".to_string(), Value::String("foo".to_string())),
+                ("c".to_string(), Value::Enum(1, "spades".to_string())),
+            ])
+        );
+        assert!(reader.next().is_none());
+
+        Ok(())
     }
 }

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -564,7 +564,7 @@ impl Value {
     pub fn resolve(self, schema: &Schema) -> AvroResult<Self> {
         let enclosing_namespace = schema.namespace();
         let rs = ResolvedSchema::try_from(schema)?;
-        self.resolve_internal(schema, rs.get_names(), &enclosing_namespace)
+        self.resolve_internal(schema, rs.get_names(), &enclosing_namespace, &None)
     }
 
     /// Attempt to perform schema resolution on the value, with the given
@@ -576,7 +576,7 @@ impl Value {
     pub fn resolve_schemata(self, schema: &Schema, schemata: Vec<&Schema>) -> AvroResult<Self> {
         let enclosing_namespace = schema.namespace();
         let rs = ResolvedSchema::try_from(schemata)?;
-        self.resolve_internal(schema, rs.get_names(), &enclosing_namespace)
+        self.resolve_internal(schema, rs.get_names(), &enclosing_namespace, &None)
     }
 
     fn resolve_internal(
@@ -584,6 +584,7 @@ impl Value {
         schema: &Schema,
         names: &NamesRef,
         enclosing_namespace: &Namespace,
+        field_default: &Option<JsonValue>,
     ) -> AvroResult<Self> {
         // Check if this schema is a union, and if the reader schema is not.
         if SchemaKind::from(&self) == SchemaKind::Union
@@ -602,7 +603,7 @@ impl Value {
 
                 if let Some(resolved) = names.get(&name) {
                     debug!("Resolved {:?}", name);
-                    self.resolve_internal(resolved, names, &name.namespace)
+                    self.resolve_internal(resolved, names, &name.namespace, field_default)
                 } else {
                     error!("Failed to resolve schema {:?}", name);
                     Err(Error::SchemaResolutionError(name.clone()))
@@ -617,8 +618,12 @@ impl Value {
             Schema::Bytes => self.resolve_bytes(),
             Schema::String => self.resolve_string(),
             Schema::Fixed(FixedSchema { size, .. }) => self.resolve_fixed(size),
-            Schema::Union(ref inner) => self.resolve_union(inner, names, enclosing_namespace),
-            Schema::Enum(EnumSchema { ref symbols, .. }) => self.resolve_enum(symbols),
+            Schema::Union(ref inner) => {
+                self.resolve_union(inner, names, enclosing_namespace, field_default)
+            }
+            Schema::Enum(EnumSchema { ref symbols, .. }) => {
+                self.resolve_enum(symbols, field_default)
+            }
             Schema::Array(ref inner) => self.resolve_array(inner, names, enclosing_namespace),
             Schema::Map(ref inner) => self.resolve_map(inner, names, enclosing_namespace),
             Schema::Record(RecordSchema { ref fields, .. }) => {
@@ -837,15 +842,31 @@ impl Value {
         }
     }
 
-    fn resolve_enum(self, symbols: &[String]) -> Result<Self, Error> {
+    fn resolve_enum(
+        self,
+        symbols: &[String],
+        field_default: &Option<JsonValue>,
+    ) -> Result<Self, Error> {
         let validate_symbol = |symbol: String, symbols: &[String]| {
             if let Some(index) = symbols.iter().position(|item| item == &symbol) {
                 Ok(Value::Enum(index as u32, symbol))
             } else {
-                Err(Error::GetEnumDefault {
-                    symbol,
-                    symbols: symbols.into(),
-                })
+                match field_default {
+                    Some(JsonValue::String(default)) => {
+                        if let Some(index) = symbols.iter().position(|item| item == default) {
+                            Ok(Value::Enum(index as u32, default.clone()))
+                        } else {
+                            Err(Error::GetEnumDefault {
+                                symbol,
+                                symbols: symbols.into(),
+                            })
+                        }
+                    }
+                    _ => Err(Error::GetEnumDefault {
+                        symbol,
+                        symbols: symbols.into(),
+                    }),
+                }
             }
         };
 
@@ -872,6 +893,7 @@ impl Value {
         schema: &UnionSchema,
         names: &NamesRef,
         enclosing_namespace: &Namespace,
+        field_default: &Option<JsonValue>,
     ) -> Result<Self, Error> {
         let v = match self {
             // Both are unions case.
@@ -905,7 +927,7 @@ impl Value {
 
         Ok(Value::Union(
             i as u32,
-            Box::new(v.resolve_internal(inner, names, enclosing_namespace)?),
+            Box::new(v.resolve_internal(inner, names, enclosing_namespace, field_default)?),
         ))
     }
 
@@ -919,7 +941,7 @@ impl Value {
             Value::Array(items) => Ok(Value::Array(
                 items
                     .into_iter()
-                    .map(|item| item.resolve_internal(schema, names, enclosing_namespace))
+                    .map(|item| item.resolve_internal(schema, names, enclosing_namespace, &None))
                     .collect::<Result<_, _>>()?,
             )),
             other => Err(Error::GetArray {
@@ -941,7 +963,7 @@ impl Value {
                     .into_iter()
                     .map(|(key, value)| {
                         value
-                            .resolve_internal(schema, names, enclosing_namespace)
+                            .resolve_internal(schema, names, enclosing_namespace, &None)
                             .map(|value| (key, value))
                     })
                     .collect::<Result<_, _>>()?,
@@ -979,7 +1001,8 @@ impl Value {
                     None => match field.default {
                         Some(ref value) => match field.schema {
                             Schema::Enum(EnumSchema { ref symbols, .. }) => {
-                                Value::from(value.clone()).resolve_enum(symbols)?
+                                Value::from(value.clone())
+                                    .resolve_enum(symbols, &field.default.clone())?
                             }
                             Schema::Union(ref union_schema) => {
                                 let first = &union_schema.variants()[0];
@@ -993,6 +1016,7 @@ impl Value {
                                             first,
                                             names,
                                             enclosing_namespace,
+                                            &field.default,
                                         )?),
                                     ),
                                 }
@@ -1005,7 +1029,7 @@ impl Value {
                     },
                 };
                 value
-                    .resolve_internal(&field.schema, names, enclosing_namespace)
+                    .resolve_internal(&field.schema, names, enclosing_namespace, &field.default)
                     .map(|value| (field.name.clone(), value))
             })
             .collect::<Result<Vec<_>, _>>()?;

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -871,18 +871,7 @@ impl Value {
         };
 
         match self {
-            Value::Enum(raw_index, s) => {
-                let index = usize::try_from(raw_index)
-                    .map_err(|e| Error::ConvertU32ToUsize(e, raw_index))?;
-                if (0..=symbols.len()).contains(&index) {
-                    validate_symbol(s, symbols)
-                } else {
-                    Err(Error::GetEnumValue {
-                        index,
-                        nsymbols: symbols.len(),
-                    })
-                }
-            }
+            Value::Enum(_raw_index, s) => validate_symbol(s, symbols),
             Value::String(s) => validate_symbol(s, symbols),
             other => Err(Error::GetEnum(other.into())),
         }


### PR DESCRIPTION
AVRO-3772

Take into account the field's default value when resolving an enum in a reader schema

## What is the purpose of the change

* Fix the resolution of an `enum` with a symbol which is no more available in the reader schema. Use any `default` value if available before returning an error

See https://avro.apache.org/docs/1.11.1/specification/#schema-resolution 

## Verifying this change

* An old test has been updated to the new logic

## Documentation

- Does this pull request introduce a new feature? no