### PR TITLE
AVRO-3788: escape 'code extracts' in Javadoc

### DIFF
--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
@@ -1057,7 +1057,7 @@ public class SpecificCompiler {
    * Utility for template use. Escapes comment end with HTML entities.
    */
   public static String escapeForJavadoc(String s) {
-    return s.replace("*/", "*&#47;");
+    return s.replace("*/", "*&#47;").replace("<", "&lt;").replace(">", "&gt;");
   }
 
   /**

--- a/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/record.vm
+++ b/lang/java/compiler/src/main/velocity/org/apache/avro/compiler/specific/templates/java/classic/record.vm
@@ -228,10 +228,10 @@ public class ${this.mangleTypeIdentifier($schema.getName())}#if ($schema.isError
 #foreach ($field in $schema.getFields())
 #if (${this.gettersReturnOptional} && (!${this.optionalGettersForNullableFieldsOnly} || ${field.schema().isNullable()}))
   /**
-   * Gets the value of the '${this.mangle($field.name(), $schema.isError())}' field as an Optional&lt;${this.javaType($field.schema())}&gt;.
+   * Gets the value of the '${this.mangle($field.name(), $schema.isError())}' field as an Optional&lt;${this.escapeForJavadoc(${this.javaType($field.schema())})}&gt;.
 #if ($field.doc())   * $field.doc()
 #end
-   * @return The value wrapped in an Optional&lt;${this.javaType($field.schema())}&gt;.
+   * @return The value wrapped in an Optional&lt;${this.escapeForJavadoc(${this.javaType($field.schema())})}&gt;.
    */
   public Optional<${this.javaType($field.schema())}> ${this.generateGetMethod($schema, $field)}() {
     return Optional.<${this.javaType($field.schema())}>ofNullable(${this.mangle($field.name(), $schema.isError())});
@@ -250,10 +250,10 @@ public class ${this.mangleTypeIdentifier($schema.getName())}#if ($schema.isError
 
 #if (${this.createOptionalGetters})
   /**
-   * Gets the value of the '${this.mangle($field.name(), $schema.isError())}' field as an Optional&lt;${this.javaType($field.schema())}&gt;.
+   * Gets the value of the '${this.mangle($field.name(), $schema.isError())}' field as an Optional&lt;${this.escapeForJavadoc(${this.javaType($field.schema())})}&gt;.
 #if ($field.doc())   * $field.doc()
 #end
-   * @return The value wrapped in an Optional&lt;${this.javaType($field.schema())}&gt;.
+   * @return The value wrapped in an Optional&lt;${this.escapeForJavadoc(${this.javaType($field.schema())})}&gt;.
    */
   public Optional<${this.javaType($field.schema())}> ${this.generateGetOptionalMethod($schema, $field)}() {
     return Optional.<${this.javaType($field.schema())}>ofNullable(${this.mangle($field.name(), $schema.isError())});
@@ -406,10 +406,10 @@ public class ${this.mangleTypeIdentifier($schema.getName())}#if ($schema.isError
 
 #if (${this.createOptionalGetters})
     /**
-      * Gets the value of the '${this.mangle($field.name(), $schema.isError())}' field as an Optional&lt;${this.javaType($field.schema())}&gt;.
+      * Gets the value of the '${this.mangle($field.name(), $schema.isError())}' field as an Optional&lt;${this.escapeForJavadoc(${this.javaType($field.schema())})}&gt;.
 #if ($field.doc())      * $field.doc()
 #end
-      * @return The value wrapped in an Optional&lt;${this.javaType($field.schema())}&gt;.
+      * @return The value wrapped in an Optional&lt;${this.escapeForJavadoc(${this.javaType($field.schema())})}&gt;.
       */
     public Optional<${this.javaType($field.schema())}> ${this.generateGetOptionalMethod($schema, $field)}() {
       return Optional.<${this.javaType($field.schema())}>ofNullable(${this.mangle($field.name(), $schema.isError())});

--- a/lang/java/tools/src/test/compiler/input/optionalgettersnullablefieldstest.avsc
+++ b/lang/java/tools/src/test/compiler/input/optionalgettersnullablefieldstest.avsc
@@ -3,6 +3,7 @@
     {"name": "name", "type": "string"},
     {"name": "nullable_name",  "type": ["string", "null"]},
     {"name": "favorite_number",  "type": ["int"]},
-    {"name": "nullable_favorite_number", "type": ["int", "null"]}
+    {"name": "nullable_favorite_number", "type": ["int", "null"]},
+    {"name": "nullable_array", "type": [{ "type": "array",  "items": "string" }, "null"]}
   ]
 }

--- a/lang/java/tools/src/test/compiler/output/OptionalGettersNullableFieldsTest.java
+++ b/lang/java/tools/src/test/compiler/output/OptionalGettersNullableFieldsTest.java
@@ -15,8 +15,10 @@ import java.util.Optional;
 /** Test that optional getters are created only for nullable fields */
 @org.apache.avro.specific.AvroGenerated
 public class OptionalGettersNullableFieldsTest extends org.apache.avro.specific.SpecificRecordBase implements org.apache.avro.specific.SpecificRecord {
-  private static final long serialVersionUID = 7830366875847294825L;
-  public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"OptionalGettersNullableFieldsTest\",\"namespace\":\"avro.examples.baseball\",\"doc\":\"Test that optional getters are created only for nullable fields\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"nullable_name\",\"type\":[\"string\",\"null\"]},{\"name\":\"favorite_number\",\"type\":[\"int\"]},{\"name\":\"nullable_favorite_number\",\"type\":[\"int\",\"null\"]}]}");
+  private static final long serialVersionUID = -6919829133416680993L;
+
+
+  public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"OptionalGettersNullableFieldsTest\",\"namespace\":\"avro.examples.baseball\",\"doc\":\"Test that optional getters are created only for nullable fields\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"nullable_name\",\"type\":[\"string\",\"null\"]},{\"name\":\"favorite_number\",\"type\":[\"int\"]},{\"name\":\"nullable_favorite_number\",\"type\":[\"int\",\"null\"]},{\"name\":\"nullable_array\",\"type\":[{\"type\":\"array\",\"items\":\"string\"},\"null\"]}]}");
   public static org.apache.avro.Schema getClassSchema() { return SCHEMA$; }
 
   private static final SpecificData MODEL$ = new SpecificData();
@@ -76,6 +78,7 @@ public class OptionalGettersNullableFieldsTest extends org.apache.avro.specific.
   private java.lang.CharSequence nullable_name;
   private java.lang.Object favorite_number;
   private java.lang.Integer nullable_favorite_number;
+  private java.util.List<java.lang.CharSequence> nullable_array;
 
   /**
    * Default constructor.  Note that this does not initialize fields
@@ -90,12 +93,14 @@ public class OptionalGettersNullableFieldsTest extends org.apache.avro.specific.
    * @param nullable_name The new value for nullable_name
    * @param favorite_number The new value for favorite_number
    * @param nullable_favorite_number The new value for nullable_favorite_number
+   * @param nullable_array The new value for nullable_array
    */
-  public OptionalGettersNullableFieldsTest(java.lang.CharSequence name, java.lang.CharSequence nullable_name, java.lang.Object favorite_number, java.lang.Integer nullable_favorite_number) {
+  public OptionalGettersNullableFieldsTest(java.lang.CharSequence name, java.lang.CharSequence nullable_name, java.lang.Object favorite_number, java.lang.Integer nullable_favorite_number, java.util.List<java.lang.CharSequence> nullable_array) {
     this.name = name;
     this.nullable_name = nullable_name;
     this.favorite_number = favorite_number;
     this.nullable_favorite_number = nullable_favorite_number;
+    this.nullable_array = nullable_array;
   }
 
   @Override
@@ -112,6 +117,7 @@ public class OptionalGettersNullableFieldsTest extends org.apache.avro.specific.
     case 1: return nullable_name;
     case 2: return favorite_number;
     case 3: return nullable_favorite_number;
+    case 4: return nullable_array;
     default: throw new IndexOutOfBoundsException("Invalid index: " + field$);
     }
   }
@@ -125,6 +131,7 @@ public class OptionalGettersNullableFieldsTest extends org.apache.avro.specific.
     case 1: nullable_name = (java.lang.CharSequence)value$; break;
     case 2: favorite_number = value$; break;
     case 3: nullable_favorite_number = (java.lang.Integer)value$; break;
+    case 4: nullable_array = (java.util.List<java.lang.CharSequence>)value$; break;
     default: throw new IndexOutOfBoundsException("Invalid index: " + field$);
     }
   }
@@ -198,6 +205,23 @@ public class OptionalGettersNullableFieldsTest extends org.apache.avro.specific.
   }
 
   /**
+   * Gets the value of the 'nullable_array' field as an Optional&lt;java.util.List&lt;java.lang.CharSequence&gt;&gt;.
+   * @return The value wrapped in an Optional&lt;java.util.List&lt;java.lang.CharSequence&gt;&gt;.
+   */
+  public Optional<java.util.List<java.lang.CharSequence>> getNullableArray() {
+    return Optional.<java.util.List<java.lang.CharSequence>>ofNullable(nullable_array);
+  }
+
+
+  /**
+   * Sets the value of the 'nullable_array' field.
+   * @param value the value to set.
+   */
+  public void setNullableArray(java.util.List<java.lang.CharSequence> value) {
+    this.nullable_array = value;
+  }
+
+  /**
    * Creates a new OptionalGettersNullableFieldsTest RecordBuilder.
    * @return A new OptionalGettersNullableFieldsTest RecordBuilder
    */
@@ -242,6 +266,7 @@ public class OptionalGettersNullableFieldsTest extends org.apache.avro.specific.
     private java.lang.CharSequence nullable_name;
     private java.lang.Object favorite_number;
     private java.lang.Integer nullable_favorite_number;
+    private java.util.List<java.lang.CharSequence> nullable_array;
 
     /** Creates a new Builder */
     private Builder() {
@@ -270,6 +295,10 @@ public class OptionalGettersNullableFieldsTest extends org.apache.avro.specific.
         this.nullable_favorite_number = data().deepCopy(fields()[3].schema(), other.nullable_favorite_number);
         fieldSetFlags()[3] = other.fieldSetFlags()[3];
       }
+      if (isValidValue(fields()[4], other.nullable_array)) {
+        this.nullable_array = data().deepCopy(fields()[4].schema(), other.nullable_array);
+        fieldSetFlags()[4] = other.fieldSetFlags()[4];
+      }
     }
 
     /**
@@ -293,6 +322,10 @@ public class OptionalGettersNullableFieldsTest extends org.apache.avro.specific.
       if (isValidValue(fields()[3], other.nullable_favorite_number)) {
         this.nullable_favorite_number = data().deepCopy(fields()[3].schema(), other.nullable_favorite_number);
         fieldSetFlags()[3] = true;
+      }
+      if (isValidValue(fields()[4], other.nullable_array)) {
+        this.nullable_array = data().deepCopy(fields()[4].schema(), other.nullable_array);
+        fieldSetFlags()[4] = true;
       }
     }
 
@@ -456,6 +489,46 @@ public class OptionalGettersNullableFieldsTest extends org.apache.avro.specific.
       return this;
     }
 
+    /**
+      * Gets the value of the 'nullable_array' field.
+      * @return The value.
+      */
+    public java.util.List<java.lang.CharSequence> getNullableArray() {
+      return nullable_array;
+    }
+
+
+    /**
+      * Sets the value of the 'nullable_array' field.
+      * @param value The value of 'nullable_array'.
+      * @return This builder.
+      */
+    public avro.examples.baseball.OptionalGettersNullableFieldsTest.Builder setNullableArray(java.util.List<java.lang.CharSequence> value) {
+      validate(fields()[4], value);
+      this.nullable_array = value;
+      fieldSetFlags()[4] = true;
+      return this;
+    }
+
+    /**
+      * Checks whether the 'nullable_array' field has been set.
+      * @return True if the 'nullable_array' field has been set, false otherwise.
+      */
+    public boolean hasNullableArray() {
+      return fieldSetFlags()[4];
+    }
+
+
+    /**
+      * Clears the value of the 'nullable_array' field.
+      * @return This builder.
+      */
+    public avro.examples.baseball.OptionalGettersNullableFieldsTest.Builder clearNullableArray() {
+      nullable_array = null;
+      fieldSetFlags()[4] = false;
+      return this;
+    }
+
     @Override
     @SuppressWarnings("unchecked")
     public OptionalGettersNullableFieldsTest build() {
@@ -465,6 +538,7 @@ public class OptionalGettersNullableFieldsTest extends org.apache.avro.specific.
         record.nullable_name = fieldSetFlags()[1] ? this.nullable_name : (java.lang.CharSequence) defaultValue(fields()[1]);
         record.favorite_number = fieldSetFlags()[2] ? this.favorite_number :  defaultValue(fields()[2]);
         record.nullable_favorite_number = fieldSetFlags()[3] ? this.nullable_favorite_number : (java.lang.Integer) defaultValue(fields()[3]);
+        record.nullable_array = fieldSetFlags()[4] ? this.nullable_array : (java.util.List<java.lang.CharSequence>) defaultValue(fields()[4]);
         return record;
       } catch (org.apache.avro.AvroMissingFieldException e) {
         throw e;


### PR DESCRIPTION
<!--

*Thank you very much for contributing to Apache Avro - we are happy that you want to help us improve Avro. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Avro a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/AVRO/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "AVRO-XXXX: [component] Title of the pull request", where *AVRO-XXXX* should be replaced by the actual issue number. 
    The *component* is optional, but can help identify the correct reviewers faster: either the language ("java", "python") or subsystem such as "build" or "doc" are good candidates.  

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests. You can [build the entire project](https://github.com/apache/avro/blob/master/BUILD.md) or just the [language-specific SDK](https://avro.apache.org/project/how-to-contribute/#unit-tests).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Every commit message references Jira issues in their subject lines. In addition, commits follow the guidelines from [How to write a good git commit message](https://chris.beams.io/posts/git-commit/)
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

-->

## What is the purpose of the change

[AVRO-3788](https://issues.apache.org/jira/browse/AVRO-3788) : fix issue for generated java doc, to replace charater < by &lt; and > by &gt;


## Verifying this change

Unit test **TestSpecificCompilerTool.compileSchemaWithOptionalGettersForNullableFieldsOnly** has been augmented to add nullable array (by modifying optionalgettersnullablefieldstest.avsc file)


## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)
