### PR TITLE
AVRO-3814: Fix schema resolution for records in union types

### DIFF
--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -839,13 +839,9 @@ impl UnionSchema {
                 let namespace = &schema.namespace().or_else(|| enclosing_namespace.clone());
 
                 // Attempt to validate the value in order to ensure we've selected the right schema.
-                match value.validate_internal(schema, &collected_names, namespace, true) {
-                    None => true,
-                    Some(err) => {
-                        println!("Validation failed: {:?}", err);
-                        false
-                    }
-                }
+                value
+                    .validate_internal(schema, &collected_names, namespace, true)
+                    .is_none()
             })
         }
     }

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -838,7 +838,6 @@ impl UnionSchema {
                 collected_names.extend(resolved_names);
                 let namespace = &schema.namespace().or_else(|| enclosing_namespace.clone());
 
-                // Attempt to validate the value in order to ensure we've selected the right schema.
                 value
                     .clone()
                     .resolve_internal(schema, &collected_names, namespace, &None)

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -5328,6 +5328,7 @@ mod tests {
 
         // Deserialization should succeed and we should be able to resolve the schema.
         let deser_value = crate::from_avro_datum(&writer_schema, &mut x, Some(&reader_schema))?;
+        assert!(deser_value.validate(&reader_schema));
 
         // Verify that we can read a field from the record.
         let d: MyRecordReader = crate::from_value(&deser_value)?;

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -832,6 +832,7 @@ impl UnionSchema {
                     &collected_names,
                 )
                 .expect("Schema didn't successfully parse");
+
                 let resolved_names = resolved_schema.names_ref;
 
                 // extend known schemas with just resolved names
@@ -5207,6 +5208,129 @@ mod tests {
         let qname = name.fully_qualified_name(&None).to_string();
         assert_eq!(qname, "my_name");
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_avro_3814_schema_resolution_failure() -> TestResult {
+        // Define a reader schema: a nested record with an optional field.
+        let reader_schema = json!(
+            {
+                "type": "record",
+                "name": "MyOuterRecord",
+                "fields": [
+                    {
+                        "name": "inner_record",
+                        "type": [
+                            "null",
+                            {
+                                "type": "record",
+                                "name": "MyRecord",
+                                "fields": [
+                                    {"name": "a", "type": "string"}
+                                ]
+                            }
+                        ],
+                        "default": null
+                    }
+                ]
+            }
+        );
+
+        // Define a writer schema: a nested record with an optional field, which
+        // may optionally contain an enum.
+        let writer_schema = json!(
+            {
+                "type": "record",
+                "name": "MyOuterRecord",
+                "fields": [
+                    {
+                        "name": "inner_record",
+                        "type": [
+                            "null",
+                            {
+                                "type": "record",
+                                "name": "MyRecord",
+                                "fields": [
+                                    {"name": "a", "type": "string"},
+                                    {
+                                        "name": "b",
+                                        "type": [
+                                            "null",
+                                            {
+                                                "type": "enum",
+                                                "name": "MyEnum",
+                                                "symbols": ["A", "B", "C"],
+                                                "default": "C"
+                                            }
+                                        ],
+                                        "default": null
+                                    },
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "default": null
+            }
+        );
+
+        // Use different structs to represent the "Reader" and the "Writer"
+        // to mimic two different versions of a producer & consumer application.
+        #[derive(Serialize, Deserialize, Debug)]
+        struct MyInnerRecordReader {
+            a: String,
+        }
+
+        #[derive(Serialize, Deserialize, Debug)]
+        struct MyRecordReader {
+            inner_record: Option<MyInnerRecordReader>,
+        }
+
+        #[derive(Serialize, Deserialize, Debug)]
+        enum MyEnum {
+            A,
+            B,
+            C,
+        }
+
+        #[derive(Serialize, Deserialize, Debug)]
+        struct MyInnerRecordWriter {
+            a: String,
+            b: Option<MyEnum>,
+        }
+
+        #[derive(Serialize, Deserialize, Debug)]
+        struct MyRecordWriter {
+            inner_record: Option<MyInnerRecordWriter>,
+        }
+
+        let s = MyRecordWriter {
+            inner_record: Some(MyInnerRecordWriter {
+                a: "foo".to_string(),
+                b: None,
+            }),
+        };
+
+        // Serialize using the writer schema (newer).
+        let writer_schema = Schema::parse(&writer_schema)?;
+        let avro_value = crate::to_value(s)?;
+        assert!(
+            avro_value.validate(&writer_schema),
+            "value is valid for schema",
+        );
+        let datum = crate::to_avro_datum(&writer_schema, avro_value)?;
+
+        // Now, attempt to deserialize using the reader schema (older).
+        let reader_schema = Schema::parse(&reader_schema)?;
+        let mut x = &datum[..];
+
+        // Deserialization should succeed and we should be able to resolve the schema.
+        let deser_value = crate::from_avro_datum(&writer_schema, &mut x, Some(&reader_schema))?;
+
+        // Verify that we can read a field from the record.
+        let d: MyRecordReader = crate::from_value(&deser_value)?;
+        assert_eq!(d.inner_record.unwrap().a, "foo".to_string());
         Ok(())
     }
 }

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -840,8 +840,9 @@ impl UnionSchema {
 
                 // Attempt to validate the value in order to ensure we've selected the right schema.
                 value
-                    .validate_internal(schema, &collected_names, namespace, true)
-                    .is_none()
+                    .clone()
+                    .resolve_internal(schema, &collected_names, namespace, &None)
+                    .is_ok()
             })
         }
     }

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -814,6 +814,7 @@ impl UnionSchema {
             Some((i, &self.schemas[i]))
         } else {
             // slow path (required for matching logical or named types)
+
             // first collect what schemas we already know
             let mut collected_names: HashMap<Name, &Schema> = known_schemata
                 .map(|names| {
@@ -831,7 +832,6 @@ impl UnionSchema {
                     &collected_names,
                 )
                 .expect("Schema didn't successfully parse");
-
                 let resolved_names = resolved_schema.names_ref;
 
                 // extend known schemas with just resolved names

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -5313,7 +5313,7 @@ mod tests {
             }),
         };
 
-        // Serialize using the writer schema (newer).
+        // Serialize using the writer schema.
         let writer_schema = Schema::parse(&writer_schema)?;
         let avro_value = crate::to_value(s)?;
         assert!(
@@ -5322,7 +5322,7 @@ mod tests {
         );
         let datum = crate::to_avro_datum(&writer_schema, avro_value)?;
 
-        // Now, attempt to deserialize using the reader schema (older).
+        // Now, attempt to deserialize using the reader schema.
         let reader_schema = Schema::parse(&reader_schema)?;
         let mut x = &datum[..];
 

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -814,7 +814,6 @@ impl UnionSchema {
             Some((i, &self.schemas[i]))
         } else {
             // slow path (required for matching logical or named types)
-
             // first collect what schemas we already know
             let mut collected_names: HashMap<Name, &Schema> = known_schemata
                 .map(|names| {
@@ -838,8 +837,10 @@ impl UnionSchema {
                 // extend known schemas with just resolved names
                 collected_names.extend(resolved_names);
                 let namespace = &schema.namespace().or_else(|| enclosing_namespace.clone());
+
+                // Attempt to validate the value in order to ensure we've selected the right schema.
                 value
-                    .validate_internal(schema, &collected_names, namespace)
+                    .validate_internal(schema, &collected_names, namespace, true)
                     .is_none()
             })
         }

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -839,9 +839,13 @@ impl UnionSchema {
                 let namespace = &schema.namespace().or_else(|| enclosing_namespace.clone());
 
                 // Attempt to validate the value in order to ensure we've selected the right schema.
-                value
-                    .validate_internal(schema, &collected_names, namespace, true)
-                    .is_none()
+                match value.validate_internal(schema, &collected_names, namespace, true) {
+                    None => true,
+                    Some(err) => {
+                        println!("Validation failed: {:?}", err);
+                        false
+                    }
+                }
             })
         }
     }

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -656,7 +656,7 @@ impl Value {
         self.resolve_internal(schema, rs.get_names(), &enclosing_namespace, &None)
     }
 
-    fn resolve_internal(
+    pub(crate) fn resolve_internal(
         mut self,
         schema: &Schema,
         names: &NamesRef,

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -378,9 +378,6 @@ impl Value {
     }
 
     /// Validates the value against the provided schema.
-    ///
-    /// Arguments:
-    /// * `schema_resolution` - whether schema resolution rules should be applied when validating the `value`.
     pub(crate) fn validate_internal<S: std::borrow::Borrow<Schema> + Debug>(
         &self,
         schema: &Schema,

--- a/lang/rust/avro/src/writer.rs
+++ b/lang/rust/avro/src/writer.rs
@@ -425,7 +425,7 @@ fn write_avro_datum_schemata<T: Into<Value>>(
     let rs = ResolvedSchema::try_from(schemata)?;
     let names = rs.get_names();
     let enclosing_namespace = schema.namespace();
-    if let Some(_err) = avro.validate_internal(schema, names, &enclosing_namespace, false) {
+    if let Some(_err) = avro.validate_internal(schema, names, &enclosing_namespace) {
         return Err(Error::Validation);
     }
     encode_internal(&avro, schema, names, &enclosing_namespace, buffer)
@@ -544,12 +544,7 @@ fn write_value_ref_resolved(
     value: &Value,
     buffer: &mut Vec<u8>,
 ) -> AvroResult<()> {
-    match value.validate_internal(
-        schema,
-        resolved_schema.get_names(),
-        &schema.namespace(),
-        false,
-    ) {
+    match value.validate_internal(schema, resolved_schema.get_names(), &schema.namespace()) {
         Some(err) => Err(Error::ValidationWithReason(err)),
         None => encode_internal(
             value,
@@ -571,7 +566,6 @@ fn write_value_ref_owned_resolved(
         root_schema,
         resolved_schema.get_names(),
         &root_schema.namespace(),
-        false,
     ) {
         return Err(Error::ValidationWithReason(err));
     }

--- a/lang/rust/avro/src/writer.rs
+++ b/lang/rust/avro/src/writer.rs
@@ -425,7 +425,7 @@ fn write_avro_datum_schemata<T: Into<Value>>(
     let rs = ResolvedSchema::try_from(schemata)?;
     let names = rs.get_names();
     let enclosing_namespace = schema.namespace();
-    if let Some(_err) = avro.validate_internal(schema, names, &enclosing_namespace) {
+    if let Some(_err) = avro.validate_internal(schema, names, &enclosing_namespace, false) {
         return Err(Error::Validation);
     }
     encode_internal(&avro, schema, names, &enclosing_namespace, buffer)
@@ -544,7 +544,12 @@ fn write_value_ref_resolved(
     value: &Value,
     buffer: &mut Vec<u8>,
 ) -> AvroResult<()> {
-    match value.validate_internal(schema, resolved_schema.get_names(), &schema.namespace()) {
+    match value.validate_internal(
+        schema,
+        resolved_schema.get_names(),
+        &schema.namespace(),
+        false,
+    ) {
         Some(err) => Err(Error::ValidationWithReason(err)),
         None => encode_internal(
             value,
@@ -566,6 +571,7 @@ fn write_value_ref_owned_resolved(
         root_schema,
         resolved_schema.get_names(),
         &root_schema.namespace(),
+        false,
     ) {
         return Err(Error::ValidationWithReason(err));
     }

--- a/lang/rust/avro/tests/avro-3786.rs
+++ b/lang/rust/avro/tests/avro-3786.rs
@@ -248,10 +248,10 @@ fn avro_3786_deserialize_union_with_different_enum_order_defined_in_record() -> 
         ]
     }"#;
     let writer_schema = Schema::parse_str(writer_schema)?;
-    let foo = Foo {
+    let foo1 = Foo {
         bar_parent: Some(BarParent { bar: Bar::Bar0 }),
     };
-    let avro_value = crate::to_value(foo)?;
+    let avro_value = crate::to_value(foo1)?;
     assert!(
         avro_value.validate(&writer_schema),
         "value is valid for schema",
@@ -361,10 +361,10 @@ fn test_avro_3786_deserialize_union_with_different_enum_order_defined_in_record_
             ]
         }"#;
     let writer_schema = Schema::parse_str(writer_schema)?;
-    let foo = Foo {
+    let foo1 = Foo {
         bar_parent: Some(BarParent { bar: Bar::Bar1 }),
     };
-    let avro_value = crate::to_value(foo)?;
+    let avro_value = crate::to_value(foo1)?;
     assert!(
         avro_value.validate(&writer_schema),
         "value is valid for schema",
@@ -474,10 +474,10 @@ fn test_avro_3786_deserialize_union_with_different_enum_order_defined_in_record_
             ]
         }"#;
     let writer_schema = Schema::parse_str(writer_schema)?;
-    let foo = Foo {
+    let foo1 = Foo {
         bar_parent: Some(BarParent { bar: Bar::Bar1 }),
     };
-    let avro_value = crate::to_value(foo)?;
+    let avro_value = crate::to_value(foo1)?;
     assert!(
         avro_value.validate(&writer_schema),
         "value is valid for schema",
@@ -587,10 +587,10 @@ fn deserialize_union_with_different_enum_order_defined_in_record() -> TestResult
             ]
         }"#;
     let writer_schema = Schema::parse_str(writer_schema)?;
-    let foo = Foo {
+    let foo1 = Foo {
         bar_parent: Some(BarParent { bar: Bar::Bar2 }),
     };
-    let avro_value = crate::to_value(foo)?;
+    let avro_value = crate::to_value(foo1)?;
     assert!(
         avro_value.validate(&writer_schema),
         "value is valid for schema",
@@ -853,7 +853,7 @@ fn deserialize_union_with_record_with_enum_defined_inline_reader_has_different_i
             ]
         }"#;
     let writer_schema = Schema::parse_str(writer_schema)?;
-    let foo = Foo {
+    let foo1 = Foo {
         bar_init: Bar::Bar0,
         baz: Baz::Baz0,
         parent: Some(Parent {
@@ -864,7 +864,7 @@ fn deserialize_union_with_record_with_enum_defined_inline_reader_has_different_i
             defined_in_record: DefinedInRecord::Val1,
         }),
     };
-    let avro_value = crate::to_value(foo)?;
+    let avro_value = crate::to_value(foo1)?;
     assert!(
         avro_value.validate(&writer_schema),
         "value is valid for schema",

--- a/lang/rust/avro/tests/avro-3786.rs
+++ b/lang/rust/avro/tests/avro-3786.rs
@@ -157,3 +157,730 @@ fn avro_3786_deserialize_union_with_different_enum_order() -> TestResult {
     }
     Ok(())
 }
+
+#[test]
+fn avro_3786_deserialize_union_with_different_enum_order_defined_in_record() -> TestResult {
+    #[derive(
+        Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, serde::Deserialize, serde::Serialize,
+    )]
+    pub enum Bar {
+        #[serde(rename = "bar0")]
+        Bar0,
+        #[serde(rename = "bar1")]
+        Bar1,
+        #[serde(rename = "bar2")]
+        Bar2,
+    }
+    #[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
+    pub struct BarParent {
+        pub bar: Bar,
+    }
+    #[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
+    pub struct Foo {
+        #[serde(rename = "barParent")]
+        pub bar_parent: Option<BarParent>,
+    }
+    let writer_schema = r#"{
+        "type": "record",
+        "name": "Foo",
+        "namespace": "com.rallyhealth.devices.canonical.avro.model.v6_0",
+        "fields":
+        [
+            {
+                "name": "barParent",
+                "type": [
+                    "null",
+                    {
+                        "type": "record",
+                        "name": "BarParent",
+                        "fields": [
+                            {
+                                "name": "bar",
+                                "type": {
+                                    "type": "enum",
+                                    "name": "Bar",
+                                    "symbols":
+                                    [
+                                        "bar0",
+                                        "bar1",
+                                        "bar2"
+                                    ],
+                                    "default": "bar0"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }"#;
+    let reader_schema = r#"{
+        "type": "record",
+        "name": "Foo",
+        "namespace": "com.rallyhealth.devices.canonical.avro.model.v6_0",
+        "fields":
+        [
+            {
+                "name": "barParent",
+                "type": [
+                    "null",
+                    {
+                        "type": "record",
+                        "name": "BarParent",
+                        "fields": [
+                            {
+                                "name": "bar",
+                                "type": {
+                                    "type": "enum",
+                                    "name": "Bar",
+                                    "symbols":
+                                    [
+                                        "bar0",
+                                        "bar2"
+                                    ],
+                                    "default": "bar0"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }"#;
+    let writer_schema = Schema::parse_str(writer_schema)?;
+    let foo = Foo {
+        bar_parent: Some(BarParent { bar: Bar::Bar0 }),
+    };
+    let avro_value = crate::to_value(foo)?;
+    assert!(
+        avro_value.validate(&writer_schema),
+        "value is valid for schema",
+    );
+    let datum = crate::to_avro_datum(&writer_schema, avro_value)?;
+    let mut x = &datum[..];
+    let reader_schema = Schema::parse_str(reader_schema)?;
+    let deser_value = crate::from_avro_datum(&writer_schema, &mut x, Some(&reader_schema))?;
+    match deser_value {
+        types::Value::Record(fields) => {
+            assert_eq!(fields.len(), 1);
+            assert_eq!(fields[0].0, "barParent");
+            // TODO: better validation
+        }
+        _ => panic!("Expected Value::Record"),
+    }
+    Ok(())
+}
+
+#[test]
+fn test_avro_3786_deserialize_union_with_different_enum_order_defined_in_record_v1() -> TestResult {
+    #[derive(
+        Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, serde::Deserialize, serde::Serialize,
+    )]
+    pub enum Bar {
+        #[serde(rename = "bar0")]
+        Bar0,
+        #[serde(rename = "bar1")]
+        Bar1,
+        #[serde(rename = "bar2")]
+        Bar2,
+    }
+    #[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
+    pub struct BarParent {
+        pub bar: Bar,
+    }
+    #[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
+    pub struct Foo {
+        #[serde(rename = "barParent")]
+        pub bar_parent: Option<BarParent>,
+    }
+    let writer_schema = r#"{
+            "type": "record",
+            "name": "Foo",
+            "namespace": "com.rallyhealth.devices.canonical.avro.model.v6_0",
+            "fields":
+            [
+                {
+                    "name": "barParent",
+                    "type": [
+                        "null",
+                        {
+                            "type": "record",
+                            "name": "BarParent",
+                            "fields": [
+                                {
+                                    "name": "bar",
+                                    "type": {
+                                        "type": "enum",
+                                        "name": "Bar",
+                                        "symbols":
+                                        [
+                                            "bar0",
+                                            "bar1",
+                                            "bar2"
+                                        ],
+                                        "default": "bar0"
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }"#;
+    let reader_schema = r#"{
+            "type": "record",
+            "name": "Foo",
+            "namespace": "com.rallyhealth.devices.canonical.avro.model.v6_0",
+            "fields":
+            [
+                {
+                    "name": "barParent",
+                    "type": [
+                        "null",
+                        {
+                            "type": "record",
+                            "name": "BarParent",
+                            "fields": [
+                                {
+                                    "name": "bar",
+                                    "type": {
+                                        "type": "enum",
+                                        "name": "Bar",
+                                        "symbols":
+                                        [
+                                            "bar0",
+                                            "bar2"
+                                        ],
+                                        "default": "bar0"
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }"#;
+    let writer_schema = Schema::parse_str(writer_schema)?;
+    let foo = Foo {
+        bar_parent: Some(BarParent { bar: Bar::Bar1 }),
+    };
+    let avro_value = crate::to_value(foo)?;
+    assert!(
+        avro_value.validate(&writer_schema),
+        "value is valid for schema",
+    );
+    let datum = crate::to_avro_datum(&writer_schema, avro_value)?;
+    let mut x = &datum[..];
+    let reader_schema = Schema::parse_str(reader_schema)?;
+    let deser_value = crate::from_avro_datum(&writer_schema, &mut x, Some(&reader_schema))?;
+    match deser_value {
+        types::Value::Record(fields) => {
+            assert_eq!(fields.len(), 1);
+            assert_eq!(fields[0].0, "barParent");
+            // TODO: better validation
+        }
+        _ => panic!("Expected Value::Record"),
+    }
+    Ok(())
+}
+
+#[test]
+fn test_avro_3786_deserialize_union_with_different_enum_order_defined_in_record_v2() -> TestResult {
+    #[derive(
+        Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, serde::Deserialize, serde::Serialize,
+    )]
+    pub enum Bar {
+        #[serde(rename = "bar0")]
+        Bar0,
+        #[serde(rename = "bar1")]
+        Bar1,
+        #[serde(rename = "bar2")]
+        Bar2,
+    }
+    #[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
+    pub struct BarParent {
+        pub bar: Bar,
+    }
+    #[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
+    pub struct Foo {
+        #[serde(rename = "barParent")]
+        pub bar_parent: Option<BarParent>,
+    }
+    let writer_schema = r#"{
+            "type": "record",
+            "name": "Foo",
+            "namespace": "com.rallyhealth.devices.canonical.avro.model.v6_0",
+            "fields":
+            [
+                {
+                    "name": "barParent",
+                    "type": [
+                        "null",
+                        {
+                            "type": "record",
+                            "name": "BarParent",
+                            "fields": [
+                                {
+                                    "name": "bar",
+                                    "type": {
+                                        "type": "enum",
+                                        "name": "Bar",
+                                        "symbols":
+                                        [
+                                            "bar0",
+                                            "bar1",
+                                            "bar2"
+                                        ],
+                                        "default": "bar2"
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }"#;
+    let reader_schema = r#"{
+            "type": "record",
+            "name": "Foo",
+            "namespace": "com.rallyhealth.devices.canonical.avro.model.v6_0",
+            "fields":
+            [
+                {
+                    "name": "barParent",
+                    "type": [
+                        "null",
+                        {
+                            "type": "record",
+                            "name": "BarParent",
+                            "fields": [
+                                {
+                                    "name": "bar",
+                                    "type": {
+                                        "type": "enum",
+                                        "name": "Bar",
+                                        "symbols":
+                                        [
+                                            "bar1",
+                                            "bar2"
+                                        ],
+                                        "default": "bar2"
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }"#;
+    let writer_schema = Schema::parse_str(writer_schema)?;
+    let foo = Foo {
+        bar_parent: Some(BarParent { bar: Bar::Bar1 }),
+    };
+    let avro_value = crate::to_value(foo)?;
+    assert!(
+        avro_value.validate(&writer_schema),
+        "value is valid for schema",
+    );
+    let datum = crate::to_avro_datum(&writer_schema, avro_value)?;
+    let mut x = &datum[..];
+    let reader_schema = Schema::parse_str(reader_schema)?;
+    let deser_value = crate::from_avro_datum(&writer_schema, &mut x, Some(&reader_schema))?;
+    match deser_value {
+        types::Value::Record(fields) => {
+            assert_eq!(fields.len(), 1);
+            assert_eq!(fields[0].0, "barParent");
+            // TODO: better validation
+        }
+        _ => panic!("Expected Value::Record"),
+    }
+    Ok(())
+}
+
+#[test]
+fn deserialize_union_with_different_enum_order_defined_in_record() -> TestResult {
+    #[derive(
+        Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, serde::Deserialize, serde::Serialize,
+    )]
+    pub enum Bar {
+        #[serde(rename = "bar0")]
+        Bar0,
+        #[serde(rename = "bar1")]
+        Bar1,
+        #[serde(rename = "bar2")]
+        Bar2,
+    }
+    #[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
+    pub struct BarParent {
+        pub bar: Bar,
+    }
+    #[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
+    pub struct Foo {
+        #[serde(rename = "barParent")]
+        pub bar_parent: Option<BarParent>,
+    }
+    let writer_schema = r#"{
+            "type": "record",
+            "name": "Foo",
+            "namespace": "com.rallyhealth.devices.canonical.avro.model.v6_0",
+            "fields":
+            [
+                {
+                    "name": "barParent",
+                    "type": [
+                        "null",
+                        {
+                            "type": "record",
+                            "name": "BarParent",
+                            "fields": [
+                                {
+                                    "name": "bar",
+                                    "type": {
+                                        "type": "enum",
+                                        "name": "Bar",
+                                        "symbols":
+                                        [
+                                            "bar0",
+                                            "bar1",
+                                            "bar2"
+                                        ],
+                                        "default": "bar0"
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }"#;
+    let reader_schema = r#"{
+            "type": "record",
+            "name": "Foo",
+            "namespace": "com.rallyhealth.devices.canonical.avro.model.v6_0",
+            "fields":
+            [
+                {
+                    "name": "barParent",
+                    "type": [
+                        "null",
+                        {
+                            "type": "record",
+                            "name": "BarParent",
+                            "fields": [
+                                {
+                                    "name": "bar",
+                                    "type": {
+                                        "type": "enum",
+                                        "name": "Bar",
+                                        "symbols":
+                                        [
+                                            "bar0",
+                                            "bar2"
+                                        ],
+                                        "default": "bar0"
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }"#;
+    let writer_schema = Schema::parse_str(writer_schema)?;
+    let foo = Foo {
+        bar_parent: Some(BarParent { bar: Bar::Bar2 }),
+    };
+    let avro_value = crate::to_value(foo)?;
+    assert!(
+        avro_value.validate(&writer_schema),
+        "value is valid for schema",
+    );
+    let datum = crate::to_avro_datum(&writer_schema, avro_value)?;
+    let mut x = &datum[..];
+    let reader_schema = Schema::parse_str(reader_schema)?;
+    let deser_value = crate::from_avro_datum(&writer_schema, &mut x, Some(&reader_schema))?;
+    match deser_value {
+        types::Value::Record(fields) => {
+            assert_eq!(fields.len(), 1);
+            assert_eq!(fields[0].0, "barParent");
+            // TODO: better validation
+        }
+        _ => panic!("Expected Value::Record"),
+    }
+    Ok(())
+}
+
+#[test]
+fn deserialize_union_with_record_with_enum_defined_inline_reader_has_different_indices(
+) -> TestResult {
+    #[derive(
+        Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, serde::Deserialize, serde::Serialize,
+    )]
+    pub enum DefinedInRecord {
+        #[serde(rename = "val0")]
+        Val0,
+        #[serde(rename = "val1")]
+        Val1,
+        #[serde(rename = "val2")]
+        Val2,
+        #[serde(rename = "UNKNOWN")]
+        Unknown,
+    }
+    #[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
+    pub struct Parent {
+        pub date: i64,
+        #[serde(rename = "barUse")]
+        pub bar_use: Bar,
+        #[serde(rename = "bazUse")]
+        pub baz_use: Option<Vec<Baz>>,
+        #[serde(rename = "definedInRecord")]
+        pub defined_in_record: DefinedInRecord,
+        #[serde(rename = "optionalString")]
+        pub optional_string: Option<String>,
+    }
+    #[derive(
+        Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, serde::Deserialize, serde::Serialize,
+    )]
+    pub enum Baz {
+        #[serde(rename = "baz0")]
+        Baz0,
+        #[serde(rename = "baz1")]
+        Baz1,
+        #[serde(rename = "baz2")]
+        Baz2,
+    }
+    #[derive(
+        Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, serde::Deserialize, serde::Serialize,
+    )]
+    pub enum Bar {
+        #[serde(rename = "bar0")]
+        Bar0,
+        #[serde(rename = "bar1")]
+        Bar1,
+        #[serde(rename = "bar2")]
+        Bar2,
+    }
+    #[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
+    pub struct Foo {
+        #[serde(rename = "barInit")]
+        pub bar_init: Bar,
+        pub baz: Baz,
+        pub parent: Option<Parent>,
+    }
+    let writer_schema = r#"{
+            "type": "record",
+            "name": "Foo",
+            "namespace": "fake",
+            "fields":
+            [
+                {
+                    "name": "barInit",
+                    "type":
+                    {
+                        "type": "enum",
+                        "name": "Bar",
+                        "symbols":
+                        [
+                            "bar0",
+                            "bar1",
+                            "bar2"
+                        ],
+                        "default": "bar0"
+                    }
+                },
+                {
+                    "name": "baz",
+                    "type":
+                    {
+                        "type": "enum",
+                        "name": "Baz",
+                        "symbols":
+                        [
+                            "baz0",
+                            "baz1",
+                            "baz2"
+                        ],
+                        "default": "baz0"
+                    }
+                },
+                {
+                    "name": "parent",
+                    "type": [
+                        "null",
+                        {
+                            "type": "record",
+                            "name": "Parent",
+                            "fields": [
+                                {
+                                    "name": "date",
+                                    "type": {
+                                      "type": "long",
+                                      "avro.java.long": "Long"
+                                    }
+                                },
+                                {
+                                    "name": "barUse",
+                                    "type": "Bar"
+                                },
+                                {
+                                    "name": "bazUse",
+                                    "type": [
+                                        "null",
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "Baz"
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "definedInRecord",
+                                    "type": {
+                                      "name": "DefinedInRecord",
+                                      "type": "enum",
+                                      "symbols": [
+                                        "val0",
+                                        "val1",
+                                        "val2",
+                                        "UNKNOWN"
+                                      ],
+                                      "default": "UNKNOWN"
+                                    }
+                                },
+                                {
+                                  "name": "optionalString",
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }"#;
+    let reader_schema = r#"{
+            "type": "record",
+            "name": "Foo",
+            "namespace": "fake",
+            "fields":
+            [
+                {
+                    "name": "barInit",
+                    "type":
+                    {
+                        "type": "enum",
+                        "name": "Bar",
+                        "symbols":
+                        [
+                            "bar0",
+                            "bar2"
+                        ],
+                        "default": "bar0"
+                    }
+                },
+                {
+                    "name": "baz",
+                    "type":
+                    {
+                        "type": "enum",
+                        "name": "Baz",
+                        "symbols":
+                        [
+                            "baz0",
+                            "baz2"
+                        ],
+                        "default": "baz0"
+                    }
+                },
+                {
+                    "name": "parent",
+                    "type": [
+                        "null",
+                        {
+                            "type": "record",
+                            "name": "Parent",
+                            "fields": [
+                                {
+                                    "name": "date",
+                                    "type": {
+                                      "type": "long",
+                                      "avro.java.long": "Long"
+                                    }
+                                },
+                                {
+                                    "name": "barUse",
+                                    "type": "Bar"
+                                },
+                                {
+                                    "name": "bazUse",
+                                    "type": [
+                                        "null",
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "Baz"
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "definedInRecord",
+                                    "type": {
+                                      "name": "DefinedInRecord",
+                                      "type": "enum",
+                                      "symbols": [
+                                        "val1",
+                                        "val2",
+                                        "UNKNOWN"
+                                      ],
+                                      "default": "UNKNOWN"
+                                    }
+                                },
+                                {
+                                  "name": "optionalString",
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }"#;
+    let writer_schema = Schema::parse_str(writer_schema)?;
+    let foo = Foo {
+        bar_init: Bar::Bar0,
+        baz: Baz::Baz0,
+        parent: Some(Parent {
+            bar_use: Bar::Bar0,
+            baz_use: Some(vec![Baz::Baz0]),
+            optional_string: Some("test".to_string()),
+            date: 1689197893,
+            defined_in_record: DefinedInRecord::Val1,
+        }),
+    };
+    let avro_value = crate::to_value(foo)?;
+    assert!(
+        avro_value.validate(&writer_schema),
+        "value is valid for schema",
+    );
+    let datum = crate::to_avro_datum(&writer_schema, avro_value)?;
+    let mut x = &datum[..];
+    let reader_schema = Schema::parse_str(reader_schema)?;
+    let deser_value = crate::from_avro_datum(&writer_schema, &mut x, Some(&reader_schema))?;
+    match deser_value {
+        types::Value::Record(fields) => {
+            assert_eq!(fields.len(), 3);
+            assert_eq!(fields[0].0, "barInit");
+            assert_eq!(fields[0].1, types::Value::Enum(0, "bar0".to_string()));
+            // TODO: better validation
+        }
+        _ => panic!("Expected Value::Record"),
+    }
+    Ok(())
+}


### PR DESCRIPTION
AVRO-3814

Successor-of: https://github.com/apache/avro/pull/2394


## What is the purpose of the change

* Use `types::Value::resolve_internal()` to find the matching schema in an union

## Documentation

- Does this pull request introduce a new feature? no