### PR TITLE
AVRO-3772: [Rust] Use the enum default field instead of the field default

### DIFF
--- a/lang/rust/avro/src/error.rs
+++ b/lang/rust/avro/src/error.rs
@@ -310,6 +310,9 @@ pub enum Error {
     #[error("Duplicate enum symbol {0}")]
     EnumSymbolDuplicate(String),
 
+    #[error("Default value for enum must be a string! Got: {0}")]
+    EnumDefaultWrongType(serde_json::Value),
+
     #[error("No `items` in array")]
     GetArrayItemsField,
 

--- a/lang/rust/avro/src/schema_compatibility.rs
+++ b/lang/rust/avro/src/schema_compatibility.rs
@@ -912,7 +912,7 @@ mod tests {
     }
 
     #[test]
-    fn avro_3772_enum_default() -> TestResult {
+    fn test_avro_3772_enum_default() -> TestResult {
         let writer_raw_schema = r#"
         {
           "type": "record",
@@ -925,9 +925,9 @@ mod tests {
               "type": {
                 "type": "enum",
                 "name": "suit",
-                "symbols": ["diamonds", "spades", "clubs", "hearts"]
-              },
-              "default": "spades"
+                "symbols": ["diamonds", "spades", "clubs", "hearts"],
+                "default": "spades"
+              }
             }
           ]
         }
@@ -944,10 +944,10 @@ mod tests {
               "name": "c",
               "type": {
                  "type": "enum",
-                "name": "suit",
-                  "symbols": ["diamonds", "spades", "ninja", "hearts"]
-              },
-              "default": "spades"
+                 "name": "suit",
+                 "symbols": ["diamonds", "spades", "ninja", "hearts"],
+                 "default": "spades"
+              }
             }
           ]
         }
@@ -976,7 +976,7 @@ mod tests {
     }
 
     #[test]
-    fn avro_3772_enum_default_less_symbols() -> TestResult {
+    fn test_avro_3772_enum_default_less_symbols() -> TestResult {
         let writer_raw_schema = r#"
         {
           "type": "record",
@@ -989,9 +989,9 @@ mod tests {
               "type": {
                 "type": "enum",
                 "name": "suit",
-                "symbols": ["diamonds", "spades", "clubs", "hearts"]
-              },
-              "default": "spades"
+                "symbols": ["diamonds", "spades", "clubs", "hearts"],
+                "default": "spades"
+              }
             }
           ]
         }
@@ -1008,10 +1008,10 @@ mod tests {
               "name": "c",
               "type": {
                  "type": "enum",
-                "name": "suit",
-                  "symbols": ["hearts", "spades"]
-              },
-              "default": "spades"
+                  "name": "suit",
+                  "symbols": ["hearts", "spades"],
+                  "default": "spades"
+              }
             }
           ]
         }

--- a/lang/rust/avro_derive/src/lib.rs
+++ b/lang/rust/avro_derive/src/lib.rs
@@ -222,6 +222,7 @@ fn get_data_enum_schema_def(
                 aliases: #enum_aliases,
                 doc: #doc,
                 symbols: vec![#(#symbols.to_owned()),*],
+                default: None,
                 attributes: Default::default(),
             })
         })


### PR DESCRIPTION

AVRO-3772

## What is the purpose of the change

* During schema resolution use the enum's `default` field instead of the field's default

## Verifying this change

* All tests should pass
 
## Documentation

- Does this pull request introduce a new feature? no
