### PR TITLE
AVRO-3847: [Rust] Support default value of pre-defined name for Union type field

### DIFF
--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -1610,9 +1610,17 @@ impl Parser {
             .and_then(|schemas| {
                 if let Some(default_value) = default.cloned() {
                     let avro_value = types::Value::from(default_value);
-                    let resolved = schemas
-                        .iter()
-                        .any(|schema| avro_value.to_owned().resolve(schema).is_ok());
+                    let resolved = schemas.iter().any(|schema| {
+                        avro_value
+                            .to_owned()
+                            .resolve_internal(
+                                schema,
+                                &self.parsed_schemas,
+                                &schema.namespace(),
+                                &None,
+                            )
+                            .is_ok()
+                    });
 
                     if !resolved {
                         let schema: Option<&Schema> = schemas.get(0);


### PR DESCRIPTION
AVRO-3847

## What is the purpose of the change
This PR fixes an issue that the current Rust binding doesn't support default value of pre-defined name for `Union` type field.

Given we have a schema like as follows.
```
{
    "name": "record1",
    "type": "record",
    "fields": [
        {
            "name": "f1",
            "type": {
                "name": "record2",
                "type": "record",
                "fields": [
                    {
                        "name": "f1_1",
                        "type": "int"
                    }
                ]
            }
        },  {
            "name": "f2",
            "type": ["record2", "int"],
            "default": {
                "f1_1": 100
            }
        }
    ]
}
```

The type of the field `f2` is `union` of `record2` and `int`, and the type of the default value is `record2`, which is pre-defined.
Current Rust binding doesn't accept such schemas, raising a error message like as follows.
```
Error: One union type Ref must match the `default`'s value type Map
```
The root cause is the resolution for the type of default value doesn't care about known schemas.
So, the fix is giving such schemas to the resolution.

## Verifying this change
Added new tests.

## Documentation

- Does this pull request introduce a new feature? (no)
