### PR TITLE
[Rust]: Incorrect decimal resolving checks

### DIFF
--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -694,7 +694,7 @@ impl Value {
         match self {
             Value::Decimal(num) => {
                 let num_bytes = num.len();
-                if max_prec_for_len(num_bytes)? > precision {
+                if max_prec_for_len(num_bytes)? < precision {
                     Err(Error::ComparePrecisionAndSize {
                         precision,
                         num_bytes,
@@ -705,7 +705,7 @@ impl Value {
                 // check num.bits() here
             }
             Value::Fixed(_, bytes) | Value::Bytes(bytes) => {
-                if max_prec_for_len(bytes.len())? > precision {
+                if max_prec_for_len(bytes.len())? < precision {
                     Err(Error::ComparePrecisionAndSize {
                         precision,
                         num_bytes: bytes.len(),
@@ -1501,7 +1501,7 @@ Field with name '"b"' is not a member of the map items"#,
 
     #[test]
     fn resolve_decimal_bytes() -> TestResult {
-        let value = Value::Decimal(Decimal::from(vec![1, 2]));
+        let value = Value::Decimal(Decimal::from(vec![1, 2, 3, 4, 5]));
         value.clone().resolve(&Schema::Decimal(DecimalSchema {
             precision: 10,
             scale: 4,
@@ -1514,7 +1514,7 @@ Field with name '"b"' is not a member of the map items"#,
 
     #[test]
     fn resolve_decimal_invalid_scale() {
-        let value = Value::Decimal(Decimal::from(vec![1]));
+        let value = Value::Decimal(Decimal::from(vec![1, 2]));
         assert!(value
             .resolve(&Schema::Decimal(DecimalSchema {
                 precision: 2,
@@ -1533,12 +1533,12 @@ Field with name '"b"' is not a member of the map items"#,
                 scale: 0,
                 inner: Box::new(Schema::Bytes),
             }))
-            .is_err());
+            .is_ok());
     }
 
     #[test]
     fn resolve_decimal_fixed() {
-        let value = Value::Decimal(Decimal::from(vec![1, 2]));
+        let value = Value::Decimal(Decimal::from(vec![1, 2, 3, 4, 5]));
         assert!(value
             .clone()
             .resolve(&Schema::Decimal(DecimalSchema {
@@ -2766,17 +2766,19 @@ Field with name '"b"' is not a member of the map items"#,
     }
 
     #[test]
-    fn test_avro_incorrect_decimal_resolving() {
+    fn test_avro_3782_incorrect_decimal_resolving() -> TestResult {
         let schema = r#"{"name": "decimalSchema", "logicalType": "decimal", "type": "fixed", "precision": 8, "scale": 0, "size": 8}"#;
 
         let avro_value = Value::Decimal(Decimal::from(
             BigInt::from(12345678u32).to_signed_bytes_be(),
         ));
-        let schema = Schema::parse_str(schema).unwrap();
+        let schema = Schema::parse_str(schema)?;
         let resolve_result = avro_value.resolve(&schema);
         assert!(
             resolve_result.is_ok(),
             "resolve result must be ok, got: {resolve_result:?}"
         );
+
+        Ok(())
     }
 }

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -1035,6 +1035,7 @@ mod tests {
         logger::{assert_logged, assert_not_logged},
         TestResult,
     };
+    use num_bigint::BigInt;
     use pretty_assertions::assert_eq;
     use uuid::Uuid;
 
@@ -2762,5 +2763,20 @@ Field with name '"b"' is not a member of the map items"#,
         );
 
         Ok(())
+    }
+
+    #[test]
+    fn test_avro_incorrect_decimal_resolving() {
+        let schema = r#"{"name": "decimalSchema", "logicalType": "decimal", "type": "fixed", "precision": 8, "scale": 0, "size": 8}"#;
+
+        let avro_value = Value::Decimal(Decimal::from(
+            BigInt::from(12345678u32).to_signed_bytes_be(),
+        ));
+        let schema = Schema::parse_str(schema).unwrap();
+        let resolve_result = avro_value.resolve(&schema);
+        assert!(
+            resolve_result.is_ok(),
+            "resolve result must be ok, got: {resolve_result:?}"
+        );
     }
 }


### PR DESCRIPTION
Currently shows only a failing test case, described in the [JIRA issue](https://issues.apache.org/jira/browse/AVRO-3782).
