### PR TITLE
AVRO-312: Python Sphinx Documentation

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -6,7 +6,7 @@ The following packages must be installed before Avro can be built:
 
  - Java: JDK 1.8, Maven 3 or better, protobuf-compile
  - PHP: php7, phpunit, php7-gmp
- - Python 3: 3.6 or greater
+ - Python 3: 3.7 or greater, tox (tox will install other dependencies as needed)
  - C: gcc, cmake, asciidoc, source-highlight, Jansson, pkg-config
  - C++: cmake 3.7.2 or greater, g++, flex, bison, libboost-dev
  - C#: .NET Core 2.2 SDK

--- a/doc/content/en/docs/++version++/api-py.md
+++ b/doc/content/en/docs/++version++/api-py.md
@@ -1,0 +1,29 @@
+---
+title: "Python API"
+linkTitle: "Python API"
+weight: 104
+manualLink: /docs/++version++/api/py/html/
+---
+
+<!--
+
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+-->
+
+The Python API documentation can be found <a href="/docs/++version++/api/py/html/">here</a>.

--- a/lang/py/build.sh
+++ b/lang/py/build.sh
@@ -51,6 +51,14 @@ dist() (
   "$virtualenv/bin/python3" -m build --outdir "$destination"
 )
 
+doc() {
+  local doc_dir
+  [[ -s VERSION.txt ]] || cp ../../share/VERSION.txt .
+  doc_dir="../../build/avro-doc-$(<VERSION.txt)/api/py"
+  python3 -m tox -e docs
+  cp -a docs/build/* "$doc_dir"
+}
+
 interop-data-generate() {
   ./setup.py generate_interop_data
   cp -r avro/test/interop/data ../../build/interop
@@ -76,6 +84,7 @@ main() {
     case "$target" in
       clean) clean;;
       dist) dist;;
+      doc) doc;;
       interop-data-generate) interop-data-generate;;
       interop-data-test) interop-data-test;;
       lint) lint;;

--- a/lang/py/build.sh
+++ b/lang/py/build.sh
@@ -56,6 +56,7 @@ doc() {
   [[ -s VERSION.txt ]] || cp ../../share/VERSION.txt .
   doc_dir="../../build/avro-doc-$(<VERSION.txt)/api/py"
   python3 -m tox -e docs
+  mkdir -p "$doc_dir"
   cp -a docs/build/* "$doc_dir"
 }
 

--- a/lang/py/docs/Makefile
+++ b/lang/py/docs/Makefile
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/lang/py/docs/make.bat
+++ b/lang/py/docs/make.bat
@@ -1,0 +1,50 @@
+REM Licensed to the Apache Software Foundation (ASF) under one or more
+REM contributor license agreements.  See the NOTICE file distributed with
+REM this work for additional information regarding copyright ownership.
+REM The ASF licenses this file to You under the Apache License, Version 2.0
+REM (the "License"); you may not use this file except in compliance with
+REM the License.  You may obtain a copy of the License at
+REM
+REM     https://www.apache.org/licenses/LICENSE-2.0
+REM
+REM Unless required by applicable law or agreed to in writing, software
+REM distributed under the License is distributed on an "AS IS" BASIS,
+REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM See the License for the specific language governing permissions and
+REM limitations under the License.
+
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/lang/py/docs/source/automodule.rst
+++ b/lang/py/docs/source/automodule.rst
@@ -1,0 +1,54 @@
+.. Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+   
+       https://www.apache.org/licenses/LICENSE-2.0
+   
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+.. automodule:: avro
+   :members:
+.. automodule:: avro.compatibility
+   :members:
+.. automodule:: avro.datafile
+   :members:
+.. automodule:: avro.ipc
+   :members:
+.. automodule:: avro.protocol
+   :members:
+.. automodule:: avro.codecs
+   :members:
+.. automodule:: avro.constants
+   :members:
+.. automodule:: avro.io
+   :members:
+.. automodule:: avro.tether
+   :members:
+.. automodule:: avro.tether.tether_task_runner
+   :members:
+.. automodule:: avro.tether.util
+   :members:
+.. automodule:: avro.tether.tether_task
+   :members:
+.. automodule:: avro.utils
+   :members:
+.. automodule:: avro.errors
+   :members:
+.. automodule:: avro.name
+   :members:
+.. automodule:: avro.tool
+   :members:
+.. automodule:: avro.timezones
+   :members:
+.. automodule:: avro.__main__
+   :members:
+.. automodule:: avro.schema
+   :members:

--- a/lang/py/docs/source/conf.py
+++ b/lang/py/docs/source/conf.py
@@ -1,0 +1,47 @@
+##
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+import sys
+
+sys.path.append("..")
+
+project = "Apache Avro"
+copyright = "2023, Apache"
+author = "Apache"
+release = "1.12.0"
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = ["sphinx.ext.autodoc"]
+
+templates_path = ["_templates"]
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "alabaster"
+html_static_path = ["_static"]

--- a/lang/py/docs/source/index.rst
+++ b/lang/py/docs/source/index.rst
@@ -1,0 +1,31 @@
+.. Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+   
+       https://www.apache.org/licenses/LICENSE-2.0
+   
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+   intro
+   automodule
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/lang/py/docs/source/intro.rst
+++ b/lang/py/docs/source/intro.rst
@@ -1,0 +1,29 @@
+.. Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+   
+       https://www.apache.org/licenses/LICENSE-2.0
+   
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+Welcome to Avro's Python documentation!
+=======================================
+
+Avro is a data serialization system. See `avro.apache.org <https://avro.apache.org/docs/current/>`_ for background information.
+
+Avro Python is a Python library that implements parts of the `Avro Specification <https://avro.apache.org/docs/current/specification/>`_.
+
+The library includes the following functionality:
+
+* Assembling schemas programmatically.
+* A schema parser, which can parse Avro schema (written in JSON) into a Schema object.
+* Binary encoders and decoders to encode data into Avro format and decode it back using primitive functions.
+* Streams for storing and reading data, which Encoders and Decoders use.
+* Support for Avro DataFile.

--- a/lang/py/tox.ini
+++ b/lang/py/tox.ini
@@ -18,6 +18,7 @@
 envlist =
     build  # Build the wheel
     # Fastest checks first
+    docs
     lint
     typechecks
     py36
@@ -64,6 +65,14 @@ deps =
 allowlist_externals =
 commands_pre =
 commands =
+commands_post =
+
+[testenv:docs]
+deps =
+    sphinx
+commands_pre =
+commands =
+    sphinx-build -b html docs/source/ docs/build/html
 commands_post =
 
 [testenv:lint]


### PR DESCRIPTION
AVRO-312 Python Sphinx Documentation

This is a backport of #2370, to 1.11.x.

Generate Documentation in docs/build/*.html when ./build.sh docs is run.

Implementation detail: Uses tox to install build-time dependencies.

* Add Tox to Python Build Requirements

