### PR TITLE
AVRO-3844: [Rust] Fix clippy errors with Rust 1.72.0

### DIFF
--- a/lang/rust/Cargo.toml
+++ b/lang/rust/Cargo.toml
@@ -26,6 +26,8 @@ exclude = [
     "fuzz"
 ]
 
+resolver = "2"
+
 [workspace.package]
 version = "0.16.0"
 authors = ["Apache Avro team <dev@avro.apache.org>"]

--- a/lang/rust/avro/src/reader.rs
+++ b/lang/rust/avro/src/reader.rs
@@ -888,7 +888,7 @@ mod tests {
             c: vec!["cat".into(), "dog".into()],
         };
         // The two-byte marker, to show that the message uses this single-record format
-        let to_read_1 = vec![0xC3, 0x01];
+        let to_read_1 = [0xC3, 0x01];
         let mut to_read_2 = Vec::<u8>::new();
         to_read_2.extend_from_slice(
             &TestSingleObjectReader::get_schema()

--- a/lang/rust/avro/src/schema_compatibility.rs
+++ b/lang/rust/avro/src/schema_compatibility.rs
@@ -293,7 +293,7 @@ impl SchemaCompatibility {
         }
 
         if w_type == SchemaKind::Int
-            && vec![SchemaKind::Long, SchemaKind::Float, SchemaKind::Double]
+            && [SchemaKind::Long, SchemaKind::Float, SchemaKind::Double]
                 .iter()
                 .any(|&t| t == r_type)
         {
@@ -301,7 +301,7 @@ impl SchemaCompatibility {
         }
 
         if w_type == SchemaKind::Long
-            && vec![SchemaKind::Float, SchemaKind::Double]
+            && [SchemaKind::Float, SchemaKind::Double]
                 .iter()
                 .any(|&t| t == r_type)
         {

--- a/lang/rust/avro/src/writer.rs
+++ b/lang/rust/avro/src/writer.rs
@@ -672,7 +672,7 @@ mod tests {
         let mut expected = Vec::new();
         zig_i64(27, &mut expected);
         zig_i64(3, &mut expected);
-        expected.extend(vec![b'f', b'o', b'o'].into_iter());
+        expected.extend([b'f', b'o', b'o']);
 
         assert_eq!(to_avro_datum(&schema, record)?, expected);
 

--- a/lang/rust/avro/tests/io.rs
+++ b/lang/rust/avro/tests/io.rs
@@ -148,7 +148,7 @@ fn test_binary_long_encoding() -> TestResult {
 fn test_schema_promotion() -> TestResult {
     // Each schema is present in order of promotion (int -> long, long -> float, float -> double)
     // Each value represents the expected decoded value when promoting a value previously encoded with a promotable schema
-    let promotable_schemas = vec![r#""int""#, r#""long""#, r#""float""#, r#""double""#];
+    let promotable_schemas = [r#""int""#, r#""long""#, r#""float""#, r#""double""#];
     let promotable_values = vec![
         Value::Int(219),
         Value::Long(219),


### PR DESCRIPTION
AVRO-3844

## What is the purpose of the change

* Fix lint errors

## Verifying this change

* The build and tests should pass with Rust stable (1.72.0)

## Documentation

- Does this pull request introduce a new feature? no