### PR TITLE
AVRO-3819: Centralize system properties that limit allocations

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/Schema.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Schema.java
@@ -1295,8 +1295,7 @@ public abstract class Schema extends JsonProperties implements Serializable {
 
     public FixedSchema(Name name, String doc, int size) {
       super(Type.FIXED, name, doc);
-      if (size < 0)
-        throw new IllegalArgumentException("Invalid fixed size: " + size);
+      SystemLimitException.checkMaxBytesLength(size);
       this.size = size;
     }
 
@@ -1706,7 +1705,7 @@ public abstract class Schema extends JsonProperties implements Serializable {
 
   /**
    * Validate a value against the schema.
-   * 
+   *
    * @param schema : schema for value.
    * @param value  : value to validate.
    * @return true if ok.

--- a/lang/java/avro/src/main/java/org/apache/avro/SystemLimitException.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/SystemLimitException.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.avro;
+
+import org.slf4j.LoggerFactory;
+
+/**
+ * Thrown to prevent making large allocations when reading potentially
+ * pathological input data from an untrusted source.
+ * <p/>
+ * The following system properties can be set to limit the size of bytes,
+ * strings and collection types to be allocated:
+ * <ul>
+ * <li><tt>org.apache.avro.limits.byte.maxLength</tt></li> limits the maximum
+ * size of <tt>byte</tt> types.</li>
+ * <li><tt>org.apache.avro.limits.collectionItems.maxLength</tt></li> limits the
+ * maximum number of <tt>map</tt> and <tt>list</tt> items that can be read at
+ * once single sequence.</li>
+ * <li><tt>org.apache.avro.limits.string.maxLength</tt></li> limits the maximum
+ * size of <tt>string</tt> types.</li>
+ * </ul>
+ *
+ * The default is to permit sizes up to {@link #MAX_ARRAY_VM_LIMIT}.
+ */
+public class SystemLimitException extends AvroRuntimeException {
+
+  /**
+   * The maximum length of array to allocate (unless necessary). Some VMs reserve
+   * some header words in an array. Attempts to allocate larger arrays may result
+   * in {@code OutOfMemoryError: Requested array size exceeds VM limit}
+   *
+   * @see <a href="https://bugs.openjdk.org/browse/JDK-8246725">JDK-8246725</a>
+   */
+  // VisibleForTesting
+  static final int MAX_ARRAY_VM_LIMIT = Integer.MAX_VALUE - 8;
+
+  public static final String MAX_BYTES_LENGTH_PROPERTY = "org.apache.avro.limits.bytes.maxLength";
+  public static final String MAX_COLLECTION_LENGTH_PROPERTY = "org.apache.avro.limits.collectionItems.maxLength";
+  public static final String MAX_STRING_LENGTH_PROPERTY = "org.apache.avro.limits.string.maxLength";
+
+  private static int maxBytesLength = MAX_ARRAY_VM_LIMIT;
+  private static int maxCollectionLength = MAX_ARRAY_VM_LIMIT;
+  private static int maxStringLength = MAX_ARRAY_VM_LIMIT;
+
+  static {
+    resetLimits();
+  }
+
+  public SystemLimitException(String message) {
+    super(message);
+  }
+
+  /**
+   * Get an integer value stored in a system property, used to configure the
+   * system behaviour of decoders
+   *
+   * @param property     The system property to fetch
+   * @param defaultValue The value to use if the system property is not present or
+   *                     parsable as an int
+   * @return The value from the system property
+   */
+  private static int getLimitFromProperty(String property, int defaultValue) {
+    String o = System.getProperty(property);
+    int i = defaultValue;
+    if (o != null) {
+      try {
+        i = Integer.parseUnsignedInt(o);
+      } catch (NumberFormatException nfe) {
+        LoggerFactory.getLogger(SystemLimitException.class).warn("Could not parse property " + property + ": " + o,
+            nfe);
+      }
+    }
+    return i;
+  }
+
+  /**
+   * Check to ensure that reading the bytes is within the specified limits.
+   *
+   * @param length The proposed size of the bytes to read
+   * @return The size of the bytes if and only if it is within the limit and
+   *         non-negative.
+   * @throws UnsupportedOperationException if reading the datum would allocate a
+   *                                       collection that the Java VM would be
+   *                                       unable to handle
+   * @throws SystemLimitException          if the decoding should fail because it
+   *                                       would otherwise result in an allocation
+   *                                       exceeding the set limit
+   * @throws AvroRuntimeException          if the length is negative
+   */
+  public static int checkMaxBytesLength(long length) {
+    if (length < 0) {
+      throw new AvroRuntimeException("Malformed data. Length is negative: " + length);
+    }
+    if (length > MAX_ARRAY_VM_LIMIT) {
+      throw new UnsupportedOperationException(
+          "Cannot read arrays longer than " + MAX_ARRAY_VM_LIMIT + " bytes in Java library");
+    }
+    if (length > maxBytesLength) {
+      throw new SystemLimitException("Bytes length " + length + " exceeds maximum allowed");
+    }
+    return (int) length;
+  }
+
+  /**
+   * Check to ensure that reading the specified number of items remains within the
+   * specified limits.
+   *
+   * @param existing The number of elements items read in the collection
+   * @param items    The next number of items to read. In normal usage, this is
+   *                 always a positive, permitted value. Negative and zero values
+   *                 have a special meaning in Avro decoding.
+   * @return The total number of items in the collection if and only if it is
+   *         within the limit and non-negative.
+   * @throws UnsupportedOperationException if reading the items would allocate a
+   *                                       collection that the Java VM would be
+   *                                       unable to handle
+   * @throws SystemLimitException          if the decoding should fail because it
+   *                                       would otherwise result in an allocation
+   *                                       exceeding the set limit
+   * @throws AvroRuntimeException          if the length is negative
+   */
+  public static int checkMaxCollectionLength(long existing, long items) {
+    long length = existing + items;
+    if (existing < 0) {
+      throw new AvroRuntimeException("Malformed data. Length is negative: " + existing);
+    }
+    if (items < 0) {
+      throw new AvroRuntimeException("Malformed data. Length is negative: " + items);
+    }
+    if (length > MAX_ARRAY_VM_LIMIT || length < existing) {
+      throw new UnsupportedOperationException(
+          "Cannot read collections larger than " + MAX_ARRAY_VM_LIMIT + " items in Java library");
+    }
+    if (length > maxCollectionLength) {
+      throw new SystemLimitException("Collection length " + length + " exceeds maximum allowed");
+    }
+    return (int) length;
+  }
+
+  /**
+   * Check to ensure that reading the string size is within the specified limits.
+   *
+   * @param length The proposed size of the string to read
+   * @return The size of the string if and only if it is within the limit and
+   *         non-negative.
+   * @throws UnsupportedOperationException if reading the items would allocate a
+   *                                       collection that the Java VM would be
+   *                                       unable to handle
+   * @throws SystemLimitException          if the decoding should fail because it
+   *                                       would otherwise result in an allocation
+   *                                       exceeding the set limit
+   * @throws AvroRuntimeException          if the length is negative
+   */
+  public static int checkMaxStringLength(long length) {
+    if (length < 0) {
+      throw new AvroRuntimeException("Malformed data. Length is negative: " + length);
+    }
+    if (length > MAX_ARRAY_VM_LIMIT) {
+      throw new UnsupportedOperationException("Cannot read strings longer than " + MAX_ARRAY_VM_LIMIT + " bytes");
+    }
+    if (length > maxStringLength) {
+      throw new SystemLimitException("String length " + length + " exceeds maximum allowed");
+    }
+    return (int) length;
+  }
+
+  /** Reread the limits from the system properties. */
+  // VisibleForTesting
+  static void resetLimits() {
+    maxBytesLength = getLimitFromProperty(MAX_BYTES_LENGTH_PROPERTY, MAX_ARRAY_VM_LIMIT);
+    maxCollectionLength = getLimitFromProperty(MAX_COLLECTION_LENGTH_PROPERTY, MAX_ARRAY_VM_LIMIT);
+    maxStringLength = getLimitFromProperty(MAX_STRING_LENGTH_PROPERTY, MAX_ARRAY_VM_LIMIT);
+  }
+}

--- a/lang/java/avro/src/main/java/org/apache/avro/io/BinaryDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/BinaryDecoder.java
@@ -26,8 +26,8 @@ import java.util.Arrays;
 
 import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.InvalidNumberEncodingException;
+import org.apache.avro.SystemLimitException;
 import org.apache.avro.util.Utf8;
-import org.slf4j.LoggerFactory;
 
 /**
  * An {@link Decoder} for binary-format data.
@@ -39,27 +39,20 @@ import org.slf4j.LoggerFactory;
  * can be accessed by inputStream().remaining(), if the BinaryDecoder is not
  * 'direct'.
  * <p/>
- * To prevent this class from making large allocations when handling potentially
- * pathological input data, set Java properties
- * <tt>org.apache.avro.limits.string.maxLength</tt> and
- * <tt>org.apache.avro.limits.bytes.maxLength</tt> before instantiating this
- * class to limit the maximum sizes of <tt>string</tt> and <tt>bytes</tt> types
- * handled. The default is to permit sizes up to Java's maximum array length.
  *
  * @see Encoder
+ * @see SystemLimitException
  */
 
 public class BinaryDecoder extends Decoder {
 
   /**
-   * The maximum size of array to allocate. Some VMs reserve some header words in
-   * an array. Attempts to allocate larger arrays may result in OutOfMemoryError:
-   * Requested array size exceeds VM limit
+   * When reading a collection (MAP or ARRAY), this keeps track of the number of
+   * elements to ensure that the
+   * {@link SystemLimitException#checkMaxCollectionLength} constraint is
+   * respected.
    */
-  static final long MAX_ARRAY_SIZE = (long) Integer.MAX_VALUE - 8L;
-
-  private static final String MAX_BYTES_LENGTH_PROPERTY = "org.apache.avro.limits.bytes.maxLength";
-  protected final int maxBytesLength;
+  private long collectionCount = 0L;
 
   private ByteSource source = null;
   // we keep the buffer and its state variables in this class and not in a
@@ -99,17 +92,6 @@ public class BinaryDecoder extends Decoder {
   /** protected constructor for child classes */
   protected BinaryDecoder() {
     super();
-    String o = System.getProperty(MAX_BYTES_LENGTH_PROPERTY);
-    int i = Integer.MAX_VALUE;
-    if (o != null) {
-      try {
-        i = Integer.parseUnsignedInt(o);
-      } catch (NumberFormatException nfe) {
-        LoggerFactory.getLogger(BinaryDecoder.class)
-            .warn("Could not parse property " + MAX_BYTES_LENGTH_PROPERTY + ": " + o, nfe);
-      }
-    }
-    maxBytesLength = i;
   }
 
   BinaryDecoder(InputStream in, int bufferSize) {
@@ -300,17 +282,11 @@ public class BinaryDecoder extends Decoder {
 
   @Override
   public Utf8 readString(Utf8 old) throws IOException {
-    long length = readLong();
-    if (length > MAX_ARRAY_SIZE) {
-      throw new UnsupportedOperationException("Cannot read strings longer than " + MAX_ARRAY_SIZE + " bytes");
-    }
-    if (length < 0L) {
-      throw new AvroRuntimeException("Malformed data. Length is negative: " + length);
-    }
+    int length = SystemLimitException.checkMaxStringLength(readLong());
     Utf8 result = (old != null ? old : new Utf8());
-    result.setByteLength((int) length);
-    if (0L != length) {
-      doReadBytes(result.getBytes(), 0, (int) length);
+    result.setByteLength(length);
+    if (0 != length) {
+      doReadBytes(result.getBytes(), 0, length);
     }
     return result;
   }
@@ -329,17 +305,7 @@ public class BinaryDecoder extends Decoder {
 
   @Override
   public ByteBuffer readBytes(ByteBuffer old) throws IOException {
-    long length = readLong();
-    if (length > MAX_ARRAY_SIZE) {
-      throw new UnsupportedOperationException(
-          "Cannot read arrays longer than " + MAX_ARRAY_SIZE + " bytes in Java library");
-    }
-    if (length > maxBytesLength) {
-      throw new AvroRuntimeException("Bytes length " + length + " exceeds maximum allowed");
-    }
-    if (length < 0L) {
-      throw new AvroRuntimeException("Malformed data. Length is negative: " + length);
-    }
+    int length = SystemLimitException.checkMaxBytesLength(readLong());
     final ByteBuffer result;
     if (old != null && length <= old.capacity()) {
       result = old;
@@ -444,7 +410,6 @@ public class BinaryDecoder extends Decoder {
    * @return Zero if there are no more items to skip and end of array/map is
    *         reached. Positive number if some items are found that cannot be
    *         skipped and the client needs to skip them individually.
-   *
    * @throws IOException If the first byte cannot be read for any reason other
    *                     than the end of the file, if the input stream has been
    *                     closed, or if some other I/O error occurs.
@@ -461,12 +426,15 @@ public class BinaryDecoder extends Decoder {
 
   @Override
   public long readArrayStart() throws IOException {
-    return doReadItemCount();
+    collectionCount = SystemLimitException.checkMaxCollectionLength(0L, doReadItemCount());
+    return collectionCount;
   }
 
   @Override
   public long arrayNext() throws IOException {
-    return doReadItemCount();
+    long length = doReadItemCount();
+    collectionCount = SystemLimitException.checkMaxCollectionLength(collectionCount, length);
+    return length;
   }
 
   @Override
@@ -476,12 +444,15 @@ public class BinaryDecoder extends Decoder {
 
   @Override
   public long readMapStart() throws IOException {
-    return doReadItemCount();
+    collectionCount = SystemLimitException.checkMaxCollectionLength(0L, doReadItemCount());
+    return collectionCount;
   }
 
   @Override
   public long mapNext() throws IOException {
-    return doReadItemCount();
+    long length = doReadItemCount();
+    collectionCount = SystemLimitException.checkMaxCollectionLength(collectionCount, length);
+    return length;
   }
 
   @Override
@@ -933,7 +904,6 @@ public class BinaryDecoder extends Decoder {
   /**
    * This byte source is special. It will avoid copying data by using the source's
    * byte[] as a buffer in the decoder.
-   *
    */
   private static class ByteArrayByteSource extends ByteSource {
     private static final int MIN_SIZE = 16;

--- a/lang/java/avro/src/main/java/org/apache/avro/io/DirectBinaryDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/DirectBinaryDecoder.java
@@ -22,8 +22,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 
-import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.InvalidNumberEncodingException;
+import org.apache.avro.SystemLimitException;
 import org.apache.avro.util.ByteBufferInputStream;
 
 /**
@@ -39,8 +39,7 @@ class DirectBinaryDecoder extends BinaryDecoder {
   private InputStream in;
 
   private class ByteReader {
-    public ByteBuffer read(ByteBuffer old, long length) throws IOException {
-      this.checkLength(length);
+    public ByteBuffer read(ByteBuffer old, int length) throws IOException {
       final ByteBuffer result;
       if (old != null && length <= old.capacity()) {
         result = old;
@@ -52,19 +51,6 @@ class DirectBinaryDecoder extends BinaryDecoder {
       result.limit((int) length);
       return result;
     }
-
-    protected final void checkLength(long length) {
-      if (length < 0L) {
-        throw new AvroRuntimeException("Malformed data. Length is negative: " + length);
-      }
-      if (length > MAX_ARRAY_SIZE) {
-        throw new UnsupportedOperationException(
-            "Cannot read arrays longer than " + MAX_ARRAY_SIZE + " bytes in Java library");
-      }
-      if (length > maxBytesLength) {
-        throw new AvroRuntimeException("Bytes length " + length + " exceeds maximum allowed");
-      }
-    }
   }
 
   private class ReuseByteReader extends ByteReader {
@@ -75,15 +61,13 @@ class DirectBinaryDecoder extends BinaryDecoder {
     }
 
     @Override
-    public ByteBuffer read(ByteBuffer old, long length) throws IOException {
-      this.checkLength(length);
+    public ByteBuffer read(ByteBuffer old, int length) throws IOException {
       if (old != null) {
         return super.read(old, length);
       } else {
         return bbi.readBuffer((int) length);
       }
     }
-
   }
 
   private ByteReader byteReader;
@@ -172,7 +156,7 @@ class DirectBinaryDecoder extends BinaryDecoder {
   @Override
   public ByteBuffer readBytes(ByteBuffer old) throws IOException {
     long length = readLong();
-    return byteReader.read(old, length);
+    return byteReader.read(old, SystemLimitException.checkMaxBytesLength(length));
   }
 
   @Override

--- a/lang/java/avro/src/main/java/org/apache/avro/util/Utf8.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/util/Utf8.java
@@ -24,9 +24,8 @@ import java.io.ObjectOutput;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
-import org.apache.avro.AvroRuntimeException;
+import org.apache.avro.SystemLimitException;
 import org.apache.avro.io.BinaryData;
-import org.slf4j.LoggerFactory;
 
 /**
  * A Utf8 string. Unlike {@link String}, instances are mutable. This is more
@@ -34,22 +33,8 @@ import org.slf4j.LoggerFactory;
  * as a single instance may be reused.
  */
 public class Utf8 implements Comparable<Utf8>, CharSequence, Externalizable {
-  private static final String MAX_LENGTH_PROPERTY = "org.apache.avro.limits.string.maxLength";
-  private static final int MAX_LENGTH;
-  private static final byte[] EMPTY = new byte[0];
 
-  static {
-    String o = System.getProperty(MAX_LENGTH_PROPERTY);
-    int i = Integer.MAX_VALUE;
-    if (o != null) {
-      try {
-        i = Integer.parseUnsignedInt(o);
-      } catch (NumberFormatException nfe) {
-        LoggerFactory.getLogger(Utf8.class).warn("Could not parse property " + MAX_LENGTH_PROPERTY + ": " + o, nfe);
-      }
-    }
-    MAX_LENGTH = i;
-  }
+  private static final byte[] EMPTY = new byte[0];
 
   private byte[] bytes;
   private int hash;
@@ -63,7 +48,7 @@ public class Utf8 implements Comparable<Utf8>, CharSequence, Externalizable {
   public Utf8(String string) {
     byte[] bytes = getBytesFor(string);
     int length = bytes.length;
-    checkLength(length);
+    SystemLimitException.checkMaxStringLength(length);
     this.bytes = bytes;
     this.length = length;
     this.string = string;
@@ -78,7 +63,7 @@ public class Utf8 implements Comparable<Utf8>, CharSequence, Externalizable {
 
   public Utf8(byte[] bytes) {
     int length = bytes.length;
-    checkLength(length);
+    SystemLimitException.checkMaxStringLength(length);
     this.bytes = bytes;
     this.length = length;
   }
@@ -121,7 +106,7 @@ public class Utf8 implements Comparable<Utf8>, CharSequence, Externalizable {
    * length does not change, as this also clears the cached String.
    */
   public Utf8 setByteLength(int newLength) {
-    checkLength(newLength);
+    SystemLimitException.checkMaxStringLength(newLength);
     if (this.bytes.length < newLength) {
       this.bytes = Arrays.copyOf(this.bytes, newLength);
     }
@@ -135,7 +120,7 @@ public class Utf8 implements Comparable<Utf8>, CharSequence, Externalizable {
   public Utf8 set(String string) {
     byte[] bytes = getBytesFor(string);
     int length = bytes.length;
-    checkLength(length);
+    SystemLimitException.checkMaxStringLength(length);
     this.bytes = bytes;
     this.length = length;
     this.string = string;
@@ -213,12 +198,6 @@ public class Utf8 implements Comparable<Utf8>, CharSequence, Externalizable {
   @Override
   public CharSequence subSequence(int start, int end) {
     return toString().subSequence(start, end);
-  }
-
-  private static void checkLength(int length) {
-    if (length > MAX_LENGTH) {
-      throw new AvroRuntimeException("String length " + length + " exceeds maximum allowed");
-    }
   }
 
   /** Gets the UTF-8 bytes for a String */

--- a/lang/java/avro/src/test/java/org/apache/avro/TestFixed.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestFixed.java
@@ -18,10 +18,9 @@
 
 package org.apache.avro;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestFixed {
 
@@ -35,4 +34,16 @@ public class TestFixed {
     assertArrayEquals(new byte[16], (byte[]) field.defaultVal());
   }
 
+  @Test
+  void fixedLengthOutOfLimit() {
+    Exception ex = assertThrows(UnsupportedOperationException.class,
+        () -> Schema.createFixed("oversize", "doc", "space", Integer.MAX_VALUE));
+    assertEquals(TestSystemLimitException.ERROR_VM_LIMIT_BYTES, ex.getMessage());
+  }
+
+  @Test
+  void fixedNegativeLength() {
+    Exception ex = assertThrows(AvroRuntimeException.class, () -> Schema.createFixed("negative", "doc", "space", -1));
+    assertEquals(TestSystemLimitException.ERROR_NEGATIVE, ex.getMessage());
+  }
 }

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSystemLimitException.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSystemLimitException.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2017 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.avro;
+
+import static org.apache.avro.SystemLimitException.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Function;
+
+public class TestSystemLimitException {
+
+  /** Delegated here for package visibility. */
+  public static final int MAX_ARRAY_VM_LIMIT = SystemLimitException.MAX_ARRAY_VM_LIMIT;
+
+  public static final String ERROR_NEGATIVE = "Malformed data. Length is negative: -1";
+  public static final String ERROR_VM_LIMIT_BYTES = "Cannot read arrays longer than " + MAX_ARRAY_VM_LIMIT
+      + " bytes in Java library";
+  public static final String ERROR_VM_LIMIT_COLLECTION = "Cannot read collections larger than " + MAX_ARRAY_VM_LIMIT
+      + " items in Java library";
+  public static final String ERROR_VM_LIMIT_STRING = "Cannot read strings longer than " + MAX_ARRAY_VM_LIMIT + " bytes";
+
+  /** Delegated here for package visibility. */
+  public static void resetLimits() {
+    SystemLimitException.resetLimits();
+  }
+
+  @AfterEach
+  void reset() {
+    System.clearProperty(MAX_BYTES_LENGTH_PROPERTY);
+    System.clearProperty(MAX_COLLECTION_LENGTH_PROPERTY);
+    System.clearProperty(MAX_STRING_LENGTH_PROPERTY);
+    resetLimits();
+  }
+
+  /**
+   * A helper method that tests the consistent limit handling from system
+   * properties.
+   *
+   * @param f                The function to be tested.
+   * @param sysProperty      The system property used to control the custom limit.
+   * @param errorVmLimit     The error message used when the property would be
+   *                         over the VM limit.
+   * @param errorCustomLimit The error message used when the property would be
+   *                         over the custom limit of 1000.
+   */
+  void helpCheckSystemLimits(Function<Long, Integer> f, String sysProperty, String errorVmLimit,
+      String errorCustomLimit) {
+    // Correct values pass through
+    assertEquals(0, f.apply(0L));
+    assertEquals(1024, f.apply(1024L));
+    assertEquals(MAX_ARRAY_VM_LIMIT, f.apply((long) MAX_ARRAY_VM_LIMIT));
+
+    // Values that exceed the default system limits throw exceptions
+    Exception ex = assertThrows(UnsupportedOperationException.class, () -> f.apply(Long.MAX_VALUE));
+    assertEquals(errorVmLimit, ex.getMessage());
+    ex = assertThrows(UnsupportedOperationException.class, () -> f.apply((long) MAX_ARRAY_VM_LIMIT + 1));
+    assertEquals(errorVmLimit, ex.getMessage());
+    ex = assertThrows(AvroRuntimeException.class, () -> f.apply(-1L));
+    assertEquals(ERROR_NEGATIVE, ex.getMessage());
+
+    // Setting the system property to provide a custom limit.
+    System.setProperty(sysProperty, Long.toString(1000L));
+    resetLimits();
+
+    // Correct values pass through
+    assertEquals(0, f.apply(0L));
+    assertEquals(102, f.apply(102L));
+
+    // Values that exceed the custom system limits throw exceptions
+    ex = assertThrows(UnsupportedOperationException.class, () -> f.apply((long) MAX_ARRAY_VM_LIMIT + 1));
+    assertEquals(errorVmLimit, ex.getMessage());
+    ex = assertThrows(SystemLimitException.class, () -> f.apply(1024L));
+    assertEquals(errorCustomLimit, ex.getMessage());
+    ex = assertThrows(AvroRuntimeException.class, () -> f.apply(-1L));
+    assertEquals(ERROR_NEGATIVE, ex.getMessage());
+  }
+
+  @Test
+  void testCheckMaxBytesLength() {
+    helpCheckSystemLimits(SystemLimitException::checkMaxBytesLength, MAX_BYTES_LENGTH_PROPERTY, ERROR_VM_LIMIT_BYTES,
+        "Bytes length 1024 exceeds maximum allowed");
+  }
+
+  @Test
+  void testCheckMaxCollectionLengthFromZero() {
+    helpCheckSystemLimits(l -> checkMaxCollectionLength(0L, l), MAX_COLLECTION_LENGTH_PROPERTY,
+        ERROR_VM_LIMIT_COLLECTION, "Collection length 1024 exceeds maximum allowed");
+  }
+
+  @Test
+  void testCheckMaxStringLength() {
+    helpCheckSystemLimits(SystemLimitException::checkMaxStringLength, MAX_STRING_LENGTH_PROPERTY, ERROR_VM_LIMIT_STRING,
+        "String length 1024 exceeds maximum allowed");
+  }
+
+  @Test
+  void testCheckMaxCollectionLengthFromNonZero() {
+    // Correct values pass through
+    assertEquals(10, checkMaxCollectionLength(10L, 0L));
+    assertEquals(MAX_ARRAY_VM_LIMIT, checkMaxCollectionLength(10L, MAX_ARRAY_VM_LIMIT - 10L));
+    assertEquals(MAX_ARRAY_VM_LIMIT, checkMaxCollectionLength(MAX_ARRAY_VM_LIMIT - 10L, 10L));
+
+    // Values that exceed the default system limits throw exceptions
+    Exception ex = assertThrows(UnsupportedOperationException.class,
+        () -> checkMaxCollectionLength(10L, MAX_ARRAY_VM_LIMIT - 9L));
+    assertEquals(ERROR_VM_LIMIT_COLLECTION, ex.getMessage());
+    ex = assertThrows(UnsupportedOperationException.class,
+        () -> checkMaxCollectionLength(SystemLimitException.MAX_ARRAY_VM_LIMIT - 9L, 10L));
+    assertEquals(ERROR_VM_LIMIT_COLLECTION, ex.getMessage());
+
+    ex = assertThrows(UnsupportedOperationException.class, () -> checkMaxCollectionLength(10L, Long.MAX_VALUE - 10L));
+    assertEquals(ERROR_VM_LIMIT_COLLECTION, ex.getMessage());
+    ex = assertThrows(UnsupportedOperationException.class, () -> checkMaxCollectionLength(Long.MAX_VALUE - 10L, 10L));
+    assertEquals(ERROR_VM_LIMIT_COLLECTION, ex.getMessage());
+
+    // Overflow that adds to negative
+    ex = assertThrows(UnsupportedOperationException.class, () -> checkMaxCollectionLength(10L, Long.MAX_VALUE));
+    assertEquals(ERROR_VM_LIMIT_COLLECTION, ex.getMessage());
+    ex = assertThrows(UnsupportedOperationException.class, () -> checkMaxCollectionLength(Long.MAX_VALUE, 10L));
+    assertEquals(ERROR_VM_LIMIT_COLLECTION, ex.getMessage());
+
+    ex = assertThrows(AvroRuntimeException.class, () -> checkMaxCollectionLength(10L, -1L));
+    assertEquals(ERROR_NEGATIVE, ex.getMessage());
+    ex = assertThrows(AvroRuntimeException.class, () -> checkMaxCollectionLength(-1L, 10L));
+    assertEquals(ERROR_NEGATIVE, ex.getMessage());
+
+    // Setting the system property to provide a custom limit.
+    System.setProperty(MAX_COLLECTION_LENGTH_PROPERTY, Long.toString(1000L));
+    resetLimits();
+
+    // Correct values pass through
+    assertEquals(10, checkMaxCollectionLength(10L, 0L));
+    assertEquals(102, checkMaxCollectionLength(10L, 92L));
+    assertEquals(102, checkMaxCollectionLength(92L, 10L));
+
+    // Values that exceed the custom system limits throw exceptions
+    ex = assertThrows(UnsupportedOperationException.class, () -> checkMaxCollectionLength(MAX_ARRAY_VM_LIMIT, 1));
+    assertEquals(ERROR_VM_LIMIT_COLLECTION, ex.getMessage());
+    ex = assertThrows(UnsupportedOperationException.class, () -> checkMaxCollectionLength(1, MAX_ARRAY_VM_LIMIT));
+    assertEquals(ERROR_VM_LIMIT_COLLECTION, ex.getMessage());
+
+    ex = assertThrows(SystemLimitException.class, () -> checkMaxCollectionLength(999, 25));
+    assertEquals("Collection length 1024 exceeds maximum allowed", ex.getMessage());
+    ex = assertThrows(SystemLimitException.class, () -> checkMaxCollectionLength(25, 999));
+    assertEquals("Collection length 1024 exceeds maximum allowed", ex.getMessage());
+  }
+}

--- a/lang/java/avro/src/test/java/org/apache/avro/util/TestUtf8.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/util/TestUtf8.java
@@ -28,6 +28,8 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.nio.charset.StandardCharsets;
 
+import org.apache.avro.SystemLimitException;
+import org.apache.avro.TestSystemLimitException;
 import org.junit.jupiter.api.Test;
 
 public class TestUtf8 {
@@ -94,6 +96,26 @@ public class TestUtf8 {
     assertEquals(99162322, u.hashCode());
     u.setByteLength(4);
     assertEquals(3198781, u.hashCode());
+  }
+
+  @Test
+  void oversizeUtf8() {
+    Utf8 u = new Utf8();
+    u.setByteLength(1024);
+    assertEquals(1024, u.getByteLength());
+    assertThrows(UnsupportedOperationException.class,
+        () -> u.setByteLength(TestSystemLimitException.MAX_ARRAY_VM_LIMIT + 1));
+
+    try {
+      System.setProperty(SystemLimitException.MAX_STRING_LENGTH_PROPERTY, Long.toString(1000L));
+      TestSystemLimitException.resetLimits();
+
+      Exception ex = assertThrows(SystemLimitException.class, () -> u.setByteLength(1024));
+      assertEquals("String length 1024 exceeds maximum allowed", ex.getMessage());
+    } finally {
+      System.clearProperty(SystemLimitException.MAX_STRING_LENGTH_PROPERTY);
+      TestSystemLimitException.resetLimits();
+    }
   }
 
   @Test


### PR DESCRIPTION
<!--

*Thank you very much for contributing to Apache Avro - we are happy that you want to help us improve Avro. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Avro a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/AVRO/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "AVRO-XXXX: [component] Title of the pull request", where *AVRO-XXXX* should be replaced by the actual issue number. 
    The *component* is optional, but can help identify the correct reviewers faster: either the language ("java", "python") or subsystem such as "build" or "doc" are good candidates.  

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests. You can [build the entire project](https://github.com/apache/avro/blob/master/BUILD.md) or just the [language-specific SDK](https://avro.apache.org/project/how-to-contribute/#unit-tests).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Every commit message references Jira issues in their subject lines. In addition, commits follow the guidelines from [How to write a good git commit message](https://chris.beams.io/posts/git-commit/)
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

-->

## What is the purpose of the change

As described in AVRO-3819, the system properties, exception types and messages dealing with the limits when allocating strings, bytes and collections are distributed throughout the code: `BinaryDecoder`, `Utf8`, `ByteReader` all have similar logic and checks.

These have been centralised as helper methods in one  location and a new exception: `SystemLimitException` extending `AvroRuntimeException`.

In addition, these checks were applied to the collection sizes in BinaryDecoder (allocating arrays and maps), as well as applied to the `FIXED` type schema.

When dealing with untrusted or corrupt data, these checks ensure that an exception is thrown and can be gracefully handled, as opposed to an `OutOfMemoryError`.

## Verifying this change

This change added tests, especially in the `TestBinaryDecoder` covering these scenarios.

## Documentation

- Does this pull request introduce a new feature? **no**
- If yes, how is the feature documented? **JavaDocs**
