### PR TITLE
[Rust]: Update Strum to 0.25.0

### DIFF
--- a/lang/rust/Cargo.lock
+++ b/lang/rust/Cargo.lock
@@ -471,9 +471,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hello-wasm"
@@ -918,21 +918,21 @@ checksum = "5e9f0ab6ef7eb7353d9119c170a436d1bf248eea575ac42d19d12f4e34130831"
 
 [[package]]
 name = "strum"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 
 [[package]]
 name = "strum_macros"
-version = "0.24.3"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+checksum = "fe9f3bd7d2e45dcc5e265fbb88d6513e4747d8ef9444cf01a533119bce28a157"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]

--- a/lang/rust/avro/Cargo.toml
+++ b/lang/rust/avro/Cargo.toml
@@ -67,8 +67,8 @@ regex = { default-features = false, version = "1.8.4", features = ["std", "perf"
 serde = { default-features = false, version = "1.0.164", features = ["derive"] }
 serde_json = { default-features = false, version = "1.0.97", features = ["std"] }
 snap = { default-features = false, version = "1.1.0", optional = true }
-strum = { default-features = false, version = "0.24.1" }
-strum_macros = { default-features = false, version = "0.24.3" }
+strum = { default-features = false, version = "0.25.0" }
+strum_macros = { default-features = false, version = "0.25.0" }
 thiserror = { default-features = false, version = "1.0.40" }
 typed-builder = { default-features = false, version = "0.14.0" }
 uuid = { default-features = false, version = "1.3.4", features = ["serde", "std"] }


### PR DESCRIPTION
It is based on syn 2.x

No Jira: I'd let dependabot provide the PR but since 1.11.2 could be cut any time now I open this PR myself.