### PR TITLE
AVRO-3800: [Rust] profile section should be declared in the root package.

### DIFF
--- a/lang/rust/Cargo.toml
+++ b/lang/rust/Cargo.toml
@@ -37,3 +37,7 @@ rust-version = "1.65.0"
 keywords = ["avro", "data", "serialization"]
 categories = ["encoding"]
 documentation = "https://docs.rs/apache-avro"
+
+[profile.release.package.hello-wasm]
+# Tell `rustc` to optimize for small code size.
+opt-level = "s"

--- a/lang/rust/wasm-demo/Cargo.toml
+++ b/lang/rust/wasm-demo/Cargo.toml
@@ -42,7 +42,3 @@ wasm-bindgen = "0.2.87"
 [dev-dependencies]
 console_error_panic_hook = { version = "0.1.6" }
 wasm-bindgen-test = "0.3.37"
-
-[profile.release]
-# Tell `rustc` to optimize for small code size.
-opt-level = "s"


### PR DESCRIPTION
AVRO-3800

## What is the purpose of the change

This PR fixes an issue that [profile.release] declared in `wasm-demo/Cargo.toml` is ignored.
In that section, `opt-level = "s"` is specified but it's ignored.

```
$ cargo test -v --test demos --release
...
     Running `rustc --crate-name hello_wasm ... opt-level=3 ...`
     Running `rustc --crate-name demos ... opt-level=3 ...`
```

To fix this issue, this change moves the section to `Cargo.toml` of the root package.

## Verifying this change

After this change is applied, we can confirm that opt-level is changed as expected.
```
$ cargo test -v --test demos --release
...
     Running `rustc --crate-name hello_wasm ... opt-level=s ...`
     Running `rustc --crate-name demos ... opt-level=s ...`
```

## Documentation

No new docs as this PR introduces no new features.