### PR TITLE
AVRO-3814: Fix schema resolution for records in union types

### DIFF
--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -826,13 +826,9 @@ impl UnionSchema {
                 let namespace = &schema.namespace().or_else(|| enclosing_namespace.clone());
 
                 // Attempt to validate the value in order to ensure we've selected the right schema.
-                match value.validate_internal(schema, &collected_names, namespace, true) {
-                    None => true,
-                    Some(err) => {
-                        println!("Validation failed: {:?}", err);
-                        false
-                    }
-                }
+                value
+                    .validate_internal(schema, &collected_names, namespace, true)
+                    .is_none()
             })
         }
     }

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -4969,7 +4969,7 @@ mod tests {
             }),
         };
 
-        // Serialize using the writer schema (newer).
+        // Serialize using the writer schema.
         let writer_schema = Schema::parse(&writer_schema)?;
         let avro_value = crate::to_value(s)?;
         assert!(
@@ -4978,7 +4978,7 @@ mod tests {
         );
         let datum = crate::to_avro_datum(&writer_schema, avro_value)?;
 
-        // Now, attempt to deserialize using the reader schema (older).
+        // Now, attempt to deserialize using the reader schema.
         let reader_schema = Schema::parse(&reader_schema)?;
         let mut x = &datum[..];
 

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -4984,6 +4984,7 @@ mod tests {
 
         // Deserialization should succeed and we should be able to resolve the schema.
         let deser_value = crate::from_avro_datum(&writer_schema, &mut x, Some(&reader_schema))?;
+        assert!(deser_value.validate(&reader_schema));
 
         // Verify that we can read a field from the record.
         let d: MyRecordReader = crate::from_value(&deser_value)?;

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -819,6 +819,7 @@ impl UnionSchema {
                     &collected_names,
                 )
                 .expect("Schema didn't successfully parse");
+
                 let resolved_names = resolved_schema.names_ref;
 
                 // extend known schemas with just resolved names
@@ -4863,6 +4864,129 @@ mod tests {
         let qname = name.fully_qualified_name(&Some("".to_string())).to_string();
         assert_eq!(qname, "my_name");
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_avro_3814_schema_resolution_failure() -> TestResult {
+        // Define a reader schema: a nested record with an optional field.
+        let reader_schema = json!(
+            {
+                "type": "record",
+                "name": "MyOuterRecord",
+                "fields": [
+                    {
+                        "name": "inner_record",
+                        "type": [
+                            "null",
+                            {
+                                "type": "record",
+                                "name": "MyRecord",
+                                "fields": [
+                                    {"name": "a", "type": "string"}
+                                ]
+                            }
+                        ],
+                        "default": null
+                    }
+                ]
+            }
+        );
+
+        // Define a writer schema: a nested record with an optional field, which
+        // may optionally contain an enum.
+        let writer_schema = json!(
+            {
+                "type": "record",
+                "name": "MyOuterRecord",
+                "fields": [
+                    {
+                        "name": "inner_record",
+                        "type": [
+                            "null",
+                            {
+                                "type": "record",
+                                "name": "MyRecord",
+                                "fields": [
+                                    {"name": "a", "type": "string"},
+                                    {
+                                        "name": "b",
+                                        "type": [
+                                            "null",
+                                            {
+                                                "type": "enum",
+                                                "name": "MyEnum",
+                                                "symbols": ["A", "B", "C"],
+                                                "default": "C"
+                                            }
+                                        ],
+                                        "default": null
+                                    },
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "default": null
+            }
+        );
+
+        // Use different structs to represent the "Reader" and the "Writer"
+        // to mimick two different versions of a producer & consumer application.
+        #[derive(Serialize, Deserialize, Debug)]
+        struct MyInnerRecordReader {
+            a: String
+        }
+
+        #[derive(Serialize, Deserialize, Debug)]
+        struct MyRecordReader {
+            inner_record: Option<MyInnerRecordReader>
+        }
+
+        #[derive(Serialize, Deserialize, Debug)]
+        enum MyEnum {
+            A,
+            B,
+            C
+        }
+
+        #[derive(Serialize, Deserialize, Debug)]
+        struct MyInnerRecordWriter {
+            a: String,
+            b: Option<MyEnum>
+        }
+
+        #[derive(Serialize, Deserialize, Debug)]
+        struct MyRecordWriter {
+            inner_record: Option<MyInnerRecordWriter>
+        }
+
+        let s = MyRecordWriter {
+            inner_record: Some(MyInnerRecordWriter {
+                a: "foo".to_string(),
+                b: None
+            })
+        };
+
+        // Serialize using the writer schema (newer).
+        let writer_schema = Schema::parse(&writer_schema)?;
+        let avro_value = crate::to_value(s)?;
+        assert!(
+            avro_value.validate(&writer_schema),
+            "value is valid for schema",
+        );
+        let datum = crate::to_avro_datum(&writer_schema, avro_value)?;
+
+        // Now, attempt to deserialize using the reader schema (older).
+        let reader_schema = Schema::parse(&reader_schema)?;
+        let mut x = &datum[..];
+
+        // Deserialization should succeed and we should be able to resolve the schema.
+        let deser_value = crate::from_avro_datum(&writer_schema, &mut x, Some(&reader_schema))?;
+
+        // Verify that we can read a field from the record.
+        let d: MyRecordReader = crate::from_value(&deser_value)?;
+        assert_eq!(d.inner_record.unwrap().a, "foo".to_string());
         Ok(())
     }
 }

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -801,6 +801,7 @@ impl UnionSchema {
             Some((i, &self.schemas[i]))
         } else {
             // slow path (required for matching logical or named types)
+
             // first collect what schemas we already know
             let mut collected_names: HashMap<Name, &Schema> = known_schemata
                 .map(|names| {
@@ -818,7 +819,6 @@ impl UnionSchema {
                     &collected_names,
                 )
                 .expect("Schema didn't successfully parse");
-
                 let resolved_names = resolved_schema.names_ref;
 
                 // extend known schemas with just resolved names

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -826,9 +826,13 @@ impl UnionSchema {
                 let namespace = &schema.namespace().or_else(|| enclosing_namespace.clone());
 
                 // Attempt to validate the value in order to ensure we've selected the right schema.
-                value
-                    .validate_internal(schema, &collected_names, namespace, true)
-                    .is_none()
+                match value.validate_internal(schema, &collected_names, namespace, true) {
+                    None => true,
+                    Some(err) => {
+                        println!("Validation failed: {:?}", err);
+                        false
+                    }
+                }
             })
         }
     }

--- a/lang/rust/avro/src/writer.rs
+++ b/lang/rust/avro/src/writer.rs
@@ -425,7 +425,7 @@ fn write_avro_datum_schemata<T: Into<Value>>(
     let rs = ResolvedSchema::try_from(schemata)?;
     let names = rs.get_names();
     let enclosing_namespace = schema.namespace();
-    if let Some(_err) = avro.validate_internal(schema, names, &enclosing_namespace) {
+    if let Some(_err) = avro.validate_internal(schema, names, &enclosing_namespace, false) {
         return Err(Error::Validation);
     }
     encode_internal(&avro, schema, names, &enclosing_namespace, buffer)
@@ -544,7 +544,12 @@ fn write_value_ref_resolved(
     value: &Value,
     buffer: &mut Vec<u8>,
 ) -> AvroResult<()> {
-    match value.validate_internal(schema, resolved_schema.get_names(), &schema.namespace()) {
+    match value.validate_internal(
+        schema,
+        resolved_schema.get_names(),
+        &schema.namespace(),
+        false,
+    ) {
         Some(err) => Err(Error::ValidationWithReason(err)),
         None => encode_internal(
             value,
@@ -566,6 +571,7 @@ fn write_value_ref_owned_resolved(
         root_schema,
         resolved_schema.get_names(),
         &root_schema.namespace(),
+        false,
     ) {
         return Err(Error::ValidationWithReason(err));
     }

--- a/lang/rust/avro/tests/avro-3786.rs
+++ b/lang/rust/avro/tests/avro-3786.rs
@@ -157,3 +157,730 @@ fn avro_3786_deserialize_union_with_different_enum_order() -> TestResult {
     }
     Ok(())
 }
+
+#[test]
+fn avro_3786_deserialize_union_with_different_enum_order_defined_in_record() -> TestResult {
+    #[derive(
+        Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, serde::Deserialize, serde::Serialize,
+    )]
+    pub enum Bar {
+        #[serde(rename = "bar0")]
+        Bar0,
+        #[serde(rename = "bar1")]
+        Bar1,
+        #[serde(rename = "bar2")]
+        Bar2,
+    }
+    #[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
+    pub struct BarParent {
+        pub bar: Bar,
+    }
+    #[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
+    pub struct Foo {
+        #[serde(rename = "barParent")]
+        pub bar_parent: Option<BarParent>,
+    }
+    let writer_schema = r#"{
+        "type": "record",
+        "name": "Foo",
+        "namespace": "com.rallyhealth.devices.canonical.avro.model.v6_0",
+        "fields":
+        [
+            {
+                "name": "barParent",
+                "type": [
+                    "null",
+                    {
+                        "type": "record",
+                        "name": "BarParent",
+                        "fields": [
+                            {
+                                "name": "bar",
+                                "type": {
+                                    "type": "enum",
+                                    "name": "Bar",
+                                    "symbols":
+                                    [
+                                        "bar0",
+                                        "bar1",
+                                        "bar2"
+                                    ],
+                                    "default": "bar0"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }"#;
+    let reader_schema = r#"{
+        "type": "record",
+        "name": "Foo",
+        "namespace": "com.rallyhealth.devices.canonical.avro.model.v6_0",
+        "fields":
+        [
+            {
+                "name": "barParent",
+                "type": [
+                    "null",
+                    {
+                        "type": "record",
+                        "name": "BarParent",
+                        "fields": [
+                            {
+                                "name": "bar",
+                                "type": {
+                                    "type": "enum",
+                                    "name": "Bar",
+                                    "symbols":
+                                    [
+                                        "bar0",
+                                        "bar2"
+                                    ],
+                                    "default": "bar0"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }"#;
+    let writer_schema = Schema::parse_str(writer_schema)?;
+    let foo = Foo {
+        bar_parent: Some(BarParent { bar: Bar::Bar0 }),
+    };
+    let avro_value = crate::to_value(foo)?;
+    assert!(
+        avro_value.validate(&writer_schema),
+        "value is valid for schema",
+    );
+    let datum = crate::to_avro_datum(&writer_schema, avro_value)?;
+    let mut x = &datum[..];
+    let reader_schema = Schema::parse_str(reader_schema)?;
+    let deser_value = crate::from_avro_datum(&writer_schema, &mut x, Some(&reader_schema))?;
+    match deser_value {
+        types::Value::Record(fields) => {
+            assert_eq!(fields.len(), 1);
+            assert_eq!(fields[0].0, "barParent");
+            // TODO: better validation
+        }
+        _ => panic!("Expected Value::Record"),
+    }
+    Ok(())
+}
+
+#[test]
+fn test_avro_3786_deserialize_union_with_different_enum_order_defined_in_record_v1() -> TestResult {
+    #[derive(
+        Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, serde::Deserialize, serde::Serialize,
+    )]
+    pub enum Bar {
+        #[serde(rename = "bar0")]
+        Bar0,
+        #[serde(rename = "bar1")]
+        Bar1,
+        #[serde(rename = "bar2")]
+        Bar2,
+    }
+    #[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
+    pub struct BarParent {
+        pub bar: Bar,
+    }
+    #[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
+    pub struct Foo {
+        #[serde(rename = "barParent")]
+        pub bar_parent: Option<BarParent>,
+    }
+    let writer_schema = r#"{
+            "type": "record",
+            "name": "Foo",
+            "namespace": "com.rallyhealth.devices.canonical.avro.model.v6_0",
+            "fields":
+            [
+                {
+                    "name": "barParent",
+                    "type": [
+                        "null",
+                        {
+                            "type": "record",
+                            "name": "BarParent",
+                            "fields": [
+                                {
+                                    "name": "bar",
+                                    "type": {
+                                        "type": "enum",
+                                        "name": "Bar",
+                                        "symbols":
+                                        [
+                                            "bar0",
+                                            "bar1",
+                                            "bar2"
+                                        ],
+                                        "default": "bar0"
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }"#;
+    let reader_schema = r#"{
+            "type": "record",
+            "name": "Foo",
+            "namespace": "com.rallyhealth.devices.canonical.avro.model.v6_0",
+            "fields":
+            [
+                {
+                    "name": "barParent",
+                    "type": [
+                        "null",
+                        {
+                            "type": "record",
+                            "name": "BarParent",
+                            "fields": [
+                                {
+                                    "name": "bar",
+                                    "type": {
+                                        "type": "enum",
+                                        "name": "Bar",
+                                        "symbols":
+                                        [
+                                            "bar0",
+                                            "bar2"
+                                        ],
+                                        "default": "bar0"
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }"#;
+    let writer_schema = Schema::parse_str(writer_schema)?;
+    let foo = Foo {
+        bar_parent: Some(BarParent { bar: Bar::Bar1 }),
+    };
+    let avro_value = crate::to_value(foo)?;
+    assert!(
+        avro_value.validate(&writer_schema),
+        "value is valid for schema",
+    );
+    let datum = crate::to_avro_datum(&writer_schema, avro_value)?;
+    let mut x = &datum[..];
+    let reader_schema = Schema::parse_str(reader_schema)?;
+    let deser_value = crate::from_avro_datum(&writer_schema, &mut x, Some(&reader_schema))?;
+    match deser_value {
+        types::Value::Record(fields) => {
+            assert_eq!(fields.len(), 1);
+            assert_eq!(fields[0].0, "barParent");
+            // TODO: better validation
+        }
+        _ => panic!("Expected Value::Record"),
+    }
+    Ok(())
+}
+
+#[test]
+fn test_avro_3786_deserialize_union_with_different_enum_order_defined_in_record_v2() -> TestResult {
+    #[derive(
+        Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, serde::Deserialize, serde::Serialize,
+    )]
+    pub enum Bar {
+        #[serde(rename = "bar0")]
+        Bar0,
+        #[serde(rename = "bar1")]
+        Bar1,
+        #[serde(rename = "bar2")]
+        Bar2,
+    }
+    #[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
+    pub struct BarParent {
+        pub bar: Bar,
+    }
+    #[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
+    pub struct Foo {
+        #[serde(rename = "barParent")]
+        pub bar_parent: Option<BarParent>,
+    }
+    let writer_schema = r#"{
+            "type": "record",
+            "name": "Foo",
+            "namespace": "com.rallyhealth.devices.canonical.avro.model.v6_0",
+            "fields":
+            [
+                {
+                    "name": "barParent",
+                    "type": [
+                        "null",
+                        {
+                            "type": "record",
+                            "name": "BarParent",
+                            "fields": [
+                                {
+                                    "name": "bar",
+                                    "type": {
+                                        "type": "enum",
+                                        "name": "Bar",
+                                        "symbols":
+                                        [
+                                            "bar0",
+                                            "bar1",
+                                            "bar2"
+                                        ],
+                                        "default": "bar2"
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }"#;
+    let reader_schema = r#"{
+            "type": "record",
+            "name": "Foo",
+            "namespace": "com.rallyhealth.devices.canonical.avro.model.v6_0",
+            "fields":
+            [
+                {
+                    "name": "barParent",
+                    "type": [
+                        "null",
+                        {
+                            "type": "record",
+                            "name": "BarParent",
+                            "fields": [
+                                {
+                                    "name": "bar",
+                                    "type": {
+                                        "type": "enum",
+                                        "name": "Bar",
+                                        "symbols":
+                                        [
+                                            "bar1",
+                                            "bar2"
+                                        ],
+                                        "default": "bar2"
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }"#;
+    let writer_schema = Schema::parse_str(writer_schema)?;
+    let foo = Foo {
+        bar_parent: Some(BarParent { bar: Bar::Bar1 }),
+    };
+    let avro_value = crate::to_value(foo)?;
+    assert!(
+        avro_value.validate(&writer_schema),
+        "value is valid for schema",
+    );
+    let datum = crate::to_avro_datum(&writer_schema, avro_value)?;
+    let mut x = &datum[..];
+    let reader_schema = Schema::parse_str(reader_schema)?;
+    let deser_value = crate::from_avro_datum(&writer_schema, &mut x, Some(&reader_schema))?;
+    match deser_value {
+        types::Value::Record(fields) => {
+            assert_eq!(fields.len(), 1);
+            assert_eq!(fields[0].0, "barParent");
+            // TODO: better validation
+        }
+        _ => panic!("Expected Value::Record"),
+    }
+    Ok(())
+}
+
+#[test]
+fn deserialize_union_with_different_enum_order_defined_in_record() -> TestResult {
+    #[derive(
+        Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, serde::Deserialize, serde::Serialize,
+    )]
+    pub enum Bar {
+        #[serde(rename = "bar0")]
+        Bar0,
+        #[serde(rename = "bar1")]
+        Bar1,
+        #[serde(rename = "bar2")]
+        Bar2,
+    }
+    #[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
+    pub struct BarParent {
+        pub bar: Bar,
+    }
+    #[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
+    pub struct Foo {
+        #[serde(rename = "barParent")]
+        pub bar_parent: Option<BarParent>,
+    }
+    let writer_schema = r#"{
+            "type": "record",
+            "name": "Foo",
+            "namespace": "com.rallyhealth.devices.canonical.avro.model.v6_0",
+            "fields":
+            [
+                {
+                    "name": "barParent",
+                    "type": [
+                        "null",
+                        {
+                            "type": "record",
+                            "name": "BarParent",
+                            "fields": [
+                                {
+                                    "name": "bar",
+                                    "type": {
+                                        "type": "enum",
+                                        "name": "Bar",
+                                        "symbols":
+                                        [
+                                            "bar0",
+                                            "bar1",
+                                            "bar2"
+                                        ],
+                                        "default": "bar0"
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }"#;
+    let reader_schema = r#"{
+            "type": "record",
+            "name": "Foo",
+            "namespace": "com.rallyhealth.devices.canonical.avro.model.v6_0",
+            "fields":
+            [
+                {
+                    "name": "barParent",
+                    "type": [
+                        "null",
+                        {
+                            "type": "record",
+                            "name": "BarParent",
+                            "fields": [
+                                {
+                                    "name": "bar",
+                                    "type": {
+                                        "type": "enum",
+                                        "name": "Bar",
+                                        "symbols":
+                                        [
+                                            "bar0",
+                                            "bar2"
+                                        ],
+                                        "default": "bar0"
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }"#;
+    let writer_schema = Schema::parse_str(writer_schema)?;
+    let foo = Foo {
+        bar_parent: Some(BarParent { bar: Bar::Bar2 }),
+    };
+    let avro_value = crate::to_value(foo)?;
+    assert!(
+        avro_value.validate(&writer_schema),
+        "value is valid for schema",
+    );
+    let datum = crate::to_avro_datum(&writer_schema, avro_value)?;
+    let mut x = &datum[..];
+    let reader_schema = Schema::parse_str(reader_schema)?;
+    let deser_value = crate::from_avro_datum(&writer_schema, &mut x, Some(&reader_schema))?;
+    match deser_value {
+        types::Value::Record(fields) => {
+            assert_eq!(fields.len(), 1);
+            assert_eq!(fields[0].0, "barParent");
+            // TODO: better validation
+        }
+        _ => panic!("Expected Value::Record"),
+    }
+    Ok(())
+}
+
+#[test]
+fn deserialize_union_with_record_with_enum_defined_inline_reader_has_different_indices(
+) -> TestResult {
+    #[derive(
+        Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, serde::Deserialize, serde::Serialize,
+    )]
+    pub enum DefinedInRecord {
+        #[serde(rename = "val0")]
+        Val0,
+        #[serde(rename = "val1")]
+        Val1,
+        #[serde(rename = "val2")]
+        Val2,
+        #[serde(rename = "UNKNOWN")]
+        Unknown,
+    }
+    #[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
+    pub struct Parent {
+        pub date: i64,
+        #[serde(rename = "barUse")]
+        pub bar_use: Bar,
+        #[serde(rename = "bazUse")]
+        pub baz_use: Option<Vec<Baz>>,
+        #[serde(rename = "definedInRecord")]
+        pub defined_in_record: DefinedInRecord,
+        #[serde(rename = "optionalString")]
+        pub optional_string: Option<String>,
+    }
+    #[derive(
+        Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, serde::Deserialize, serde::Serialize,
+    )]
+    pub enum Baz {
+        #[serde(rename = "baz0")]
+        Baz0,
+        #[serde(rename = "baz1")]
+        Baz1,
+        #[serde(rename = "baz2")]
+        Baz2,
+    }
+    #[derive(
+        Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, serde::Deserialize, serde::Serialize,
+    )]
+    pub enum Bar {
+        #[serde(rename = "bar0")]
+        Bar0,
+        #[serde(rename = "bar1")]
+        Bar1,
+        #[serde(rename = "bar2")]
+        Bar2,
+    }
+    #[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
+    pub struct Foo {
+        #[serde(rename = "barInit")]
+        pub bar_init: Bar,
+        pub baz: Baz,
+        pub parent: Option<Parent>,
+    }
+    let writer_schema = r#"{
+            "type": "record",
+            "name": "Foo",
+            "namespace": "fake",
+            "fields":
+            [
+                {
+                    "name": "barInit",
+                    "type":
+                    {
+                        "type": "enum",
+                        "name": "Bar",
+                        "symbols":
+                        [
+                            "bar0",
+                            "bar1",
+                            "bar2"
+                        ],
+                        "default": "bar0"
+                    }
+                },
+                {
+                    "name": "baz",
+                    "type":
+                    {
+                        "type": "enum",
+                        "name": "Baz",
+                        "symbols":
+                        [
+                            "baz0",
+                            "baz1",
+                            "baz2"
+                        ],
+                        "default": "baz0"
+                    }
+                },
+                {
+                    "name": "parent",
+                    "type": [
+                        "null",
+                        {
+                            "type": "record",
+                            "name": "Parent",
+                            "fields": [
+                                {
+                                    "name": "date",
+                                    "type": {
+                                      "type": "long",
+                                      "avro.java.long": "Long"
+                                    }
+                                },
+                                {
+                                    "name": "barUse",
+                                    "type": "Bar"
+                                },
+                                {
+                                    "name": "bazUse",
+                                    "type": [
+                                        "null",
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "Baz"
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "definedInRecord",
+                                    "type": {
+                                      "name": "DefinedInRecord",
+                                      "type": "enum",
+                                      "symbols": [
+                                        "val0",
+                                        "val1",
+                                        "val2",
+                                        "UNKNOWN"
+                                      ],
+                                      "default": "UNKNOWN"
+                                    }
+                                },
+                                {
+                                  "name": "optionalString",
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }"#;
+    let reader_schema = r#"{
+            "type": "record",
+            "name": "Foo",
+            "namespace": "fake",
+            "fields":
+            [
+                {
+                    "name": "barInit",
+                    "type":
+                    {
+                        "type": "enum",
+                        "name": "Bar",
+                        "symbols":
+                        [
+                            "bar0",
+                            "bar2"
+                        ],
+                        "default": "bar0"
+                    }
+                },
+                {
+                    "name": "baz",
+                    "type":
+                    {
+                        "type": "enum",
+                        "name": "Baz",
+                        "symbols":
+                        [
+                            "baz0",
+                            "baz2"
+                        ],
+                        "default": "baz0"
+                    }
+                },
+                {
+                    "name": "parent",
+                    "type": [
+                        "null",
+                        {
+                            "type": "record",
+                            "name": "Parent",
+                            "fields": [
+                                {
+                                    "name": "date",
+                                    "type": {
+                                      "type": "long",
+                                      "avro.java.long": "Long"
+                                    }
+                                },
+                                {
+                                    "name": "barUse",
+                                    "type": "Bar"
+                                },
+                                {
+                                    "name": "bazUse",
+                                    "type": [
+                                        "null",
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "Baz"
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "definedInRecord",
+                                    "type": {
+                                      "name": "DefinedInRecord",
+                                      "type": "enum",
+                                      "symbols": [
+                                        "val1",
+                                        "val2",
+                                        "UNKNOWN"
+                                      ],
+                                      "default": "UNKNOWN"
+                                    }
+                                },
+                                {
+                                  "name": "optionalString",
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }"#;
+    let writer_schema = Schema::parse_str(writer_schema)?;
+    let foo = Foo {
+        bar_init: Bar::Bar0,
+        baz: Baz::Baz0,
+        parent: Some(Parent {
+            bar_use: Bar::Bar0,
+            baz_use: Some(vec![Baz::Baz0]),
+            optional_string: Some("test".to_string()),
+            date: 1689197893,
+            defined_in_record: DefinedInRecord::Val1,
+        }),
+    };
+    let avro_value = crate::to_value(foo)?;
+    assert!(
+        avro_value.validate(&writer_schema),
+        "value is valid for schema",
+    );
+    let datum = crate::to_avro_datum(&writer_schema, avro_value)?;
+    let mut x = &datum[..];
+    let reader_schema = Schema::parse_str(reader_schema)?;
+    let deser_value = crate::from_avro_datum(&writer_schema, &mut x, Some(&reader_schema))?;
+    match deser_value {
+        types::Value::Record(fields) => {
+            assert_eq!(fields.len(), 3);
+            assert_eq!(fields[0].0, "barInit");
+            assert_eq!(fields[0].1, types::Value::Enum(0, "bar0".to_string()));
+            // TODO: better validation
+        }
+        _ => panic!("Expected Value::Record"),
+    }
+    Ok(())
+}


### PR DESCRIPTION
<!--

*Thank you very much for contributing to Apache Avro - we are happy that you want to help us improve Avro. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Avro a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/AVRO/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "AVRO-XXXX: [component] Title of the pull request", where *AVRO-XXXX* should be replaced by the actual issue number. 
    The *component* is optional, but can help identify the correct reviewers faster: either the language ("java", "python") or subsystem such as "build" or "doc" are good candidates.  

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests. You can [build the entire project](https://github.com/apache/avro/blob/master/BUILD.md) or just the [language-specific SDK](https://avro.apache.org/project/how-to-contribute/#unit-tests).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Every commit message references Jira issues in their subject lines. In addition, commits follow the guidelines from [How to write a good git commit message](https://chris.beams.io/posts/git-commit/)
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

-->

## What is the purpose of the change

[AVRO-3814](https://issues.apache.org/jira/browse/AVRO-3814)

This adds a test case to reproduce AVRO-3814 and proposes a fix.

The following rules apply when performing schema resolution for records:

> if both are records:
>
> * the ordering of fields may be different: fields are matched by name.
> * schemas for fields with the same name in both records are resolved recursively.
> * if the writer’s record contains a field with a name not present in the reader’s record, the writer’s value for that field is ignored.
> * if the reader’s record schema has a field that contains a default value, and writer’s schema does not have a field with the same name, then the reader should use the default value from its field.
> * if the reader’s record schema has a field with no default value, and writer’s schema does not have a field with the same name, an error is signalled.

The logic in `UnionSchema::find_schema_with_known_schemata()` contains logic to select the right schema for a given `Value`. It does this by enumerating over known schemas which then get resolved. After resolving a schema the logic will then attempt to check if the schema is compatible with the provided value by invoking `Value::validate_internal()`, however at this stage the `Value::Record` that may be contained in a Union type has not yet been resolved. This causes validation to fail, which subsequently causes `Error::FindUnionVariant` to be returned from `Value::resolve_union()`.

Given that `Value::validate_internal()` appears to be serving two uses:
1. to strictly validate whether a given schema is correct for the given value
2. to select the right schema when resolving a union

It appears that the most appropriate way to fix this is to inform the logic in `validate_internal()` whether schema resolution rules should be applied. To this end I extended the interface with a new boolean `schema_resolution` which governs whether schema resolution rules should be applied during validation. In the specific case of the test-case that I added for AVRO-3814 this implies that the `Value::Record` is allowed to contain extraneous fields not present in the schema.

An alternative approach to fixing this could be to alter the logic in `UnionSchema::find_schema_with_known_schemata()` to not rely on `Value.validate_internal()` but this seemed like a larger lift to me.

## Verifying this change

This change added tests and can be verified as follows:

- Run `cargo test` from `lang/rust/avro`

## Documentation

- Does this pull request introduce a new feature? No
- If yes, how is the feature documented? Not applicable