### PR TITLE
AVRO-3824: [Doc] The instruction for building the website should be more precise

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1,6 +1,11 @@
 # Apache Avro website
 
 This website is base on [Hugo](https://gohugo.io) and uses the [Docsy](https://www.docsy.dev/) theme.
+Before building the website, you need to initialize submodules.
+
+```
+git submodule update --init --recursive
+```
 
 ## Previewing the website locally
 


### PR DESCRIPTION
AVRO-3824

## What is the purpose of the change

How to build the website is instructed in `doc/README.md` but we cannot build even though we follow it.
The cause is that an instruction to do `git submodule update --init --recursive` is missing.

## Verifying this change

After `git submodule update --init --recursive`, I confirmed I can build the website with the instructions in `doc/README.md`.

## Documentation

No new features added.