### PR TITLE
AVRO-3749: [Java] avoid conflict in method name for generated code

### DIFF
--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
@@ -1262,10 +1262,7 @@ public class SpecificCompiler {
 
     // Check for the special case in which the schema defines two fields whose
     // names are identical except for the case of the first character:
-    char firstChar = field.name().charAt(0);
-    String conflictingFieldName = (Character.isLowerCase(firstChar) ? Character.toUpperCase(firstChar)
-        : Character.toLowerCase(firstChar)) + (field.name().length() > 1 ? field.name().substring(1) : "");
-    boolean fieldNameConflict = schema.getField(conflictingFieldName) != null;
+    int indexNameConflict = calcNameIndex(field.name(), schema);
 
     StringBuilder methodBuilder = new StringBuilder(prefix);
     String fieldName = mangle(field.name(), schema.isError() ? ERROR_RESERVED_WORDS : ACCESSOR_MUTATOR_RESERVED_WORDS,
@@ -1285,14 +1282,73 @@ public class SpecificCompiler {
     methodBuilder.append(postfix);
 
     // If there is a field name conflict append $0 or $1
-    if (fieldNameConflict) {
+    if (indexNameConflict >= 0) {
       if (methodBuilder.charAt(methodBuilder.length() - 1) != '$') {
         methodBuilder.append('$');
       }
-      methodBuilder.append(Character.isLowerCase(firstChar) ? '0' : '1');
+      methodBuilder.append(indexNameConflict);
     }
 
     return methodBuilder.toString();
+  }
+
+  /**
+   * Calc name index for getter / setter field in case of conflict as example,
+   * having a schema with fields __X, _X, _x, X, x should result with indexes __X:
+   * 3, _X: 2, _x: 1, X: 0 x: None (-1)
+   *
+   * @param fieldName : field name.
+   * @param schema    : schema.
+   * @return index for field.
+   */
+  private static int calcNameIndex(String fieldName, Schema schema) {
+    // get name without underscore at start
+    // and calc number of other similar fields with same subname.
+    int countSimilar = 0;
+    String pureFieldName = fieldName;
+    while (!pureFieldName.isEmpty() && pureFieldName.charAt(0) == '_') {
+      pureFieldName = pureFieldName.substring(1);
+      if (schema.getField(pureFieldName) != null) {
+        countSimilar++;
+      }
+      String reversed = reverseFirstLetter(pureFieldName);
+      if (schema.getField(reversed) != null) {
+        countSimilar++;
+      }
+    }
+    // field name start with upper have +1
+    String reversed = reverseFirstLetter(fieldName);
+    if (!pureFieldName.isEmpty() && Character.isUpperCase(pureFieldName.charAt(0))
+        && schema.getField(reversed) != null) {
+      countSimilar++;
+    }
+
+    int ret = -1; // if no similar name, no index.
+    if (countSimilar > 0) {
+      ret = countSimilar - 1; // index is count similar -1 (start with $0)
+    }
+
+    return ret;
+  }
+
+  /**
+   * Reverse first letter upper <=> lower. __Name <=> __name
+   *
+   * @param name : input name.
+   * @return name with change case of first letter.
+   */
+  private static String reverseFirstLetter(String name) {
+    StringBuilder builder = new StringBuilder(name);
+    int index = 0;
+    while (builder.length() > index && builder.charAt(index) == '_') {
+      index++;
+    }
+    if (builder.length() > index) {
+      char c = builder.charAt(index);
+      char inverseC = Character.isLowerCase(c) ? Character.toUpperCase(c) : Character.toLowerCase(c);
+      builder.setCharAt(index, inverseC);
+    }
+    return builder.toString();
   }
 
   /**

--- a/lang/java/compiler/src/test/java/org/apache/avro/compiler/specific/TestSpecificCompiler.java
+++ b/lang/java/compiler/src/test/java/org/apache/avro/compiler/specific/TestSpecificCompiler.java
@@ -929,4 +929,59 @@ public class TestSpecificCompiler {
     }
   }
 
+  @Test
+  void fieldWithUnderscore_avro3826() {
+    String jsonSchema = "{\n" + "  \"name\": \"Value\",\n" + "  \"type\": \"record\",\n" + "  \"fields\": [\n"
+        + "    { \"name\": \"__deleted\",  \"type\": \"string\"\n" + "    }\n" + "  ]\n" + "}";
+    Collection<SpecificCompiler.OutputFile> outputs = new SpecificCompiler(new Schema.Parser().parse(jsonSchema))
+        .compile();
+    assertEquals(1, outputs.size());
+    SpecificCompiler.OutputFile outputFile = outputs.iterator().next();
+    assertTrue(outputFile.contents.contains("getDeleted()"));
+    assertFalse(outputFile.contents.contains("$0"));
+    assertFalse(outputFile.contents.contains("$1"));
+
+    String jsonSchema2 = "{\n" + "  \"name\": \"Value\",  \"type\": \"record\",\n" + "  \"fields\": [\n"
+        + "    { \"name\": \"__deleted\",  \"type\": \"string\"},\n"
+        + "    { \"name\": \"_deleted\",  \"type\": \"string\"}\n" + "  ]\n" + "}";
+    Collection<SpecificCompiler.OutputFile> outputs2 = new SpecificCompiler(new Schema.Parser().parse(jsonSchema2))
+        .compile();
+    assertEquals(1, outputs2.size());
+    SpecificCompiler.OutputFile outputFile2 = outputs2.iterator().next();
+
+    assertTrue(outputFile2.contents.contains("getDeleted()"));
+    assertTrue(outputFile2.contents.contains("getDeleted$0()"));
+    assertFalse(outputFile.contents.contains("$1"));
+
+    String jsonSchema3 = "{\n" + "  \"name\": \"Value\",  \"type\": \"record\",\n" + "  \"fields\": [\n"
+        + "    { \"name\": \"__deleted\",  \"type\": \"string\"},\n"
+        + "    { \"name\": \"_deleted\",  \"type\": \"string\"},\n"
+        + "    { \"name\": \"deleted\",  \"type\": \"string\"}\n" + "  ]\n" + "}";
+    Collection<SpecificCompiler.OutputFile> outputs3 = new SpecificCompiler(new Schema.Parser().parse(jsonSchema3))
+        .compile();
+    assertEquals(1, outputs3.size());
+    SpecificCompiler.OutputFile outputFile3 = outputs3.iterator().next();
+
+    assertTrue(outputFile3.contents.contains("getDeleted()"));
+    assertTrue(outputFile3.contents.contains("getDeleted$0()"));
+    assertTrue(outputFile3.contents.contains("getDeleted$1()"));
+    assertFalse(outputFile3.contents.contains("$2"));
+
+    String jsonSchema4 = "{\n" + "  \"name\": \"Value\",  \"type\": \"record\",\n" + "  \"fields\": [\n"
+        + "    { \"name\": \"__deleted\",  \"type\": \"string\"},\n"
+        + "    { \"name\": \"_deleted\",  \"type\": \"string\"},\n"
+        + "    { \"name\": \"deleted\",  \"type\": \"string\"},\n"
+        + "    { \"name\": \"Deleted\",  \"type\": \"string\"}\n" + "  ]\n" + "}";
+    Collection<SpecificCompiler.OutputFile> outputs4 = new SpecificCompiler(new Schema.Parser().parse(jsonSchema4))
+        .compile();
+    assertEquals(1, outputs4.size());
+    SpecificCompiler.OutputFile outputFile4 = outputs4.iterator().next();
+
+    assertTrue(outputFile4.contents.contains("getDeleted()"));
+    assertTrue(outputFile4.contents.contains("getDeleted$0()"));
+    assertTrue(outputFile4.contents.contains("getDeleted$1()"));
+    assertTrue(outputFile4.contents.contains("getDeleted$2()"));
+    assertFalse(outputFile4.contents.contains("$3"));
+  }
+
 }

--- a/lang/java/ipc/src/test/java/org/apache/avro/compiler/specific/TestSpecificCompiler.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/compiler/specific/TestSpecificCompiler.java
@@ -300,12 +300,11 @@ public class TestSpecificCompiler {
 
     height = new Field("height", Schema.create(Type.INT), null, null);
     Height = new Field("Height", Schema.create(Type.INT), null, null);
-    assertEquals("getHeight$0",
-        SpecificCompiler.generateGetMethod(createRecord("test", false, height, Height), height));
+    assertEquals("getHeight", SpecificCompiler.generateGetMethod(createRecord("test", false, height, Height), height));
 
     height = new Field("height", Schema.create(Type.INT), null, null);
     Height = new Field("Height", Schema.create(Type.INT), null, null);
-    assertEquals("getHeight$1",
+    assertEquals("getHeight$0",
         SpecificCompiler.generateGetMethod(createRecord("test", false, height, Height), Height));
 
     message = new Field("message", Schema.create(Type.STRING), null, null);
@@ -314,12 +313,12 @@ public class TestSpecificCompiler {
 
     message = new Field("message", Schema.create(Type.STRING), null, null);
     Message = new Field("Message", Schema.create(Type.STRING), null, null);
-    assertEquals("getMessage$0",
+    assertEquals("getMessage$",
         SpecificCompiler.generateGetMethod(createRecord("test", true, message, Message), message));
 
     message = new Field("message", Schema.create(Type.STRING), null, null);
     Message = new Field("Message", Schema.create(Type.STRING), null, null);
-    assertEquals("getMessage$1",
+    assertEquals("getMessage$0",
         SpecificCompiler.generateGetMethod(createRecord("test", true, message, Message), Message));
 
     schema = new Field("schema", Schema.create(Type.STRING), null, null);
@@ -328,12 +327,12 @@ public class TestSpecificCompiler {
 
     schema = new Field("schema", Schema.create(Type.STRING), null, null);
     Schema$ = new Field("Schema", Schema.create(Type.STRING), null, null);
-    assertEquals("getSchema$0",
+    assertEquals("getSchema$",
         SpecificCompiler.generateGetMethod(createRecord("test", false, schema, Schema$), schema));
 
     schema = new Field("schema", Schema.create(Type.STRING), null, null);
     Schema$ = new Field("Schema", Schema.create(Type.STRING), null, null);
-    assertEquals("getSchema$1",
+    assertEquals("getSchema$0",
         SpecificCompiler.generateGetMethod(createRecord("test", false, schema, Schema$), Schema$));
   }
 
@@ -376,12 +375,11 @@ public class TestSpecificCompiler {
 
     height = new Field("height", Schema.create(Type.INT), null, null);
     Height = new Field("Height", Schema.create(Type.INT), null, null);
-    assertEquals("setHeight$0",
-        SpecificCompiler.generateSetMethod(createRecord("test", false, height, Height), height));
+    assertEquals("setHeight", SpecificCompiler.generateSetMethod(createRecord("test", false, height, Height), height));
 
     height = new Field("height", Schema.create(Type.INT), null, null);
     Height = new Field("Height", Schema.create(Type.INT), null, null);
-    assertEquals("setHeight$1",
+    assertEquals("setHeight$0",
         SpecificCompiler.generateSetMethod(createRecord("test", false, height, Height), Height));
 
     message = new Field("message", Schema.create(Type.STRING), null, null);
@@ -390,12 +388,12 @@ public class TestSpecificCompiler {
 
     message = new Field("message", Schema.create(Type.STRING), null, null);
     Message = new Field("Message", Schema.create(Type.STRING), null, null);
-    assertEquals("setMessage$0",
+    assertEquals("setMessage$",
         SpecificCompiler.generateSetMethod(createRecord("test", true, message, Message), message));
 
     message = new Field("message", Schema.create(Type.STRING), null, null);
     Message = new Field("Message", Schema.create(Type.STRING), null, null);
-    assertEquals("setMessage$1",
+    assertEquals("setMessage$0",
         SpecificCompiler.generateSetMethod(createRecord("test", true, message, Message), Message));
 
     schema = new Field("schema", Schema.create(Type.STRING), null, null);
@@ -404,12 +402,12 @@ public class TestSpecificCompiler {
 
     schema = new Field("schema", Schema.create(Type.STRING), null, null);
     Schema$ = new Field("Schema", Schema.create(Type.STRING), null, null);
-    assertEquals("setSchema$0",
+    assertEquals("setSchema$",
         SpecificCompiler.generateSetMethod(createRecord("test", false, schema, Schema$), schema));
 
     schema = new Field("schema", Schema.create(Type.STRING), null, null);
     Schema$ = new Field("Schema", Schema.create(Type.STRING), null, null);
-    assertEquals("setSchema$1",
+    assertEquals("setSchema$0",
         SpecificCompiler.generateSetMethod(createRecord("test", false, schema, Schema$), Schema$));
   }
 
@@ -452,12 +450,11 @@ public class TestSpecificCompiler {
 
     height = new Field("height", Schema.create(Type.INT), null, null);
     Height = new Field("Height", Schema.create(Type.INT), null, null);
-    assertEquals("hasHeight$0",
-        SpecificCompiler.generateHasMethod(createRecord("test", false, height, Height), height));
+    assertEquals("hasHeight", SpecificCompiler.generateHasMethod(createRecord("test", false, height, Height), height));
 
     height = new Field("height", Schema.create(Type.INT), null, null);
     Height = new Field("Height", Schema.create(Type.INT), null, null);
-    assertEquals("hasHeight$1",
+    assertEquals("hasHeight$0",
         SpecificCompiler.generateHasMethod(createRecord("test", false, height, Height), Height));
 
     message = new Field("message", Schema.create(Type.STRING), null, null);
@@ -466,12 +463,12 @@ public class TestSpecificCompiler {
 
     message = new Field("message", Schema.create(Type.STRING), null, null);
     Message = new Field("Message", Schema.create(Type.STRING), null, null);
-    assertEquals("hasMessage$0",
+    assertEquals("hasMessage$",
         SpecificCompiler.generateHasMethod(createRecord("test", true, message, Message), message));
 
     message = new Field("message", Schema.create(Type.STRING), null, null);
     Message = new Field("Message", Schema.create(Type.STRING), null, null);
-    assertEquals("hasMessage$1",
+    assertEquals("hasMessage$0",
         SpecificCompiler.generateHasMethod(createRecord("test", true, message, Message), Message));
 
     schema = new Field("schema", Schema.create(Type.STRING), null, null);
@@ -480,12 +477,12 @@ public class TestSpecificCompiler {
 
     schema = new Field("schema", Schema.create(Type.STRING), null, null);
     Schema$ = new Field("Schema", Schema.create(Type.STRING), null, null);
-    assertEquals("hasSchema$0",
+    assertEquals("hasSchema$",
         SpecificCompiler.generateHasMethod(createRecord("test", false, schema, Schema$), schema));
 
     schema = new Field("schema", Schema.create(Type.STRING), null, null);
     Schema$ = new Field("Schema", Schema.create(Type.STRING), null, null);
-    assertEquals("hasSchema$1",
+    assertEquals("hasSchema$0",
         SpecificCompiler.generateHasMethod(createRecord("test", false, schema, Schema$), Schema$));
   }
 
@@ -528,12 +525,12 @@ public class TestSpecificCompiler {
 
     height = new Field("height", Schema.create(Type.INT), null, null);
     Height = new Field("Height", Schema.create(Type.INT), null, null);
-    assertEquals("clearHeight$0",
+    assertEquals("clearHeight",
         SpecificCompiler.generateClearMethod(createRecord("test", false, height, Height), height));
 
     height = new Field("height", Schema.create(Type.INT), null, null);
     Height = new Field("Height", Schema.create(Type.INT), null, null);
-    assertEquals("clearHeight$1",
+    assertEquals("clearHeight$0",
         SpecificCompiler.generateClearMethod(createRecord("test", false, height, Height), Height));
 
     message = new Field("message", Schema.create(Type.STRING), null, null);
@@ -542,12 +539,12 @@ public class TestSpecificCompiler {
 
     message = new Field("message", Schema.create(Type.STRING), null, null);
     Message = new Field("Message", Schema.create(Type.STRING), null, null);
-    assertEquals("clearMessage$0",
+    assertEquals("clearMessage$",
         SpecificCompiler.generateClearMethod(createRecord("test", true, message, Message), message));
 
     message = new Field("message", Schema.create(Type.STRING), null, null);
     Message = new Field("Message", Schema.create(Type.STRING), null, null);
-    assertEquals("clearMessage$1",
+    assertEquals("clearMessage$0",
         SpecificCompiler.generateClearMethod(createRecord("test", true, message, Message), Message));
 
     schema = new Field("schema", Schema.create(Type.STRING), null, null);
@@ -556,12 +553,12 @@ public class TestSpecificCompiler {
 
     schema = new Field("schema", Schema.create(Type.STRING), null, null);
     Schema$ = new Field("Schema", Schema.create(Type.STRING), null, null);
-    assertEquals("clearSchema$0",
+    assertEquals("clearSchema$",
         SpecificCompiler.generateClearMethod(createRecord("test", false, schema, Schema$), schema));
 
     schema = new Field("schema", Schema.create(Type.STRING), null, null);
     Schema$ = new Field("Schema", Schema.create(Type.STRING), null, null);
-    assertEquals("clearSchema$1",
+    assertEquals("clearSchema$0",
         SpecificCompiler.generateClearMethod(createRecord("test", false, schema, Schema$), Schema$));
   }
 


### PR DESCRIPTION
<!--

*Thank you very much for contributing to Apache Avro - we are happy that you want to help us improve Avro. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Avro a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/AVRO/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "AVRO-XXXX: [component] Title of the pull request", where *AVRO-XXXX* should be replaced by the actual issue number. 
    The *component* is optional, but can help identify the correct reviewers faster: either the language ("java", "python") or subsystem such as "build" or "doc" are good candidates.  

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests. You can [build the entire project](https://github.com/apache/avro/blob/master/BUILD.md) or just the [language-specific SDK](https://avro.apache.org/project/how-to-contribute/#unit-tests).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Every commit message references Jira issues in their subject lines. In addition, commits follow the guidelines from [How to write a good git commit message](https://chris.beams.io/posts/git-commit/)
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

-->

## What is the purpose of the change

As decribe in [JIRA  AVRO-3749](https://issues.apache.org/jira/browse/AVRO-3749), SqlCompiler **can generate same method name** when field name start with undescore '_' name.
hence, a schema with fields
`"x", "X", "_x"`
generates several method getX$0(), and source can't compile.

With this PR, it will generate getX() of x, getX$0 for X and getX$1() for _x 
(but a schema that contains only field _x will generate only getX() method.)
For each field, it count number of collision with "preceding fields" to generate method. Preceding is defined with order, number of underscore (start with 0), and, for same number of underscore, start with lower case.

**This PR can also modify the generated code for a given schema.** thats why ipc TestSpecificCompiler is modify.

## Verifying this change

new Unit test on TestSpecificCompiler for compiler module.
Test on TestSpecificCompiler for module IPC is changed.


## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
