### PR TITLE
AVRO-3811: [Java][Doc] Mention about xz and zstandard as default registerd codecs in JavaDoc

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/file/CodecFactory.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/file/CodecFactory.java
@@ -28,12 +28,14 @@ import org.slf4j.LoggerFactory;
 /**
  * Encapsulates the ability to specify and configure a compression codec.
  *
- * Currently there are three codecs registered by default:
+ * Currently there are five codecs registered by default:
  * <ul>
  * <li>{@code null}</li>
  * <li>{@code deflate}</li>
  * <li>{@code snappy}</li>
  * <li>{@code bzip2}</li>
+ * <li>{@code xz}</li>
+ * <li>{@code zstandard}</li>
  * </ul>
  *
  * New and custom codecs can be registered using


### PR DESCRIPTION
AVRO-3811

## What is the purpose of the change

This PR proposes to mention about `xz` and `zstandard` as default registered codec in JavaDoc for `CodecFactory`.

## Verifying this change

Verified the rendered JavaDoc.
![avro-codec-factory-doc](https://github.com/apache/avro/assets/4736016/31a996f4-27c4-4129-9b3e-38418aa4ba32)


## Documentation

This change is for JavaDoc.
