### PR TITLE
AVRO-3838: [Rust] Replace "regex" with "regex-lite"

### DIFF
--- a/lang/rust/Cargo.lock
+++ b/lang/rust/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
  "pretty_assertions",
  "quad-rand",
  "rand",
- "regex",
+ "regex-lite",
  "serde",
  "serde_json",
  "sha2",
@@ -882,6 +882,12 @@ dependencies = [
  "memchr",
  "regex-syntax 0.7.4",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f96ede7f386ba6e910092e7ccdc04176cface62abebea07ed6b46d870ed95ca2"
 
 [[package]]
 name = "regex-syntax"

--- a/lang/rust/avro/Cargo.toml
+++ b/lang/rust/avro/Cargo.toml
@@ -62,7 +62,7 @@ lazy_static = { default-features = false, version = "1.4.0" }
 libflate = { default-features = false, version = "2.0.0", features = ["std"] }
 log = { default-features = false, version = "0.4.20" }
 num-bigint = { default-features = false, version = "0.4.3" }
-regex = { default-features = false, version = "1.9.3", features = ["std", "perf"] }
+regex-lite = { default-features = false, version = "0.1.0", features = ["std", "string"] }
 serde = { default-features = false, version = "1.0.183", features = ["derive"] }
 serde_json = { default-features = false, version = "1.0.105", features = ["std"] }
 snap = { default-features = false, version = "1.1.0", optional = true }

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -19,7 +19,7 @@
 use crate::{error::Error, types, util::MapHelper, AvroResult};
 use digest::Digest;
 use lazy_static::lazy_static;
-use regex::Regex;
+use regex_lite::Regex;
 use serde::{
     ser::{SerializeMap, SerializeSeq},
     Deserialize, Serialize, Serializer,


### PR DESCRIPTION
AVRO-3838

Reduces the time for `cargo clean && cargo build --release" from 30secs to 22secs on my dev machine

## What is the purpose of the change

* Improve the build times by around 30%

## Verifying this change

* All unit tests should still pass

## Documentation

- Does this pull request introduce a new feature? no
