### PR TITLE
Minor: [Python] Usage of build.sh should mention about `doc`

### DIFF
--- a/lang/py/build.sh
+++ b/lang/py/build.sh
@@ -18,7 +18,7 @@
 set -e
 
 usage() {
-  echo "Usage: $0 {clean|dist|interop-data-generate|interop-data-test|lint|test}"
+  echo "Usage: $0 {clean|dist|doc|interop-data-generate|interop-data-test|lint|test}"
   exit 1
 }
 


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes a minor issue that the usage of `build.sh` doesn't mention about `doc` option even though it supports the option.

## Verifying this change
Now `./build.sh` shows the usage with the `doc` option.

```
$ ./build.sh
Usage: ./build.sh {clean|dist|doc|interop-data-generate|interop-data-test|lint|test}
```

## Documentation
No new features added.