### PR TITLE
AVRO-3823: [Rust] Show helpful error messages

### DIFF
--- a/lang/rust/avro/src/error.rs
+++ b/lang/rust/avro/src/error.rs
@@ -19,9 +19,9 @@ use crate::{
     schema::{Name, SchemaKind},
     types::ValueKind,
 };
-use std::fmt;
+use std::{error::Error as _, fmt};
 
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error)]
 pub enum Error {
     #[error("Bad Snappy CRC32; expected {expected:x} but got {actual:x}")]
     SnappyCrc32 { expected: u32, actual: u32 },
@@ -459,5 +459,15 @@ impl serde::ser::Error for Error {
 impl serde::de::Error for Error {
     fn custom<T: fmt::Display>(msg: T) -> Self {
         Error::DeserializeValue(msg.to_string())
+    }
+}
+
+impl fmt::Debug for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut msg = self.to_string();
+        if let Some(e) = self.source() {
+            msg.extend([": ", &e.to_string()]);
+        }
+        write!(f, "{}", msg)
     }
 }


### PR DESCRIPTION
AVRO-3823

## What is the purpose of the change
This PR fixes an issue that the current Rust binding doesn't show helpful error messages.
Actually, error types are implemented with helpful error messages.
This is an example.
```
#[error("No `name` field")] 
GetNameField,  
```

But those error messages are not shown.
Given we try to a invalid schema which contains no name field, we expect to get ```No `name` field``` but the actual is `GetNameFIeld`, which makes it difficult for users to resolve the problem.

The cause is that when an error is return from `main`, the error message is made by `Debug::fmt` instead of `Display::fmt`.
So, the solution is implemented `Debug` trait for errors manually.

## Verifying this change

Tested manually with the following schemas.
```
{
  "type": "record",
  "fields": []
}

Error: No `name` field
```

```
{
  "name": "my_schema",
  "type": "record",
  "fields": [
}

Error: Failed to parse schema from JSON: expected value at line 5 column 1
```
## Documentation
No new feature added.