### PR TITLE
AVRO-3794: [Rust] Do not fail the shared tests when the shared folder is not available

### DIFF
--- a/lang/rust/avro/tests/shared.rs
+++ b/lang/rust/avro/tests/shared.rs
@@ -28,8 +28,14 @@ use std::{
 const ROOT_DIRECTORY: &str = "../../../share/test/data/schemas";
 
 #[test]
-fn test_schema() -> TestResult {
-    let directory: ReadDir = scan_shared_folder();
+fn aa_test_schema() -> TestResult {
+    let directory: ReadDir = match std::fs::read_dir(ROOT_DIRECTORY) {
+        Ok(root_folder) => root_folder,
+        Err(err) => {
+            log::warn!("Can't read the root folder: {err}");
+            return Ok(());
+        }
+    };
     let mut result: Result<(), ErrorsDesc> = Ok(());
     for f in directory {
         let entry: DirEntry = match f {
@@ -142,8 +148,4 @@ fn test_folder(folder: &str) -> Result<(), ErrorsDesc> {
         }
     }
     result
-}
-
-fn scan_shared_folder() -> ReadDir {
-    std::fs::read_dir(ROOT_DIRECTORY).expect("Can't read root folder")
 }


### PR DESCRIPTION
AVRO-3794

## What is the purpose of the change

* Modifies a test to not fail when the shared folder is not available

## Verifying this change

* The tests should still pass in the CI
* The test should print a warning and succeed when the shared folder is not available for any reason

## Documentation

- Does this pull request introduce a new feature? no