### PR TITLE
AVRO-3792 [java]: Fix comparison of Maps within GenericData (java).

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/generic/GenericData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/generic/GenericData.java
@@ -1174,11 +1174,11 @@ public class GenericData {
   }
 
   protected int compareMaps(final Map<?, ?> m1, final Map<?, ?> m2) {
-    if (m1 == m2) {
+    if (m1 == m2 || (m1.isEmpty() && m2.isEmpty())) {
       return 0;
     }
 
-    if (m2.size() != m2.size()) {
+    if (m1.size() != m2.size()) {
       return 1;
     }
 

--- a/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericData.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericData.java
@@ -566,6 +566,73 @@ public class TestGenericData {
   }
 
   @Test
+  void mapCompareMatch() {
+    Schema mapSchema = Schema.createMap(Schema.create(Type.STRING));
+    List<Field> fields = new ArrayList<>();
+    fields.add(new Field("map", mapSchema, null, null));
+
+    Schema schema = Schema.createRecord("Foo", "test", "mytest", false);
+    schema.setFields(fields);
+
+    Map<String, String> map1 = new HashMap<>();
+    map1.put("dummy", "foo");
+
+    Map<String, String> map2 = new HashMap<>();
+    map1.put("dummy", "foo");
+
+    Record testRecord1 = new Record(schema);
+    testRecord1.put("map", map1);
+    Record testRecord2 = new Record(schema);
+    testRecord2.put("map", map2);
+
+    assertEquals(0, testRecord1.compareTo(testRecord2));
+  }
+
+  @Test
+  void mapCompareMismatch() {
+    Schema mapSchema = Schema.createMap(Schema.create(Type.STRING));
+    List<Field> fields = new ArrayList<>();
+    fields.add(new Field("map", mapSchema, null, null));
+
+    Schema schema = Schema.createRecord("Foo", "test", "mytest", false);
+    schema.setFields(fields);
+
+    Map<String, String> map1 = new HashMap<>();
+    map1.put("dummy", "foo");
+
+    Map<String, String> map2 = new HashMap<>();
+    map1.put("dummy", "foo");
+    map1.put("dummy2", "bar");
+
+    Record testRecord1 = new Record(schema);
+    testRecord1.put("map", map1);
+    Record testRecord2 = new Record(schema);
+    testRecord2.put("map", map2);
+
+    assertNotEquals(0, testRecord1.compareTo(testRecord2));
+  }
+
+  @Test
+  void mapCompareEmptyMatch() {
+    Schema mapSchema = Schema.createMap(Schema.create(Type.STRING));
+    List<Field> fields = new ArrayList<>();
+    fields.add(new Field("map", mapSchema, null, null));
+
+    Schema schema = Schema.createRecord("Foo", "test", "mytest", false);
+    schema.setFields(fields);
+
+    Map<String, String> map1 = new HashMap<>();
+    Map<String, String> map2 = new HashMap<>();
+
+    Record testRecord1 = new Record(schema);
+    testRecord1.put("map", map1);
+    Record testRecord2 = new Record(schema);
+    testRecord2.put("map", map2);
+
+    assertEquals(0, testRecord1.compareTo(testRecord2));
+  }
+
+  @Test
   void byteBufferDeepCopy() {
     // Test that a deep copy of a byte buffer respects the byte buffer
     // limits and capacity.


### PR DESCRIPTION
## What is the purpose of the change

2 bugs in comparing Maps within GenericData: 
* Comparison of size incorrectly compared map1 with map1 not map1 with map2. 
* When maps are empty an exception is incorrectly thrown (iterator().next() fails in that instance).

## Verifying this change

This change added unit tests for empty and mismatched size maps.

## Documentation

- Does this pull request introduce a new feature? no