### PR TITLE
AVRO-3790 Provide namespace on UnknownSchemaError raise

### DIFF
--- a/lang/ruby/lib/avro/schema.rb
+++ b/lang/ruby/lib/avro/schema.rb
@@ -111,7 +111,7 @@ module Avro
       elsif PRIMITIVE_TYPES.include? json_obj
         return PrimitiveSchema.new(json_obj)
       else
-        raise UnknownSchemaError.new(json_obj)
+        raise UnknownSchemaError.new(json_obj, default_namespace)
       end
     end
 
@@ -621,9 +621,11 @@ module Avro
 
   class UnknownSchemaError < SchemaParseError
     attr_reader :type_name
+    attr_reader :default_namespace
 
-    def initialize(type)
+    def initialize(type, default_namespace)
       @type_name = type
+      @default_namespace = default_namespace
       super("#{type.inspect} is not a schema we know about.")
     end
   end

--- a/lang/ruby/test/test_schema.rb
+++ b/lang/ruby/test/test_schema.rb
@@ -176,6 +176,8 @@ class TestSchema < Test::Unit::TestCase
     end
 
     assert_equal '"MissingType" is not a schema we know about.', error.message
+    assert_equal "MissingType", error.type_name
+    assert_equal "my.name.space", error.default_namespace
   end
 
   def test_invalid_name


### PR DESCRIPTION
## What is the purpose of the change

If an UnknownSchemaError is raised for a nested type that should inherit its parent namespace, the default_namespace information is lost when rescuing this exception.
This prevents users of the library to use the raised exception to load the missing schema that may be defined in a separate file fore readability when handling large schema files.

## Verifying this change

This is a simple addition of information when raising an exception on encountering an unknown schema reference. The existing unit test has been updated to make sure the correct information is added to the exception.

## Documentation

- Does this pull request introduce a new feature?: YES
- Documentation for the raised exception seems to be missing from the project. I did not create it to mention the addition I made in it.
