### PR TITLE
Cherry-picks for 1.11.2 release

### DIFF
--- a/.github/workflows/codeql-csharp-analysis.yml
+++ b/.github/workflows/codeql-csharp-analysis.yml
@@ -67,6 +67,7 @@ jobs:
           3.1.x
           5.0.x
           6.0.x
+          7.0.x
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/maven4.yml
+++ b/.github/workflows/maven4.yml
@@ -1,0 +1,65 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'Maven 4'
+on:
+  workflow_dispatch:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+    paths:
+    - .github/workflows/maven4.yml
+    - lang/java/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  maven4:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Cache Local Maven Repository
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Cache Maven 4 Build Cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/build-cache
+          key: ${{ runner.os }}-maven-build-cache-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-build-cache
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+
+      - name: Setup Maven 4
+        uses: stCarolas/setup-maven@v4.5
+        with:
+          maven-version: 4.0.0-alpha-3
+
+      - name: Test
+        run: mvn clean package

--- a/.github/workflows/test-lang-csharp.yml
+++ b/.github/workflows/test-lang-csharp.yml
@@ -36,21 +36,22 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Add libzstd
         shell: bash
         run: sudo apt-get install -y libzstd-dev
 
       - name: Install .NET SDKs
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
             3.1.x
             5.0.x
             6.0.x
+            7.0.x
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
@@ -63,38 +64,26 @@ jobs:
       - name: Test
         run: ./build.sh test
 
-      # Build and test against .NET 7
-      # .NET 7 is not released yet, however this is a good way to test if the project is ready for the release
-      # Once .NET 7 is officially released, this can be removed and 7.0.x can be used instead above
-      - name: Install .NET SDK 7.0 (pre-release)
-        uses: actions/setup-dotnet@v1
-        with:
-          include-prerelease: true
-          dotnet-version: |
-            7.0.x
-      
-      - name: Test .NET 7.0 (pre-release)
-        run: ./build.sh test
-
   interop:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Add libzstd
         shell: bash
         run: sudo apt-get install -y libzstd-dev
 
       - name: Install .NET SDKs
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
             3.1.x
             5.0.x
             6.0.x
+            7.0.x
 
       - name: Cache Local Maven Repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/test-lang-java.yml
+++ b/.github/workflows/test-lang-java.yml
@@ -125,6 +125,7 @@ jobs:
             3.1.x
             5.0.x
             6.0.x
+            7.0.x
 
       - name: Install Java Avro for Interop Test
         working-directory: .

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+    <extension>
+        <groupId>org.apache.maven.extensions</groupId>
+        <artifactId>maven-build-cache-extension</artifactId>
+        <version>1.0.0</version>
+    </extension>
+</extensions>

--- a/lang/c++/api/Reader.hh
+++ b/lang/c++/api/Reader.hh
@@ -84,7 +84,7 @@ public:
         union {
             double d;
             uint64_t i;
-        } v;
+        } v = { 0 };
         reader_.read(v.i);
         val = v.d;
     }

--- a/lang/c++/api/buffer/Buffer.hh
+++ b/lang/c++/api/buffer/Buffer.hh
@@ -145,7 +145,7 @@ public:
      **/
 
     size_type wroteTo(size_type size) {
-        int wrote = 0;
+        size_type wrote = 0;
         if (size) {
             if (size > freeSpace()) {
                 throw std::length_error("Impossible to write more data than free space");

--- a/lang/c/tests/test_avro_commons_schema.c
+++ b/lang/c/tests/test_avro_commons_schema.c
@@ -104,6 +104,8 @@ static void read_data(const char *dirpath, avro_schema_t schema) {
     fprintf(stdout, "\nExit run test OK => %d records", records_read);
     remove("./copy.avro");
     fflush(stdout);
+    avro_file_reader_close(reader);
+    avro_file_writer_close(writer);
 }
 
 static void run_tests(const char *dirpath)
@@ -111,6 +113,7 @@ static void run_tests(const char *dirpath)
     fprintf(stdout, "\nRun test for path '%s'", dirpath);
     avro_schema_t schema = read_common_schema_test(dirpath);
     read_data(dirpath, schema);
+    avro_schema_decref(schema);
 }
 
 

--- a/lang/csharp/README.md
+++ b/lang/csharp/README.md
@@ -17,20 +17,20 @@ Install-Package Apache.Avro
 
 ## Project Target Frameworks
 
-| Project             | Published to nuget.org     | Type       | .NET Standard 2.0  | .NET Standard 2.1 | .NET Core 3.1 | .NET 5.0  | .NET 6.0  |
-|:-------------------:|:--------------------------:|:----------:|:------------------:|:-----------------:|:-------------:|:---------:|:---------:|
-| Avro.main           | Apache.Avro                | Library    | ✔️                 | ✔️               |               |           |           |
-| Avro.File.Snappy    | Apache.Avro.File.Snappy    | Library    | ✔️                 | ✔️               |               |           |           |
-| Avro.File.BZip2     | Apache.Avro.File.BZip2     | Library    | ✔️                 | ✔️               |               |           |           |
-| Avro.File.XZ        | Apache.Avro.File.XZ        | Library    | ✔️                 | ✔️               |               |           |           |
-| Avro.File.Zstandard | Apache.Avro.File.Zstandard | Library    | ✔️                 | ✔️               |               |           |           |
-| Avro.codegen        | Apache.Avro.Tools          |  Exe        |                    |                   | ✔️            |✔️        |✔️        |
-| Avro.ipc            |                            | Library    | ✔️                 | ✔️               |               |           |           |
-| Avro.ipc.test       |                            | Unit Tests |                    |                   | ✔️            |✔️        |✔️        |
-| Avro.msbuild        |                            | Library    | ✔️                 | ✔️               |               |           |           |
-| Avro.perf           |                            | Exe        |                    |                   | ✔️            |✔️        |✔️        |
-| Avro.test           |                            | Unit Tests |                    |                   | ✔️            |✔️        |✔️        |
-| Avro.benchmark      |                            | Exe        |                    |                   | ✔️            |✔️        |✔️        |
+| Project             | Published to nuget.org     | Type       | .NET Standard 2.0  | .NET Standard 2.1 | .NET Core 3.1 | .NET 5.0  | .NET 6.0  | .NET 7.0  |
+|:-------------------:|:--------------------------:|:----------:|:------------------:|:-----------------:|:-------------:|:---------:|:---------:|:---------:|
+| Avro.main           | Apache.Avro                | Library    | ✔️                 | ✔️               |               |           |           |           |
+| Avro.File.Snappy    | Apache.Avro.File.Snappy    | Library    | ✔️                 | ✔️               |               |           |           |           |
+| Avro.File.BZip2     | Apache.Avro.File.BZip2     | Library    | ✔️                 | ✔️               |               |           |           |           |
+| Avro.File.XZ        | Apache.Avro.File.XZ        | Library    | ✔️                 | ✔️               |               |           |           |           |
+| Avro.File.Zstandard | Apache.Avro.File.Zstandard | Library    | ✔️                 | ✔️               |               |           |           |           |
+| Avro.codegen        | Apache.Avro.Tools          |  Exe        |                    |                   | ✔️            |✔️        |✔️        |✔️        |
+| Avro.ipc            |                            | Library    | ✔️                 | ✔️               |               |           |           |           |
+| Avro.ipc.test       |                            | Unit Tests |                    |                   | ✔️            |✔️        |✔️        |✔️        |
+| Avro.msbuild        |                            | Library    | ✔️                 | ✔️               |               |           |           |           |
+| Avro.perf           |                            | Exe        |                    |                   | ✔️            |✔️        |✔️        |✔️        |
+| Avro.test           |                            | Unit Tests |                    |                   | ✔️            |✔️        |✔️        |✔️        |
+| Avro.benchmark      |                            | Exe        |                    |                   | ✔️            |✔️        |✔️        |✔️        |
 
 ## Dependency package version strategy
 

--- a/lang/csharp/build.sh
+++ b/lang/csharp/build.sh
@@ -42,7 +42,7 @@ do
 
     perf)
       pushd ./src/apache/perf/
-      dotnet run --configuration Release --framework net6.0
+      dotnet run --configuration Release --framework net7.0
       ;;
 
     dist)
@@ -77,7 +77,7 @@ do
       ;;
 
     interop-data-generate)
-      dotnet run --project src/apache/test/Avro.test.csproj --framework net6.0 ../../share/test/schemas/interop.avsc ../../build/interop/data
+      dotnet run --project src/apache/test/Avro.test.csproj --framework net7.0 ../../share/test/schemas/interop.avsc ../../build/interop/data
       ;;
 
     interop-data-test)

--- a/lang/csharp/common.props
+++ b/lang/csharp/common.props
@@ -37,9 +37,7 @@
 
   <PropertyGroup Label="Target Frameworks">
     <!-- Exe -->
-    <!-- NOTE: .NET 7 is still in preview state, use it only if it is available to make sure the project is ready for it. When .NET 7 SDK is released preview, update this -->
-    <DefaultExeTargetFrameworks Condition="'$(NETCoreAppMaximumVersion)' != '7.0' or '$(_NETCoreSdkIsPreview)' == 'false'">netcoreapp3.1;net5.0;net6.0</DefaultExeTargetFrameworks>
-    <DefaultExeTargetFrameworks Condition="'$(NETCoreAppMaximumVersion)' == '7.0' and '$(_NETCoreSdkIsPreview)' == 'true'">net7.0</DefaultExeTargetFrameworks>
+    <DefaultExeTargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</DefaultExeTargetFrameworks>
     <!-- Library -->
     <DefaultLibraryTargetFrameworks>netstandard2.0;netstandard2.1</DefaultLibraryTargetFrameworks>
     <!-- Unit Tests -->
@@ -60,6 +58,12 @@
     <None Include="$(MSBuildThisFileDirectory)\LICENSE" Pack="true" Visible="false" PackagePath=""/>
     <None Include="$(MSBuildThisFileDirectory)\..\..\doc\assets\icons\logo.png" Pack="true" Visible="false" PackagePath=""/>
   </ItemGroup>
+
+  <PropertyGroup>
+    <!-- Disable warning for EOL target frameworks -->
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+  </PropertyGroup>
 
   <PropertyGroup>
     <IsTestProject Condition="'$(IsTestProject)' == ''">false</IsTestProject>

--- a/lang/csharp/src/apache/benchmark/Avro.benchmark.csproj
+++ b/lang/csharp/src/apache/benchmark/Avro.benchmark.csproj
@@ -31,6 +31,12 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- Some schemas use lower cased names, which causes some class names being lower case only -->
+    <!-- e.g. The type name 'test' only contains lower-cased ascii characters. Such names may become reserved for the language. -->
+    <NoWarn>$(NoWarn);CS8981</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
   </ItemGroup>

--- a/lang/csharp/src/apache/benchmark/Program.cs
+++ b/lang/csharp/src/apache/benchmark/Program.cs
@@ -21,8 +21,8 @@ namespace Avro.Benchmark
 {
     public class Program
     {
-        // dotnet run -c Release -f net6.0
-        // dotnet run -c Release -f net6.0 --runtimes netcoreapp3.1 net5.0 net6.0
+        // dotnet run -c Release -f net7.0
+        // dotnet run -c Release -f net7.0 --runtimes netcoreapp3.1 net5.0 net6.0 net7.0
         public static void Main(string[] args)
         {
             BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/lang/csharp/src/apache/main/IO/Encoder.cs
+++ b/lang/csharp/src/apache/main/IO/Encoder.cs
@@ -187,5 +187,10 @@ namespace Avro.IO
         /// <param name="start">Position within data where the contents start.</param>
         /// <param name="len">Number of bytes to write.</param>
         void WriteFixed(byte[] data, int start, int len);
+
+        /// <summary>
+        /// Flushes the encoder.
+        /// </summary>
+        void Flush();
     }
 }

--- a/lang/csharp/src/apache/main/IO/JsonEncoder.cs
+++ b/lang/csharp/src/apache/main/IO/JsonEncoder.cs
@@ -28,7 +28,7 @@ namespace Avro.IO
     /// An <see cref="Encoder"/> for Avro's JSON data encoding.
     ///
     /// JsonEncoder buffers output, and data may not appear on the output until
-    /// <see cref="Flush()"/> is called.
+    /// <see cref="Encoder.Flush()"/> is called.
     ///
     /// JsonEncoder is not thread-safe.
     /// </summary>

--- a/lang/csharp/src/apache/test/IO/JsonCodecTests.cs
+++ b/lang/csharp/src/apache/test/IO/JsonCodecTests.cs
@@ -316,8 +316,8 @@ namespace Avro.Test
             GenericDatumWriter<object> writer = new GenericDatumWriter<object>(schema);
             MemoryStream output = new MemoryStream();
 
-            JsonDecoder decoder = new JsonDecoder(schema, json);
-            BinaryEncoder encoder = new BinaryEncoder(output);
+            Decoder decoder = new JsonDecoder(schema, json);
+            Encoder encoder = new BinaryEncoder(output);
 
             object datum = reader.Read(null, decoder);
 

--- a/lang/csharp/versions.props
+++ b/lang/csharp/versions.props
@@ -26,14 +26,14 @@
     !!! SHIPPED CLASS LIBRARIES SHOULD USE MINIMUMVERSIONs FOR SOME LIBRARIES. SEE BELOW !!!
   -->
   <PropertyGroup Label="Latest Package Versions">
-    <NewtonsoftJsonVersion>12.0.3</NewtonsoftJsonVersion>
-    <SystemCodeDomVersion>6.0.0</SystemCodeDomVersion>
+    <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
+    <SystemCodeDomVersion>7.0.0</SystemCodeDomVersion>
     <SystemReflectionVersion>4.3.0</SystemReflectionVersion>
     <SystemReflectionEmitILGenerationVersion>4.7.0</SystemReflectionEmitILGenerationVersion>
     <SystemReflectionEmitLightweightVersion>4.7.0</SystemReflectionEmitLightweightVersion>
 
     <!-- The following packages are required for the extra codec libraries. These are not direct dependencies of the Avro.main library. -->
-    <SharpZipLibVersion>1.3.3</SharpZipLibVersion>
+    <SharpZipLibVersion>1.4.1</SharpZipLibVersion>
     <IronSnappyVersion>1.3.0</IronSnappyVersion>
     <JovelerCompressionXZVersion>4.1.0</JovelerCompressionXZVersion>
     <ZstandardNetVersion>1.1.7</ZstandardNetVersion>
@@ -55,21 +55,19 @@
 	Please sort the packages alphabetically
   -->
   <PropertyGroup Label="Build, Test, Code Analysis, Benchmark Package Versions">
-    <BenchmarkDotNetVersion>0.13.1</BenchmarkDotNetVersion>
-    <CoverletCollectorVersion>3.1.2</CoverletCollectorVersion>
-    <CoverletMSBuildVersion>3.1.2</CoverletMSBuildVersion>
-    <MicrosoftBuildFrameworkVersion>17.1.0</MicrosoftBuildFrameworkVersion>
-    <MicrosoftBuildUtilitiesCoreVersion>17.1.0</MicrosoftBuildUtilitiesCoreVersion>
-    <MicrosoftCodeAnalysisVersion>4.1.0</MicrosoftCodeAnalysisVersion>
-    <MicrosoftCodeAnalysisCSharpVersion>4.1.0</MicrosoftCodeAnalysisCSharpVersion>
-    <MicrosoftCodeAnalysisCSharpCodeStyleVersion>4.1.0</MicrosoftCodeAnalysisCSharpCodeStyleVersion>
-    <!-- When .NET 7 SDK is released or the package is not in preview, update this version -->
-    <MicrosoftCodeAnalysisNetAnalyzersVersion Condition="'$(TargetFramework)' != 'net7.0'">6.0.0</MicrosoftCodeAnalysisNetAnalyzersVersion>
-    <MicrosoftCodeAnalysisNetAnalyzersVersion Condition="'$(TargetFramework)' == 'net7.0'">7.0.0-preview*</MicrosoftCodeAnalysisNetAnalyzersVersion>
-    <MicrosoftNETTestSdkVersion>17.1.0</MicrosoftNETTestSdkVersion>
-    <NUnitVersion>3.13.2</NUnitVersion>
-    <NUnitConsoleRunnerVersion>3.15.0</NUnitConsoleRunnerVersion>
-    <NUnit3TestAdapterVersion>4.2.1</NUnit3TestAdapterVersion>
+    <BenchmarkDotNetVersion>0.13.2</BenchmarkDotNetVersion>
+    <CoverletCollectorVersion>3.2.0</CoverletCollectorVersion>
+    <CoverletMSBuildVersion>3.2.0</CoverletMSBuildVersion>
+    <MicrosoftBuildFrameworkVersion>17.4.0</MicrosoftBuildFrameworkVersion>
+    <MicrosoftBuildUtilitiesCoreVersion>17.4.0</MicrosoftBuildUtilitiesCoreVersion>
+    <MicrosoftCodeAnalysisVersion>4.3.1</MicrosoftCodeAnalysisVersion>
+    <MicrosoftCodeAnalysisCSharpVersion>4.3.1</MicrosoftCodeAnalysisCSharpVersion>
+    <MicrosoftCodeAnalysisCSharpCodeStyleVersion>4.3.1</MicrosoftCodeAnalysisCSharpCodeStyleVersion>
+    <MicrosoftCodeAnalysisNetAnalyzersVersion>7.0.0-preview*</MicrosoftCodeAnalysisNetAnalyzersVersion>
+    <MicrosoftNETTestSdkVersion>17.4.0</MicrosoftNETTestSdkVersion>
+    <NUnitVersion>3.13.3</NUnitVersion>
+    <NUnitConsoleRunnerVersion>3.15.2</NUnitConsoleRunnerVersion>
+    <NUnit3TestAdapterVersion>4.3.0</NUnit3TestAdapterVersion>
     <StyleCopAnalyzersVersion>1.1.118</StyleCopAnalyzersVersion>
   </PropertyGroup>
 </Project>

--- a/lang/csharp/versions.props
+++ b/lang/csharp/versions.props
@@ -63,7 +63,7 @@
     <MicrosoftCodeAnalysisVersion>4.3.1</MicrosoftCodeAnalysisVersion>
     <MicrosoftCodeAnalysisCSharpVersion>4.3.1</MicrosoftCodeAnalysisCSharpVersion>
     <MicrosoftCodeAnalysisCSharpCodeStyleVersion>4.3.1</MicrosoftCodeAnalysisCSharpCodeStyleVersion>
-    <MicrosoftCodeAnalysisNetAnalyzersVersion>7.0.0-preview*</MicrosoftCodeAnalysisNetAnalyzersVersion>
+    <MicrosoftCodeAnalysisNetAnalyzersVersion>7.0.1</MicrosoftCodeAnalysisNetAnalyzersVersion>
     <MicrosoftNETTestSdkVersion>17.4.0</MicrosoftNETTestSdkVersion>
     <NUnitVersion>3.13.3</NUnitVersion>
     <NUnitConsoleRunnerVersion>3.15.2</NUnitConsoleRunnerVersion>

--- a/lang/java/avro/src/main/java/org/apache/avro/generic/GenericData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/generic/GenericData.java
@@ -1137,6 +1137,69 @@ public class GenericData {
     return compare(o1, o2, s, false);
   }
 
+  protected int compareMaps(final Map<?, ?> m1, final Map<?, ?> m2) {
+    if (m1 == m2) {
+      return 0;
+    }
+
+    if (m2.size() != m2.size()) {
+      return 1;
+    }
+
+    /**
+     * Peek at keys, assuming they're all the same type within a Map
+     */
+    final Object key1 = m1.keySet().iterator().next();
+    final Object key2 = m2.keySet().iterator().next();
+    boolean utf8ToString = false;
+    boolean stringToUtf8 = false;
+
+    if (key1 instanceof Utf8 && key2 instanceof String) {
+      utf8ToString = true;
+    } else if (key1 instanceof String && key2 instanceof Utf8) {
+      stringToUtf8 = true;
+    }
+
+    try {
+      for (Map.Entry e : m1.entrySet()) {
+        final Object key = e.getKey();
+        Object lookupKey = key;
+        if (utf8ToString) {
+          lookupKey = key.toString();
+        } else if (stringToUtf8) {
+          lookupKey = new Utf8((String) lookupKey);
+        }
+        final Object value = e.getValue();
+        if (value == null) {
+          if (!(m2.get(lookupKey) == null && m2.containsKey(lookupKey))) {
+            return 1;
+          }
+        } else {
+          final Object value2 = m2.get(lookupKey);
+          if (value instanceof Utf8 && value2 instanceof String) {
+            if (!value.toString().equals(value2)) {
+              return 1;
+            }
+          } else if (value instanceof String && value2 instanceof Utf8) {
+            if (!new Utf8((String) value).equals(value2)) {
+              return 1;
+            }
+          } else {
+            if (!value.equals(value2)) {
+              return 1;
+            }
+          }
+        }
+      }
+    } catch (ClassCastException unused) {
+      return 1;
+    } catch (NullPointerException unused) {
+      return 1;
+    }
+
+    return 0;
+  }
+
   /**
    * Comparison implementation. When equals is true, only checks for equality, not
    * for order.
@@ -1173,7 +1236,7 @@ public class GenericData {
       return e1.hasNext() ? 1 : (e2.hasNext() ? -1 : 0);
     case MAP:
       if (equals)
-        return o1.equals(o2) ? 0 : 1;
+        return compareMaps((Map) o1, (Map) o2);
       throw new AvroRuntimeException("Can't compare maps!");
     case UNION:
       int i1 = resolveUnion(s, o1);

--- a/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericData.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericData.java
@@ -146,9 +146,8 @@ public class TestGenericData {
   }
 
   @Test
-  public void testMapKeyEquals() {
-    Schema mapSchema = new Schema.Parser().parse("{\"type\": \"map\", \"values\": \"string\"}");
-    Field myMapField = new Field("my_map", Schema.createMap(mapSchema), null, null);
+  public void testMapKeyEqualsStringAndUtf8Compatibility() {
+    Field myMapField = new Field("my_map", Schema.createMap(Schema.create(Schema.Type.STRING)), null, null);
     Schema schema = Schema.createRecord("my_record", "doc", "mytest", false);
     schema.setFields(Arrays.asList(myMapField));
     GenericRecord r0 = new GenericData.Record(schema);
@@ -167,9 +166,8 @@ public class TestGenericData {
   }
 
   @Test
-  public void testMapValuesEquals() {
-    Schema mapSchema = new Schema.Parser().parse("{\"type\": \"map\", \"values\": \"string\"}");
-    Field myMapField = new Field("my_map", Schema.createMap(mapSchema), null, null);
+  public void testMapValuesEqualsStringAndUtf8Compatibility() {
+    Field myMapField = new Field("my_map", Schema.createMap(Schema.create(Schema.Type.STRING)), null, null);
     Schema schema = Schema.createRecord("my_record", "doc", "mytest", false);
     schema.setFields(Arrays.asList(myMapField));
     GenericRecord r0 = new GenericData.Record(schema);
@@ -182,6 +180,24 @@ public class TestGenericData {
     HashMap<CharSequence, CharSequence> pair2 = new HashMap<>();
     pair2.put("keyOne", new Utf8("valueOne"));
     r1.put("my_map", pair2);
+
+    assertEquals(r0, r1);
+    assertEquals(r1, r0);
+  }
+
+  @Test
+  public void testArrayValuesEqualsStringAndUtf8Compatibility() {
+    Field myArrayField = new Field("my_array", Schema.createArray(Schema.create(Schema.Type.STRING)), null, null);
+    Schema schema = Schema.createRecord("my_record", "doc", "mytest", false);
+    schema.setFields(Arrays.asList(myArrayField));
+    GenericRecord r0 = new GenericData.Record(schema);
+    GenericRecord r1 = new GenericData.Record(schema);
+
+    List<CharSequence> array1 = Arrays.asList("valueOne");
+    r0.put("my_array", array1);
+
+    List<CharSequence> array2 = Arrays.asList(new Utf8("valueOne"));
+    r1.put("my_array", array2);
 
     assertEquals(r0, r1);
     assertEquals(r1, r0);

--- a/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericData.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericData.java
@@ -145,6 +145,48 @@ public class TestGenericData {
     assertEquals(r1, r2);
   }
 
+  @Test
+  public void testMapKeyEquals() {
+    Schema mapSchema = new Schema.Parser().parse("{\"type\": \"map\", \"values\": \"string\"}");
+    Field myMapField = new Field("my_map", Schema.createMap(mapSchema), null, null);
+    Schema schema = Schema.createRecord("my_record", "doc", "mytest", false);
+    schema.setFields(Arrays.asList(myMapField));
+    GenericRecord r0 = new GenericData.Record(schema);
+    GenericRecord r1 = new GenericData.Record(schema);
+
+    HashMap<CharSequence, String> pair1 = new HashMap<>();
+    pair1.put("keyOne", "valueOne");
+    r0.put("my_map", pair1);
+
+    HashMap<CharSequence, String> pair2 = new HashMap<>();
+    pair2.put(new Utf8("keyOne"), "valueOne");
+    r1.put("my_map", pair2);
+
+    assertEquals(r0, r1);
+    assertEquals(r1, r0);
+  }
+
+  @Test
+  public void testMapValuesEquals() {
+    Schema mapSchema = new Schema.Parser().parse("{\"type\": \"map\", \"values\": \"string\"}");
+    Field myMapField = new Field("my_map", Schema.createMap(mapSchema), null, null);
+    Schema schema = Schema.createRecord("my_record", "doc", "mytest", false);
+    schema.setFields(Arrays.asList(myMapField));
+    GenericRecord r0 = new GenericData.Record(schema);
+    GenericRecord r1 = new GenericData.Record(schema);
+
+    HashMap<CharSequence, CharSequence> pair1 = new HashMap<>();
+    pair1.put("keyOne", "valueOne");
+    r0.put("my_map", pair1);
+
+    HashMap<CharSequence, CharSequence> pair2 = new HashMap<>();
+    pair2.put("keyOne", new Utf8("valueOne"));
+    r1.put("my_map", pair2);
+
+    assertEquals(r0, r1);
+    assertEquals(r1, r0);
+  }
+
   private Schema recordSchema() {
     List<Field> fields = new ArrayList<>();
     fields.add(new Field("anArray", Schema.createArray(Schema.create(Type.STRING)), null, null));

--- a/lang/java/avro/src/test/java/org/apache/avro/specific/TestSpecificData.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/specific/TestSpecificData.java
@@ -176,7 +176,7 @@ public class TestSpecificData {
   }
 
   @Test
-  void classNameContainingReservedWords() {
+  public void classNameContainingReservedWords() {
     final Schema schema = Schema.createRecord("AnyName", null, "db.public.table", false);
 
     assertEquals("db.public$.table.AnyName", SpecificData.getClassName(schema));

--- a/lang/java/maven-plugin/pom.xml
+++ b/lang/java/maven-plugin/pom.xml
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>3.5.0</version>
+      <version>3.5.1</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -67,7 +67,7 @@
     <file-management.version>3.1.0</file-management.version>
     <javacc-plugin.version>3.0.3</javacc-plugin.version>
     <javacc.version>7.0.12</javacc.version>
-    <cyclonedx-maven-plugin.version>2.7.3</cyclonedx-maven-plugin.version>
+    <cyclonedx-maven-plugin.version>2.7.4</cyclonedx-maven-plugin.version>
   </properties>
 
   <modules>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -59,7 +59,7 @@
     <mockito.version>4.11.0</mockito.version>
     <hamcrest.version>2.2</hamcrest.version>
     <grpc.version>1.53.0</grpc.version>
-    <zstd-jni.version>1.5.4-1</zstd-jni.version>
+    <zstd-jni.version>1.5.4-2</zstd-jni.version>
     <!-- version properties for plugins -->
     <archetype-plugin.version>3.2.1</archetype-plugin.version>
     <bundle-plugin-version>5.1.8</bundle-plugin-version>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -58,7 +58,7 @@
     <tukaani.version>1.9</tukaani.version>
     <mockito.version>4.11.0</mockito.version>
     <hamcrest.version>2.2</hamcrest.version>
-    <grpc.version>1.52.1</grpc.version>
+    <grpc.version>1.53.0</grpc.version>
     <zstd-jni.version>1.5.4-1</zstd-jni.version>
     <!-- version properties for plugins -->
     <archetype-plugin.version>3.2.1</archetype-plugin.version>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -40,7 +40,7 @@
     <hadoop.version>3.3.4</hadoop.version>
     <jackson-bom.version>2.14.2</jackson-bom.version>
     <servlet-api.version>4.0.1</servlet-api.version>
-    <jetty.version>9.4.50.v20221201</jetty.version>
+    <jetty.version>9.4.51.v20230217</jetty.version>
     <jopt-simple.version>5.0.4</jopt-simple.version>
     <junit5.version>5.9.2</junit5.version>
     <netty.version>4.1.89.Final</netty.version>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -59,7 +59,7 @@
     <mockito.version>4.11.0</mockito.version>
     <hamcrest.version>2.2</hamcrest.version>
     <grpc.version>1.52.1</grpc.version>
-    <zstd-jni.version>1.5.2-5</zstd-jni.version>
+    <zstd-jni.version>1.5.4-1</zstd-jni.version>
     <!-- version properties for plugins -->
     <archetype-plugin.version>3.2.1</archetype-plugin.version>
     <bundle-plugin-version>5.1.8</bundle-plugin-version>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -47,7 +47,7 @@
     <protobuf.version>3.22.2</protobuf.version>
     <thrift.version>0.16.0</thrift.version>
     <slf4j.version>1.7.36</slf4j.version>
-    <reload4j.version>1.2.24</reload4j.version>
+    <reload4j.version>1.2.25</reload4j.version>
     <snappy.version>1.1.9.1</snappy.version>
     <velocity.version>2.3</velocity.version>
     <maven-core.version>3.3.9</maven-core.version>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -37,7 +37,7 @@
     <main.basedir>${project.parent.basedir}</main.basedir>
 
     <!-- version properties for dependencies -->
-    <hadoop.version>3.3.4</hadoop.version>
+    <hadoop.version>3.3.5</hadoop.version>
     <jackson-bom.version>2.14.2</jackson-bom.version>
     <servlet-api.version>4.0.1</servlet-api.version>
     <jetty.version>9.4.51.v20230217</jetty.version>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -43,7 +43,7 @@
     <jetty.version>9.4.51.v20230217</jetty.version>
     <jopt-simple.version>5.0.4</jopt-simple.version>
     <junit5.version>5.9.2</junit5.version>
-    <netty.version>4.1.89.Final</netty.version>
+    <netty.version>4.1.90.Final</netty.version>
     <protobuf.version>3.22.2</protobuf.version>
     <thrift.version>0.16.0</thrift.version>
     <slf4j.version>1.7.36</slf4j.version>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -58,7 +58,7 @@
     <tukaani.version>1.9</tukaani.version>
     <mockito.version>4.11.0</mockito.version>
     <hamcrest.version>2.2</hamcrest.version>
-    <grpc.version>1.53.0</grpc.version>
+    <grpc.version>1.54.0</grpc.version>
     <zstd-jni.version>1.5.4-2</zstd-jni.version>
     <!-- version properties for plugins -->
     <archetype-plugin.version>3.2.1</archetype-plugin.version>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -156,7 +156,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M7</version>
+          <version>${maven-surefire-plugin.version}</version>
           <configuration>
             <includes>
               <!-- Avro naming convention for JUnit tests -->

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -38,7 +38,7 @@
 
     <!-- version properties for dependencies -->
     <hadoop.version>3.3.4</hadoop.version>
-    <jackson-bom.version>2.14.1</jackson-bom.version>
+    <jackson-bom.version>2.14.2</jackson-bom.version>
     <servlet-api.version>4.0.1</servlet-api.version>
     <jetty.version>9.4.50.v20221201</jetty.version>
     <jopt-simple.version>5.0.4</jopt-simple.version>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -48,7 +48,7 @@
     <thrift.version>0.16.0</thrift.version>
     <slf4j.version>1.7.36</slf4j.version>
     <reload4j.version>1.2.24</reload4j.version>
-    <snappy.version>1.1.9.0</snappy.version>
+    <snappy.version>1.1.9.1</snappy.version>
     <velocity.version>2.3</velocity.version>
     <maven-core.version>3.3.9</maven-core.version>
     <ant.version>1.10.13</ant.version>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -67,6 +67,7 @@
     <file-management.version>3.1.0</file-management.version>
     <javacc-plugin.version>3.0.3</javacc-plugin.version>
     <javacc.version>7.0.12</javacc.version>
+    <cyclonedx-maven-plugin.version>2.7.3</cyclonedx-maven-plugin.version>
   </properties>
 
   <modules>
@@ -233,6 +234,11 @@
           <artifactId>spotless-maven-plugin</artifactId>
           <version>${spotless-maven-plugin.version}</version>
         </plugin>
+        <plugin>
+          <groupId>org.cyclonedx</groupId>
+          <artifactId>cyclonedx-maven-plugin</artifactId>
+          <version>${cyclonedx-maven-plugin.version}</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -316,6 +322,18 @@
             <phase>compile</phase>
             <goals>
               <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.cyclonedx</groupId>
+        <artifactId>cyclonedx-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>makeBom</goal>
             </goals>
           </execution>
         </executions>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -67,7 +67,7 @@
     <file-management.version>3.1.0</file-management.version>
     <javacc-plugin.version>3.0.3</javacc-plugin.version>
     <javacc.version>7.0.12</javacc.version>
-    <cyclonedx-maven-plugin.version>2.7.4</cyclonedx-maven-plugin.version>
+    <cyclonedx-maven-plugin.version>2.7.5</cyclonedx-maven-plugin.version>
   </properties>
 
   <modules>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -48,7 +48,7 @@
     <thrift.version>0.16.0</thrift.version>
     <slf4j.version>1.7.36</slf4j.version>
     <reload4j.version>1.2.25</reload4j.version>
-    <snappy.version>1.1.9.1</snappy.version>
+    <snappy.version>1.1.10.0</snappy.version>
     <velocity.version>2.3</velocity.version>
     <maven-core.version>3.3.9</maven-core.version>
     <ant.version>1.10.13</ant.version>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -59,7 +59,7 @@
     <mockito.version>4.11.0</mockito.version>
     <hamcrest.version>2.2</hamcrest.version>
     <grpc.version>1.55.1</grpc.version>
-    <zstd-jni.version>1.5.5-3</zstd-jni.version>
+    <zstd-jni.version>1.5.5-4</zstd-jni.version>
     <!-- version properties for plugins -->
     <archetype-plugin.version>3.2.1</archetype-plugin.version>
     <bundle-plugin-version>5.1.8</bundle-plugin-version>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -67,7 +67,7 @@
     <file-management.version>3.1.0</file-management.version>
     <javacc-plugin.version>3.0.3</javacc-plugin.version>
     <javacc.version>7.0.12</javacc.version>
-    <cyclonedx-maven-plugin.version>2.7.8</cyclonedx-maven-plugin.version>
+    <cyclonedx-maven-plugin.version>2.7.9</cyclonedx-maven-plugin.version>
   </properties>
 
   <modules>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -44,7 +44,7 @@
     <jopt-simple.version>5.0.4</jopt-simple.version>
     <junit5.version>5.9.3</junit5.version>
     <netty.version>4.1.92.Final</netty.version>
-    <protobuf.version>3.23.1</protobuf.version>
+    <protobuf.version>3.23.2</protobuf.version>
     <thrift.version>0.16.0</thrift.version>
     <slf4j.version>1.7.36</slf4j.version>
     <reload4j.version>1.2.25</reload4j.version>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -67,7 +67,7 @@
     <file-management.version>3.1.0</file-management.version>
     <javacc-plugin.version>3.0.3</javacc-plugin.version>
     <javacc.version>7.0.12</javacc.version>
-    <cyclonedx-maven-plugin.version>2.7.5</cyclonedx-maven-plugin.version>
+    <cyclonedx-maven-plugin.version>2.7.6</cyclonedx-maven-plugin.version>
   </properties>
 
   <modules>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -67,7 +67,7 @@
     <file-management.version>3.1.0</file-management.version>
     <javacc-plugin.version>3.0.3</javacc-plugin.version>
     <javacc.version>7.0.12</javacc.version>
-    <cyclonedx-maven-plugin.version>2.7.6</cyclonedx-maven-plugin.version>
+    <cyclonedx-maven-plugin.version>2.7.7</cyclonedx-maven-plugin.version>
   </properties>
 
   <modules>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -59,7 +59,7 @@
     <mockito.version>4.11.0</mockito.version>
     <hamcrest.version>2.2</hamcrest.version>
     <grpc.version>1.54.0</grpc.version>
-    <zstd-jni.version>1.5.4-2</zstd-jni.version>
+    <zstd-jni.version>1.5.5-2</zstd-jni.version>
     <!-- version properties for plugins -->
     <archetype-plugin.version>3.2.1</archetype-plugin.version>
     <bundle-plugin-version>5.1.8</bundle-plugin-version>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -43,7 +43,7 @@
     <jetty.version>9.4.51.v20230217</jetty.version>
     <jopt-simple.version>5.0.4</jopt-simple.version>
     <junit5.version>5.9.2</junit5.version>
-    <netty.version>4.1.90.Final</netty.version>
+    <netty.version>4.1.91.Final</netty.version>
     <protobuf.version>3.22.2</protobuf.version>
     <thrift.version>0.16.0</thrift.version>
     <slf4j.version>1.7.36</slf4j.version>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -58,7 +58,7 @@
     <tukaani.version>1.9</tukaani.version>
     <mockito.version>4.11.0</mockito.version>
     <hamcrest.version>2.2</hamcrest.version>
-    <grpc.version>1.54.1</grpc.version>
+    <grpc.version>1.55.1</grpc.version>
     <zstd-jni.version>1.5.5-3</zstd-jni.version>
     <!-- version properties for plugins -->
     <archetype-plugin.version>3.2.1</archetype-plugin.version>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -38,7 +38,7 @@
 
     <!-- version properties for dependencies -->
     <hadoop.version>3.3.4</hadoop.version>
-    <jackson-bom.version>2.12.7.20221012</jackson-bom.version>
+    <jackson-bom.version>2.14.0</jackson-bom.version>
     <servlet-api.version>4.0.1</servlet-api.version>
     <jetty.version>9.4.50.v20221201</jetty.version>
     <jopt-simple.version>5.0.4</jopt-simple.version>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -43,7 +43,7 @@
     <jetty.version>9.4.51.v20230217</jetty.version>
     <jopt-simple.version>5.0.4</jopt-simple.version>
     <junit5.version>5.9.3</junit5.version>
-    <netty.version>4.1.92.Final</netty.version>
+    <netty.version>4.1.93.Final</netty.version>
     <protobuf.version>3.23.2</protobuf.version>
     <thrift.version>0.16.0</thrift.version>
     <slf4j.version>1.7.36</slf4j.version>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -44,7 +44,7 @@
     <jopt-simple.version>5.0.4</jopt-simple.version>
     <junit5.version>5.9.3</junit5.version>
     <netty.version>4.1.92.Final</netty.version>
-    <protobuf.version>3.22.4</protobuf.version>
+    <protobuf.version>3.23.1</protobuf.version>
     <thrift.version>0.16.0</thrift.version>
     <slf4j.version>1.7.36</slf4j.version>
     <reload4j.version>1.2.25</reload4j.version>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -38,7 +38,7 @@
 
     <!-- version properties for dependencies -->
     <hadoop.version>3.3.4</hadoop.version>
-    <jackson-bom.version>2.14.0</jackson-bom.version>
+    <jackson-bom.version>2.14.1</jackson-bom.version>
     <servlet-api.version>4.0.1</servlet-api.version>
     <jetty.version>9.4.50.v20221201</jetty.version>
     <jopt-simple.version>5.0.4</jopt-simple.version>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -44,7 +44,7 @@
     <jopt-simple.version>5.0.4</jopt-simple.version>
     <junit5.version>5.9.3</junit5.version>
     <netty.version>4.1.92.Final</netty.version>
-    <protobuf.version>3.22.2</protobuf.version>
+    <protobuf.version>3.22.3</protobuf.version>
     <thrift.version>0.16.0</thrift.version>
     <slf4j.version>1.7.36</slf4j.version>
     <reload4j.version>1.2.25</reload4j.version>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -43,7 +43,7 @@
     <jetty.version>9.4.51.v20230217</jetty.version>
     <jopt-simple.version>5.0.4</jopt-simple.version>
     <junit5.version>5.9.3</junit5.version>
-    <netty.version>4.1.91.Final</netty.version>
+    <netty.version>4.1.92.Final</netty.version>
     <protobuf.version>3.22.2</protobuf.version>
     <thrift.version>0.16.0</thrift.version>
     <slf4j.version>1.7.36</slf4j.version>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -44,7 +44,7 @@
     <jopt-simple.version>5.0.4</jopt-simple.version>
     <junit5.version>5.9.3</junit5.version>
     <netty.version>4.1.92.Final</netty.version>
-    <protobuf.version>3.22.3</protobuf.version>
+    <protobuf.version>3.22.4</protobuf.version>
     <thrift.version>0.16.0</thrift.version>
     <slf4j.version>1.7.36</slf4j.version>
     <reload4j.version>1.2.25</reload4j.version>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -42,7 +42,7 @@
     <servlet-api.version>4.0.1</servlet-api.version>
     <jetty.version>9.4.51.v20230217</jetty.version>
     <jopt-simple.version>5.0.4</jopt-simple.version>
-    <junit5.version>5.9.2</junit5.version>
+    <junit5.version>5.9.3</junit5.version>
     <netty.version>4.1.91.Final</netty.version>
     <protobuf.version>3.22.2</protobuf.version>
     <thrift.version>0.16.0</thrift.version>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -98,7 +98,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.4.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -67,7 +67,7 @@
     <file-management.version>3.1.0</file-management.version>
     <javacc-plugin.version>3.0.3</javacc-plugin.version>
     <javacc.version>7.0.12</javacc.version>
-    <cyclonedx-maven-plugin.version>2.7.7</cyclonedx-maven-plugin.version>
+    <cyclonedx-maven-plugin.version>2.7.8</cyclonedx-maven-plugin.version>
   </properties>
 
   <modules>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -59,7 +59,7 @@
     <mockito.version>4.11.0</mockito.version>
     <hamcrest.version>2.2</hamcrest.version>
     <grpc.version>1.54.1</grpc.version>
-    <zstd-jni.version>1.5.5-2</zstd-jni.version>
+    <zstd-jni.version>1.5.5-3</zstd-jni.version>
     <!-- version properties for plugins -->
     <archetype-plugin.version>3.2.1</archetype-plugin.version>
     <bundle-plugin-version>5.1.8</bundle-plugin-version>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -58,7 +58,7 @@
     <tukaani.version>1.9</tukaani.version>
     <mockito.version>4.11.0</mockito.version>
     <hamcrest.version>2.2</hamcrest.version>
-    <grpc.version>1.54.0</grpc.version>
+    <grpc.version>1.54.1</grpc.version>
     <zstd-jni.version>1.5.5-2</zstd-jni.version>
     <!-- version properties for plugins -->
     <archetype-plugin.version>3.2.1</archetype-plugin.version>

--- a/lang/py/avro/io.py
+++ b/lang/py/avro/io.py
@@ -482,7 +482,7 @@ class BinaryEncoder:
         signed long is 8, 8 bytes are written.
         """
         sign, digits, exp = datum.as_tuple()
-        if (-1 * exp) > scale:
+        if (-1 * int(exp)) > scale:
             raise avro.errors.AvroOutOfScaleException(scale, datum, exp)
 
         unscaled_datum = 0
@@ -508,7 +508,7 @@ class BinaryEncoder:
         Decimal in fixed are encoded as size of fixed bytes.
         """
         sign, digits, exp = datum.as_tuple()
-        if (-1 * exp) > scale:
+        if (-1 * int(exp)) > scale:
             raise avro.errors.AvroOutOfScaleException(scale, datum, exp)
 
         unscaled_datum = 0

--- a/lang/py/avro/test/test_compatibility.py
+++ b/lang/py/avro/test/test_compatibility.py
@@ -691,7 +691,7 @@ class TestCompatibility(unittest.TestCase):
             (WITHOUT_NAMESPACE_RECORD, WITH_NAMESPACE_RECORD),
         ]
 
-        for (reader, writer) in compatible_reader_writer_test_cases:
+        for reader, writer in compatible_reader_writer_test_cases:
             self.assertTrue(self.are_compatible(reader, writer))
 
     def test_schema_compatibility_fixed_size_mismatch(self):
@@ -711,7 +711,7 @@ class TestCompatibility(unittest.TestCase):
                 "/fields/1/type/size",
             ),
         ]
-        for (reader, writer, message, location) in incompatible_fixed_pairs:
+        for reader, writer, message, location in incompatible_fixed_pairs:
             result = ReaderWriterCompatibilityChecker().get_compatibility(reader, writer)
             self.assertIs(result.compatibility, SchemaCompatibilityType.incompatible)
             self.assertIn(
@@ -737,7 +737,7 @@ class TestCompatibility(unittest.TestCase):
                 "/fields/0/type/symbols",
             ),
         ]
-        for (reader, writer, message, location) in incompatible_pairs:
+        for reader, writer, message, location in incompatible_pairs:
             result = ReaderWriterCompatibilityChecker().get_compatibility(reader, writer)
             self.assertIs(result.compatibility, SchemaCompatibilityType.incompatible)
             self.assertIn(message, result.messages)
@@ -853,7 +853,7 @@ class TestCompatibility(unittest.TestCase):
             ),
         ]
 
-        for (reader, writer, message, location) in incompatible_pairs:
+        for reader, writer, message, location in incompatible_pairs:
             result = ReaderWriterCompatibilityChecker().get_compatibility(reader, writer)
             self.assertIs(result.compatibility, SchemaCompatibilityType.incompatible)
             self.assertEqual(result.messages, message)
@@ -872,7 +872,7 @@ class TestCompatibility(unittest.TestCase):
             ),
         ]
 
-        for (reader, writer, message, location) in incompatible_pairs:
+        for reader, writer, message, location in incompatible_pairs:
             result = ReaderWriterCompatibilityChecker().get_compatibility(reader, writer)
             self.assertIs(result.compatibility, SchemaCompatibilityType.incompatible)
             self.assertIn(message, result.messages)
@@ -883,7 +883,7 @@ class TestCompatibility(unittest.TestCase):
             (A_INT_RECORD1, EMPTY_RECORD1, "a", "/fields/0"),
             (A_INT_B_DINT_RECORD1, EMPTY_RECORD1, "a", "/fields/0"),
         ]
-        for (reader, writer, message, location) in incompatible_pairs:
+        for reader, writer, message, location in incompatible_pairs:
             result = ReaderWriterCompatibilityChecker().get_compatibility(reader, writer)
             self.assertIs(result.compatibility, SchemaCompatibilityType.incompatible)
             self.assertEqual(len(result.messages), 1)
@@ -1063,7 +1063,7 @@ class TestCompatibility(unittest.TestCase):
                 "/",
             ),
         ]
-        for (reader, writer, message, location) in incompatible_pairs:
+        for reader, writer, message, location in incompatible_pairs:
             result = ReaderWriterCompatibilityChecker().get_compatibility(reader, writer)
             self.assertIs(result.compatibility, SchemaCompatibilityType.incompatible)
             self.assertIn(message, result.messages)

--- a/lang/py/avro/test/test_datafile_interop.py
+++ b/lang/py/avro/test/test_datafile_interop.py
@@ -42,7 +42,6 @@ class TestDataFileInterop(unittest.TestCase):
                 continue
             i = None
             with self.subTest(filename=filename), avro.datafile.DataFileReader(filename.open("rb"), avro.io.DatumReader()) as dfr:
-
                 user_metadata = dfr.get_meta("user_metadata")
                 if user_metadata is not None:
                     self.assertEqual(user_metadata, b"someByteArray")

--- a/lang/py/avro/test/test_io.py
+++ b/lang/py/avro/test/test_io.py
@@ -450,7 +450,6 @@ class DefaultValueTestCase(unittest.TestCase):
 
 class TestIncompatibleSchemaReading(unittest.TestCase):
     def test_deserialization_fails(self) -> None:
-
         reader_schema = avro.schema.parse(
             json.dumps(
                 {

--- a/lang/py/avro/test/test_io.py
+++ b/lang/py/avro/test/test_io.py
@@ -504,7 +504,7 @@ class TestMisc(unittest.TestCase):
         """Avro should raise an AvroTypeException when attempting to write a decimal with a larger exponent than the schema's scale."""
         datum = decimal.Decimal("3.1415")
         _, _, exp = datum.as_tuple()
-        scale = -1 * exp - 1
+        scale = -1 * int(exp) - 1
         schema = avro.schema.parse(
             json.dumps(
                 {
@@ -521,7 +521,7 @@ class TestMisc(unittest.TestCase):
         """Avro should raise an AvroTypeException when attempting to write a decimal with a larger exponent than the schema's scale."""
         datum = decimal.Decimal("3.1415")
         _, _, exp = datum.as_tuple()
-        scale = -1 * exp - 1
+        scale = -1 * int(exp) - 1
         schema = avro.schema.parse(
             json.dumps(
                 {

--- a/lang/py/avro/test/test_schema.py
+++ b/lang/py/avro/test/test_schema.py
@@ -662,7 +662,7 @@ class SchemaParseTestCase(unittest.TestCase):
         try:
             warnings.filterwarnings(action="error", category=avro.errors.IgnoredLogicalType)
             self.test_schema.parse()
-        except (avro.errors.IgnoredLogicalType) as e:
+        except avro.errors.IgnoredLogicalType as e:
             self.assertIn(type(e), (type(w) for w in test_warnings))
             self.assertIn(str(e), (str(w) for w in test_warnings))
         except (avro.errors.AvroException, avro.errors.SchemaParseException):  # pragma: no coverage

--- a/lang/py/avro/tether/tether_task.py
+++ b/lang/py/avro/tether/tether_task.py
@@ -300,7 +300,6 @@ class TetherTask(abc.ABC):
                 self._red_fkeys = [f.name for f in self.midschema.fields if not (f.order == "ignore")]
 
         except Exception as e:
-
             estr = traceback.format_exc()
             self.fail(estr)
 
@@ -335,7 +334,6 @@ class TetherTask(abc.ABC):
                     self.map(inRecord, self.midCollector)
 
                 elif self.taskType == TaskType.REDUCE:
-
                     # store the previous record
                     prev = self.midRecord
 

--- a/lang/rust/.gitignore
+++ b/lang/rust/.gitignore
@@ -4,3 +4,5 @@
 .idea/
 *.iml
 precommit_venv/
+fleet.toml
+**/.cargo/config.toml

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <apache-rat-plugin.version>0.15</apache-rat-plugin.version>
     <checkstyle-plugin.version>3.2.1</checkstyle-plugin.version>
     <checkstyle.version>9.3</checkstyle.version>
-    <enforcer-plugin.version>3.1.0</enforcer-plugin.version>
+    <enforcer-plugin.version>3.2.1</enforcer-plugin.version>
     <extra-enforcer-rules.version>1.6.1</extra-enforcer-rules.version>
     <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
     <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
     <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
     <maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>
-    <maven-plugin-plugin.version>3.7.1</maven-plugin-plugin.version>
+    <maven-plugin-plugin.version>3.8.1</maven-plugin-plugin.version>
     <maven-remote-resources-plugin.version>3.0.0</maven-remote-resources-plugin.version>
     <maven-shade-plugin.version>3.4.1</maven-shade-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>28</version>
+    <version>29</version>
   </parent>
 
   <groupId>org.apache.avro</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -345,17 +345,6 @@
               </execution>
             </executions>
             <configuration>
-              <licenses>
-                <!-- TODO (low prio): Remove this simple workaround when Apache Rat 0.14 has been released. -->
-                <!-- See also: https://issues.apache.org/jira/browse/RAT-212 -->
-                <!-- and       https://issues.apache.org/jira/browse/LEGAL-265 -->
-                <license implementation="org.apache.rat.analysis.license.ApacheSoftwareLicense20">
-                  <notes>Also allow the license url to be https.</notes>
-                  <patterns>
-                    <pattern>https://www.apache.org/licenses/LICENSE-2.0</pattern>
-                  </patterns>
-                </license>
-              </licenses>
               <consoleOutput>true</consoleOutput>
               <excludeSubProjects>false</excludeSubProjects>
               <excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <plugin-tools-javadoc.version>3.5.2</plugin-tools-javadoc.version>
     <spotless-maven-plugin.version>2.27.2</spotless-maven-plugin.version>
-    <maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
+    <maven-surefire-plugin.version>3.1.0</maven-surefire-plugin.version>
 
     <!-- Pin output timestamp to make the Java build reproducible -->
     <project.build.outputTimestamp>10</project.build.outputTimestamp>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <enforcer-plugin.version>3.3.0</enforcer-plugin.version>
     <extra-enforcer-rules.version>1.6.2</extra-enforcer-rules.version>
     <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
-    <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
+    <maven-gpg-plugin.version>3.1.0</maven-gpg-plugin.version>
     <maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>
     <maven-plugin-plugin.version>3.8.2</maven-plugin-plugin.version>
     <maven-remote-resources-plugin.version>3.0.0</maven-remote-resources-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <checkstyle-plugin.version>3.2.2</checkstyle-plugin.version>
     <checkstyle.version>9.3</checkstyle.version>
     <enforcer-plugin.version>3.3.0</enforcer-plugin.version>
-    <extra-enforcer-rules.version>1.6.2</extra-enforcer-rules.version>
+    <extra-enforcer-rules.version>1.7.0</extra-enforcer-rules.version>
     <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
     <maven-gpg-plugin.version>3.1.0</maven-gpg-plugin.version>
     <maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
     <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
     <maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>
-    <maven-plugin-plugin.version>3.8.1</maven-plugin-plugin.version>
+    <maven-plugin-plugin.version>3.8.2</maven-plugin-plugin.version>
     <maven-remote-resources-plugin.version>3.0.0</maven-remote-resources-plugin.version>
     <maven-shade-plugin.version>3.4.1</maven-shade-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <apache-rat-plugin.version>0.15</apache-rat-plugin.version>
     <checkstyle-plugin.version>3.2.1</checkstyle-plugin.version>
     <checkstyle.version>9.3</checkstyle.version>
-    <enforcer-plugin.version>3.2.1</enforcer-plugin.version>
+    <enforcer-plugin.version>3.3.0</enforcer-plugin.version>
     <extra-enforcer-rules.version>1.6.1</extra-enforcer-rules.version>
     <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
     <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <maven-remote-resources-plugin.version>3.0.0</maven-remote-resources-plugin.version>
     <maven-shade-plugin.version>3.4.1</maven-shade-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
-    <plugin-tools-javadoc.version>3.7.0</plugin-tools-javadoc.version>
+    <plugin-tools-javadoc.version>3.5.2</plugin-tools-javadoc.version>
     <spotless-maven-plugin.version>2.27.2</spotless-maven-plugin.version>
     <maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -254,6 +254,19 @@
           <goalPrefix>avro</goalPrefix>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.cyclonedx</groupId>
+        <artifactId>cyclonedx-maven-plugin</artifactId>
+        <version>2.7.3</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>makeBom</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>27</version>
+    <version>28</version>
   </parent>
 
   <groupId>org.apache.avro</groupId>
@@ -64,7 +64,7 @@
     <maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
 
     <!-- Pin output timestamp to make the Java build reproducible -->
-    <project.build.outputTimestamp>1659285393</project.build.outputTimestamp>
+    <project.build.outputTimestamp>10</project.build.outputTimestamp>
   </properties>
 
   <modules>
@@ -365,11 +365,13 @@
                 <exclude>**/.gitattributes</exclude>
                 <exclude>**/.gitignore</exclude>
                 <exclude>**/.gitmodules</exclude>
-                <!-- Docsy -->
+                <!-- Hugo / Docsy -->
                 <exclude>doc/build/**</exclude>
                 <exclude>doc/themes/docsy/**</exclude>
                 <exclude>doc/examples/java-example/target/**</exclude>
                 <exclude>doc/examples/mr-example/target/**</exclude>
+                <exclude>doc/node_modules/**</exclude>
+                <exclude>**/.hugo_build.lock</exclude>
                 <!-- build or test files (some are generated files that we commit as-is for testing purposes) -->
                 <exclude>**/*.log</exclude>
                 <exclude>**/*.rej</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <checkstyle-plugin.version>3.2.1</checkstyle-plugin.version>
     <checkstyle.version>9.3</checkstyle.version>
     <enforcer-plugin.version>3.3.0</enforcer-plugin.version>
-    <extra-enforcer-rules.version>1.6.1</extra-enforcer-rules.version>
+    <extra-enforcer-rules.version>1.6.2</extra-enforcer-rules.version>
     <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
     <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
     <maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -254,19 +254,6 @@
           <goalPrefix>avro</goalPrefix>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.cyclonedx</groupId>
-        <artifactId>cyclonedx-maven-plugin</artifactId>
-        <version>2.7.3</version>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>makeBom</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 
     <!-- plugin versions -->
     <apache-rat-plugin.version>0.15</apache-rat-plugin.version>
-    <checkstyle-plugin.version>3.2.1</checkstyle-plugin.version>
+    <checkstyle-plugin.version>3.2.2</checkstyle-plugin.version>
     <checkstyle.version>9.3</checkstyle.version>
     <enforcer-plugin.version>3.3.0</enforcer-plugin.version>
     <extra-enforcer-rules.version>1.6.2</extra-enforcer-rules.version>

--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -86,7 +86,7 @@ RUN apt-get -qqy install --no-install-recommends libzstd-dev \
 
 # Install a maven release  -------------------------------------------
 # Inspired from https://github.com/apache/accumulo-docker/blob/master/Dockerfile#L53
-ENV MAVEN_VERSION 3.8.4
+ENV MAVEN_VERSION 3.8.6
 ENV APACHE_DIST_URLS \
   https://www.apache.org/dyn/closer.cgi?action=download&filename= \
   # if the version is outdated (or we're grabbing the .asc file), we might have to pull from the dist/archive :/

--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -185,6 +185,12 @@ RUN wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-p
 # Install Ruby
 RUN apt-get -qqy install ruby-full \
  && apt-get -qqy clean
+RUN mkdir -p /tmp/lang/ruby/lib/avro && mkdir -p /tmp/share
+COPY lang/ruby/* /tmp/lang/ruby/
+COPY share/VERSION.txt /tmp/share/
+RUN gem install bundler --no-document && \
+    apt-get install -qqy libyaml-dev && \
+    cd /tmp/lang/ruby && bundle install
 
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.60.0

--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -179,7 +179,7 @@ RUN wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-p
  && dpkg -i packages-microsoft-prod.deb \
  && rm packages-microsoft-prod.deb \
  && apt-get update \
- && apt-get -qqy install --no-install-recommends dotnet-sdk-3.1 dotnet-sdk-5.0 dotnet-sdk-6.0 \
+ && apt-get -qqy install --no-install-recommends dotnet-sdk-3.1 dotnet-sdk-5.0 dotnet-sdk-6.0 dotnet-sdk-7.0 \
  && apt-get -qqy clean
 
 # Install Ruby


### PR DESCRIPTION
Going through all of the candidate commits and (especially) bumps for 1.11.2.

The commits listed here show the difference between `master` and `branch-1.11` using the command `git --no-pager log --left-right --graph --cherry-pick --oneline master...branch-1.11`.  This lists attempts to list commits that are on either branch, but *not* both.  Successfully detected cherry picks (on both) are not listed here, so your favourite feature might already be present for the 1.11.2 release candidate!

**This must not be merge-squashed**!

| ? | ! |
|------|--------------------------------------------------------------------------------------------------------------|
| 🔵 | There is a matching commit with the same subject; this was probably correctly cherry-picked but not detected |
| 🟥 | **Don't cherry-pick** New major features and changes, project website, github actions not run on branch |
| 🔶 | In progress, to verify |
| 🟢 | **Do cherry-pick** Version bumps for CVE and fixes, bug fixes, minor release improvements |
| ⚔️🟢 | **Do cherry-pick (merge conflict)** |
| 🔥 | Follow-up JIRA maintenance |

`master`
==============================================================================

| Commit | Subject | |
|--------------|------------------------------------------------------------------------------------------------------|------------------------------------------------|
| [131f2c503b] | Preparing for 1.12.0-SNAPSHOT (#1356) | 🟥 Version specific |
| [6c2e3700b6] | [AVRO-3241] [Java] Publish SNAPSHOT artifacts (#1385) | 🟥 Version specific |
| [13de1f06ea] | Merge branch 'fd-remove-redundant-generic-hints' of https://github.com/Fokko/avro into Fokko-fd-r... | ??? Probably unnecessary |
| [d5b85d820f] | Merge branch 'Fokko-fd-remove-redundant-generic-hints' | ??? |
| [5b003cba08] | [AVRO-3242] Add config for TravisCI on Linux ARM64 (#1380) | 🟥 TravisCI only |
| [2e68b3ff4f] | Minor non-functional cleanup. | 🟥 Mistaken commit immediately reverted |
| [4209b14b87] | [AVRO-2624] Revert casting to super type | 🟥 Revert of below |
| [6603e7777e] | [AVRO-3285]: Upgrade JavaCC plugin and library (#1447) | 🔵[34e75a3995] |
| [bdb7fadefe] | Bump commons-cli from 1.4 to 1.5.0 in /lang/java (#1470) | 🔵Bump [4b60d817a0] |
| [100574019b] | [AVRO-3344] Deprecating DataBlock (#1494) | 🟥 C# Delete file |
| [18d74959d7] | [AVRO-3345] Made Magic readonly in DataFileConstants (#1495) | 🟥 Improvement |
| [5d2f01a1ea] | The dotnet stuff isn't installable via deb packages on aarch64/arm64. Use the dotnet installer to... | ??? |
| [443614c12a] | Adjust how dotnet stuff is added to Docker container, add browserify since we claim to support it... | ??? |
| [11595499d6] | [AVRO-3386]: [PHP] Pin composer to a common version 2.2.5 (#1532) | ??? |
| [d7f9b9072c] | Fix a typo in javadoc | 🟥 Unimportant |
| [9b83acd4c7] | Bump reload4j from 1.2.18.0 to 1.2.19 in /lang/java (#1556) | 🔵Bump [065fb7d721] |
| [a5ba8b4452] | Bump Mockito to 4.3.1 | 🔵Bump [f89c79dff3] |
| [5a8c87a96d] | Update from the Ubuntu repositories before installing the dependencies | ??? |
| [ad585c29ef] | [AVRO-3388]: Extra codecs in C# (#1536) | 🔵[b796146cf4] |
| [bdbb2a0379] | [AVRO-3431]: CI: Cancel in-progress workflows if there are new commits in PR (#1577) | 🔵[307adc0c3a] |
| [9cd3c0e6df] | Bump grpc.version from 1.44.0 to 1.44.1 in /lang/java (#1572) | 🔵Bump [ae77f72f93] |
| [7ec12f99c3] | Bump netty-bom from 4.1.72.Final to 4.1.74.Final in /lang/java (#1581) | 🔵Bump [dcb2b06e84] |
| [a4e42112ce] | Bump grpc.version from 1.44.1 to 1.45.0 in /lang/java (#1612) | 🔵Bump [26daa9e937] |
| [d44ed5ae2f] | Bump jetty.version in /lang/java (#1633) | 🟥 Bump (superceded to jetty.version 9.4.50) |
| [fee1a73979] | Add an entry for Rust to Github keywords/labels | 🟥 Unnecessary |
| [387f497285] | [AVRO-3487]: Update Jackson to 2.12.6.1 (#1640) | 🔵[94bbb7bcaf] |
| [f0b183f277] | Configure Dependabot to check for Rust updates daily | 🟥 (GitHub actions Rust) |
| [8cc6650d6d] | Bump zstd-jni from 1.5.1-1 to 1.5.2-2 in /lang/java (#1663) | 🔵Bump [8847826577] |
| [64c8da735d] | Bump grpc.version from 1.45.0 to 1.45.1 in /lang/java (#1671) | 🔵Bump [25cc1b6f85] |
| [76e55d8775] | [AVRO-2870]: Avoid throwing from destructor in DataFileWriterBase (#921) | |
| [95440c4c5b] | [AVRO-3510]: Do not hardcode the PHP Composer installer Sha384 in TravisCI (#1678) | 🟥 TravisCI only |
| [e429672ba6] | Bump maven-bundle-plugin from 5.1.4 to 5.1.6 in /lang/java (#1699) | 🔵Bump [b015fe3a22] |
| [285858f7d9] | Bump netty-bom from 4.1.75.Final to 4.1.77.Final in /lang/java (#1694) | 🔵Bump [c290e1da80] |
| [b821b223c6] | Bump hadoop-client from 3.3.2 to 3.3.3 in /lang/java (#1697) | 🔵Bump [872038d4da] |
| [5ad0008486] | Bump jackson-bom from 2.12.6.20220326 to 2.12.7 in /lang/java (#1703) | 🔵Bump [fff979a316] |
| [051249634a] | [AVRO-3530]: Rust: Use dependency-review-action for Rust (#1714) | 🟥 (GitHub actions Rust) |
| [a8ee8778df] | [AVRO-3534]: Rust: Use dependency-review-action only for pull_request events (#1717) | 🔵[440ab18b09] |
| [5a80e32e6b] | [AVRO-3076]: Fix incorrect Javadoc regarding custom coder defaults (#1715) | 🔵[87778e6c56] |
| [5af6e43fa0] | Bump netty-bom from 4.1.77.Final to 4.1.78.Final in /lang/java (#1724) | 🔵Bump [77258c88c9] |
| [e42a570fe5] | Bump jetty.version in /lang/java (#1737) | 🔵Bump [96de1933d9] |
| [2c80b563a3] | [AVRO-3589]: Update github actions versions (#1789) | 🟥 (GitHub actions bumps) |
| [816f025d3c] | Bump actions/setup-node from 2 to 3 (#1791) | 🟥 (GitHub actions JS bump) |
| [e9c10d552c] | Bump github/codeql-action from 1 to 2 (#1792) | 🟥 (GitHub actions C# bump) |
| [7c99739a40] | Bump postcss-cli from 9.1.0 to 10.0.0 in /doc (#1754) | 🟢 Bump |
| [7825226b1d] | Add myself to the list of committers (#1808) | 🟥 (Project-only website) |
| [e233f2ff89] | [AVRO-3623]: Update the PR template (#1851) | 🟥 (GitHub PR template) |
| [859645d4a5] | [AVRO-3628]: [Java] JUnit 4.x tests are not executed (#1863) | 🔵[d75abd5915] |
| [eb2b19d0e0] | [AVRO-3624]: Add apache links (#1870) | 🟥 (Headers/Footers, so maybe?) |
| [8e965fae15] | Bump commons-text from 1.9 to 1.10.0 in /lang/java (#1898) | 🔵Bump [8e8a547cb8] |
| [77692d8c14] | Bump actions/setup-dotnet from 2 to 3 (#1899) | 🟥 (GitHub actions C#/Java bump) |
| [1027938c46] | [AVRO-3639]: Add fleet.toml and .cargo/config.toml to gitignore | 🟢 Clean-up on build |
| [627b005493] | [AVRO-3644]: handle java.util.Optional as a nullable value (#1915) | 🟥 New feature 1.12.0 |
| [5a0fb0ffce] | Update blog to invite Martin Grigorov (#1865) | 🟥 (Project-only website) |
| [016323828f] | [AVRO-3650]: [C++] Fix build on Manjaro (#1920) | 🟥 New feature marked 1.12.0 |
| [efb977928a] | Bump commons-compress from 1.21 to 1.22 in /lang/java (#1943) | 🟥 Bump (Merged with ant) |
| [edd59e166c] | Bump jackson-bom from 2.12.7.20221012 to 2.14.0 in /lang/java (#1944) | 🟢 Bump |
| [73d208fa64] | [AVRO-3653]: [CI] Remove Travis-ci config files (#1948) | 🟥 TravisCI only |
| [e93a2ab345] | Bump actions/dependency-review-action from 2 to 3 (#1958) | 🔵Bump [c68b531839] |
| [41fb846ec3] | Bump mockito-core from 4.8.1 to 4.9.0 in /lang/java (#1976) | 🔵Bump [e8556562d6] |
| [b8937526d3] | Bump Maven plugin versions and maven version for the docker based build (#1983) | ⚔️🟢 Bump |
| [44d32c001c] | Bump jackson-bom from 2.14.0 to 2.14.1 in /lang/java (#1987) | 🟢 Bump |
| [e3dc0ea60d] | [AVRO-3670]: Add NET 7.0 support (#1956) | ⚔️🟢 (priority) Asked on JIRA [AVRO-3670] |
| [95acbd5c43] | Bump jetty.version in /lang/java (#2007) | 🔵Bump [bb40b2a025] |
| [5016cd5c3f] | Fix minor warnings from rust 1.66.0 (#2018) | 🔵[280326e51a] |
| [cd6eb11335] | docs: fix small error (#2025) | 🟥 (Project-only website) |
| [43b5d7e3c1] | Bump mockito-core from 4.9.0 to 4.10.0 in /lang/java (#2021) | 🔵Bump [e261852e9e] |
| [12fdbc55ab] | [AVRO-3697]: [ruby] Test against Ruby 3.2 (#2041) | 🔵[5d940daac9] |
| [b1de7a6a1b] | Bump mockito-core from 4.10.0 to 4.11.0 in /lang/java (#2044) | 🔵Bump [f8c49a0961] |
| [62f45ecc90] | [AVRO-3696]: Replace tox-wheel with standard tox (#2040) | 🔵[787df564b1] |
| [05099c3263] | [AVRO-3278]: [ruby] Drop support for Ruby 2.6 (#2045) | 🟥 Asked not to backport on JIRA |
| [6743a41d33] | [AVRO-3611]: fix generator | |
| [08adf9140f] | [AVRO-3611]: update comment | |
| [bf8cde0f66] | [AVRO-3611]: add constants | |
| [c28dbe9f7d] | [AVRO-3649]: default for union inside union | |
| [e4e1633077] | [AVRO-3579]: JUnit5 migration step 2 | |
| [b2aeb2adbc] | [AVRO-3579]: change comment | |
| [27eaf7038b] | [AVRO-3527]: Optim hashcode | |
| [1f7bfc4470] | avro-3527: GenericData, extract hashcode logic in inner class | |
| [0dcb351689] | [AVRO-3701] Add github action to validate maven 4 build compatibility (#2036) | 🟢 (GitHub actions workflow, but also pom.xml) |
| [be4c37a9eb] | Add myself to the list of committers (#2047) | 🟥 (Project-only website) |
| [82fc40bbc5] | [AVRO-3700]: Publish Java SBOM artifacts with CycloneDX | 🟢 |
| [a7ad5ac585] | [AVRO-3700]: Move CycloneDX configuration to Java specific project (#2049) | 🟢 |
| [8f06f2b5a0] | Bump cyclonedx-maven-plugin from 2.7.3 to 2.7.4 in /lang/java (#2051) | 🟢 Bump |
| [ee27a1fa9c] | Bump ant from 1.10.12 to 1.10.13 in /lang/java (#2059) | 🔵Bump [976ecbe950] |
| [41e330a14a] | Bump maven-checkstyle-plugin from 3.2.0 to 3.2.1 in /lang/java (#2071) | 🔵Bump [5b1e1ebc4f] |
| [d22e55501c] | Bump maven-plugin-plugin from 3.6.4 to 3.7.1 in /lang/java (#2070) | 🔵Bump [026129ac4c] |
| [9b7230210c] | Bump maven-surefire-plugin from 3.0.0-M7 to 3.0.0-M8 in /lang/java (#2067) | 🔵Bump [3d2761da15] |
| [d2083c340d] | Bump jackson-bom from 2.14.1 to 2.14.2 in /lang/java (#2069) | 🟢 Bump |
| [52d670f72d] | [AVRO-3712]: Fix build by initializing union (#2079) | 🟢 |
| [1998f9ee81] | [AVRO-3701]: Bump Maven 4 to 4.0.0-alpha-4 | 🟥 (GitHub actions Java bump) |
| [5d9fbb286f] | [AVRO-3701]: Bump Maven 4 to 4.0.0-alpha-4 | 🟥 (GitHub actions Java bump) |
| [12adf0bc57] | [AVRO-3715]: [Java] Oracle JDK 18 no longer exists | 🟥 (GitHub actions Java) |
| [f84392d47c] | [AVRO-3715]: [Java] CycloneDX is not reproducible by design. | 🟥 (GitHub actions Java) |
| [0b17623c1c] | [AVRO-3715]: [Java] plugin-tools-javadoc 3.7.0 does not exist. | 🟢 (priority) (🔥Ping PR#2178) |
| [ebeeebb4da] | Bump maven-enforcer-plugin from 3.1.0 to 3.2.1 in /lang/java | 🟢 Bump |
| [2d54b9ea5b] | Bump netty-bom from 4.1.87.Final to 4.1.89.Final in /lang/java | 🟥 Bump already merged with [34ac34942a] |
| [f3cd30131b] | Bump zstd-jni from 1.5.2-5 to 1.5.4-1 in /lang/java | 🟢 Bump |
| [35f531d16e] | Bump snappy-java from 1.1.9.0 to 1.1.9.1 in /lang/java | 🟢 Bump |
| [5883a4d9e6] | Bump grpc.version from 1.52.1 to 1.53.0 in /lang/java | 🟢 Bump |
| [6459ec00bf] | [C++] Fix compiler warnings | 🟢 |
| [74bd287cff] | [AVRO-3715]: [Python] Fix lint issues (reformat code). | 🟢 (priority) (🔥Ping PR#2178) |
| [72e38dc8ff] | [AVRO-3715]: [Python] Fix type issues | 🟢 (priority) (🔥Ping PR#2178) |
| [ad5cf6857e] | [AVRO-3713]: [Java] Fix Map synchronization regression | (🔥 Missing Fix Version) |
| [fa0bb70980] | [AVRO-3717]: [Java] Fix NPE when basic type with Nullable annotation. | (🔥 Missing Fix Version) |
| [30c4cbfde5] | [AVRO-3690]: [Java] Fix flaky test ‘testMultipleFieldAliases’ | (🔥 Missing Fix Version and Assigned to) |
| [101048de5b] | [AVRO-3684]: [Java] testAppendStream test | 🟥 Commit and revert |
| [8565b87c12] | Revert "[AVRO-3684]: [Java] testAppendStream test" (#2108) | 🟥 Commit and revert |
| [2a246049ac] | [AVRO-3690]: Fix spotless problem (#2107) | See above |
| [536dcc35c2] | [AVRO-3690]: [Java] Fix testMultipleFieldAliases test (#2109) | See above |
| [0f4cdc0cb9] | [AVRO-3718]: [Java] Fix flaky NettyServer test (#2110) | 🟥 (🔥 Missing Fix Version) |
| [dd4385ba2a] | Bump cyclonedx-maven-plugin from 2.7.4 to 2.7.5 in /lang/java (#2112) | 🟢Bump |
| [95fec21c31] | Bump maven-surefire-plugin from 3.0.0-M8 to 3.0.0-M9 in /lang/java (#2114) | 🔵Bump [879620925b] |
| [5548c9dff7] | Bump protobuf-java from 3.21.12 to 3.22.0 in /lang/java (#2111) | 🔵Bump [34ac34942a] |
| [e7d9be91ef] | [AVRO-2404]: Remove now obsolete Apache Rat workaround (#2119) | 🟢 (if it cherry-picks) |
| [2231b77a61] | Bump maven-plugin-plugin from 3.7.1 to 3.8.1 in /lang/java (#2127) | 🟢 Bump |
| [b6eb0f7794] | Bump zstd-jni from 1.5.4-1 to 1.5.4-2 in /lang/java (#2126) | 🟢 Bump |
| [389fb2acb1] | Bump plexus-utils from 3.5.0 to 3.5.1 in /lang/java (#2125) | 🟢 Bump |
| [b9fd71a730] | Bump jetty.version in /lang/java (#2122) | 🟢 Bump |
| [197a0ecaa0] | [AVRO-2943] improve GenericRecord MAP type comparison | 🟢 (🔥 Ping on JIRA) |
| [c2e6e13194] | [AVRO-3721]: add method to JsonProperties | 🟥 New feature |
| [5c0b17dec3] | [AVRO-2943] Add new GenericData String/Utf8 ARRAY comparison test (#2137) | 🟢 (🔥 Ping on JIRA) |
| [b6178acc7a] | Bump maven-surefire-plugin from 3.0.0-M9 to 3.0.0 in /lang/java (#2151) | 🔵Bump [91fee3d854] |
| [ace4d5d2e5] | [AVRO-3264]: Improvements to the project section of the Avro website (#2145) | 🟥 Project website |
| [5acb6d619b] | Bump grpc.version from 1.53.0 to 1.54.0 in /lang/java | 🟢 Bump |
| [a8d5f1b562] | Bump hadoop-client from 3.3.4 to 3.3.5 in /lang/java | 🟢 Bump |
| [5f4f406dc3] | Bump netty-bom from 4.1.89.Final to 4.1.90.Final in /lang/java | 🟢 Bump |
| [96c2d8419e] | Bump reload4j from 1.2.24 to 1.2.25 in /lang/java | 🟢 Bump |
| [4fbd448fec] | Add RollForward prop (#2162) | 🟥 New feature |
| [8e0513c95d] | Bump maven-enforcer-plugin from 3.2.1 to 3.3.0 in /lang/java | 🟢 Bump |
| [6bdd8b2fd8] | Bump netty-bom from 4.1.90.Final to 4.1.91.Final in /lang/java | 🟢 Bump |
| [7aca93124e] | Bump cyclonedx-maven-plugin from 2.7.5 to 2.7.6 in /lang/java | 🟢 Bump |
| [0c53710f51] | Bump extra-enforcer-rules from 1.6.1 to 1.6.2 in /lang/java | 🟢 Bump |
| [6f0692f965] | Add NET 7 SDK to Dockerfile (#2193) | ⚔️🟢 Yes (priority) |
| [1b67705bfd] | Bump maven-plugin-plugin from 3.8.1 to 3.8.2 in /lang/java | 🟢 Bump |
| [327ce13cc4] | Bump maven-checkstyle-plugin from 3.2.1 to 3.2.2 in /lang/java | 🟢 Bump |
| [842e192ccd] | Bump zstd-jni from 1.5.4-2 to 1.5.5-2 in /lang/java | 🟢 Bump |
| [0b5859adce] | Bump cyclonedx-maven-plugin from 2.7.6 to 2.7.7 in /lang/java | 🟢 Bump |
| [3b6c6cc43d] | Bump jackson-bom from 2.14.2 to 2.15.0 in /lang/java | Bump 🟥 Reverted later |
| [96cd2074a6] | Bump cyclonedx-maven-plugin from 2.7.7 to 2.7.8 in /lang/java | 🟢 Bump |
| [61b5c17703] | Bump junit5.version from 5.9.2 to 5.9.3 in /lang/java | 🟢 Bump |
| [c0a06b6c88] | Bump netty-bom from 4.1.91.Final to 4.1.92.Final in /lang/java | 🟢 Bump |
| [15bda5f0a8] | Bump grpc.version from 1.54.0 to 1.54.1 in /lang/java | 🟢 Bump |
| [6c900f41a0] | Bump protobuf-java from 3.22.2 to 3.22.3 in /lang/java | 🟢 Bump |
| [61e74e5927] | [AVRO-3737]: fix memcheck test (#2213) | 🟢 Yes (priority) |
| [c8eec97dd0] | Bump maven-surefire-plugin from 3.0.0 to 3.1.0 in /lang/java | 🟢 Bump |
| [7f8a3813ea] | Bump protobuf-java from 3.22.3 to 3.22.4 in /lang/java | 🟢 Bump |
| [f7ad78b4d5] | Revert "Bump jackson-bom from 2.14.2 to 2.15.0 in /lang/java" | 🟥 Revert |
| [c2ae949a16] | [AVRO-3747]: [Rust] Set `is_human_readable` hint to `false` for `Value` (#2202) | 🔵[107c903fac] |
| [1b9b0858e6] | [AVRO-3759]: Add extra types for RecordSchema, EnumSchema, FixedSchema and DecimalSchema (#2241) | 🔵[47fd3b600d] |
| [fc6af3dde7] | Bump protobuf-java from 3.22.4 to 3.23.1 in /lang/java (#2246) | 🟢 Bump |
| [aa1b878a7c] | Bump zstd-jni from 1.5.5-2 to 1.5.5-3 in /lang/java (#2244) | 🟢 Bump |
| [2919020ddf] | Bump maven-gpg-plugin from 3.0.1 to 3.1.0 in /lang/java (#2218) | 🟢 Bump |
| [493188cd62] | Bump grpc.version from 1.54.1 to 1.55.1 in /lang/java (#2229) | 🟢 Bump |
| [3dbf0a0409] | [AVRO-3736]: [Ruby] Preinstall gems in ubertool docker (#2191) | 🟢 Yes (priority) |
| [57f1d52784] | [AVRO-3766]: [Rust] Print friendlier errors when test cases fail (#2263) | 🔵[1969b8f51d] |
| [79e5033578] | [AVRO-3766]: [Rust] Fix the formatting | 🔵[54b426a4bb] |
| [24fa855db6] | Bump protobuf-java from 3.23.1 to 3.23.2 in /lang/java (#2259) | 🟢 Bump |
| [cc094e5b70] | Bump extra-enforcer-rules from 1.6.2 to 1.7.0 in /lang/java (#2267) | 🟢 Bump |
| [ace5ffd0d9] | Bump zstd-jni from 1.5.5-3 to 1.5.5-4 in /lang/java (#2279) | 🟢 Bump |
| [087672e526] | Bump snappy-java from 1.1.9.1 to 1.1.10.0 in /lang/java (#2255) | 🟢 Bump |
| [43c39e45b5] | Bump cyclonedx-maven-plugin from 2.7.8 to 2.7.9 in /lang/java (#2243) | 🟢 Bump |
| [167ca07375] | Bump build-helper-maven-plugin from 3.3.0 to 3.4.0 in /lang/java (#2233) | 🟢 Bump |
| [53ad6c4cc6] | Bump netty-bom from 4.1.92.Final to 4.1.93.Final in /lang/java (#2256) | 🟢 Bump |

`branch-1.11`
==============================================================================

| Commit | Subject | |
|--------------|--------------------------------------------------------------------------------------------------|--------------------------|
| [622343fdc7] | Preparing for 1.11.0 | 🟥 Version specific |
| [b9977c7b3a] | Preparing for release 1.11.1 | 🟥 Version specific |
| [4b60d817a0] | Bump commons-cli from 1.4 to 1.5.0 in /lang/java (#1470) | 🔵Bump [bdb7fadefe] |
| [34e75a3995] | [AVRO-3285]: Upgrade JavaCC plugin and library (#1447) | 🔵[6603e7777e] |
| [065fb7d721] | Bump reload4j from 1.2.18.0 to 1.2.19 in /lang/java (#1556) | 🔵Bump [9b83acd4c7] |
| [fa8938faef] | [AVRO-3273]: Support older versions of maven | |
| [f89c79dff3] | Bump Mockito to 4.3.1 | 🔵Bump [a5ba8b4452] |
| [b796146cf4] | [AVRO-3388]: Extra codecs in C# (#1536) | 🔵[ad585c29ef] |
| [307adc0c3a] | [AVRO-3431]: CI: Cancel in-progress workflows if there are new commits in PR (#1577) | 🔵[bdbb2a0379] |
| [ae77f72f93] | Bump grpc.version from 1.44.0 to 1.44.1 in /lang/java (#1572) | 🔵Bump [9cd3c0e6df] |
| [dcb2b06e84] | Bump netty-bom from 4.1.72.Final to 4.1.74.Final in /lang/java (#1581) | 🔵Bump [7ec12f99c3] |
| [26daa9e937] | Bump grpc.version from 1.44.1 to 1.45.0 in /lang/java (#1612) | 🔵Bump [a4e42112ce] |
| [94bbb7bcaf] | [AVRO-3487]: Update Jackson to 2.12.6.1 (#1640) | 🔵[387f497285] |
| [8847826577] | Bump zstd-jni from 1.5.1-1 to 1.5.2-2 in /lang/java (#1663) | 🔵Bump [8cc6650d6d] |
| [25cc1b6f85] | Bump grpc.version from 1.45.0 to 1.45.1 in /lang/java (#1671) | 🔵Bump [64c8da735d] |
| [b015fe3a22] | Bump maven-bundle-plugin from 5.1.4 to 5.1.6 in /lang/java (#1699) | 🔵Bump [e429672ba6] |
| [c290e1da80] | Bump netty-bom from 4.1.75.Final to 4.1.77.Final in /lang/java (#1694) | 🔵Bump [285858f7d9] |
| [872038d4da] | Bump hadoop-client from 3.3.2 to 3.3.3 in /lang/java (#1697) | 🔵Bump [b821b223c6] |
| [fff979a316] | Bump jackson-bom from 2.12.6.20220326 to 2.12.7 in /lang/java (#1703) | 🔵Bump [5ad0008486] |
| [87778e6c56] | [AVRO-3076]: Fix incorrect Javadoc regarding custom coder defaults (#1715) | 🔵[5a80e32e6b] |
| [77258c88c9] | Bump netty-bom from 4.1.77.Final to 4.1.78.Final in /lang/java (#1724) | 🔵Bump [5af6e43fa0] |
| [440ab18b09] | [AVRO-3534]: Rust: Use dependency-review-action only for pull_request events (#1717) | 🔵[a8ee8778df] |
| [96de1933d9] | Bump jetty.version in /lang/java (#1737) | 🔵Bump [e42a570fe5] |
| [3a9e5a789b] | Preparing to build 1.11.1 | 🟥 Version specific |
| [ecdeda8fd9] | Preparing for release 1.11.2 | 🟥 Version specific |
| [a60b748c16] | [AVRO-3001] [AVRO-3274] [AVRO-3568] [AVRO-3613]: Add JSON encoder/decoder for C# | 🔥 Needs to be reverted? |
| [d75abd5915] | [AVRO-3628]: [Java] JUnit 4.x tests are not executed (#1863) | 🔵[859645d4a5] |
| [8e8a547cb8] | Bump commons-text from 1.9 to 1.10.0 in /lang/java (#1898) | 🔵Bump [8e965fae15] |
| [c68b531839] | Bump actions/dependency-review-action from 2 to 3 (#1958) | 🔵Bump [e93a2ab345] |
| [e8556562d6] | Bump mockito-core from 4.8.1 to 4.9.0 in /lang/java (#1976) | 🔵Bump [41fb846ec3] |
| [bb40b2a025] | Bump jetty.version in /lang/java (#2007) | 🔵Bump [95acbd5c43] |
| [280326e51a] | Fix minor warnings from rust 1.66.0 (#2018) | 🔵[5016cd5c3f] |
| [e261852e9e] | Bump mockito-core from 4.9.0 to 4.10.0 in /lang/java (#2021) | 🔵Bump [43b5d7e3c1] |
| [5d940daac9] | [AVRO-3697]: [ruby] Test against Ruby 3.2 (#2041) | 🔵[12fdbc55ab] |
| [f8c49a0961] | Bump mockito-core from 4.10.0 to 4.11.0 in /lang/java (#2044) | 🔵Bump [b1de7a6a1b] |
| [787df564b1] | [AVRO-3696]: Replace tox-wheel with standard tox (#2040) | 🔵[62f45ecc90] |
| [976ecbe950] | Bump ant from 1.10.12 to 1.10.13 in /lang/java (#2059) | 🔵Bump [ee27a1fa9c] |
| [5b1e1ebc4f] | Bump maven-checkstyle-plugin from 3.2.0 to 3.2.1 in /lang/java (#2071) | 🔵Bump [41e330a14a] |
| [026129ac4c] | Bump maven-plugin-plugin from 3.6.4 to 3.7.1 in /lang/java (#2070) | 🔵Bump [d22e55501c] |
| [3d2761da15] | Bump maven-surefire-plugin from 3.0.0-M7 to 3.0.0-M8 in /lang/java (#2067) | 🔵Bump [9b7230210c] |
| [879620925b] | Bump maven-surefire-plugin from 3.0.0-M8 to 3.0.0-M9 in /lang/java (#2114) | 🔵Bump [95fec21c31] |
| [34ac34942a] | Bump protobuf-java from 3.21.12 to 3.22.0 in /lang/java (#2111) | 🔵Bump [5548c9dff7] |
| [91fee3d854] | Bump maven-surefire-plugin from 3.0.0-M9 to 3.0.0 in /lang/java (#2151) | 🔵Bump [b6178acc7a] |
| [107c903fac] | [AVRO-3747]: [Rust] Set `is_human_readable` hint to `false` for `Value` (#2202) | 🔵[c2ae949a16] |
| [47fd3b600d] | [AVRO-3759]: Add extra types for RecordSchema, EnumSchema, FixedSchema and DecimalSchema (#2241) | 🔵[1b9b0858e6] |
| [1969b8f51d] | [AVRO-3766]: [Rust] Print friendlier errors when test cases fail (#2263) | 🔵[57f1d52784] |
| [54b426a4bb] | [AVRO-3766]: [Rust] Fix the formatting | 🔵[79e5033578] |

[016323828f]: https://github.com/apache/avro/commit/016323828f147f185d03f50d2223a2f50bfafce1 "AVRO-3650: [C++] Fix build on Manjaro (#1920)"
[026129ac4c]: https://github.com/apache/avro/commit/026129ac4c9209ec2317c31d65997e223606c99f "Bump maven-plugin-plugin from 3.6.4 to 3.7.1 in /lang/java (#2070)"
[05099c3263]: https://github.com/apache/avro/commit/05099c3263081e264eb95ee41609095d44a0acfd "AVRO-3278: [ruby] Drop support for Ruby 2.6 (#2045)"
[051249634a]: https://github.com/apache/avro/commit/051249634ad726f703c13341ad70917d300f517a "AVRO-3530: Rust: Use dependency-review-action for Rust (#1714)"
[065fb7d721]: https://github.com/apache/avro/commit/065fb7d721b99aff1e4523f3eeb268f8b8ad0e33 "Bump reload4j from 1.2.18.0 to 1.2.19 in /lang/java (#1556)"
[087672e526]: https://github.com/apache/avro/commit/087672e526d64f8bc4a32ecf6cda754ce46f08d9 "Bump snappy-java from 1.1.9.1 to 1.1.10.0 in /lang/java (#2255)"
[08adf9140f]: https://github.com/apache/avro/commit/08adf9140f474e2bcbce1acf2b7b8344cb42ba73 "AVRO-3611: update comment"
[0b17623c1c]: https://github.com/apache/avro/commit/0b17623c1ca98899b4b2b98b7e63a3508f61ea21 "AVRO-3715: [Java] plugin-tools-javadoc 3.7.0 does not exist."
[0b5859adce]: https://github.com/apache/avro/commit/0b5859adcec102b1647d25298b609cefde29e433 "Bump cyclonedx-maven-plugin from 2.7.6 to 2.7.7 in /lang/java"
[0be01a58bd]: https://github.com/apache/avro/commit/0be01a58bd7586982953dda45d53ac3551c7b6c4 "Bump quote from 1.0.27 to 1.0.28 in /lang/rust (#2253)"
[0c53710f51]: https://github.com/apache/avro/commit/0c53710f511e36340d73c3f96aef02771d886156 "Bump extra-enforcer-rules from 1.6.1 to 1.6.2 in /lang/java"
[0dcb351689]: https://github.com/apache/avro/commit/0dcb351689b75470136921cec18e4ae2872bd5c5 "[AVRO-3701] Add github action to validate maven 4 build compatibility (#2036)"
[0f4cdc0cb9]: https://github.com/apache/avro/commit/0f4cdc0cb986452c158f8d8a651ea92512ff8282 "AVRO-3718: [Java] Fix flaky NettyServer test (#2110)"
[100574019b]: https://github.com/apache/avro/commit/100574019b35465831d1b2fb0bff4fe2f512c89a "AVRO-3344 Deprecating DataBlock (#1494)"
[101048de5b]: https://github.com/apache/avro/commit/101048de5bb213aed4cff1b262205979662580bd "AVRO-3684: [Java] testAppendStream test"
[1027938c46]: https://github.com/apache/avro/commit/1027938c46ed3ae07ac7c23ecd0764bd357df23f "AVRO-3639: Add fleet.toml and .cargo/config.toml to gitignore"
[107c903fac]: https://github.com/apache/avro/commit/107c903fac0ed9992ddda21bd2e7659da68e5485 "AVRO-3747: [Rust] Set `is_human_readable` hint to `false` for `Value` (#2202)"
[11595499d6]: https://github.com/apache/avro/commit/11595499d6d410bf8663c365ad161e0c5d1e1358 "AVRO-3386: [PHP] Pin composer to a common version 2.2.5 (#1532)"
[12adf0bc57]: https://github.com/apache/avro/commit/12adf0bc57cb1ddcb58a4f6aa41695fb7512140a "AVRO-3715: [Java] Oracle JDK 18 no longer exists"
[12fdbc55ab]: https://github.com/apache/avro/commit/12fdbc55ab624d4697b6f13db84e42bec62184b1 "AVRO-3697: [ruby] Test against Ruby 3.2 (#2041)"
[131f2c503b]: https://github.com/apache/avro/commit/131f2c503b38ca7513fc9657205c7c67db3ab3ba "Preparing for 1.12.0-SNAPSHOT (#1356)"
[13de1f06ea]: https://github.com/apache/avro/commit/13de1f06ea6a4a64646a8dea5edc1d2538f2eadc "Merge branch 'fd-remove-redundant-generic-hints' of https://github.com/Fokko/avro into Fokko-fd-remove-redundant-generic-hints"
[15bda5f0a8]: https://github.com/apache/avro/commit/15bda5f0a895d274ce84fb706e248aef7e5201f5 "Bump grpc.version from 1.54.0 to 1.54.1 in /lang/java"
[167ca07375]: https://github.com/apache/avro/commit/167ca073752b22335dab7fe87910783710a48ee8 "Bump build-helper-maven-plugin from 3.3.0 to 3.4.0 in /lang/java (#2233)"
[18d74959d7]: https://github.com/apache/avro/commit/18d74959d73346f9d1e1fa9dd8881177a1f49233 "AVRO-3345 Made Magic readonly in DataFileConstants (#1495)"
[1969b8f51d]: https://github.com/apache/avro/commit/1969b8f51dd23420b18ff585c137c6e5ee19c495 "AVRO-3766: [Rust] Print friendlier errors when test cases fail (#2263)"
[197a0ecaa0]: https://github.com/apache/avro/commit/197a0ecaa00906b3a809c60df300ace796819df3 "AVRO-2943 improve GenericRecord MAP type comparison"
[1998f9ee81]: https://github.com/apache/avro/commit/1998f9ee819e0002df6e7c170644b53a7ee5b762 "AVRO-3701: Bump Maven 4 to 4.0.0-alpha-4"
[1b67705bfd]: https://github.com/apache/avro/commit/1b67705bfd345d6c0b66a4625c3a61000368a11f "Bump maven-plugin-plugin from 3.8.1 to 3.8.2 in /lang/java"
[1b9b0858e6]: https://github.com/apache/avro/commit/1b9b0858e66968ce3a1d396e879e4803495030aa "AVRO-3759: Add extra types for RecordSchema, EnumSchema, FixedSchema and DecimalSchema (#2241)"
[1f7bfc4470]: https://github.com/apache/avro/commit/1f7bfc44703b7b4c193efb1a2f44e1ce432a6e0c "avro-3527: GenericData, extract hashcode logic in inner class"
[2231b77a61]: https://github.com/apache/avro/commit/2231b77a61de38d081fd619fadd5291149559497 "Bump maven-plugin-plugin from 3.7.1 to 3.8.1 in /lang/java (#2127)"
[24fa855db6]: https://github.com/apache/avro/commit/24fa855db6ee110c089af1c4b1eadb0ef2ba0592 "Bump protobuf-java from 3.23.1 to 3.23.2 in /lang/java (#2259)"
[25cc1b6f85]: https://github.com/apache/avro/commit/25cc1b6f850c37605542b56efc72e339e27f7bca "Bump grpc.version from 1.45.0 to 1.45.1 in /lang/java (#1671)"
[26daa9e937]: https://github.com/apache/avro/commit/26daa9e9375a557267784139d6fb9ad30287e507 "Bump grpc.version from 1.44.1 to 1.45.0 in /lang/java (#1612)"
[27eaf7038b]: https://github.com/apache/avro/commit/27eaf7038b952ff03768118326113cb7f5e371b4 "AVRO-3527: Optim hashcode"
[280326e51a]: https://github.com/apache/avro/commit/280326e51a24c7fa0044778d9d96239248086062 "Fix minor warnings from rust 1.66.0 (#2018)"
[285858f7d9]: https://github.com/apache/avro/commit/285858f7d9b7da8a5ae74990c785bc4e4818b940 "Bump netty-bom from 4.1.75.Final to 4.1.77.Final in /lang/java (#1694)"
[2919020ddf]: https://github.com/apache/avro/commit/2919020ddf19c951049d4731727211450c3253ad "Bump maven-gpg-plugin from 3.0.1 to 3.1.0 in /lang/java (#2218)"
[2a246049ac]: https://github.com/apache/avro/commit/2a246049ac015a0b33458b31fc945942c672a5d0 "AVRO-3690: Fix spotless problem (#2107)"
[2c80b563a3]: https://github.com/apache/avro/commit/2c80b563a323dc24bd684385f0b2d95c3a066bd2 "AVRO-3589: Update github actions versions (#1789)"
[2d54b9ea5b]: https://github.com/apache/avro/commit/2d54b9ea5b8e226a99788356d1b918d99e61efb5 "Bump netty-bom from 4.1.87.Final to 4.1.89.Final in /lang/java"
[2e68b3ff4f]: https://github.com/apache/avro/commit/2e68b3ff4f7f3633a418219cd1dcee5e5bd08921 "Minor non-functional cleanup."
[307adc0c3a]: https://github.com/apache/avro/commit/307adc0c3acc600205c2777ac71bdc9cafabc523 "AVRO-3431: CI: Cancel in-progress workflows if there are new commits in PR (#1577)"
[30c4cbfde5]: https://github.com/apache/avro/commit/30c4cbfde573100d60f1e27dac26bd4803ca6d31 "AVRO-3690: [Java] Fix flaky test ‘testMultipleFieldAliases’"
[327ce13cc4]: https://github.com/apache/avro/commit/327ce13cc4600bd09d45aa85b942f28e2eb95825 "Bump maven-checkstyle-plugin from 3.2.1 to 3.2.2 in /lang/java"
[34ac34942a]: https://github.com/apache/avro/commit/34ac34942a2f8ea282c523592f87e5cfbb9178a5 "Bump protobuf-java from 3.21.12 to 3.22.0 in /lang/java (#2111)"
[34e75a3995]: https://github.com/apache/avro/commit/34e75a3995feb26721ecb90e89023392e27d9f8b "AVRO-3285: Upgrade JavaCC plugin and library (#1447)"
[35f531d16e]: https://github.com/apache/avro/commit/35f531d16e5235f5619bfdd43838bdab47287a96 "Bump snappy-java from 1.1.9.0 to 1.1.9.1 in /lang/java"
[387f497285]: https://github.com/apache/avro/commit/387f497285d49ffc577263d154bca968e2b5ea65 "AVRO-3487: Update Jackson to 2.12.6.1 (#1640)"
[389fb2acb1]: https://github.com/apache/avro/commit/389fb2acb149df182ec1fddc2658cee400c601f2 "Bump plexus-utils from 3.5.0 to 3.5.1 in /lang/java (#2125)"
[3a9e5a789b]: https://github.com/apache/avro/commit/3a9e5a789b5165e0c8c4da799c387fdf84bfb75e "Preparing to build 1.11.1"
[3b6c6cc43d]: https://github.com/apache/avro/commit/3b6c6cc43d54ae56b51dacfd6d86d54a0733d57b "Bump jackson-bom from 2.14.2 to 2.15.0 in /lang/java"
[3d2761da15]: https://github.com/apache/avro/commit/3d2761da151923389f23642cc5e0c4bf5725b1ba "Bump maven-surefire-plugin from 3.0.0-M7 to 3.0.0-M8 in /lang/java (#2067)"
[3dbf0a0409]: https://github.com/apache/avro/commit/3dbf0a04094a926b82616c3e88308da092cf7b58 "AVRO-3736: [Ruby] Preinstall gems in ubertool docker (#2191)"
[41e330a14a]: https://github.com/apache/avro/commit/41e330a14a4dbae597d491a541ef0c0c024e4347 "Bump maven-checkstyle-plugin from 3.2.0 to 3.2.1 in /lang/java (#2071)"
[41fb846ec3]: https://github.com/apache/avro/commit/41fb846ec3aaefba762dbc4c691688bbb722311a "Bump mockito-core from 4.8.1 to 4.9.0 in /lang/java (#1976)"
[4209b14b87]: https://github.com/apache/avro/commit/4209b14b8750c5d631a77e2b84906a449c43f706 "AVRO-2624 Revert casting to super type"
[43b5d7e3c1]: https://github.com/apache/avro/commit/43b5d7e3c141573379c1a16093a3191dd070e291 "Bump mockito-core from 4.9.0 to 4.10.0 in /lang/java (#2021)"
[43c39e45b5]: https://github.com/apache/avro/commit/43c39e45b564f7086e03aba94a36d85fa302e9a9 "Bump cyclonedx-maven-plugin from 2.7.8 to 2.7.9 in /lang/java (#2243)"
[440ab18b09]: https://github.com/apache/avro/commit/440ab18b097fce7ea0ca1ab03488f3e4c8769095 "AVRO-3534: Rust: Use dependency-review-action only for pull_request events (#1717)"
[443614c12a]: https://github.com/apache/avro/commit/443614c12a15bb58fcf2487eb67ca6f885a68f96 "Adjust how dotnet stuff is added to Docker container, add browserify since we claim to support it so having it available for building/testing is needed."
[44d32c001c]: https://github.com/apache/avro/commit/44d32c001c3ceea07ca2a98a840c75e26568a641 "Bump jackson-bom from 2.14.0 to 2.14.1 in /lang/java (#1987)"
[47fd3b600d]: https://github.com/apache/avro/commit/47fd3b600d9eba16f5f2f57a496dae60fd198976 "AVRO-3759: Add extra types for RecordSchema, EnumSchema, FixedSchema and DecimalSchema (#2241)"
[493188cd62]: https://github.com/apache/avro/commit/493188cd62c577cbe715747208bc74f5ba2e1c66 "Bump grpc.version from 1.54.1 to 1.55.1 in /lang/java (#2229)"
[4b60d817a0]: https://github.com/apache/avro/commit/4b60d817a072b4fd6be096603828d2a0167c757b "Bump commons-cli from 1.4 to 1.5.0 in /lang/java (#1470)"
[4e135b0325]: https://github.com/apache/avro/commit/4e135b0325a2b585a390944a8d6f1bcd93c1d1fe "Bump proc-macro2 from 1.0.58 to 1.0.59 in /lang/rust (#2254)"
[4fbd448fec]: https://github.com/apache/avro/commit/4fbd448fecb4a45dbe5b493eeb769ee1d2ac7310 "Add RollForward prop (#2162)"
[5016cd5c3f]: https://github.com/apache/avro/commit/5016cd5c3f2054ebacce7983785c228798e47f59 "Fix minor warnings from rust 1.66.0 (#2018)"
[52d670f72d]: https://github.com/apache/avro/commit/52d670f72dbb35e06755bd288ab6eca84a3920a5 "AVRO-3712: Fix build by initializing union (#2079)"
[536dcc35c2]: https://github.com/apache/avro/commit/536dcc35c2c832275b3ce1d1de94f559a63313a7 "AVRO-3690: [Java] Fix testMultipleFieldAliases test (#2109)"
[53ad6c4cc6]: https://github.com/apache/avro/commit/53ad6c4cc6d3bd030c0a2fb04e088e84f7f07eaa "Bump netty-bom from 4.1.92.Final to 4.1.93.Final in /lang/java (#2256)"
[54b426a4bb]: https://github.com/apache/avro/commit/54b426a4bb11fbc79fde9787bd090614394cd3f1 "AVRO-3766: [Rust] Fix the formatting"
[5548c9dff7]: https://github.com/apache/avro/commit/5548c9dff7a3bd851eacc791b52b21804f9f8408 "Bump protobuf-java from 3.21.12 to 3.22.0 in /lang/java (#2111)"
[57f1d52784]: https://github.com/apache/avro/commit/57f1d5278427e2b095ec8d539d32bb9b309f9e07 "AVRO-3766: [Rust] Print friendlier errors when test cases fail (#2263)"
[5883a4d9e6]: https://github.com/apache/avro/commit/5883a4d9e60b515b9dcd6b9c743340f918535842 "Bump grpc.version from 1.52.1 to 1.53.0 in /lang/java"
[5a0fb0ffce]: https://github.com/apache/avro/commit/5a0fb0ffcebf3cc2c268fbe74fe117ff64cdfbe1 "Update blog to invite Martin Grigorov (#1865)"
[5a80e32e6b]: https://github.com/apache/avro/commit/5a80e32e6bba7d44fef0edfe333ff62c55da1392 "AVRO-3076: Fix incorrect Javadoc regarding custom coder defaults (#1715)"
[5a8c87a96d]: https://github.com/apache/avro/commit/5a8c87a96d9aeb63b68b1f93bcff99347913a81b "Update from the Ubuntu repositories before installing the dependencies"
[5acb6d619b]: https://github.com/apache/avro/commit/5acb6d619b2de2bbb8963e028ff272123331de2f "Bump grpc.version from 1.53.0 to 1.54.0 in /lang/java"
[5ad0008486]: https://github.com/apache/avro/commit/5ad000848653d85a7a47699eb84c411ca037b0e4 "Bump jackson-bom from 2.12.6.20220326 to 2.12.7 in /lang/java (#1703)"
[5af6e43fa0]: https://github.com/apache/avro/commit/5af6e43fa03be6d2a6dba4842479ae06e70bcd68 "Bump netty-bom from 4.1.77.Final to 4.1.78.Final in /lang/java (#1724)"
[5b003cba08]: https://github.com/apache/avro/commit/5b003cba088e122c553b0c648d13edb5ba250409 "AVRO-3242 Add config for TravisCI on Linux ARM64 (#1380)"
[5b1e1ebc4f]: https://github.com/apache/avro/commit/5b1e1ebc4f534d586c461c9213fe23b05ab4a589 "Bump maven-checkstyle-plugin from 3.2.0 to 3.2.1 in /lang/java (#2071)"
[5bcd8e3da3]: https://github.com/apache/avro/commit/5bcd8e3da3039d5be9f33644e77233dbe90b95bb "Bump proc-macro2 from 1.0.59 to 1.0.60 in /lang/rust (#2273)"
[5c0b17dec3]: https://github.com/apache/avro/commit/5c0b17dec3dc0e9693db6e87a41b1d37ded7cfea "[AVRO-2943] Add new GenericData String/Utf8 ARRAY comparison test (#2137)"
[5d2f01a1ea]: https://github.com/apache/avro/commit/5d2f01a1ea73ba45391fcfaf0f349b81ec577f51 "The dotnet stuff isn't installable via deb packages on aarch64/arm64. Use the dotnet installer to install. Also configure .dotnet for the user."
[5d940daac9]: https://github.com/apache/avro/commit/5d940daac93c74991a0875f25734644a90d076a6 "AVRO-3697: [ruby] Test against Ruby 3.2 (#2041)"
[5d9fbb286f]: https://github.com/apache/avro/commit/5d9fbb286f16da8c4fa2d991861724f0f4b1841e "AVRO-3701: Bump Maven 4 to 4.0.0-alpha-4"
[5f4f406dc3]: https://github.com/apache/avro/commit/5f4f406dc3504a565011108ea21dd1dde6747ec4 "Bump netty-bom from 4.1.89.Final to 4.1.90.Final in /lang/java"
[61b5c17703]: https://github.com/apache/avro/commit/61b5c17703ec7338896f07901812f217998b3e51 "Bump junit5.version from 5.9.2 to 5.9.3 in /lang/java"
[61e74e5927]: https://github.com/apache/avro/commit/61e74e5927a81d6c62e168de80d09e9b70e84753 "AVRO-3737: fix memcheck test (#2213)"
[622343fdc7]: https://github.com/apache/avro/commit/622343fdc705ccbc5a918f598d60a0df802119d8 "Preparing for 1.11.0"
[627b005493]: https://github.com/apache/avro/commit/627b005493bb8abe6a0ffc53c709ad1b7967c769 "AVRO-3644: handle java.util.Optional as a nullable value (#1915)"
[62f45ecc90]: https://github.com/apache/avro/commit/62f45ecc90ab8bf550333abfe976884110a0b768 "AVRO-3696: Replace tox-wheel with standard tox (#2040)"
[6459ec00bf]: https://github.com/apache/avro/commit/6459ec00bfd9efcf48dbae0ca7584d1847e85acc "[C++] Fix compiler warnings"
[64c8da735d]: https://github.com/apache/avro/commit/64c8da735db1a6e2f8492de820e80f3174be3cb1 "Bump grpc.version from 1.45.0 to 1.45.1 in /lang/java (#1671)"
[6603e7777e]: https://github.com/apache/avro/commit/6603e7777eda6f81ba7ed49c4672951b824bd6df "AVRO-3285: Upgrade JavaCC plugin and library (#1447)"
[6743a41d33]: https://github.com/apache/avro/commit/6743a41d33a55cb6b4468385142dbc86292842ae "AVRO-3611: fix generator"
[6bdd8b2fd8]: https://github.com/apache/avro/commit/6bdd8b2fd88edeec6f80d41713fde9a95a50a0be "Bump netty-bom from 4.1.90.Final to 4.1.91.Final in /lang/java"
[6c2e3700b6]: https://github.com/apache/avro/commit/6c2e3700b6c17e518755386fd81a2caa9deb1797 "AVRO-3241 [Java] Publish SNAPSHOT artifacts (#1385)"
[6c900f41a0]: https://github.com/apache/avro/commit/6c900f41a0bec798c42ddd7e881bbaceb7a8a88e "Bump protobuf-java from 3.22.2 to 3.22.3 in /lang/java"
[6f0692f965]: https://github.com/apache/avro/commit/6f0692f965a8d2b3f935ec3453ddf162617b84bc "Add NET 7 SDK to Dockerfile (#2193)"
[6f4162e3d7]: https://github.com/apache/avro/commit/6f4162e3d71e602bc398563b102d569846d5f39f "Bump serde from 1.0.163 to 1.0.164 in /lang/rust (#2274)"
[72e38dc8ff]: https://github.com/apache/avro/commit/72e38dc8ff4b78ad7c66e002208d404669f94ac8 "AVRO-3715: [Python] Fix type issues"
[73d208fa64]: https://github.com/apache/avro/commit/73d208fa64ee3c145f4d2a259571e1c88b3c4144 "AVRO-3653: [CI] Remove Travis-ci config files (#1948)"
[74bd287cff]: https://github.com/apache/avro/commit/74bd287cff5ac09fd47e67d1d5814f331c52cee6 "AVRO-3715: [Python] Fix lint issues (reformat code)."
[76e55d8775]: https://github.com/apache/avro/commit/76e55d8775efb02b5248aadf0bd512b137b58443 "AVRO-2870: Avoid throwing from destructor in DataFileWriterBase (#921)"
[77258c88c9]: https://github.com/apache/avro/commit/77258c88c90ef567f3b05eeb2d86ff8dfa99b302 "Bump netty-bom from 4.1.77.Final to 4.1.78.Final in /lang/java (#1724)"
[77692d8c14]: https://github.com/apache/avro/commit/77692d8c147e3a83812fa1a409ea31349962eb49 "Bump actions/setup-dotnet from 2 to 3 (#1899)"
[7825226b1d]: https://github.com/apache/avro/commit/7825226b1d43c6dda4964f4f1090f77d4dfb7eee "Add myself to the list of committers (#1808)"
[787df564b1]: https://github.com/apache/avro/commit/787df564b18b6539880536fe8f586537cf4ea6eb "AVRO-3696: Replace tox-wheel with standard tox (#2040)"
[79e5033578]: https://github.com/apache/avro/commit/79e5033578bb8a5c36d48b502c35ba4edd9826e8 "AVRO-3766: [Rust] Fix the formatting"
[7aca93124e]: https://github.com/apache/avro/commit/7aca93124e6753d89085e5c8de164700e24ed0a5 "Bump cyclonedx-maven-plugin from 2.7.5 to 2.7.6 in /lang/java"
[7bf4f5e392]: https://github.com/apache/avro/commit/7bf4f5e392b383df456cf3f711885756a77aefbe "AVRO-3771: [Rust] Logging flood during validate method (#2272)"
[7c99739a40]: https://github.com/apache/avro/commit/7c99739a4063c56c229f71b32bb9271d0c5fbf5e "Bump postcss-cli from 9.1.0 to 10.0.0 in /doc (#1754)"
[7ec12f99c3]: https://github.com/apache/avro/commit/7ec12f99c3995f50c392a5a5336cd1a5c04ae1b4 "Bump netty-bom from 4.1.72.Final to 4.1.74.Final in /lang/java (#1581)"
[7f8a3813ea]: https://github.com/apache/avro/commit/7f8a3813eaceebb0f3933c16beacd8266d5991e4 "Bump protobuf-java from 3.22.3 to 3.22.4 in /lang/java"
[816f025d3c]: https://github.com/apache/avro/commit/816f025d3c4e324621b847b0268db0c5e2922afc "Bump actions/setup-node from 2 to 3 (#1791)"
[82fc40bbc5]: https://github.com/apache/avro/commit/82fc40bbc5aca780875cb07e78056978fa0a85c6 "AVRO-3700: Publish Java SBOM artifacts with CycloneDX"
[842e192ccd]: https://github.com/apache/avro/commit/842e192ccd33584d40d71f3e7d9558b786c7e502 "Bump zstd-jni from 1.5.4-2 to 1.5.5-2 in /lang/java"
[8565b87c12]: https://github.com/apache/avro/commit/8565b87c12add2c40e5917bb384762ddfc877c91 "Revert \"AVRO-3684: [Java] testAppendStream test\" (#2108)"
[859645d4a5]: https://github.com/apache/avro/commit/859645d4a55bd8d2890dafa1ce899ac990eaba9b "AVRO-3628: [Java] JUnit 4.x tests are not executed (#1863)"
[872038d4da]: https://github.com/apache/avro/commit/872038d4da35360bb71b73471c0bb73a1f60dcca "Bump hadoop-client from 3.3.2 to 3.3.3 in /lang/java (#1697)"
[87778e6c56]: https://github.com/apache/avro/commit/87778e6c56ed0d01a8fdcf0b670e327d5dad814f "AVRO-3076: Fix incorrect Javadoc regarding custom coder defaults (#1715)"
[879620925b]: https://github.com/apache/avro/commit/879620925b0d979fe9d2552643c888ff2b4634ab "Bump maven-surefire-plugin from 3.0.0-M8 to 3.0.0-M9 in /lang/java (#2114)"
[8847826577]: https://github.com/apache/avro/commit/8847826577a3315fe3663ec95ad1aa877ed44b5c "Bump zstd-jni from 1.5.1-1 to 1.5.2-2 in /lang/java (#1663)"
[8cc6650d6d]: https://github.com/apache/avro/commit/8cc6650d6d52d8192b0da80cb4b1f71e33dff822 "Bump zstd-jni from 1.5.1-1 to 1.5.2-2 in /lang/java (#1663)"
[8e0513c95d]: https://github.com/apache/avro/commit/8e0513c95db3285f9de4d4bc165c376686b157ca "Bump maven-enforcer-plugin from 3.2.1 to 3.3.0 in /lang/java"
[8e8a547cb8]: https://github.com/apache/avro/commit/8e8a547cb89877bc182b7f05b15421315529ab6c "Bump commons-text from 1.9 to 1.10.0 in /lang/java (#1898)"
[8e965fae15]: https://github.com/apache/avro/commit/8e965fae1541d72653ae73ae27499eae4f72c4a4 "Bump commons-text from 1.9 to 1.10.0 in /lang/java (#1898)"
[8f06f2b5a0]: https://github.com/apache/avro/commit/8f06f2b5a0fc8e183e4dc19c9836212da2231867 "Bump cyclonedx-maven-plugin from 2.7.3 to 2.7.4 in /lang/java (#2051)"
[91f5fa7535]: https://github.com/apache/avro/commit/91f5fa7535a2ed8406b02595413cd66adfcb2dbc "Bump log from 0.4.17 to 0.4.18 in /lang/rust (#2261)"
[91fee3d854]: https://github.com/apache/avro/commit/91fee3d8544ccb720969ea854f6a6c594f13911f "Bump maven-surefire-plugin from 3.0.0-M9 to 3.0.0 in /lang/java (#2151)"
[94bbb7bcaf]: https://github.com/apache/avro/commit/94bbb7bcaf1f70742d21b30c701983061763bec9 "AVRO-3487: Update Jackson to 2.12.6.1 (#1640)"
[95440c4c5b]: https://github.com/apache/avro/commit/95440c4c5b904d93cfa878d3e13879a20ff499ff "AVRO-3510: Do not hardcode the PHP Composer installer Sha384 in TravisCI (#1678)"
[95acbd5c43]: https://github.com/apache/avro/commit/95acbd5c439bc79d74375546bfb3af88519e23bd "Bump jetty.version in /lang/java (#2007)"
[95fec21c31]: https://github.com/apache/avro/commit/95fec21c31c693e0c7949c7cc1b19e5c24f4aed6 "Bump maven-surefire-plugin from 3.0.0-M8 to 3.0.0-M9 in /lang/java (#2114)"
[96c2d8419e]: https://github.com/apache/avro/commit/96c2d8419ef3e0a81ac49fa2bb62aa1d9b5eedfe "Bump reload4j from 1.2.24 to 1.2.25 in /lang/java"
[96cd2074a6]: https://github.com/apache/avro/commit/96cd2074a64cfa08390b0d8561ad76b22b31a16b "Bump cyclonedx-maven-plugin from 2.7.7 to 2.7.8 in /lang/java"
[96de1933d9]: https://github.com/apache/avro/commit/96de1933d992a2aee568341eba6491e99203769d "Bump jetty.version in /lang/java (#1737)"
[976ecbe950]: https://github.com/apache/avro/commit/976ecbe95098c8b95c67f65d2da3602f2a40d8dc "Bump ant from 1.10.12 to 1.10.13 in /lang/java (#2059)"
[9b7230210c]: https://github.com/apache/avro/commit/9b7230210c8867bd8a07e8e5cf42b8b047018f81 "Bump maven-surefire-plugin from 3.0.0-M7 to 3.0.0-M8 in /lang/java (#2067)"
[9b83acd4c7]: https://github.com/apache/avro/commit/9b83acd4c7fbf6beb5be2cf10f76230624c98637 "Bump reload4j from 1.2.18.0 to 1.2.19 in /lang/java (#1556)"
[9cd3c0e6df]: https://github.com/apache/avro/commit/9cd3c0e6df02e9706dc075d7be6eccd18c18d79d "Bump grpc.version from 1.44.0 to 1.44.1 in /lang/java (#1572)"
[AVRO-2404]: https://issues.apache.org/jira/browse/AVRO-2404
[AVRO-2624]: https://issues.apache.org/jira/browse/AVRO-2624
[AVRO-2870]: https://issues.apache.org/jira/browse/AVRO-2870
[AVRO-2943]: https://issues.apache.org/jira/browse/AVRO-2943
[AVRO-3001]: https://issues.apache.org/jira/browse/AVRO-3001
[AVRO-3076]: https://issues.apache.org/jira/browse/AVRO-3076
[AVRO-3241]: https://issues.apache.org/jira/browse/AVRO-3241
[AVRO-3242]: https://issues.apache.org/jira/browse/AVRO-3242
[AVRO-3264]: https://issues.apache.org/jira/browse/AVRO-3264
[AVRO-3273]: https://issues.apache.org/jira/browse/AVRO-3273
[AVRO-3274]: https://issues.apache.org/jira/browse/AVRO-3274
[AVRO-3278]: https://issues.apache.org/jira/browse/AVRO-3278
[AVRO-3285]: https://issues.apache.org/jira/browse/AVRO-3285
[AVRO-3344]: https://issues.apache.org/jira/browse/AVRO-3344
[AVRO-3345]: https://issues.apache.org/jira/browse/AVRO-3345
[AVRO-3386]: https://issues.apache.org/jira/browse/AVRO-3386
[AVRO-3388]: https://issues.apache.org/jira/browse/AVRO-3388
[AVRO-3431]: https://issues.apache.org/jira/browse/AVRO-3431
[AVRO-3487]: https://issues.apache.org/jira/browse/AVRO-3487
[AVRO-3510]: https://issues.apache.org/jira/browse/AVRO-3510
[AVRO-3527]: https://issues.apache.org/jira/browse/AVRO-3527
[AVRO-3530]: https://issues.apache.org/jira/browse/AVRO-3530
[AVRO-3534]: https://issues.apache.org/jira/browse/AVRO-3534
[AVRO-3568]: https://issues.apache.org/jira/browse/AVRO-3568
[AVRO-3579]: https://issues.apache.org/jira/browse/AVRO-3579
[AVRO-3589]: https://issues.apache.org/jira/browse/AVRO-3589
[AVRO-3611]: https://issues.apache.org/jira/browse/AVRO-3611
[AVRO-3613]: https://issues.apache.org/jira/browse/AVRO-3613
[AVRO-3623]: https://issues.apache.org/jira/browse/AVRO-3623
[AVRO-3624]: https://issues.apache.org/jira/browse/AVRO-3624
[AVRO-3628]: https://issues.apache.org/jira/browse/AVRO-3628
[AVRO-3639]: https://issues.apache.org/jira/browse/AVRO-3639
[AVRO-3644]: https://issues.apache.org/jira/browse/AVRO-3644
[AVRO-3649]: https://issues.apache.org/jira/browse/AVRO-3649
[AVRO-3650]: https://issues.apache.org/jira/browse/AVRO-3650
[AVRO-3653]: https://issues.apache.org/jira/browse/AVRO-3653
[AVRO-3670]: https://issues.apache.org/jira/browse/AVRO-3670
[AVRO-3684]: https://issues.apache.org/jira/browse/AVRO-3684
[AVRO-3690]: https://issues.apache.org/jira/browse/AVRO-3690
[AVRO-3696]: https://issues.apache.org/jira/browse/AVRO-3696
[AVRO-3697]: https://issues.apache.org/jira/browse/AVRO-3697
[AVRO-3700]: https://issues.apache.org/jira/browse/AVRO-3700
[AVRO-3701]: https://issues.apache.org/jira/browse/AVRO-3701
[AVRO-3712]: https://issues.apache.org/jira/browse/AVRO-3712
[AVRO-3713]: https://issues.apache.org/jira/browse/AVRO-3713
[AVRO-3715]: https://issues.apache.org/jira/browse/AVRO-3715
[AVRO-3717]: https://issues.apache.org/jira/browse/AVRO-3717
[AVRO-3718]: https://issues.apache.org/jira/browse/AVRO-3718
[AVRO-3721]: https://issues.apache.org/jira/browse/AVRO-3721
[AVRO-3736]: https://issues.apache.org/jira/browse/AVRO-3736
[AVRO-3737]: https://issues.apache.org/jira/browse/AVRO-3737
[AVRO-3747]: https://issues.apache.org/jira/browse/AVRO-3747
[AVRO-3759]: https://issues.apache.org/jira/browse/AVRO-3759
[AVRO-3764]: https://issues.apache.org/jira/browse/AVRO-3764
[AVRO-3766]: https://issues.apache.org/jira/browse/AVRO-3766
[AVRO-3771]: https://issues.apache.org/jira/browse/AVRO-3771
[a1fd468425]: https://github.com/apache/avro/commit/a1fd4684258a8c2a910a507d15ed7cbc27298cac "Bump ctor from 0.2.0 to 0.2.1 in /lang/rust (#2264)"
[a3bd2ac4d9]: https://github.com/apache/avro/commit/a3bd2ac4d92c40caa66abff3ed1728de8818f089 "Bump regex from 1.8.3 to 1.8.4 in /lang/rust (#2271)"
[a4e42112ce]: https://github.com/apache/avro/commit/a4e42112cea950e76dd4fc914765205c7b305ae7 "Bump grpc.version from 1.44.1 to 1.45.0 in /lang/java (#1612)"
[a5ba8b4452]: https://github.com/apache/avro/commit/a5ba8b445252987dec2d5f31e34c573823a04f0b "Bump Mockito to 4.3.1"
[a60b748c16]: https://github.com/apache/avro/commit/a60b748c1694dcf3fd2b617e75fcc9c1634fd150 "AVRO-3001 AVRO-3274 AVRO-3568 AVRO-3613: Add JSON encoder/decoder for C#"
[a7ad5ac585]: https://github.com/apache/avro/commit/a7ad5ac5858fef5edc45671f77c7f06ed37a51cc "AVRO-3700: Move CycloneDX configuration to Java specific project (#2049)"
[a8d5f1b562]: https://github.com/apache/avro/commit/a8d5f1b5624ce4cced60a28b6a140639471415fc "Bump hadoop-client from 3.3.4 to 3.3.5 in /lang/java"
[a8ee8778df]: https://github.com/apache/avro/commit/a8ee8778dfdccbc9bf5c8423d0d7dbdf1c2c0cbf "AVRO-3534: Rust: Use dependency-review-action only for pull_request events (#1717)"
[aa1b878a7c]: https://github.com/apache/avro/commit/aa1b878a7c394df808e56e446662aaa80c1681e5 "Bump zstd-jni from 1.5.5-2 to 1.5.5-3 in /lang/java (#2244)"
[ace4d5d2e5]: https://github.com/apache/avro/commit/ace4d5d2e5940f085f171df9653c94197795fa67 "AVRO-3264: Improvements to the project section of the Avro website (#2145)"
[ace5ffd0d9]: https://github.com/apache/avro/commit/ace5ffd0d98697be4c1ef70ee7982a97f186dc60 "Bump zstd-jni from 1.5.5-3 to 1.5.5-4 in /lang/java (#2279)"
[ad585c29ef]: https://github.com/apache/avro/commit/ad585c29efb46e3c056a11e4e10f9c2d408bb84b "AVRO-3388: Extra codecs in C# (#1536)"
[ad5cf6857e]: https://github.com/apache/avro/commit/ad5cf6857e28b655304a5f7f411c9d63f4ac3909 "AVRO-3713: [Java] Fix Map synchronization regression"
[ae77f72f93]: https://github.com/apache/avro/commit/ae77f72f93cfdb91397d878e7a4cdb7f32d61cdf "Bump grpc.version from 1.44.0 to 1.44.1 in /lang/java (#1572)"
[b015fe3a22]: https://github.com/apache/avro/commit/b015fe3a22b1f700cfd921bcc04f960a279fac83 "Bump maven-bundle-plugin from 5.1.4 to 5.1.6 in /lang/java (#1699)"
[b1de7a6a1b]: https://github.com/apache/avro/commit/b1de7a6a1b54642cacc6348887cb92b5c4ba3200 "Bump mockito-core from 4.10.0 to 4.11.0 in /lang/java (#2044)"
[b2aeb2adbc]: https://github.com/apache/avro/commit/b2aeb2adbc85827f2cda34eae4b27ed2c0769075 "AVRO-3579: change comment"
[b6178acc7a]: https://github.com/apache/avro/commit/b6178acc7a92f6c1ed465d5bbdd06787cf9b7f6f "Bump maven-surefire-plugin from 3.0.0-M9 to 3.0.0 in /lang/java (#2151)"
[b6eb0f7794]: https://github.com/apache/avro/commit/b6eb0f77942dca18ef6b651f51f2938094ccf5c9 "Bump zstd-jni from 1.5.4-1 to 1.5.4-2 in /lang/java (#2126)"
[b796146cf4]: https://github.com/apache/avro/commit/b796146cf41d1889d7f011e89576da5a529ccd9a "AVRO-3388: Extra codecs in C# (#1536)"
[b821b223c6]: https://github.com/apache/avro/commit/b821b223c6e9d027a14893171c858d3ed3f03196 "Bump hadoop-client from 3.3.2 to 3.3.3 in /lang/java (#1697)"
[b8937526d3]: https://github.com/apache/avro/commit/b8937526d32928b3b29040e862f7689d7230bddb "Bump Maven plugin versions and maven version for the docker based build (#1983)"
[b9977c7b3a]: https://github.com/apache/avro/commit/b9977c7b3ad7f04b72b0a0c42af70b180af472e1 "Preparing for release 1.11.1"
[b9fd71a730]: https://github.com/apache/avro/commit/b9fd71a730ac4c9d93280d487c12cf2750bc2e45 "Bump jetty.version in /lang/java (#2122)"
[bb40b2a025]: https://github.com/apache/avro/commit/bb40b2a025025c86e12045432a45f9c72518fb17 "Bump jetty.version in /lang/java (#2007)"
[bdb7fadefe]: https://github.com/apache/avro/commit/bdb7fadefe7c49488bfd38765c8eafc8b2d9b008 "Bump commons-cli from 1.4 to 1.5.0 in /lang/java (#1470)"
[bdbb2a0379]: https://github.com/apache/avro/commit/bdbb2a0379104cba9cf73a6df682c66c9e8180a4 "AVRO-3431: CI: Cancel in-progress workflows if there are new commits in PR (#1577)"
[be4c37a9eb]: https://github.com/apache/avro/commit/be4c37a9ebe31a07ab78f7186c3d22400874d96e "Add myself to the list of committers (#2047)"
[bf8cde0f66]: https://github.com/apache/avro/commit/bf8cde0f661c2d11a770c4c3343ad19f21a5388c "AVRO-3611: add constants"
[c0a06b6c88]: https://github.com/apache/avro/commit/c0a06b6c88f454160467045965d4674f23309a0b "Bump netty-bom from 4.1.91.Final to 4.1.92.Final in /lang/java"
[c28dbe9f7d]: https://github.com/apache/avro/commit/c28dbe9f7d485f5e5d1df41df1bb2c12c838b5db "AVRO-3649: default for union inside union"
[c290e1da80]: https://github.com/apache/avro/commit/c290e1da80f270065d858a8698c1742f1152d358 "Bump netty-bom from 4.1.75.Final to 4.1.77.Final in /lang/java (#1694)"
[c2ae949a16]: https://github.com/apache/avro/commit/c2ae949a16a701752af14942ec157d6612abb455 "AVRO-3747: [Rust] Set `is_human_readable` hint to `false` for `Value` (#2202)"
[c2e6e13194]: https://github.com/apache/avro/commit/c2e6e13194cb4f1879b8c98ff896c048caf6b8e5 "AVRO-3721: add method to JsonProperties"
[c648682f96]: https://github.com/apache/avro/commit/c648682f96468d1186768235ccaa252065290470 "Bump ctor from 0.2.1 to 0.2.2 in /lang/rust (#2265)"
[c68b531839]: https://github.com/apache/avro/commit/c68b531839c6ffbfd35cc4abb0dbeed49ae1d2b2 "Bump actions/dependency-review-action from 2 to 3 (#1958)"
[c8eec97dd0]: https://github.com/apache/avro/commit/c8eec97dd0f09d014466f60e51bc9ebf9b8e7c7e "Bump maven-surefire-plugin from 3.0.0 to 3.1.0 in /lang/java"
[cc094e5b70]: https://github.com/apache/avro/commit/cc094e5b70f36a35162482401235a5edeb675e07 "Bump extra-enforcer-rules from 1.6.2 to 1.7.0 in /lang/java (#2267)"
[cd6eb11335]: https://github.com/apache/avro/commit/cd6eb11335e3b9be9ef824cde5977f38e508860f "docs: fix small error (#2025)"
[cdfd66fed1]: https://github.com/apache/avro/commit/cdfd66fed1cb366400a41aa7dcbec19d1fad8a09 "AVRO-3764: [Rust]: Add resolve method with schemata for an automatic Schema::Ref resolving (#2262)"
[d1b5f9ad93]: https://github.com/apache/avro/commit/d1b5f9ad93d07ca597c23cd836d2cdfdc3a55970 "Bump syn from 2.0.16 to 2.0.18 in /lang/rust (#2260)"
[d2083c340d]: https://github.com/apache/avro/commit/d2083c340d92a24ad7bc2d0b86fe8abda3b5d0db "Bump jackson-bom from 2.14.1 to 2.14.2 in /lang/java (#2069)"
[d22e55501c]: https://github.com/apache/avro/commit/d22e55501caa19c9f19d3e9321b55a643c226773 "Bump maven-plugin-plugin from 3.6.4 to 3.7.1 in /lang/java (#2070)"
[d44ed5ae2f]: https://github.com/apache/avro/commit/d44ed5ae2fbb6b2b8d21d4a2ada218f35d59a38a "Bump jetty.version in /lang/java (#1633)"
[d5b85d820f]: https://github.com/apache/avro/commit/d5b85d820f28f0ad82864188531f853a78e33cb9 "Merge branch 'Fokko-fd-remove-redundant-generic-hints'"
[d75abd5915]: https://github.com/apache/avro/commit/d75abd591540ef34a334a3d73314f2748c8d868d "AVRO-3628: [Java] JUnit 4.x tests are not executed (#1863)"
[d7f9b9072c]: https://github.com/apache/avro/commit/d7f9b9072c82b960f9eba0615e1b9989b81273eb "Fix a typo in javadoc"
[dcb2b06e84]: https://github.com/apache/avro/commit/dcb2b06e8472c2d64a31470c67931df780fe71c9 "Bump netty-bom from 4.1.72.Final to 4.1.74.Final in /lang/java (#1581)"
[dd4385ba2a]: https://github.com/apache/avro/commit/dd4385ba2a8302410313cbc0ca32d0a895cc1095 "Bump cyclonedx-maven-plugin from 2.7.4 to 2.7.5 in /lang/java (#2112)"
[e233f2ff89]: https://github.com/apache/avro/commit/e233f2ff89ed62e8adf4b3b53ab5b187f391525d "AVRO-3623: Update the PR template (#1851)"
[e261852e9e]: https://github.com/apache/avro/commit/e261852e9e8426743e95c5e76929c01ec1d95931 "Bump mockito-core from 4.9.0 to 4.10.0 in /lang/java (#2021)"
[e3dc0ea60d]: https://github.com/apache/avro/commit/e3dc0ea60d664f5369094cf33ca9edf1b75a636c "AVRO-3670: Add NET 7.0 support (#1956)"
[e429672ba6]: https://github.com/apache/avro/commit/e429672ba6f00db5cf5fecea7f6b344b5326f47b "Bump maven-bundle-plugin from 5.1.4 to 5.1.6 in /lang/java (#1699)"
[e42a570fe5]: https://github.com/apache/avro/commit/e42a570fe5405f85dd5a3bab621b725d8766463f "Bump jetty.version in /lang/java (#1737)"
[e4e1633077]: https://github.com/apache/avro/commit/e4e1633077d0550094cd037a945b6f8e01cf2a53 "AVRO-3579: JUnit5 migration step 2"
[e7d9be91ef]: https://github.com/apache/avro/commit/e7d9be91ef0a077514f22e3e7cf38d1781b7517f "AVRO-2404: Remove now obsolete Apache Rat workaround (#2119)"
[e8556562d6]: https://github.com/apache/avro/commit/e8556562d668b83df35ec3f308acd8fb6c2f339c "Bump mockito-core from 4.8.1 to 4.9.0 in /lang/java (#1976)"
[e93a2ab345]: https://github.com/apache/avro/commit/e93a2ab345225b507c3e72bcea98a076fc9399be "Bump actions/dependency-review-action from 2 to 3 (#1958)"
[e9c10d552c]: https://github.com/apache/avro/commit/e9c10d552c14917b0bc7a13c403436d8e769dacc "Bump github/codeql-action from 1 to 2 (#1792)"
[eb2b19d0e0]: https://github.com/apache/avro/commit/eb2b19d0e034dc1157dbcca5a26440c04180c704 "AVRO-3624: Add apache links (#1870)"
[ebeeebb4da]: https://github.com/apache/avro/commit/ebeeebb4da62a792f1c369c6ab06d83362698a73 "Bump maven-enforcer-plugin from 3.1.0 to 3.2.1 in /lang/java"
[ecdeda8fd9]: https://github.com/apache/avro/commit/ecdeda8fd955a8252673042130315b2b448e4dd9 "Preparing for release 1.11.2"
[edd59e166c]: https://github.com/apache/avro/commit/edd59e166c0ff06f3b5af2c27af056d559a76aeb "Bump jackson-bom from 2.12.7.20221012 to 2.14.0 in /lang/java (#1944)"
[ee27a1fa9c]: https://github.com/apache/avro/commit/ee27a1fa9c56ab405435987a3598ff7d8e6e4b78 "Bump ant from 1.10.12 to 1.10.13 in /lang/java (#2059)"
[efb977928a]: https://github.com/apache/avro/commit/efb977928a2e1eb4afed538a0676ca046987f15d "Bump commons-compress from 1.21 to 1.22 in /lang/java (#1943)"
[f0b183f277]: https://github.com/apache/avro/commit/f0b183f2773165e616ec22ed6c32f60cc5b961fe "Configure Dependabot to check for Rust updates daily"
[f3cd30131b]: https://github.com/apache/avro/commit/f3cd30131b84c8309f9475e2688c13173d89e1bc "Bump zstd-jni from 1.5.2-5 to 1.5.4-1 in /lang/java"
[f7ad78b4d5]: https://github.com/apache/avro/commit/f7ad78b4d5a22f962aabfa31872d08e4b33a4e55 "Revert \"Bump jackson-bom from 2.14.2 to 2.15.0 in /lang/java\""
[f84392d47c]: https://github.com/apache/avro/commit/f84392d47cebb7fb885c979262088c677a60ad09 "AVRO-3715: [Java] CycloneDX is not reproducible by design."
[f89c79dff3]: https://github.com/apache/avro/commit/f89c79dff3076b15076fcb7ad3665c5605fedff8 "Bump Mockito to 4.3.1"
[f8c49a0961]: https://github.com/apache/avro/commit/f8c49a096192fdb91fac98a3c27c304a12437302 "Bump mockito-core from 4.10.0 to 4.11.0 in /lang/java (#2044)"
[fa0bb70980]: https://github.com/apache/avro/commit/fa0bb7098083aba41c9aa9d9cf6383eb3e2c2696 "AVRO-3717: [Java] Fix NPE when basic type with Nullable annotation."
[fa8938faef]: https://github.com/apache/avro/commit/fa8938faef01767ba086aab3082c928d457a14d1 "AVRO-3273: Support older versions of maven"
[fc6af3dde7]: https://github.com/apache/avro/commit/fc6af3dde7b1b7c7caaf8f4df38a465751ce1f2d "Bump protobuf-java from 3.22.4 to 3.23.1 in /lang/java (#2246)"
[fee1a73979]: https://github.com/apache/avro/commit/fee1a73979b1f9e2b98e0797812f405c1ccb6615 "Add an entry for Rust to Github keywords/labels"
[ff5a42b272]: https://github.com/apache/avro/commit/ff5a42b2722978e84d7d578dd7abbf75b04d3acd "Avro-3767 [Rust] fix complex Ref resolving in Union (#2266)"
[fff979a316]: https://github.com/apache/avro/commit/fff979a3162cce5b286baa4de28e71d2142c0425 "Bump jackson-bom from 2.12.6.20220326 to 2.12.7 in /lang/java (#1703)"