### PR TITLE
AVRO-3802: [Csharp] Fix memory leak on deflate codec decompression

### DIFF
--- a/lang/csharp/src/apache/main/File/DeflateCodec.cs
+++ b/lang/csharp/src/apache/main/File/DeflateCodec.cs
@@ -58,18 +58,19 @@ namespace Avro.File
         /// <inheritdoc/>
         public override byte[] Decompress(byte[] compressedData, int length)
         {
-
-            MemoryStream inStream = new MemoryStream(compressedData);
-            MemoryStream outStream = new MemoryStream();
-
-            using (DeflateStream Decompress =
-                        new DeflateStream(inStream,
-                        CompressionMode.Decompress))
+            using (MemoryStream inStream = new MemoryStream(compressedData))
             {
-                CopyTo(Decompress, outStream);
+                using (MemoryStream outStream = new MemoryStream(inStream.Capacity))
+                {
+                    using (DeflateStream decompress =
+                           new DeflateStream(inStream,
+                               CompressionMode.Decompress))
+                    {
+                        decompress.CopyTo(outStream, length);
+                    }
+                    return outStream.ToArray();
+                }
             }
-
-            return outStream.ToArray();
         }
 
         /// <summary>

--- a/lang/csharp/src/apache/main/File/DeflateCodec.cs
+++ b/lang/csharp/src/apache/main/File/DeflateCodec.cs
@@ -58,33 +58,14 @@ namespace Avro.File
         /// <inheritdoc/>
         public override byte[] Decompress(byte[] compressedData, int length)
         {
-            using (MemoryStream inStream = new MemoryStream(compressedData))
+            using (MemoryStream inStream = new MemoryStream(compressedData, 0, length))
+            using (MemoryStream outStream = new MemoryStream())
             {
-                using (MemoryStream outStream = new MemoryStream(inStream.Capacity))
+                using (DeflateStream decompress = new DeflateStream(inStream, CompressionMode.Decompress))
                 {
-                    using (DeflateStream decompress =
-                           new DeflateStream(inStream,
-                               CompressionMode.Decompress))
-                    {
-                        decompress.CopyTo(outStream, length);
-                    }
-                    return outStream.ToArray();
+                    decompress.CopyTo(outStream);
                 }
-            }
-        }
-
-        /// <summary>
-        /// Copies to stream.
-        /// </summary>
-        /// <param name="from">stream you are copying from</param>
-        /// <param name="to">stream you are copying to</param>
-        private static void CopyTo(Stream from, Stream to)
-        {
-            byte[] buffer = new byte[4096];
-            int read;
-            while ((read = from.Read(buffer, 0, buffer.Length)) != 0)
-            {
-                to.Write(buffer, 0, read);
+                return outStream.ToArray();
             }
         }
 

--- a/lang/csharp/src/apache/main/Generic/GenericReader.cs
+++ b/lang/csharp/src/apache/main/Generic/GenericReader.cs
@@ -297,8 +297,6 @@ namespace Avro.Generic
                 var defaultDecoder = new BinaryDecoder(defaultStream);
                 foreach (Field rf in rs.Fields.Where(rf => !writerSchema.Contains(rf.Name)))
                 {
-                    if (writerSchema.Contains(rf.Name)) continue;
-
                     defaultStream.Position = 0; // reset for writing
                     Resolver.EncodeDefaultValue(defaultEncoder, rf.Schema, rf.DefaultValue);
                     defaultStream.Flush();

--- a/lang/csharp/src/apache/main/Generic/GenericReader.cs
+++ b/lang/csharp/src/apache/main/Generic/GenericReader.cs
@@ -290,21 +290,23 @@ namespace Avro.Generic
                 }
             }
 
-            var defaultStream = new MemoryStream();
-            var defaultEncoder = new BinaryEncoder(defaultStream);
-            var defaultDecoder = new BinaryDecoder(defaultStream);
-            foreach (Field rf in rs)
+            using (var defaultStream = new MemoryStream())
             {
-                if (writerSchema.Contains(rf.Name)) continue;
+                var defaultEncoder = new BinaryEncoder(defaultStream);
+                var defaultDecoder = new BinaryDecoder(defaultStream);
+                foreach (Field rf in rs)
+                {
+                    if (writerSchema.Contains(rf.Name)) continue;
 
-                defaultStream.Position = 0; // reset for writing
-                Resolver.EncodeDefaultValue(defaultEncoder, rf.Schema, rf.DefaultValue);
-                defaultStream.Flush();
-                defaultStream.Position = 0; // reset for reading
+                    defaultStream.Position = 0; // reset for writing
+                    Resolver.EncodeDefaultValue(defaultEncoder, rf.Schema, rf.DefaultValue);
+                    defaultStream.Flush();
+                    defaultStream.Position = 0; // reset for reading
 
-                object obj = null;
-                TryGetField(rec, rf.Name, rf.Pos, out obj);
-                AddField(rec, rf.Name, rf.Pos, Read(obj, rf.Schema, rf.Schema, defaultDecoder));
+                    object obj = null;
+                    TryGetField(rec, rf.Name, rf.Pos, out obj);
+                    AddField(rec, rf.Name, rf.Pos, Read(obj, rf.Schema, rf.Schema, defaultDecoder));
+                }
             }
 
             return rec;

--- a/lang/csharp/src/apache/main/Generic/GenericReader.cs
+++ b/lang/csharp/src/apache/main/Generic/GenericReader.cs
@@ -19,6 +19,7 @@ using System;
 using System.Collections.Generic;
 using Avro.IO;
 using System.IO;
+using System.Linq;
 
 namespace Avro.Generic
 {
@@ -294,7 +295,7 @@ namespace Avro.Generic
             {
                 var defaultEncoder = new BinaryEncoder(defaultStream);
                 var defaultDecoder = new BinaryDecoder(defaultStream);
-                foreach (Field rf in rs)
+                foreach (Field rf in rs.Fields.Where(rf => !writerSchema.Contains(rf.Name)))
                 {
                     if (writerSchema.Contains(rf.Name)) continue;
 

--- a/lang/csharp/src/apache/main/IO/BinaryDecoder.cs
+++ b/lang/csharp/src/apache/main/IO/BinaryDecoder.cs
@@ -26,14 +26,25 @@ namespace Avro.IO
     public partial class BinaryDecoder : Decoder, IDisposable
     {
         private readonly Stream stream;
+        private readonly bool ownStream;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BinaryDecoder"/> class.
         /// </summary>
         /// <param name="stream">Stream to decode.</param>
-        public BinaryDecoder(Stream stream)
+        public BinaryDecoder(Stream stream) : this(stream, false)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BinaryDecoder"/> class.
+        /// </summary>
+        /// <param name="stream">Stream to decode.</param>
+        /// <param name="ownStream">Leave stream open after disposing the object.</param>
+        public BinaryDecoder(Stream stream, bool ownStream)
         {
             this.stream = stream;
+            this.ownStream = ownStream;
         }
 
         /// <summary>
@@ -298,6 +309,10 @@ namespace Avro.IO
         }
 
         /// <inheritdoc />
-        public void Dispose() => stream?.Dispose();
+        public void Dispose()
+        {
+            if(!ownStream)
+                stream?.Dispose();
+        }
     }
 }

--- a/lang/csharp/src/apache/main/IO/BinaryDecoder.cs
+++ b/lang/csharp/src/apache/main/IO/BinaryDecoder.cs
@@ -23,28 +23,17 @@ namespace Avro.IO
     /// <summary>
     /// Decoder for Avro binary format
     /// </summary>
-    public partial class BinaryDecoder : Decoder, IDisposable
+    public partial class BinaryDecoder : Decoder
     {
         private readonly Stream stream;
-        private readonly bool ownStream;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BinaryDecoder"/> class.
         /// </summary>
         /// <param name="stream">Stream to decode.</param>
-        public BinaryDecoder(Stream stream) : this(stream, false)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="BinaryDecoder"/> class.
-        /// </summary>
-        /// <param name="stream">Stream to decode.</param>
-        /// <param name="ownStream">Leave stream open after disposing the object.</param>
-        public BinaryDecoder(Stream stream, bool ownStream)
+        public BinaryDecoder(Stream stream)
         {
             this.stream = stream;
-            this.ownStream = ownStream;
         }
 
         /// <summary>
@@ -306,13 +295,6 @@ namespace Avro.IO
         private void Skip(long p)
         {
             stream.Seek(p, SeekOrigin.Current);
-        }
-
-        /// <inheritdoc />
-        public void Dispose()
-        {
-            if(!ownStream)
-                stream?.Dispose();
         }
     }
 }

--- a/lang/csharp/src/apache/main/IO/BinaryDecoder.cs
+++ b/lang/csharp/src/apache/main/IO/BinaryDecoder.cs
@@ -23,7 +23,7 @@ namespace Avro.IO
     /// <summary>
     /// Decoder for Avro binary format
     /// </summary>
-    public partial class BinaryDecoder : Decoder
+    public partial class BinaryDecoder : Decoder, IDisposable
     {
         private readonly Stream stream;
 
@@ -296,5 +296,8 @@ namespace Avro.IO
         {
             stream.Seek(p, SeekOrigin.Current);
         }
+
+        /// <inheritdoc />
+        public void Dispose() => stream?.Dispose();
     }
 }

--- a/lang/csharp/src/apache/main/IO/BinaryEncoder.cs
+++ b/lang/csharp/src/apache/main/IO/BinaryEncoder.cs
@@ -25,7 +25,8 @@ namespace Avro.IO
     /// </summary>
     public class BinaryEncoder : Encoder, IDisposable
     {
-        private readonly Stream Stream;
+        private readonly Stream stream;
+        private readonly bool ownStream;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BinaryEncoder"/> class without a backing
@@ -40,9 +41,19 @@ namespace Avro.IO
         /// the provided stream.
         /// </summary>
         /// <param name="stream">Stream to write to.</param>
-        public BinaryEncoder(Stream stream)
+        public BinaryEncoder(Stream stream) : this(stream, false)
         {
-            this.Stream = stream;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BinaryDecoder"/> class.
+        /// </summary>
+        /// <param name="stream">Stream to decode.</param>
+        /// <param name="ownStream">Leave stream open after disposing the object.</param>
+        public BinaryEncoder(Stream stream, bool ownStream)
+        {
+            this.stream = stream;
+            this.ownStream = ownStream;
         }
 
         /// <summary>
@@ -203,22 +214,22 @@ namespace Avro.IO
         /// <inheritdoc/>
         public void WriteFixed(byte[] data, int start, int len)
         {
-            Stream.Write(data, start, len);
+            stream.Write(data, start, len);
         }
 
         private void writeBytes(byte[] bytes)
         {
-            Stream.Write(bytes, 0, bytes.Length);
+            stream.Write(bytes, 0, bytes.Length);
         }
 
         private void writeBytes(byte[] bytes, int offset, int length)
         {
-            Stream.Write(bytes, offset, length);
+            stream.Write(bytes, offset, length);
         }
 
         private void writeByte(byte b)
         {
-            Stream.WriteByte(b);
+            stream.WriteByte(b);
         }
 
         /// <summary>
@@ -226,10 +237,14 @@ namespace Avro.IO
         /// </summary>
         public void Flush()
         {
-            Stream.Flush();
+            stream.Flush();
         }
 
         /// <inheritdoc />
-        public void Dispose() => Stream?.Dispose();
+        public void Dispose()
+        {
+            if (!ownStream)
+                stream?.Dispose();
+        }
     }
 }

--- a/lang/csharp/src/apache/main/IO/BinaryEncoder.cs
+++ b/lang/csharp/src/apache/main/IO/BinaryEncoder.cs
@@ -23,10 +23,9 @@ namespace Avro.IO
     /// <summary>
     /// Write leaf values.
     /// </summary>
-    public class BinaryEncoder : Encoder, IDisposable
+    public class BinaryEncoder : Encoder
     {
         private readonly Stream stream;
-        private readonly bool ownStream;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BinaryEncoder"/> class without a backing
@@ -41,19 +40,9 @@ namespace Avro.IO
         /// the provided stream.
         /// </summary>
         /// <param name="stream">Stream to write to.</param>
-        public BinaryEncoder(Stream stream) : this(stream, false)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="BinaryDecoder"/> class.
-        /// </summary>
-        /// <param name="stream">Stream to decode.</param>
-        /// <param name="ownStream">Leave stream open after disposing the object.</param>
-        public BinaryEncoder(Stream stream, bool ownStream)
+        public BinaryEncoder(Stream stream)
         {
             this.stream = stream;
-            this.ownStream = ownStream;
         }
 
         /// <summary>
@@ -238,13 +227,6 @@ namespace Avro.IO
         public void Flush()
         {
             stream.Flush();
-        }
-
-        /// <inheritdoc />
-        public void Dispose()
-        {
-            if (!ownStream)
-                stream?.Dispose();
         }
     }
 }

--- a/lang/csharp/src/apache/main/IO/BinaryEncoder.cs
+++ b/lang/csharp/src/apache/main/IO/BinaryEncoder.cs
@@ -23,7 +23,7 @@ namespace Avro.IO
     /// <summary>
     /// Write leaf values.
     /// </summary>
-    public class BinaryEncoder : Encoder
+    public class BinaryEncoder : Encoder, IDisposable
     {
         private readonly Stream Stream;
 
@@ -228,5 +228,8 @@ namespace Avro.IO
         {
             Stream.Flush();
         }
+
+        /// <inheritdoc />
+        public void Dispose() => Stream?.Dispose();
     }
 }

--- a/lang/csharp/src/apache/main/Specific/SpecificReader.cs
+++ b/lang/csharp/src/apache/main/Specific/SpecificReader.cs
@@ -130,20 +130,22 @@ namespace Avro.Specific
                 }
             }
 
-            var defaultStream = new MemoryStream();
-            var defaultEncoder = new BinaryEncoder(defaultStream);
-            var defaultDecoder = new BinaryDecoder(defaultStream);
-            foreach (Field rf in rs)
+            using (var defaultStream = new MemoryStream())
             {
-                if (writerSchema.Contains(rf.Name)) continue;
+                var defaultEncoder = new BinaryEncoder(defaultStream);
+                var defaultDecoder = new BinaryDecoder(defaultStream);
+                foreach (Field rf in rs)
+                {
+                    if (writerSchema.Contains(rf.Name)) continue;
 
-                defaultStream.Position = 0; // reset for writing
-                Resolver.EncodeDefaultValue(defaultEncoder, rf.Schema, rf.DefaultValue);
-                defaultStream.Flush();
-                defaultStream.Position = 0; // reset for reading
+                    defaultStream.Position = 0; // reset for writing
+                    Resolver.EncodeDefaultValue(defaultEncoder, rf.Schema, rf.DefaultValue);
+                    defaultStream.Flush();
+                    defaultStream.Position = 0; // reset for reading
 
-                obj = rec.Get(rf.Pos);
-                rec.Put(rf.Pos, Read(obj, rf.Schema, rf.Schema, defaultDecoder));
+                    obj = rec.Get(rf.Pos);
+                    rec.Put(rf.Pos, Read(obj, rf.Schema, rf.Schema, defaultDecoder));
+                }
             }
 
             return rec;

--- a/lang/csharp/src/apache/test/File/FileTests.cs
+++ b/lang/csharp/src/apache/test/File/FileTests.cs
@@ -18,6 +18,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -555,7 +556,6 @@ namespace Avro.Test.File
         /// position in stream
         /// </summary>
         /// <param name="schemaStr"></param>
-        /// <param name="value"></param>
         /// <param name="codecType"></param>
         [TestCaseSource(nameof(TestPartialReadSource))]
         public void TestPartialRead(string schemaStr, Codec.Type codecType, int position, int expectedRecords)
@@ -666,6 +666,55 @@ namespace Avro.Test.File
                     curPosition = nextSyncPoint;
                 }
             }
+        }
+
+        [Test]
+        public void TestDeflateReadMemoryUsage([Values(specificSchema)] string schemaStr)
+        {
+            // create and write out
+            IList<Foo> records = MakeRecords(GetTestFooObject());
+
+            Process currentProcess = Process.GetCurrentProcess();
+
+            MemoryStream dataFileOutputStream = new MemoryStream();
+
+            Schema schema = Schema.Parse(schemaStr);
+            DatumWriter<Foo> writer = new SpecificWriter<Foo>(schema);
+            using (IFileWriter<Foo> dataFileWriter = DataFileWriter<Foo>.OpenWriter(writer, dataFileOutputStream, Codec.CreateCodec(Codec.Type.Deflate)))
+            {
+                for (int i = 0; i < 10; ++i)
+                {
+                    foreach (Foo foo in records)
+                    {
+                        dataFileWriter.Append(foo);
+                    }
+
+                    // write out block
+                    if (i == 1 || i == 4)
+                    {
+                        dataFileWriter.Sync();
+                    }
+                }
+            }
+
+            long startMemoryUsedBytes = currentProcess.WorkingSet64;
+
+            MemoryStream dataFileInputStream = new MemoryStream(dataFileOutputStream.ToArray());
+            dataFileInputStream.Position = 0;
+
+            // read back
+            IList<Foo> readRecords = new List<Foo>();
+            using (IFileReader<Foo> reader = DataFileReader<Foo>.OpenReader(dataFileInputStream, schema))
+            {
+                // read records from synced position
+                foreach (Foo rec in reader.NextEntries)
+                    readRecords.Add(rec);
+            }
+
+            long totalMemoryUsedBytes = currentProcess.WorkingSet64 - startMemoryUsedBytes;
+
+            Assert.IsTrue(totalMemoryUsedBytes  == 0, "Total memory usage in working set");
+
         }
 
         /// <summary>


### PR DESCRIPTION
<!--

*Thank you very much for contributing to Apache Avro - we are happy that you want to help us improve Avro. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Avro a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/AVRO/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "AVRO-XXXX: [component] Title of the pull request", where *AVRO-XXXX* should be replaced by the actual issue number. 
    The *component* is optional, but can help identify the correct reviewers faster: either the language ("java", "python") or subsystem such as "build" or "doc" are good candidates.  

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests. You can [build the entire project](https://github.com/apache/avro/blob/master/BUILD.md) or just the [language-specific SDK](https://avro.apache.org/project/how-to-contribute/#unit-tests).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Every commit message references Jira issues in their subject lines. In addition, commits follow the guidelines from [How to write a good git commit message](https://chris.beams.io/posts/git-commit/)
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

-->

## What is the purpose of the change

The aim of this pull request is to improve memory usage when reading Avro encoded files. Fixing AVRO-3802.

This issue was detected when using Apache.Avro C# library for compression and decompression of large Avro files. Each file is 2-3MB and decompression of 20 files is using 2.1GB memory and memory keep increasing around 200-300MB for follow up calls. 

Attached are images taken of memory profiler of three calls before fix. Each call decompress the same 20 files. First call uses 2.1GB, increase to 2.37GB and then 2.68GB. 

Call tree is showing most of the memory are used by `DeflatCodec.CopyTo` method. 

- `CopyTo` method is not using Array pool. Default Microsoft's stream `copyTo` method is much more efficient. 
- `inStream` and `outStream` memory streams are not in using statement.
- On `outstream` object creation, object can be initialized with defined length/stream capacity. 

![image](https://github.com/apache/avro/assets/72411444/9078647b-5a30-45f0-a9c4-1314cc1548f8)
![image](https://github.com/apache/avro/assets/72411444/bf2d0ece-f193-4240-a70b-297bae852b36)

## Verifying this change

Added test that validates that memory usage after reading records from file reader returns to its initial value. Proving that the reader object is disposed correctly.


## Documentation

No new features added.
