### PR TITLE
AVRO-3827: [Rust] Disallow duplicate field names

### DIFF
--- a/lang/rust/avro/src/error.rs
+++ b/lang/rust/avro/src/error.rs
@@ -310,6 +310,9 @@ pub enum Error {
     #[error("Invalid field name {0}")]
     FieldName(String),
 
+    #[error("Duplicate field name {0}")]
+    FieldNameDuplicate(String),
+
     #[error("Invalid schema name {0}. It must match the regex '{1}'")]
     InvalidSchemaName(String, &'static str),
 

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -1441,10 +1441,9 @@ impl Parser {
             })?;
 
         for field in &fields {
-            if lookup.contains_key(&field.name) {
+            if let Some(_old) = lookup.insert(field.name.clone(), field.position) {
                 return Err(Error::FieldNameDuplicate(field.name.clone()));
             }
-            lookup.insert(field.name.clone(), field.position);
 
             if let Some(ref field_aliases) = field.aliases {
                 for alias in field_aliases {

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -1440,12 +1440,10 @@ impl Parser {
                     .collect::<Result<_, _>>()
             })?;
 
-        let mut existing_fields: HashSet<&String> = HashSet::with_capacity(fields.len());
         for field in &fields {
-            if existing_fields.contains(&field.name) {
+            if lookup.contains_key(&field.name) {
                 return Err(Error::FieldNameDuplicate(field.name.clone()));
             }
-            existing_fields.insert(&field.name);
             lookup.insert(field.name.clone(), field.position);
 
             if let Some(ref field_aliases) = field.aliases {

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -1440,7 +1440,12 @@ impl Parser {
                     .collect::<Result<_, _>>()
             })?;
 
+        let mut existing_fields: HashSet<&String> = HashSet::with_capacity(fields.len());
         for field in &fields {
+            if existing_fields.contains(&field.name) {
+                return Err(Error::FieldNameDuplicate(field.name.clone()));
+            }
+            existing_fields.insert(&field.name);
             lookup.insert(field.name.clone(), field.position);
 
             if let Some(ref field_aliases) = field.aliases {
@@ -5063,5 +5068,72 @@ mod tests {
             Err(Error::FieldName(x)) if x == "f1.x" => Ok(()),
             other => Err(format!("Expected Error::FieldName, got {other:?}").into()),
         }
+    }
+
+    #[test]
+    fn test_avro_3827_disallow_duplicate_field_names() -> TestResult {
+        let schema_str = r#"
+        {
+          "name": "my_schema",
+          "type": "record",
+          "fields": [
+            {
+              "name": "f1",
+              "type": {
+                "name": "a",
+                "type": "record",
+                "fields": []
+              }
+            },  {
+              "name": "f1",
+              "type": {
+                "name": "b",
+                "type": "record",
+                "fields": []
+              }
+            }
+          ]
+        }
+        "#;
+
+        match Schema::parse_str(schema_str) {
+            Err(Error::FieldNameDuplicate(_)) => (),
+            other => {
+                return Err(format!("Expected Error::FieldNameDuplicate, got {other:?}").into())
+            }
+        };
+
+        let schema_str = r#"
+        {
+          "name": "my_schema",
+          "type": "record",
+          "fields": [
+            {
+              "name": "f1",
+              "type": {
+                "name": "a",
+                "type": "record",
+                "fields": [
+                  {
+                    "name": "f1",
+                    "type": {
+                      "name": "b",
+                      "type": "record",
+                      "fields": []
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+        "#;
+
+        let expected = r#"{"name":"my_schema","type":"record","fields":[{"name":"f1","type":{"name":"a","type":"record","fields":[{"name":"f1","type":{"name":"b","type":"record","fields":[]}}]}}]}"#;
+        let schema = Schema::parse_str(schema_str)?;
+        let canonical_form = schema.canonical_form();
+        assert_eq!(canonical_form, expected);
+
+        Ok(())
     }
 }


### PR DESCRIPTION
AVRO-3827

## What is the purpose of the change

This PR aims to fix an issue that the current Rust binding accepts duplicate field names.
If a schema contains a record and some of its fields have the same field name, such schema should not be allowed.
```
{
  "name": "my_schema",
  "type": "record",
  "fields": [
    {
      "name": "f1",
      "type": {
        "name": "a",
        "type": "record",
        "fields": []
      }
    },  {
      "name": "f1",
      "type": {
        "name": "b",
        "type": "record",
        "fields": []
      }
    }
  ]
 }
```

## Verifying this change
Added new test and passed with `cargo test avro_3827`.

This change added tests and can be verified as follows:

*(example:)*
- *Extended interop tests to verify consistent valid schema names between SDKs*
- *Added test that validates that Java throws an AvroRuntimeException on invalid binary data*
- *Manually verified the change by building the website and checking the new redirect*

## Documentation
No new features added.