### PR TITLE
AVRO-3781: [Rust] Enhance Decimal resolve

### DIFF
--- a/lang/rust/avro/src/decimal.rs
+++ b/lang/rust/avro/src/decimal.rs
@@ -63,21 +63,26 @@ impl Decimal {
 
     /// Converts from f32 by converting number to string firstly, then parsing it.
     pub(crate) fn try_from_f32(num: f32) -> Result<Self, DecimalParsingError> {
-        if !num.is_finite() {}
+        if num.is_infinite() {
+            return Err(DecimalParsingError::InfiniteFloat);
+        }
         let string = num.to_string();
         string.parse()
     }
 
     /// Converts from f64 by converting number to string firstly, then parsing it.
     pub(crate) fn try_from_f64(num: f64) -> Result<Self, DecimalParsingError> {
+        if num.is_infinite() {
+            return Err(DecimalParsingError::InfiniteFloat);
+        }
         let string = num.to_string();
         string.parse()
     }
 
     /// Returns digits amount of the `self`.
     pub(crate) fn digits(&self) -> u64 {
-        // Since `num_bigint` crate has such an absurd amount of the encapsulation,
-        // we can't really get to the amount of digits directly, so we have to use `bits` and compute length ourselves.
+        // `num_bigint` encapsulates any methods related to digits amount estimation,
+        // so we have to use `bits` and compute it ourselves.
         let mut bits = self.value.bits();
         // how many bits one digit occupies.
         let digit_bits = 64;

--- a/lang/rust/avro/src/decimal.rs
+++ b/lang/rust/avro/src/decimal.rs
@@ -17,6 +17,7 @@
 
 use crate::{AvroResult, Error};
 use num_bigint::{BigInt, Sign};
+use thiserror::Error;
 
 #[derive(Debug, Clone)]
 pub struct Decimal {
@@ -52,6 +53,11 @@ impl Decimal {
         })?;
         decimal_bytes[start_byte_index..].copy_from_slice(&raw_bytes);
         Ok(decimal_bytes)
+    }
+
+    fn from_bigint(bigint: BigInt) -> Self {
+        let len = (bigint.bits() as f64 / 8.0).ceil() as usize;
+        Self { value: bigint, len }
     }
 }
 
@@ -104,6 +110,87 @@ impl<T: AsRef<[u8]>> From<T> for Decimal {
         }
     }
 }
+#[derive(Debug, Copy, Clone, Error, PartialEq)]
+pub enum DecimalExtractionError {
+    #[error("Exponent of decimal number is invalid - either incomplete or malformed")]
+    MalformedExponent,
+
+    #[error("Unexpected symbol occurred: {}", .0)]
+    UnexpectedSymbol(char),
+
+    #[error("Failed to initialize bigint to represent decimal")]
+    BigIntInitializeFailed,
+}
+
+/// Extract decimal as bigint from string representation of floating point number.
+fn parse_decimal(source: &str) -> Result<Decimal, DecimalExtractionError> {
+    let mut be_digits = Vec::<u8>::new();
+    let mut sign = Sign::Plus;
+
+    // amount of digits before dot.
+    let mut dot_position = None;
+
+    let mut exponent = None;
+
+    for (index, symbol) in source.chars().enumerate() {
+        match (index, symbol) {
+            (0, '+') => {
+                sign = Sign::Plus;
+            }
+            (0, '-') => {
+                sign = Sign::Minus;
+            }
+            // add digit to the resulting vec.
+            (_, symbol) if symbol.is_ascii_digit() => {
+                be_digits.push(symbol.to_digit(10).unwrap() as u8)
+            }
+            (_, '.') => {
+                // dot was already met.
+                if dot_position.is_some() {
+                    return Err(DecimalExtractionError::UnexpectedSymbol('.'));
+                }
+                dot_position = Some(be_digits.len());
+            }
+            (index, 'e' | 'E') => {
+                // no digits after exponent.
+                if index == source.len() - 1 {
+                    return Err(DecimalExtractionError::MalformedExponent);
+                }
+                let parsed_exponent: i64 = source[index + 1..]
+                    .parse()
+                    .map_err(|_| DecimalExtractionError::MalformedExponent)?;
+                exponent = Some(parsed_exponent);
+                // we must exist the loop, as exponent is always the end of the float.
+                break;
+            }
+            (_, symbol) => return Err(DecimalExtractionError::UnexpectedSymbol(symbol)),
+        }
+    }
+
+    let trailing_zeroes = exponent
+        .into_iter()
+        // we only care about positive exponent, as it add trailing zeroes to the final number.
+        .filter(|exponent| exponent > &0)
+        .map(|exponent| exponent as usize)
+        // determine, how much zeroes would exponent contribute.
+        .map(|exponent| {
+            if let Some(dot_position) = dot_position {
+                exponent.saturating_sub(be_digits.len() - dot_position)
+            } else {
+                exponent
+            }
+        })
+        .next()
+        .unwrap_or_default();
+
+    // add trailing zeroes.
+    be_digits.extend(std::iter::repeat(0).take(trailing_zeroes));
+
+    let bigint = BigInt::from_radix_be(sign, &be_digits, 10)
+        .ok_or(DecimalExtractionError::BigIntInitializeFailed)?;
+
+    Ok(Decimal::from_bigint(bigint))
+}
 
 #[cfg(test)]
 mod tests {
@@ -130,6 +217,100 @@ mod tests {
 
         let output = <Vec<u8>>::try_from(d)?;
         assert_eq!(output, input);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_decimal_from_string() -> TestResult {
+        #[derive(Debug)]
+        struct TestCase<'a> {
+            source: &'a str,
+            expected: Option<&'a str>,
+        }
+
+        impl<'a> TestCase<'a> {
+            fn exec(&self) {
+                let result = parse_decimal(self.source).map(|result| result.value.to_string());
+                assert_eq!(
+                    result.clone().ok(),
+                    self.expected.map(|value| value.to_string()),
+                    "test case({self:?}) failed, parsing result is: {result:?}"
+                );
+            }
+        }
+
+        // these are two "compatible" decimals - they have the same BigInt representation.
+        let huge_decimal = format!("1123456789{}", "0".repeat(10_000));
+        let decimal_with_explicit_huge_scale = format!("1.123456789{}", "0".repeat(10_000));
+
+        let success_cases = vec![
+            TestCase {
+                source: "123",
+                expected: Some("123"),
+            },
+            TestCase {
+                source: "1.1",
+                expected: Some("11"),
+            },
+            // even malformed float ideally should be working, as, for example, f64 would allow that.
+            TestCase {
+                source: "000001.1",
+                expected: Some("11"),
+            },
+            TestCase {
+                source: "1.",
+                expected: Some("1"),
+            },
+            TestCase {
+                source: ".1",
+                expected: Some("1"),
+            },
+            // exponent must compensate scale.
+            TestCase {
+                source: "1.123456789e10009",
+                expected: Some(&huge_decimal),
+            },
+            TestCase {
+                source: &decimal_with_explicit_huge_scale,
+                expected: Some(&huge_decimal),
+            },
+            TestCase {
+                source: "1e5",
+                expected: Some("100000"),
+            },
+            TestCase {
+                source: "1e-5",
+                expected: Some("1"),
+            },
+            TestCase {
+                source: "-12345.6789",
+                expected: Some("-123456789"),
+            },
+            TestCase {
+                source: "-1e+5",
+                expected: Some("-100000"),
+            },
+        ];
+
+        for case in success_cases {
+            case.exec()
+        }
+
+        let failures = vec![
+            TestCase {
+                source: "1.ee",
+                expected: None,
+            },
+            TestCase {
+                source: "+-+1.2",
+                expected: None,
+            },
+        ];
+
+        for case in failures {
+            case.exec()
+        }
 
         Ok(())
     }

--- a/lang/rust/avro/src/decimal.rs
+++ b/lang/rust/avro/src/decimal.rs
@@ -36,10 +36,6 @@ impl PartialEq for Decimal {
 }
 
 impl Decimal {
-    pub(crate) fn len(&self) -> usize {
-        self.len
-    }
-
     fn to_vec(&self) -> AvroResult<Vec<u8>> {
         self.to_sign_extended_bytes_with_len(self.len)
     }
@@ -78,13 +74,17 @@ impl Decimal {
         string.parse()
     }
 
-    /// Returns byte size of the inner `BigInt`.
-    pub(crate) fn inner_byte_size(&self) -> u64 {
+    /// Returns digits amount of the `self`.
+    pub(crate) fn digits(&self) -> u64 {
+        // Since `num_bigint` crate has such an absurd amount of the encapsulation,
+        // we can't really get to the amount of digits directly, so we have to use `bits` and compute length ourselves.
         let mut bits = self.value.bits();
-        if bits % 8 != 0 {
-            bits += 8;
+        // how many bits one digit occupies.
+        let digit_bits = 64;
+        if bits % digit_bits != 0 {
+            bits += digit_bits;
         }
-        bits / 8
+        bits / digit_bits
     }
 }
 

--- a/lang/rust/avro/src/decimal.rs
+++ b/lang/rust/avro/src/decimal.rs
@@ -77,6 +77,15 @@ impl Decimal {
         let string = num.to_string();
         string.parse()
     }
+
+    /// Returns byte size of the inner `BigInt`.
+    pub(crate) fn inner_byte_size(&self) -> u64 {
+        let mut bits = self.value.bits();
+        if bits % 8 != 0 {
+            bits += 8;
+        }
+        bits / 8
+    }
 }
 
 impl From<Decimal> for BigInt {

--- a/lang/rust/avro/src/error.rs
+++ b/lang/rust/avro/src/error.rs
@@ -134,6 +134,9 @@ pub enum Error {
     #[error("Precision {precision} too small to hold decimal values with {num_bytes} bytes")]
     ComparePrecisionAndSize { precision: usize, num_bytes: usize },
 
+    #[error("Precision {precision} too small to afford decimal with {digits} digits")]
+    ComparePrecisionAndLength { precision: usize, digits: usize },
+
     #[error("Cannot convert length to i32: {1}")]
     ConvertLengthToI32(#[source] std::num::TryFromIntError, usize),
 

--- a/lang/rust/avro/src/error.rs
+++ b/lang/rust/avro/src/error.rs
@@ -16,8 +16,9 @@
 // under the License.
 
 use crate::{
+    decimal::DecimalParsingError,
     schema::{Name, SchemaKind},
-    types::ValueKind, decimal::DecimalExtractionError,
+    types::ValueKind,
 };
 use std::fmt;
 
@@ -446,8 +447,8 @@ pub enum Error {
     #[error("Invalid Avro data! Cannot read codec type from value that is not Value::Bytes.")]
     BadCodecMetadata,
 
-    #[error("Decimal could not be extracted")]
-    DecimalExtraction(#[source] DecimalExtractionError)
+    #[error("Decimal could not be parsed")]
+    DecimalParsing(#[from] DecimalParsingError),
 }
 
 impl serde::ser::Error for Error {

--- a/lang/rust/avro/src/error.rs
+++ b/lang/rust/avro/src/error.rs
@@ -17,7 +17,7 @@
 
 use crate::{
     schema::{Name, SchemaKind},
-    types::ValueKind,
+    types::ValueKind, decimal::DecimalExtractionError,
 };
 use std::fmt;
 
@@ -445,6 +445,9 @@ pub enum Error {
 
     #[error("Invalid Avro data! Cannot read codec type from value that is not Value::Bytes.")]
     BadCodecMetadata,
+
+    #[error("Decimal could not be extracted")]
+    DecimalExtraction(#[source] DecimalExtractionError)
 }
 
 impl serde::ser::Error for Error {

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -721,7 +721,6 @@ impl Value {
                 digits: digits_amount as usize,
             });
         }
-        // check num.bits() here
 
         Ok(decimal.into())
     }

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -717,6 +717,7 @@ impl Value {
                     Ok(Value::Decimal(Decimal::from(bytes)))
                 }
             }
+
             other => Err(Error::ResolveDecimal(other.into())),
         }
     }

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -713,11 +713,12 @@ impl Value {
             other => Err(Error::ResolveDecimal(other.into())),
         }?;
 
-        let size = decimal.inner_byte_size();
-        if max_prec_for_len(size as usize)? > precision {
-            return Err(Error::ComparePrecisionAndSize {
+        let digits_amount = decimal.digits();
+
+        if digits_amount > precision as u64 {
+            return Err(Error::ComparePrecisionAndLength {
                 precision,
-                num_bytes: size as usize,
+                digits: digits_amount as usize,
             });
         }
         // check num.bits() here


### PR DESCRIPTION
This PR solves [issue](https://issues.apache.org/jira/browse/AVRO-3781).

What was done:
1) Now decimals could be resolved from strings and floats;
2) Add special algorithm for string parsing into appropriate bigint;
3) Floats parsing is done via converting to string first, then to the bigint through the string parsing algorithm.
4) Add method for estimating the precision of the decimal - in other words, added a method to check the amount of bigint digits.