### PR TITLE
AVRO-3808: Drop Python 3.6, Update Pypy

### DIFF
--- a/.github/workflows/test-lang-py.yml
+++ b/.github/workflows/test-lang-py.yml
@@ -45,9 +45,7 @@ jobs:
         - '3.9'
         - '3.8'
         - '3.7'
-        - '3.6'
         - 'pypy-3.7'
-        - 'pypy-3.6'
 
     steps:
       - uses: actions/checkout@v3
@@ -92,9 +90,7 @@ jobs:
         - '3.9'
         - '3.8'
         - '3.7'
-        - '3.6'
         - 'pypy-3.7'
-        - 'pypy-3.6'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-lang-py.yml
+++ b/.github/workflows/test-lang-py.yml
@@ -46,6 +46,9 @@ jobs:
         - '3.8'
         - '3.7'
         - 'pypy-3.7'
+        - 'pypy-3.8'
+        - 'pypy-3.9'
+        - 'pypy-3.10'
 
     steps:
       - uses: actions/checkout@v3
@@ -91,6 +94,9 @@ jobs:
         - '3.8'
         - '3.7'
         - 'pypy-3.7'
+        - 'pypy-3.8'
+        - 'pypy-3.9'
+        - 'pypy-3.10'
 
     steps:
       - uses: actions/checkout@v3

--- a/lang/py/setup.cfg
+++ b/lang/py/setup.cfg
@@ -33,7 +33,6 @@ license_files = avro/LICENSE
 license = Apache License 2.0
 classifiers =
     License :: OSI Approved :: Apache Software License
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -57,7 +56,7 @@ include_package_data = true
 install_requires =
     typing-extensions;python_version<"3.8"
 zip_safe = true
-python_requires = >=3.6
+python_requires = >=3.7
 
 [options.entry_points]
 console_scripts =

--- a/lang/py/tox.ini
+++ b/lang/py/tox.ini
@@ -21,13 +21,11 @@ envlist =
     docs
     lint
     typechecks
-    py36
     py37
     py38
     py39
     py310
     py311
-    pypy3.6
     pypy3.7
 
 

--- a/lang/py/tox.ini
+++ b/lang/py/tox.ini
@@ -27,6 +27,9 @@ envlist =
     py310
     py311
     pypy3.7
+    pypy3.8
+    pypy3.9
+    pypy3.10
 
 
 [coverage:run]

--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -174,10 +174,26 @@ RUN curl -sSL https://cpanmin.us \
                                                  Module::Install::Repository \
  && rm -rf .cpanm
 
-# Install Python packages
-ENV PIP_NO_CACHE_DIR=off
+# Install Python3
+ENV PATH="${PATH}:/opt/pypy3.8/bin:/opt/pypy3.9/bin:/opt/pypy3.10/bin" \
+    PIP_NO_CACHE_DIR=off
+    
+# https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
+ARG BUILDARCH
+RUN case "${BUILDARCH:?}" in \
+      arm64) pypyarch=aarch64;; \
+      *) pypyarch=linux64;; \
+    esac \
+ && cd /opt \
+ && for url in https://downloads.python.org/pypy/pypy3.8-v7.3.11-"$pypyarch".tar.bz2 \
+               https://downloads.python.org/pypy/pypy3.9-v7.3.12-"$pypyarch".tar.bz2 \
+               https://downloads.python.org/pypy/pypy3.10-v7.3.12-"$pypyarch".tar.bz2; \
+    do curl -fsSL "$url" | tar -xvjpf -; \
+    done \
+ && ln -s pypy3.8* pypy3.8 \
+ && ln -s pypy3.9* pypy3.9 \
+ && ln -s pypy3.10* pypy3.10
 
-# Install Python3 packages
 RUN python3 -m pip install --upgrade pip setuptools wheel \
  && python3 -m pip install tox zstandard
 

--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -67,7 +67,6 @@ RUN apt-get -qqy update \
                                                  python3-wheel \
                                                  python3.10 \
                                                  python3.11 \
-                                                 python3.6 \
                                                  python3.7 \
                                                  python3.8 \
                                                  python3.9 \


### PR DESCRIPTION
## What is the purpose of the change

AVRO-3808: Update the list of python versions to test against: Drop 3.6 and add more supported Pypy implementation.s

- AVRO-3808: Drop Python 3.6
- AVRO-3808 Test with Pypy 3.8-3.10


## Verifying this change

This change adds more python versions to test against.


## Documentation

- Does not apply
