### PR TITLE
AVRO-3836: [Rust] Fix the build with Rust 1.65.0

### DIFF
--- a/.github/workflows/test-lang-rust-clippy.yml
+++ b/.github/workflows/test-lang-rust-clippy.yml
@@ -43,6 +43,11 @@ concurrency:
 jobs:
   clippy_check:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 'stable'
+          - '1.65.0'  # MSRV
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -261,7 +261,11 @@ impl Name {
         Ok(Self {
             name: type_name.unwrap_or(name),
             namespace: namespace_from_name
-                .or_else(|| complex.string("namespace").or(enclosing_namespace.clone()))
+                .or_else(|| {
+                    complex
+                        .string("namespace")
+                        .or_else(|| enclosing_namespace.clone())
+                })
                 .filter(|ns| !ns.is_empty()),
         })
     }
@@ -1420,11 +1424,10 @@ impl Parser {
             }
         }
 
-        let name = Name::parse(complex, enclosing_namespace)?;
-        let aliases = fix_aliases_namespace(complex.aliases(), &name.namespace);
+        let fully_qualified_name = Name::parse(complex, enclosing_namespace)?;
+        let aliases = fix_aliases_namespace(complex.aliases(), &fully_qualified_name.namespace);
 
         let mut lookup = BTreeMap::new();
-        let fully_qualified_name = name.clone();
 
         self.register_resolving_schema(&fully_qualified_name, &aliases);
 

--- a/lang/rust/avro/tests/schema.rs
+++ b/lang/rust/avro/tests/schema.rs
@@ -1453,7 +1453,7 @@ fn avro_old_issue_47() -> TestResult {
 
     use serde::{Deserialize, Serialize};
 
-    #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+    #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
     pub struct MyRecord {
         b: String,
         a: i64,


### PR DESCRIPTION
Fix clippy issues with Rust 1.65.0

Run clippy also for MSRV


## What is the purpose of the change

* Fix `clippy` errors with Rust 1.65.0 (MSRV)


## Verifying this change

* CI must fully pass

## Documentation

- Does this pull request introduce a new feature? no