### PR TITLE
AVRO-3841: [Spec] Align the specification of the way to encode NaN to the actual implementations

### DIFF
--- a/doc/content/en/docs/++version++/Specification/_index.md
+++ b/doc/content/en/docs/++version++/Specification/_index.md
@@ -298,8 +298,8 @@ Primitive types are encoded in binary as follows:
 |64 | 80 01|
 |...|...|
 
-* a _float_ is written as 4 bytes. The float is converted into a 32-bit integer using a method equivalent to Java's [floatToIntBits](https://docs.oracle.com/javase/8/docs/api/java/lang/Float.html#floatToIntBits-float-) and then encoded in little-endian format.
-* a _double_ is written as 8 bytes. The double is converted into a 64-bit integer using a method equivalent to Java's [doubleToLongBits](https://docs.oracle.com/javase/8/docs/api/java/lang/Double.html#doubleToLongBits-double-) and then encoded in little-endian format.
+* a _float_ is written as 4 bytes. The float is converted into a 32-bit integer using a method equivalent to Java's [floatToRawIntBits](https://docs.oracle.com/javase/8/docs/api/java/lang/Float.html#floatToRawIntBits-float-) and then encoded in little-endian format.
+* a _double_ is written as 8 bytes. The double is converted into a 64-bit integer using a method equivalent to Java's [doubleToRawLongBits](https://docs.oracle.com/javase/8/docs/api/java/lang/Double.html#doubleToRawLongBits-double-) and then encoded in little-endian format.
 * _bytes_ are encoded as a long followed by that many bytes of data.
 * a _string_ is encoded as a long followed by that many bytes of UTF-8 encoded character data.
 For example, the three-character string "foo" would be encoded as the long value 3 (encoded as hex 06) followed by the UTF-8 encoding of 'f', 'o', and 'o' (the hex bytes 66 6f 6f):

--- a/lang/csharp/src/apache/main/IO/BinaryDecoder.netstandard2.0.cs
+++ b/lang/csharp/src/apache/main/IO/BinaryDecoder.netstandard2.0.cs
@@ -34,7 +34,7 @@ namespace Avro.IO
         /// <summary>
         /// A float is written as 4 bytes.
         /// The float is converted into a 32-bit integer using a method equivalent to
-        /// Java's floatToIntBits and then encoded in little-endian format.
+        /// Java's floatToRawIntBits and then encoded in little-endian format.
         /// </summary>
         /// <returns></returns>
         public float ReadFloat()
@@ -56,7 +56,7 @@ namespace Avro.IO
         /// <summary>
         /// A double is written as 8 bytes.
         /// The double is converted into a 64-bit integer using a method equivalent to
-        /// Java's doubleToLongBits and then encoded in little-endian format.
+        /// Java's doubleToRawLongBits and then encoded in little-endian format.
         /// </summary>
         /// <returns>A double value.</returns>
         public double ReadDouble()

--- a/lang/csharp/src/apache/main/IO/BinaryDecoder.notnetstandard2.0.cs
+++ b/lang/csharp/src/apache/main/IO/BinaryDecoder.notnetstandard2.0.cs
@@ -35,7 +35,7 @@ namespace Avro.IO
         /// <summary>
         /// A float is written as 4 bytes.
         /// The float is converted into a 32-bit integer using a method equivalent to
-        /// Java's floatToIntBits and then encoded in little-endian format.
+        /// Java's floatToRawIntBits and then encoded in little-endian format.
         /// </summary>
         /// <returns></returns>
         public float ReadFloat()
@@ -49,7 +49,7 @@ namespace Avro.IO
         /// <summary>
         /// A double is written as 8 bytes.
         /// The double is converted into a 64-bit integer using a method equivalent to
-        /// Java's doubleToLongBits and then encoded in little-endian format.
+        /// Java's doubleToRawLongBits and then encoded in little-endian format.
         /// </summary>
         /// <returns>A double value.</returns>
         public double ReadDouble()

--- a/lang/csharp/src/apache/main/IO/BinaryEncoder.cs
+++ b/lang/csharp/src/apache/main/IO/BinaryEncoder.cs
@@ -87,7 +87,7 @@ namespace Avro.IO
         /// <summary>
         /// A float is written as 4 bytes.
         /// The float is converted into a 32-bit integer using a method equivalent to
-        /// Java's floatToIntBits and then encoded in little-endian format.
+        /// Java's floatToRawIntBits and then encoded in little-endian format.
         /// </summary>
         /// <param name="value"></param>
         public void WriteFloat(float value)
@@ -99,7 +99,7 @@ namespace Avro.IO
         /// <summary>
         ///A double is written as 8 bytes.
         ///The double is converted into a 64-bit integer using a method equivalent to
-        ///Java's doubleToLongBits and then encoded in little-endian format.
+        ///Java's doubleToRawLongBits and then encoded in little-endian format.
         /// </summary>
         /// <param name="value"></param>
         public void WriteDouble(double value)

--- a/lang/py/avro/io.py
+++ b/lang/py/avro/io.py
@@ -256,7 +256,7 @@ class BinaryDecoder:
         """
         A float is written as 4 bytes.
         The float is converted into a 32-bit integer using a method equivalent to
-        Java's floatToIntBits and then encoded in little-endian format.
+        Java's floatToRawIntBits and then encoded in little-endian format.
         """
         return float(STRUCT_FLOAT.unpack(self.read(4))[0])
 
@@ -264,7 +264,7 @@ class BinaryDecoder:
         """
         A double is written as 8 bytes.
         The double is converted into a 64-bit integer using a method equivalent to
-        Java's doubleToLongBits and then encoded in little-endian format.
+        Java's doubleToRawLongBits and then encoded in little-endian format.
         """
         return float(STRUCT_DOUBLE.unpack(self.read(8))[0])
 
@@ -453,7 +453,7 @@ class BinaryEncoder:
         """
         A float is written as 4 bytes.
         The float is converted into a 32-bit integer using a method equivalent to
-        Java's floatToIntBits and then encoded in little-endian format.
+        Java's floatToRawIntBits and then encoded in little-endian format.
         """
         self.write(STRUCT_FLOAT.pack(datum))
 
@@ -461,7 +461,7 @@ class BinaryEncoder:
         """
         A double is written as 8 bytes.
         The double is converted into a 64-bit integer using a method equivalent to
-        Java's doubleToLongBits and then encoded in little-endian format.
+        Java's doubleToRawLongBits and then encoded in little-endian format.
         """
         self.write(STRUCT_DOUBLE.pack(datum))
 

--- a/lang/ruby/lib/avro/io.rb
+++ b/lang/ruby/lib/avro/io.rb
@@ -75,7 +75,7 @@ module Avro
       def read_float
         # A float is written as 4 bytes.
         # The float is converted into a 32-bit integer using a method
-        # equivalent to Java's floatToIntBits and then encoded in
+        # equivalent to Java's floatToRawIntBits and then encoded in
         # little-endian format.
         read_and_unpack(4, 'e')
       end
@@ -83,7 +83,7 @@ module Avro
       def read_double
         #  A double is written as 8 bytes.
         # The double is converted into a 64-bit integer using a method
-        # equivalent to Java's doubleToLongBits and then encoded in
+        # equivalent to Java's doubleToRawLongBits and then encoded in
         # little-endian format.
         read_and_unpack(8, 'E')
       end
@@ -203,7 +203,7 @@ module Avro
 
       # A float is written as 4 bytes.
       # The float is converted into a 32-bit integer using a method
-      # equivalent to Java's floatToIntBits and then encoded in
+      # equivalent to Java's floatToRawIntBits and then encoded in
       # little-endian format.
       def write_float(datum)
         @writer.write([datum].pack('e'))
@@ -211,7 +211,7 @@ module Avro
 
       # A double is written as 8 bytes.
       # The double is converted into a 64-bit integer using a method
-      # equivalent to Java's doubleToLongBits and then encoded in
+      # equivalent to Java's doubleToRawLongBits and then encoded in
       # little-endian format.
       def write_double(datum)
         @writer.write([datum].pack('E'))


### PR DESCRIPTION
AVRO-3841

## What is the purpose of the change
This PR proposes to slightly change the specification of the way to encode float/double values.

The specification says about the way to encode float/double like as follows.
```
a float is written as 4 bytes. The float is converted into a 32-bit integer using a method equivalent to Java’s floatToIntBits and then encoded in little-endian format.
a double is written as 8 bytes. The double is converted into a 64-bit integer using a method equivalent to Java’s doubleToLongBits and then encoded in little-endian format.
```

But the actual implementation in Java uses `floatToRawIntBits`/`doubleToRawLongBits` rather than `floatToIntBits`/`doubleToLongBits`.

The they are different in the way to encode `NaN`.
`floatToIntBits`/`doubleToLongBits` don't distinguish between `NaN` and `-NaN` but `floatToRawIntBits`/`doubleToRawLongBits` do.

I confirmed all the implementation distinguish between `NaN` and `-NaN`.
So, I think it's better to modify the specification.

## Verifying this change
All the implementations distinguish between `NaN` and `-NaN`.

* Java
```
  public static int encodeFloat(float f, byte[] buf, int pos) {
    final int bits = Float.floatToRawIntBits(f);
    buf[pos + 3] = (byte) (bits >>> 24);
    buf[pos + 2] = (byte) (bits >>> 16);
    buf[pos + 1] = (byte) (bits >>> 8);
    buf[pos] = (byte) (bits);
    return 4;
  }

  public static int encodeDouble(double d, byte[] buf, int pos) {
    final long bits = Double.doubleToRawLongBits(d);
    int first = (int) (bits & 0xFFFFFFFF);
    int second = (int) ((bits >>> 32) & 0xFFFFFFFF);
    // the compiler seems to execute this order the best, likely due to
    // register allocation -- the lifetime of constants is minimized.
    buf[pos] = (byte) (first);
    buf[pos + 4] = (byte) (second);
    buf[pos + 5] = (byte) (second >>> 8);
    buf[pos + 1] = (byte) (first >>> 8);
    buf[pos + 2] = (byte) (first >>> 16);
    buf[pos + 6] = (byte) (second >>> 16);
    buf[pos + 7] = (byte) (second >>> 24);
    buf[pos + 3] = (byte) (first >>> 24);
    return 8;
  }
```

* Rust
```
Value::Float(x) => buffer.extend_from_slice(&x.to_le_bytes()),
Value::Double(x) => buffer.extend_from_slice(&x.to_le_bytes()),
```

* Python
```
    def write_float(self, datum: float) -> None:                                                                                                  
        """                                                                                                                                       
        A float is written as 4 bytes.                                                                                                            
        The float is converted into a 32-bit integer using a method equivalent to                                                                 
        Java's floatToIntBits and then encoded in little-endian format.                                                                           
        """                                                                                                                                       
        self.write(STRUCT_FLOAT.pack(datum)) 

    def write_double(self, datum: float) -> None:                                                                                                 
        """                                                                                                                                       
        A double is written as 8 bytes.                                                                                                           
        The double is converted into a 64-bit integer using a method equivalent to                                                                
        Java's doubleToLongBits and then encoded in little-endian format.                                                                         
        """                                                                                                                                       
        self.write(STRUCT_DOUBLE.pack(datum))
```

* C
```
static int write_float(avro_writer_t writer, const float f)
{
#if AVRO_PLATFORM_IS_BIG_ENDIAN
        uint8_t buf[4];
#endif
        union {
                float f;
                int32_t i;
        } v;

        v.f = f;
#if AVRO_PLATFORM_IS_BIG_ENDIAN
        buf[0] = (uint8_t) (v.i >> 0);
        buf[1] = (uint8_t) (v.i >> 8);
        buf[2] = (uint8_t) (v.i >> 16);
        buf[3] = (uint8_t) (v.i >> 24);
        AVRO_WRITE(writer, buf, 4);
#else
        AVRO_WRITE(writer, (void *)&v.i, 4);
#endif
        return 0;
}

static int write_double(avro_writer_t writer, const double d)
{
#if AVRO_PLATFORM_IS_BIG_ENDIAN
        uint8_t buf[8];
#endif
        union {
                double d;
                int64_t l;
        } v;

        v.d = d;
#if AVRO_PLATFORM_IS_BIG_ENDIAN
        buf[0] = (uint8_t) (v.l >> 0);
        buf[1] = (uint8_t) (v.l >> 8);
        buf[2] = (uint8_t) (v.l >> 16);
        buf[3] = (uint8_t) (v.l >> 24);
        buf[4] = (uint8_t) (v.l >> 32);
        buf[5] = (uint8_t) (v.l >> 40);
        buf[6] = (uint8_t) (v.l >> 48);
        buf[7] = (uint8_t) (v.l >> 56);
        AVRO_WRITE(writer, buf, 8);
#else
        AVRO_WRITE(writer, (void *)&v.l, 8);
#endif
        return 0;
}
```

* C++
```
void BinaryEncoder::encodeFloat(float f) {
    const auto *p = reinterpret_cast<const uint8_t *>(&f);
    out_.writeBytes(p, sizeof(float));
}

void BinaryEncoder::encodeDouble(double d) {
    const auto *p = reinterpret_cast<const uint8_t *>(&d);
    out_.writeBytes(p, sizeof(double));
}
```

* C#
```
        public void WriteFloat(float value)
        {
            byte[] buffer = BitConverter.GetBytes(value);
            if (!BitConverter.IsLittleEndian) Array.Reverse(buffer);
            writeBytes(buffer);
        }

        public void WriteDouble(double value)
        {
            long bits = BitConverter.DoubleToInt64Bits(value);

            writeByte((byte)(bits & 0xFF));
            writeByte((byte)((bits >> 8) & 0xFF));
            writeByte((byte)((bits >> 16) & 0xFF));
            writeByte((byte)((bits >> 24) & 0xFF));
            writeByte((byte)((bits >> 32) & 0xFF));
            writeByte((byte)((bits >> 40) & 0xFF));
            writeByte((byte)((bits >> 48) & 0xFF));
            writeByte((byte)((bits >> 56) & 0xFF));

        }
```

* Ruby
```
      def read_float
        # A float is written as 4 bytes.
        # The float is converted into a 32-bit integer using a method
        # equivalent to Java's floatToRawIntBits and then encoded in
        # little-endian format.
        read_and_unpack(4, 'e')
      end

      def read_double
        #  A double is written as 8 bytes.
        # The double is converted into a 64-bit integer using a method
        # equivalent to Java's doubleToRawLongBits and then encoded in
        # little-endian format.
        read_and_unpack(8, 'E')
      end
```

* Perl
```
sub encode_float {
    my $class = shift;
    my ($schema, $data, $cb) = @_;
    my $enc = pack "f<", $data;
    $cb->(\$enc);
}

sub encode_double {
    my $class = shift;
    my ($schema, $data, $cb) = @_;
    my $enc = pack "d<", $data;
    $cb->(\$enc);
}
```

* PHP
```
    public static function floatToIntBits($float)
    {
        return pack('g', (float) $float);
    }

    public static function doubleToLongBits($double)
    {
        return pack('e', (double) $double);
    }
```

* JavaScript
```
Tap.prototype.writeFloat = function (f) {
  var buf = this.buf;
  var pos = this.pos;
  this.pos += 4;
  if (this.pos > buf.length) {
    return;
  }
  return this.buf.writeFloatLE(f, pos);
};

Tap.prototype.writeDouble = function (d) {
  var buf = this.buf;
  var pos = this.pos;
  this.pos += 8;
  if (this.pos > buf.length) {
    return;
  }
  return this.buf.writeDoubleLE(d, pos);
};
```

## Documentation

This change includes document modification.