### PR TITLE
AVRO-3797: Add Python 3.11 to tox.ini

### DIFF
--- a/lang/py/tox.ini
+++ b/lang/py/tox.ini
@@ -25,6 +25,7 @@ envlist =
     py38
     py39
     py310
+    py311
     pypy3.6
     pypy3.7
 


### PR DESCRIPTION
Also see AVRO-3672
