### PR TITLE
Minor: Ignore Emacs' lock file and backup file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 *.iws
 *.swp
 *~
+*#*#
+*.#*
 .idea/
 .project
 .settings


### PR DESCRIPTION
## What is the purpose of the change

This PR proposes to ignore Emacs' lock file like `.#filename` and backup file like `#filename#`.
I sometimes read/write code of Avro using Emacs, and Auto-save file like `filename~` are cared in `.gitignore` but lock file and backup file are not.

## Verifying this change

Confirmed `git status` doesn't complain that such files are not tracked.
## Documentation

No user-facing changes added.