### PR TITLE
AVRO-3835: [Rust] Get rid of byteorder and zerocopy dependencies

### DIFF
--- a/lang/rust/Cargo.lock
+++ b/lang/rust/Cargo.lock
@@ -68,7 +68,6 @@ dependencies = [
  "anyhow",
  "apache-avro-derive",
  "apache-avro-test-helper",
- "byteorder",
  "bzip2",
  "crc32fast",
  "criterion",
@@ -93,7 +92,6 @@ dependencies = [
  "typed-builder",
  "uuid",
  "xz2",
- "zerocopy",
  "zstd",
 ]
 
@@ -1347,27 +1345,6 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
-
-[[package]]
-name = "zerocopy"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3b9c234616391070b0b173963ebc65a9195068e7ed3731c6edac2ec45ebe106"
-dependencies = [
- "byteorder",
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f7f3a471f98d0a61c34322fbbfd10c384b07687f680d4119813713f72308d91"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "zstd"

--- a/lang/rust/avro/Cargo.toml
+++ b/lang/rust/avro/Cargo.toml
@@ -55,7 +55,6 @@ name = "single"
 
 [dependencies]
 apache-avro-derive = { default-features = false, version = "0.16.0", path = "../avro_derive", optional = true }
-byteorder = { default-features = false, version = "1.4.3" }
 bzip2 = { default-features = false, version = "0.4.4", optional = true }
 crc32fast = { default-features = false, version = "1.3.2", optional = true }
 digest = { default-features = false, version = "0.10.7", features = ["core-api"] }
@@ -73,7 +72,6 @@ thiserror = { default-features = false, version = "1.0.47" }
 typed-builder = { default-features = false, version = "0.15.2" }
 uuid = { default-features = false, version = "1.4.1", features = ["serde", "std"] }
 xz2 = { default-features = false, version = "0.1.7", optional = true }
-zerocopy = { default-features = false, version = "0.6.3" }
 zstd = { default-features = false, version = "0.12.4+zstd.1.5.2", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/lang/rust/avro/src/duration.rs
+++ b/lang/rust/avro/src/duration.rs
@@ -14,10 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
-use byteorder::LittleEndian;
-use zerocopy::U32;
-
 /// A struct representing duration that hides the details of endianness and conversion between
 /// platform-native u32 and byte arrays.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -28,83 +24,77 @@ pub struct Duration {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub struct Months(U32<LittleEndian>);
+pub struct Months(u32);
 
 impl Months {
     pub fn new(months: u32) -> Self {
-        Self(U32::new(months))
+        Self(months)
+    }
+
+    fn as_bytes(&self) -> [u8; 4] {
+        self.0.to_le_bytes()
     }
 }
 
 impl From<Months> for u32 {
     fn from(days: Months) -> Self {
-        days.0.get()
+        days.0
     }
 }
 
 impl From<[u8; 4]> for Months {
     fn from(bytes: [u8; 4]) -> Self {
-        Self(U32::from(bytes))
-    }
-}
-
-impl AsRef<[u8; 4]> for Months {
-    fn as_ref(&self) -> &[u8; 4] {
-        self.0.as_ref()
+        Self(u32::from_le_bytes(bytes))
     }
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub struct Days(U32<LittleEndian>);
+pub struct Days(u32);
 
 impl Days {
     pub fn new(days: u32) -> Self {
-        Self(U32::new(days))
+        Self(days)
+    }
+
+    fn as_bytes(&self) -> [u8; 4] {
+        self.0.to_le_bytes()
     }
 }
 
 impl From<Days> for u32 {
     fn from(days: Days) -> Self {
-        days.0.get()
+        days.0
     }
 }
 
 impl From<[u8; 4]> for Days {
     fn from(bytes: [u8; 4]) -> Self {
-        Self(U32::from(bytes))
-    }
-}
-
-impl AsRef<[u8; 4]> for Days {
-    fn as_ref(&self) -> &[u8; 4] {
-        self.0.as_ref()
+        Self(u32::from_le_bytes(bytes))
     }
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub struct Millis(U32<LittleEndian>);
+pub struct Millis(u32);
 
 impl Millis {
     pub fn new(millis: u32) -> Self {
-        Self(U32::new(millis))
+        Self(millis)
+    }
+
+    fn as_bytes(&self) -> [u8; 4] {
+        self.0.to_le_bytes()
     }
 }
 
 impl From<Millis> for u32 {
     fn from(days: Millis) -> Self {
-        days.0.get()
+        days.0
     }
 }
 
 impl From<[u8; 4]> for Millis {
     fn from(bytes: [u8; 4]) -> Self {
-        Self(U32::from(bytes))
-    }
-}
-
-impl AsRef<[u8; 4]> for Millis {
-    fn as_ref(&self) -> &[u8; 4] {
-        self.0.as_ref()
+        Self(u32::from_le_bytes(bytes))
     }
 }
 
@@ -137,9 +127,9 @@ impl Duration {
 impl From<Duration> for [u8; 12] {
     fn from(duration: Duration) -> Self {
         let mut bytes = [0u8; 12];
-        bytes[0..4].copy_from_slice(duration.months.as_ref());
-        bytes[4..8].copy_from_slice(duration.days.as_ref());
-        bytes[8..12].copy_from_slice(duration.millis.as_ref());
+        bytes[0..4].copy_from_slice(&duration.months.as_bytes());
+        bytes[4..8].copy_from_slice(&duration.days.as_bytes());
+        bytes[8..12].copy_from_slice(&duration.millis.as_bytes());
         bytes
     }
 }


### PR DESCRIPTION
Use standard APIs for converting integers to/from byte arrays. Get rid of byteorder and zerocopy dependencies.

## What is the purpose of the change

* Replace usage of `byteorder` and `zerocopy` dependencies with standard APIs

## Verifying this change

* All tests should still pass

## Documentation

- Does this pull request introduce a new feature? no