### PR TITLE
AVRO-3796: Use Property Decorator

### DIFF
--- a/lang/py/avro/ipc.py
+++ b/lang/py/avro/ipc.py
@@ -77,26 +77,40 @@ class BaseRequestor:
         self._send_protocol = None
 
     # read-only properties
-    local_protocol = property(lambda self: self._local_protocol)
-    transceiver = property(lambda self: self._transceiver)
+    @property
+    def local_protocol(self):
+        return self._local_protocol
+
+    @property
+    def transceiver(self):
+        return self._transceiver
 
     # read/write properties
-    def set_remote_protocol(self, new_remote_protocol):
+    @property
+    def remote_protocol(self):
+        return self._remote_protocol
+
+    @remote_protocol.setter
+    def remote_protocol(self, new_remote_protocol):
         self._remote_protocol = new_remote_protocol
         REMOTE_PROTOCOLS[self.transceiver.remote_name] = self.remote_protocol
 
-    remote_protocol = property(lambda self: self._remote_protocol, set_remote_protocol)
+    @property
+    def remote_hash(self):
+        return self._remote_hash
 
-    def set_remote_hash(self, new_remote_hash):
+    @remote_hash.setter
+    def remote_hash(self, new_remote_hash):
         self._remote_hash = new_remote_hash
         REMOTE_HASHES[self.transceiver.remote_name] = self.remote_hash
 
-    remote_hash = property(lambda self: self._remote_hash, set_remote_hash)
+    @property
+    def send_protocol(self):
+        return self._send_protocol
 
-    def set_send_protocol(self, new_send_protocol):
+    @send_protocol.setter
+    def send_protocol(self, new_send_protocol):
         self._send_protocol = new_send_protocol
-
-    send_protocol = property(lambda self: self._send_protocol, set_send_protocol)
 
     def request(self, message_name, request_datum):
         """
@@ -236,9 +250,17 @@ class Responder:
         self.set_protocol_cache(self.local_hash, self.local_protocol)
 
     # read-only properties
-    local_protocol = property(lambda self: self._local_protocol)
-    local_hash = property(lambda self: self._local_hash)
-    protocol_cache = property(lambda self: self._protocol_cache)
+    @property
+    def local_protocol(self):
+        return self._local_protocol
+
+    @property
+    def local_hash(self):
+        return self._local_hash
+
+    @property
+    def protocol_cache(self):
+        return self._protocol_cache
 
     # utility functions to manipulate protocol cache
     def get_protocol_cache(self, hash):
@@ -371,7 +393,9 @@ class FramedReader:
         self._reader = reader
 
     # read-only properties
-    reader = property(lambda self: self._reader)
+    @property
+    def reader(self):
+        return self._reader
 
     def read_framed_message(self):
         message = []
@@ -401,7 +425,9 @@ class FramedWriter:
         self._writer = writer
 
     # read-only properties
-    writer = property(lambda self: self._writer)
+    @property
+    def writer(self):
+        return self._writer
 
     def write_framed_message(self, message):
         message_length = len(message)

--- a/lang/py/avro/schema.py
+++ b/lang/py/avro/schema.py
@@ -276,9 +276,17 @@ class NamedSchema(Schema):
         return self.name if self.namespace == names.default_namespace else self.fullname
 
     # read-only properties
-    name = property(lambda self: self.get_prop("name"))
-    namespace = property(lambda self: self.get_prop("namespace"))
-    fullname = property(lambda self: self._fullname)
+    @property
+    def name(self):
+        return self.get_prop("name")
+
+    @property
+    def namespace(self):
+        return self.get_prop("namespace")
+
+    @property
+    def fullname(self):
+        return self._fullname
 
 
 #
@@ -347,10 +355,21 @@ class Field(CanonicalPropertiesMixin, EqualByJsonMixin):
             self.set_prop("doc", doc)
 
     # read-only properties
-    default = property(lambda self: self.get_prop("default"))
-    has_default = property(lambda self: self._has_default)
-    order = property(lambda self: self.get_prop("order"))
-    doc = property(lambda self: self.get_prop("doc"))
+    @property
+    def default(self):
+        return self.get_prop("default")
+
+    @property
+    def has_default(self):
+        return self._has_default
+
+    @property
+    def order(self):
+        return self.get_prop("order")
+
+    @property
+    def doc(self):
+        return self.get_prop("doc")
 
     def __str__(self):
         return json.dumps(self.to_json())
@@ -449,8 +468,13 @@ class BytesDecimalSchema(PrimitiveSchema, DecimalLogicalSchema):
         self.set_prop("scale", scale)
 
     # read-only properties
-    precision = property(lambda self: self.get_prop("precision"))
-    scale = property(lambda self: self.get_prop("scale"))
+    @property
+    def precision(self):
+        return self.get_prop("precision")
+
+    @property
+    def scale(self):
+        return self.get_prop("scale")
 
     def to_json(self, names=None):
         return self.props
@@ -477,7 +501,9 @@ class FixedSchema(EqualByPropsMixin, NamedSchema):
         self.set_prop("size", size)
 
     # read-only properties
-    size = property(lambda self: self.get_prop("size"))
+    @property
+    def size(self):
+        return self.get_prop("size")
 
     def match(self, writer):
         """Return True if the current schema (as reader) matches the writer schema.
@@ -531,8 +557,13 @@ class FixedDecimalSchema(FixedSchema, DecimalLogicalSchema):
         self.set_prop("scale", scale)
 
     # read-only properties
-    precision = property(lambda self: self.get_prop("precision"))
-    scale = property(lambda self: self.get_prop("scale"))
+    @property
+    def precision(self):
+        return self.get_prop("precision")
+
+    @property
+    def scale(self):
+        return self.get_prop("scale")
 
     def to_json(self, names=None):
         return self.props
@@ -587,7 +618,9 @@ class EnumSchema(EqualByPropsMixin, NamedSchema):
             return symbols
         raise Exception
 
-    doc = property(lambda self: self.get_prop("doc"))
+    @property
+    def doc(self):
+        return self.get_prop("doc")
 
     def match(self, writer):
         """Return True if the current schema (as reader) matches the writer schema.
@@ -645,7 +678,9 @@ class ArraySchema(EqualByJsonMixin, Schema):
         self.set_prop("items", items_schema)
 
     # read-only properties
-    items = property(lambda self: self.get_prop("items"))
+    @property
+    def items(self):
+        return self.get_prop("items")
 
     def match(self, writer):
         """Return True if the current schema (as reader) matches the writer schema.
@@ -697,7 +732,9 @@ class MapSchema(EqualByJsonMixin, Schema):
         self.set_prop("values", values_schema)
 
     # read-only properties
-    values = property(lambda self: self.get_prop("values"))
+    @property
+    def values(self):
+        return self.get_prop("values")
 
     def match(self, writer):
         """Return True if the current schema (as reader) matches the writer schema.
@@ -766,7 +803,9 @@ class UnionSchema(EqualByJsonMixin, Schema):
         self._schemas = schema_objects
 
     # read-only properties
-    schemas = property(lambda self: self._schemas)
+    @property
+    def schemas(self):
+        return self._schemas
 
     def match(self, writer):
         """Return True if the current schema (as reader) matches the writer schema.
@@ -890,8 +929,13 @@ class RecordSchema(EqualByJsonMixin, NamedSchema):
             names.default_namespace = old_default
 
     # read-only properties
-    fields = property(lambda self: self.get_prop("fields"))
-    doc = property(lambda self: self.get_prop("doc"))
+    @property
+    def fields(self):
+        return self.get_prop("fields")
+
+    @property
+    def doc(self):
+        return self.get_prop("doc")
 
     @property
     def fields_dict(self):


### PR DESCRIPTION
## What is the purpose of the change

This change updates the Python code to consistently use the `@property` decorator for class properties, which in turn will make adding type annotations easier.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Documentation

This pull request does not introduce a new feature.
