### PR TITLE
AVRO-3825: [Java] Disallow invalid namespaces

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/Schema.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Schema.java
@@ -717,9 +717,7 @@ public abstract class Schema extends JsonProperties implements Serializable {
         space = name.substring(0, lastDot); // get space from name
         this.name = validateName(name.substring(lastDot + 1));
       }
-      if ("".equals(space))
-        space = null;
-      this.space = space;
+      this.space = validateSpace(space);
       this.full = (this.space == null) ? this.name : this.space + "." + this.name;
     }
 
@@ -1643,6 +1641,17 @@ public abstract class Schema extends JsonProperties implements Serializable {
         throw new SchemaParseException("Illegal character in: " + name);
     }
     return name;
+  }
+
+  private static String validateSpace(String space) {
+    if ("".equals(space) || space == null) {
+      return null;
+    }
+
+    for (String part : space.split("\\.")) {
+      validateName(part);
+    }
+    return space;
   }
 
   private static final ThreadLocal<Boolean> VALIDATE_DEFAULTS = ThreadLocalWithInitial.of(() -> true);

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchema.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchema.java
@@ -460,4 +460,17 @@ public class TestSchema {
     assertNotNull(f1);
     assertEquals(schemaRecord1, f1.schema());
   }
+
+  @Test
+  void testInvalidNamespace() throws Exception {
+    File avscFile = Files.createTempFile("testInvalidNamespace", null).toFile();
+    String schema = "{\"type\":\"record\", \"namespace\": \"foo.123.bar\", \"name\":\"my_record\", \"fields\":[]}";
+    try (FileWriter writer = new FileWriter(avscFile)) {
+      writer.write(schema);
+      writer.flush();
+    }
+
+    Schema.Parser parser = new Schema.Parser();
+    assertThrows(SchemaParseException.class, () -> parser.parse(avscFile));
+  }
 }


### PR DESCRIPTION
## What is the purpose of the change

According to the specification, each portion of a namespace separated by dot should be `[a-z,A-Z,_][a-z,A-Z,0-9_]`.
https://avro.apache.org/docs/1.11.1/specification/#names

```
The name portion of the fullname of named types, record field names, and enum symbols must:

    start with [A-Za-z_]
    subsequently contain only [A-Za-z0-9_]

A namespace is a dot-separated sequence of such names. The empty string may also be used as a namespace to indicate the null namespace. Equality of names (including field names and enum symbols) as well as fullnames is case-sensitive.

The null namespace may not be used in a dot-separated sequence of names. So the grammar for a namespace is:

  <empty> | <name>[(<dot><name>)*]
```

But the current Java binding accept invalid namespaces.
This PR aims to fix this issue.

## Verifying this change
Added new test and it passed on my laptop.

## Documentation
No new features added.