### PR TITLE
AVRO-3812: [Rust] Handle null namespace properly for canonicalized schema representation

### DIFF
--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -295,7 +295,7 @@ impl Name {
             namespace: self
                 .namespace
                 .clone()
-                .or_else(|| enclosing_namespace.clone()),
+                .or_else(|| enclosing_namespace.clone().filter(|ns| !ns.is_empty())),
         }
     }
 }
@@ -4856,6 +4856,13 @@ mod tests {
         let schema = Schema::parse_str(schema_str)?;
         let canonical_form = schema.canonical_form();
         assert_eq!(canonical_form, expected);
+
+        let name = Name::new("my_name").unwrap();
+        let fullname = name.fullname(Some("".to_string()));
+        assert_eq!(fullname, "my_name");
+        let qname = name.fully_qualified_name(&Some("".to_string())).to_string();
+        assert_eq!(qname, "my_name");
+
         Ok(())
     }
 }

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -4857,7 +4857,7 @@ mod tests {
         let canonical_form = schema.canonical_form();
         assert_eq!(canonical_form, expected);
 
-        let name = Name::new("my_name").unwrap();
+        let name = Name::new("my_name")?;
         let fullname = name.fullname(Some("".to_string()));
         assert_eq!(fullname, "my_name");
         let qname = name.fully_qualified_name(&Some("".to_string())).to_string();

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -252,7 +252,7 @@ impl Name {
 
         Ok(Self {
             name: type_name.unwrap_or(name),
-            namespace: namespace_from_name.or_else(|| complex.string("namespace")),
+            namespace: namespace_from_name.or_else(|| complex.string("namespace").filter(|ns| !ns.is_empty())),
         })
     }
 
@@ -4817,6 +4817,41 @@ mod tests {
             }
             _ => panic!("Expected an error"),
         }
+        Ok(())
+    }
+
+    #[test]
+    fn test_avro_3812_handle_null_namespace_properly() -> TestResult {
+        let schema_str = r#"
+        {
+          "namespace": "",
+          "type": "record",
+          "name": "my_schema",
+          "fields": [
+            {
+              "name": "a",
+              "type": {
+                "type": "enum",
+                "name": "my_enum",
+                "namespace": "",
+                "symbols": ["a", "b"]
+              }
+            },  {
+              "name": "b",
+              "type": {
+                "type": "fixed",
+                "name": "my_fixed",
+                "namespace": "",
+                "size": 10
+              }
+            }
+          ]
+         }
+         "#;
+
+        let expected = r#"{"name":"my_schema","type":"record","fields":[{"name":"a","type":{"name":"my_enum","type":"enum","symbols":["a","b"]}},{"name":"b","type":{"name":"my_fixed","type":"fixed","size":10}}]}"#;
+        let schema = Schema::parse_str(schema_str).unwrap().canonical_form();
+        assert_eq!(schema, expected);
         Ok(())
     }
 }

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -268,8 +268,10 @@ impl Name {
             let namespace = self.namespace.clone().or(default_namespace);
 
             match namespace {
-                Some(ref namespace) => format!("{}.{}", namespace, self.name),
-                None => self.name.clone(),
+                Some(ref namespace) if !namespace.is_empty() => {
+                    format!("{}.{}", namespace, self.name)
+                }
+                _ => self.name.clone(),
             }
         }
     }
@@ -4851,8 +4853,9 @@ mod tests {
          "#;
 
         let expected = r#"{"name":"my_schema","type":"record","fields":[{"name":"a","type":{"name":"my_enum","type":"enum","symbols":["a","b"]}},{"name":"b","type":{"name":"my_fixed","type":"fixed","size":10}}]}"#;
-        let schema = Schema::parse_str(schema_str).unwrap().canonical_form();
-        assert_eq!(schema, expected);
+        let schema = Schema::parse_str(schema_str)?;
+        let canonical_form = schema.canonical_form();
+        assert_eq!(canonical_form, expected);
         Ok(())
     }
 }

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -252,7 +252,8 @@ impl Name {
 
         Ok(Self {
             name: type_name.unwrap_or(name),
-            namespace: namespace_from_name.or_else(|| complex.string("namespace").filter(|ns| !ns.is_empty())),
+            namespace: namespace_from_name
+                .or_else(|| complex.string("namespace").filter(|ns| !ns.is_empty())),
         })
     }
 


### PR DESCRIPTION
AVRO-3812

## What is the purpose of the change

This PR fixes a issue that the Rust binding doesn't handle null namespaces for canonicalized schema representation.

Considering the following schema, which contains namespaces of "".
```
{
 "namespace": "",
 "type": "record",
 "name": "my_schema",
 "fields": [
   {
     "name": "a",
     "type": {
       "type": "enum",
       "name": "my_enum",
       "namespace": "",
       "symbols": ["a", "b"]
     }
   },  {
     "name": "b",
     "type": {
       "type": "fixed",
       "name": "my_fixed",
       "namespace": "",
       "size": 10
     }
   }
 ]
}
```

If we try to canonicalize this schema with the following code
```
let schema = Schema::parse_str(schema_str).unwrap().canonical_form();
println!("{schema}");
```
We get the following result.
```
{"name":".my_schema","type":"record","fields":[{"name":"a","type":{"name":".my_enum","type":"enum","symbols":["a","b"]}},{"name":"b","type":{"name":".my_fixed","type":"fixed","size":10}}]}
```

But .my_schema, .my_enum and .my_fixed should not starts with a dot.

## Verifying this change

Added new test and it passed with `cargo test avro_3812`.

## Documentation

No new docs as this PR doesn't contains new features.
