### PR TITLE
AVRO-3830: [Rust] Handle namespace properly if a name starts with dot

### DIFF
--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -233,7 +233,7 @@ impl Name {
         })
     }
 
-    pub(crate) fn get_name_and_namespace(name: &str) -> AvroResult<(String, Namespace)> {
+    fn get_name_and_namespace(name: &str) -> AvroResult<(String, Namespace)> {
         let caps = SCHEMA_NAME_R
             .captures(name)
             .ok_or_else(|| Error::InvalidSchemaName(name.to_string(), SCHEMA_NAME_R.as_str()))?;

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -42,7 +42,7 @@ lazy_static! {
 
     // An optional namespace (with optional dots) followed by a name without any dots in it.
     static ref SCHEMA_NAME_R: Regex =
-        Regex::new(r"^((?P<namespace>[A-Za-z_][A-Za-z0-9_\.]*)*\.)?(?P<name>[A-Za-z_][A-Za-z0-9_]*)$").unwrap();
+        Regex::new(r"^((?P<namespace>([A-Za-z_][A-Za-z0-9_\.]*)*)\.)?(?P<name>[A-Za-z_][A-Za-z0-9_]*)$").unwrap();
 
     static ref FIELD_NAME_R: Regex = Regex::new(r"^[A-Za-z_][A-Za-z0-9_]*$").unwrap();
 }
@@ -227,7 +227,10 @@ impl Name {
     /// `aliases` will not be defined.
     pub fn new(name: &str) -> AvroResult<Self> {
         let (name, namespace) = Name::get_name_and_namespace(name)?;
-        Ok(Self { name, namespace })
+        Ok(Self {
+            name,
+            namespace: namespace.filter(|ns| !ns.is_empty()),
+        })
     }
 
     pub(crate) fn get_name_and_namespace(name: &str) -> AvroResult<(String, Namespace)> {
@@ -257,12 +260,9 @@ impl Name {
 
         Ok(Self {
             name: type_name.unwrap_or(name),
-            namespace: namespace_from_name.or_else(|| {
-                complex
-                    .string("namespace")
-                    .or(enclosing_namespace.clone())
-                    .filter(|ns| !ns.is_empty())
-            }),
+            namespace: namespace_from_name
+                .or_else(|| complex.string("namespace").or(enclosing_namespace.clone()))
+                .filter(|ns| !ns.is_empty()),
         })
     }
 
@@ -5130,6 +5130,82 @@ mod tests {
         let schema = Schema::parse_str(schema_str)?;
         let canonical_form = schema.canonical_form();
         assert_eq!(canonical_form, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_avro_3830_null_namespace_in_fully_qualified_names() -> TestResult {
+        // Check whether all the named types don't refer to the namespace field
+        // if their name starts with a dot.
+        let schema_str = r#"
+        {
+          "name": ".record1",
+          "namespace": "ns1",
+          "type": "record",
+          "fields": [
+            {
+              "name": "f1",
+              "type": {
+                "name": ".enum1",
+                "namespace": "ns2",
+                "type": "enum",
+                "symbols": ["a"]
+              }
+            },  {
+              "name": "f2",
+              "type": {
+                "name": ".fxed1",
+                "namespace": "ns3",
+                "type": "fixed",
+                "size": 1
+              }
+            }
+          ]
+        }
+        "#;
+
+        let expected = r#"{"name":"record1","type":"record","fields":[{"name":"f1","type":{"name":"enum1","type":"enum","symbols":["a"]}},{"name":"f2","type":{"name":"fxed1","type":"fixed","size":1}}]}"#;
+        let schema = Schema::parse_str(schema_str)?;
+        let canonical_form = schema.canonical_form();
+        assert_eq!(canonical_form, expected);
+
+        // Check whether inner types don't inherit ns1.
+        let schema_str = r#"
+        {
+          "name": ".record1",
+          "namespace": "ns1",
+          "type": "record",
+          "fields": [
+            {
+              "name": "f1",
+              "type": {
+                "name": "enum1",
+                "type": "enum",
+                "symbols": ["a"]
+              }
+            },  {
+              "name": "f2",
+              "type": {
+                "name": "fxed1",
+                "type": "fixed",
+                "size": 1
+              }
+            }
+          ]
+        }
+        "#;
+
+        let expected = r#"{"name":"record1","type":"record","fields":[{"name":"f1","type":{"name":"enum1","type":"enum","symbols":["a"]}},{"name":"f2","type":{"name":"fxed1","type":"fixed","size":1}}]}"#;
+        let schema = Schema::parse_str(schema_str)?;
+        let canonical_form = schema.canonical_form();
+        assert_eq!(canonical_form, expected);
+
+        let name = Name::new(".my_name")?;
+        let fullname = name.fullname(None);
+        assert_eq!(fullname, "my_name");
+        let qname = name.fully_qualified_name(&None).to_string();
+        assert_eq!(qname, "my_name");
 
         Ok(())
     }


### PR DESCRIPTION
AVRO-3830

## What is the purpose of the change
This PR aims to fix an issue that the current Rust binding doesn't handle namespaces properly if a name starts with dot.

[The specification](https://avro.apache.org/docs/1.11.1/specification/#names) says about the name and namespace like as follows.

> The empty string may also be used as a namespace to indicate the null namespace

> If the name specified contains a dot, then it is assumed to be a fullname, and any namespace also specified is ignored

According to this specification, if a name in a name field starts with a dot, it's considered that the namespace is null and the corresponding namespace field should be ignored.

For example, given the following schema.
```
{
  "name":  ".record1",
  "namespace": "ns1",
  "type": "record",
  "fields": []
}
```

The name and namespace should be "record1" and null respectively.
But the namespace is considered as "ns1" in the current Rust binding .

## Verifying this change
Added new test.

## Documentation
No new features added.