### PR TITLE
AVRO-3820: [Rust] Don't allow invalid field names

### DIFF
--- a/lang/rust/avro/src/error.rs
+++ b/lang/rust/avro/src/error.rs
@@ -307,6 +307,9 @@ pub enum Error {
     #[error("Invalid enum symbol name {0}")]
     EnumSymbolName(String),
 
+    #[error("Invalid field name {0}")]
+    FieldName(String),
+
     #[error("Invalid schema name {0}. It must match the regex '{1}'")]
     InvalidSchemaName(String, &'static str),
 


### PR DESCRIPTION
AVRO-3820

## What is the purpose of the change
This PR fixes an issue that the current Rust binding accept invalid field name.
Given we have a schema where a field name doesn't match `[A-Za-z_][A-Za-z0-9_]*` like `f1.x`.
```
{
  "name": "my_record",
  "type": "record",
  "fields": [
    {
      "name": "f1.x",
      "type": {
        "name": "my_enum",
        "type": "enum",
        "symbols": ["a"]
      }
    }
  ]
 }
```

The current Rust binding accepts such a schema but it seems illegal.

## Verifying this change
Added new test and it passed with `cargo test avro_3820`

## Documentation
No new feature added.