### PR TITLE
AVRO-3815: [Doc] Fix broken indentation in the specification doc

### DIFF
--- a/doc/content/en/docs/++version++/Specification/_index.md
+++ b/doc/content/en/docs/++version++/Specification/_index.md
@@ -75,6 +75,8 @@ Records use the type name "record" and support the following attributes:
   * _name_: a JSON string providing the name of the field (required), and
   * _doc_: a JSON string describing this field for users (optional).
   * _type_: a [schema]({{< ref "#schema-declaration" >}} "Schema declaration"), as defined above
+  * _order_: specifies how this field impacts sort ordering of this record (optional). Valid values are "ascending" (the default), "descending", or "ignore". For more details on how this is used, see the sort order section below.
+  * _aliases_: a JSON array of strings, providing alternate names for this field (optional).
   * _default_: A default value for this field, only used when reading instances that lack the field for schema evolution purposes. The presence of a default value does not make the field optional at encoding time. Permitted values depend on the field's schema type, according to the table below. Default values for union fields correspond to the first schema in the union. Default values for bytes and fixed fields are JSON strings, where Unicode code points 0-255 are mapped to unsigned 8-bit byte values 0-255. Avro encodes a field even if its value is equal to its default.
 
 *field default values*
@@ -92,9 +94,6 @@ Records use the type name "record" and support the following attributes:
 | array         | array          | `[1]`       |
 | map           | object         | `{"a": 1}`  |
 | fixed         | string         | `"\u00ff"`  |
-
-  * _order_: specifies how this field impacts sort ordering of this record (optional). Valid values are "ascending" (the default), "descending", or "ignore". For more details on how this is used, see the sort order section below.
-  * _aliases_: a JSON array of strings, providing alternate names for this field (optional).
 
 For example, a linked-list of 64-bit values may be defined with:
 ```jsonc


### PR DESCRIPTION
AVRO-3815

## What is the purpose of the change

At the `Records` section in the specification doc, _orders_ and _aliases_ are explained as attributes of `fields` but their indentation seems broken.

![complex-types-layout](https://github.com/apache/avro/assets/4736016/2163bc75-96d3-41dc-845b-2940a218747c)

The root cause seems those items are placed below the table.
So, a simple way to fix is to place those items above the table.

## Verifying this change

Build and render the doc, and confirmed that indentation is clean.

![complex-types-layout-fixed](https://github.com/apache/avro/assets/4736016/2df19991-d257-407c-a721-df56118983f6)

## Documentation

This change fixes a doc.
