### PR TITLE
AVRO-3828: [Rust] Fix CI build warnings

### DIFF
--- a/.github/workflows/test-lang-php.yml
+++ b/.github/workflows/test-lang-php.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/test-lang-rust-audit.yml
+++ b/.github/workflows/test-lang-rust-audit.yml
@@ -27,6 +27,12 @@ on:
       - lang/rust/Cargo.toml
       - lang/rust/Cargo.lock
 
+permissions:
+  contents: read
+
+env:
+  RUSTFLAGS: -Dwarnings
+
 defaults:
   run:
     working-directory: lang/rust

--- a/.github/workflows/test-lang-rust-audit.yml
+++ b/.github/workflows/test-lang-rust-audit.yml
@@ -47,12 +47,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      # Currently does not work. See https://github.com/actions-rs/audit-check/issues/194
-      #- name: Rust Audit
-      #  uses: actions-rs/audit-check@v1
-      #  with:
-      #    token: ${{ secrets.GITHUB_TOKEN }}
-      # Install it manually
       - name: Dependency Review
         if: github.event_name == 'pull_request'
         uses: actions/dependency-review-action@v3

--- a/.github/workflows/test-lang-rust-ci.yml
+++ b/.github/workflows/test-lang-rust-ci.yml
@@ -26,6 +26,12 @@ on:
       - .github/workflows/test-lang-rust-ci.yml
       - lang/rust/**
 
+permissions:
+  contents: read
+
+env:
+  RUSTFLAGS: -Dwarnings
+
 defaults:
   run:
     working-directory: lang/rust

--- a/.github/workflows/test-lang-rust-ci.yml
+++ b/.github/workflows/test-lang-rust-ci.yml
@@ -108,7 +108,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Rust Toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@nightly
         with:
           toolchain: stable
 
@@ -192,7 +192,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Rust Toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@nightly
         with:
           toolchain: stable
           targets: wasm32-unknown-unknown

--- a/.github/workflows/test-lang-rust-ci.yml
+++ b/.github/workflows/test-lang-rust-ci.yml
@@ -82,23 +82,23 @@ jobs:
 
       - name: Rust Format
         if: matrix.target != 'wasm32-unknown-unknown'
-        run: cargo fmt --manifest-path lang/rust/Cargo.toml --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: Rust Build
-        run: cargo build --manifest-path lang/rust/Cargo.toml --all-features --all-targets
+        run: cargo build --all-features --all-targets
 
       - name: Rust Test
         if: matrix.target != 'wasm32-unknown-unknown'
-        run: cargo test --manifest-path lang/rust/Cargo.toml --all-features --target ${{ matrix.target }}
+        run: cargo test --all-features --target ${{ matrix.target }}
 
       - name: Rust Test AVRO-3549
         if: matrix.target != 'wasm32-unknown-unknown'
-        run: cargo test --manifest-path lang/rust/Cargo.toml --target ${{ matrix.target }} test_avro_3549_read_not_enabled_codec
+        run: cargo test --target ${{ matrix.target }} test_avro_3549_read_not_enabled_codec
 
       # because of https://github.com/rust-lang/cargo/issues/6669
       - name: Rust Test docs
         if: matrix.target != 'wasm32-unknown-unknown'
-        run: cargo test --manifest-path lang/rust/Cargo.toml --doc
+        run: cargo test --doc
 
   interop:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-lang-rust-ci.yml
+++ b/.github/workflows/test-lang-rust-ci.yml
@@ -46,10 +46,10 @@ jobs:
     strategy:
       matrix:
         rust:
-          - stable
-          - beta
-          - nightly
-          - 1.65.0  # MSRV
+          - 'stable'
+          - 'beta'
+          - 'nightly'
+          - '1.65.0'  # MSRV
         target:
           - x86_64-unknown-linux-gnu
           - wasm32-unknown-unknown

--- a/.github/workflows/test-lang-rust-ci.yml
+++ b/.github/workflows/test-lang-rust-ci.yml
@@ -74,48 +74,31 @@ jobs:
           key: ${{ runner.os }}-target-cache1-${{ matrix.rust }}-
 
       - name: Rust Toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
           components: rustfmt
-          target: ${{ matrix.target }}
+          targets: ${{ matrix.target }}
 
       - name: Rust Format
         if: matrix.target != 'wasm32-unknown-unknown'
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --manifest-path lang/rust/Cargo.toml --all -- --check
+        run: cargo fmt --manifest-path lang/rust/Cargo.toml --all -- --check
 
       - name: Rust Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --manifest-path lang/rust/Cargo.toml --all-features --all-targets
+        run: cargo build --manifest-path lang/rust/Cargo.toml --all-features --all-targets
 
       - name: Rust Test
         if: matrix.target != 'wasm32-unknown-unknown'
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path lang/rust/Cargo.toml --all-features --target ${{ matrix.target }}
+        run: cargo test --manifest-path lang/rust/Cargo.toml --all-features --target ${{ matrix.target }}
 
       - name: Rust Test AVRO-3549
         if: matrix.target != 'wasm32-unknown-unknown'
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path lang/rust/Cargo.toml --target ${{ matrix.target }} test_avro_3549_read_not_enabled_codec
+        run: cargo test --manifest-path lang/rust/Cargo.toml --target ${{ matrix.target }} test_avro_3549_read_not_enabled_codec
 
       # because of https://github.com/rust-lang/cargo/issues/6669
       - name: Rust Test docs
         if: matrix.target != 'wasm32-unknown-unknown'
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path lang/rust/Cargo.toml --doc
+        run: cargo test --manifest-path lang/rust/Cargo.toml --doc
 
   interop:
     runs-on: ubuntu-latest
@@ -125,11 +108,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Rust Toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: stable
-          override: true
 
       - name: Cache Cargo
         uses: actions/cache@v3
@@ -211,12 +192,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Rust Toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: stable
-          override: true
-          target: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown
 
       - name: Cache Cargo
         uses: actions/cache@v3

--- a/.github/workflows/test-lang-rust-clippy.yml
+++ b/.github/workflows/test-lang-rust-clippy.yml
@@ -45,12 +45,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
           components: clippy
-          override: true
-      - uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --manifest-path lang/rust/Cargo.toml  --all-features --all-targets -- -Dclippy::all -Dunused_imports
+      - run: cargo clippy --all-features --all-targets -- -Dclippy::all -Dunused_imports

--- a/.github/workflows/test-lang-rust-clippy.yml
+++ b/.github/workflows/test-lang-rust-clippy.yml
@@ -26,6 +26,12 @@ on:
       - .github/workflows/test-lang-rust-clippy.yml
       - lang/rust/**
 
+permissions:
+  contents: read
+
+env:
+  RUSTFLAGS: -Dwarnings
+
 defaults:
   run:
     working-directory: lang/rust

--- a/.github/workflows/test-lang-rust-clippy.yml
+++ b/.github/workflows/test-lang-rust-clippy.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@nightly
         with:
           toolchain: stable
           components: clippy


### PR DESCRIPTION
AVRO-3828

Enable "RUSTFLAGS=-Dwarnings" for all Rust CI workflows, borrowed from https://github.com/serde-rs/serde/blob/master/.github/workflows/ci.yml


## What is the purpose of the change

* Make the CI build warnings-free


## Verifying this change

* Check the CI build "**Annotations**", e.g. https://github.com/apache/avro/actions/runs/5817968858?pr=2433 has several types of warnings

## Documentation

- Does this pull request introduce a new feature? no