### PR TITLE
AVRO-3793: [Rust] Bump minimum supported version of Rust to 1.65.0

### DIFF
--- a/.github/workflows/test-lang-rust-ci.yml
+++ b/.github/workflows/test-lang-rust-ci.yml
@@ -43,7 +43,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.60.0  # MSRV
+          - 1.65.0  # MSRV
         target:
           - x86_64-unknown-linux-gnu
           - wasm32-unknown-unknown

--- a/BUILD.md
+++ b/BUILD.md
@@ -17,7 +17,7 @@ The following packages must be installed before Avro can be built:
    Math::BigInt, JSON::XS, Try::Tiny, Regexp::Common, Encode,
    IO::String, Object::Tiny, Compress::ZLib, Error::Simple,
    Test::More, Test::Exception, Test::Pod
- - Rust: rustc and Cargo 1.60.0 or greater
+ - Rust: rustc and Cargo 1.65.0 or greater
  - Apache Ant 1.7
  - md5sum, sha1sum, used by top-level dist target
 

--- a/lang/rust/Cargo.toml
+++ b/lang/rust/Cargo.toml
@@ -25,3 +25,15 @@ members = [
 exclude = [
     "fuzz"
 ]
+
+[workspace.package]
+version = "0.15.0"
+authors = ["Apache Avro team <dev@avro.apache.org>"]
+license = "Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/apache/avro"
+edition = "2021"
+rust-version = "1.65.0"
+keywords = ["avro", "data", "serialization"]
+categories = ["encoding"]
+documentation = "https://docs.rs/apache-avro"

--- a/lang/rust/avro/Cargo.toml
+++ b/lang/rust/avro/Cargo.toml
@@ -17,17 +17,17 @@
 
 [package]
 name = "apache-avro"
-version = "0.15.0"
-authors = ["Apache Avro team <dev@avro.apache.org>"]
 description = "A library for working with Apache Avro in Rust"
-license = "Apache-2.0"
-readme = "README.md"
-repository = "https://github.com/apache/avro"
-edition = "2021"
-rust-version = "1.60.0"
-keywords = ["avro", "data", "serialization"]
-categories = ["encoding"]
-documentation = "https://docs.rs/apache-avro"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+keywords.workspace = true
+categories.workspace = true
+documentation.workspace = true
 
 [features]
 bzip = ["bzip2"]

--- a/lang/rust/avro/README.md
+++ b/lang/rust/avro/README.md
@@ -644,7 +644,7 @@ assert_eq!(false, SchemaCompatibility::can_read(&writers_schema, &readers_schema
 
 ## Minimal supported Rust version
 
-1.60.0
+1.65.0
 
 ## License
 This project is licensed under [Apache License 2.0](https://github.com/apache/avro/blob/master/LICENSE.txt).

--- a/lang/rust/avro_derive/Cargo.toml
+++ b/lang/rust/avro_derive/Cargo.toml
@@ -17,16 +17,16 @@
 
 [package]
 name = "apache-avro-derive"
-version = "0.15.0"
-authors = ["Apache Avro team <dev@avro.apache.org>"]
+version.workspace = true
+authors.workspace = true
 description = "A library for deriving Avro schemata from Rust structs and enums"
-license = "Apache-2.0"
-readme = "README.md"
-repository = "https://github.com/apache/avro"
-edition = "2021"
-rust-version = "1.60.0"
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 keywords = ["avro", "data", "serialization", "derive"]
-categories = ["encoding"]
+categories.workspace = true
 documentation = "https://docs.rs/apache-avro-derive"
 
 [lib]

--- a/lang/rust/avro_test_helper/Cargo.toml
+++ b/lang/rust/avro_test_helper/Cargo.toml
@@ -17,16 +17,16 @@
 
 [package]
 name = "apache-avro-test-helper"
-version = "0.15.0"
-edition = "2021"
-rust-version = "1.60.0"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 description = "Apache Avro tests helper."
-authors = ["Apache Avro team <dev@avro.apache.org>"]
-license = "Apache-2.0"
-readme = "README.md"
-repository = "https://github.com/apache/avro"
+authors.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 keywords = ["avro", "data", "serialization", "test"]
-categories = ["encoding"]
+categories.workspace = true
 documentation = "https://docs.rs/apache-avro-test-helper"
 
 

--- a/lang/rust/fuzz/Cargo.toml
+++ b/lang/rust/fuzz/Cargo.toml
@@ -20,7 +20,7 @@ name = "apache-avro-fuzz"
 version = "0.0.0"
 publish = false
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.65.0"
 
 [package.metadata]
 cargo-fuzz = true

--- a/lang/rust/wasm-demo/Cargo.toml
+++ b/lang/rust/wasm-demo/Cargo.toml
@@ -18,16 +18,16 @@
 [package]
 name = "hello-wasm"
 version = "0.1.0"
-authors = ["Apache Avro team <dev@avro.apache.org>"]
+authors.workspace = true
 description = "A demo project for testing apache_avro in WebAssembly"
-license = "Apache-2.0"
-readme = "README.md"
-repository = "https://github.com/apache/avro"
-edition = "2021"
-rust-version = "1.60.0"
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 keywords = ["avro", "data", "serialization", "wasm", "web assembly"]
-categories = ["encoding"]
-documentation = "https://docs.rs/apache-avro"
+categories.workspace = true
+documentation.workspace = true
 publish = false
 
 

--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -187,7 +187,7 @@ RUN gem install bundler --no-document && \
     cd /tmp/lang/ruby && bundle install
 
 # Install Rust
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.60.0
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.65.0
 
 # Note: This "ubertool" container has two JDK versions:
 # - OpenJDK 8


### PR DESCRIPTION
AVRO-3793

Use [workspace.package] in the parent Cargo.toml to reduce duplication

## What is the purpose of the change

* Bump the minimum supported Rust version to 1.65.0

## Verifying this change

* Run the test suite

## Documentation

- Does this pull request introduce a new feature? no