### PR TITLE
AVRO-2035 enable validation of default values in schemas by default

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/Schema.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Schema.java
@@ -1817,8 +1817,11 @@ public abstract class Schema extends JsonProperties implements Serializable {
         if (!isValidDefault(schema.getValueType(), value))
           return false;
       return true;
-    case UNION: // union default: first branch
-      return isValidDefault(schema.getTypes().get(0), defaultValue);
+    case UNION: // check against each branch of union
+      for (Schema branch : schema.getTypes())
+        if (isValidDefault(branch, defaultValue))
+          return true;
+      return false;
     case RECORD:
       if (!defaultValue.isObject())
         return false;

--- a/lang/java/avro/src/main/java/org/apache/avro/util/internal/JacksonUtils.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/util/internal/JacksonUtils.java
@@ -103,7 +103,12 @@ public class JacksonUtils {
 
   public static Object toObject(JsonNode jsonNode, Schema schema) {
     if (schema != null && schema.getType().equals(Schema.Type.UNION)) {
-      return toObject(jsonNode, schema.getTypes().get(0));
+      for (Schema type : schema.getTypes()) {
+        Object o = toObject(jsonNode, type);
+        if (o != null) {
+          return o;
+        }
+      }
     }
     if (jsonNode == null) {
       return null;

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchema.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchema.java
@@ -40,9 +40,14 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
 import org.apache.avro.Schema.Field;
 import org.apache.avro.Schema.Type;
 import org.apache.avro.generic.GenericData;
+import org.apache.avro.AvroRuntimeException;
+import org.apache.avro.SchemaParseException;
+import org.apache.avro.AvroTypeException;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -231,6 +236,18 @@ public class TestSchema {
     // The generated string should be the same as the original parent
     // schema string that did not have the child schema inlined.
     assertEquals(parent, parentWithoutInlinedChildReference);
+  }
+  @Test
+  void unionDefaultValue() {
+    Schema.Field field = new Schema.Field("myField", Schema.createUnion(Schema.create(Type.NULL), Schema.create(Type.INT)), "doc", null);
+    assertTrue(field.hasDefaultValue());
+    assertNull(field.defaultVal());
+    assertNull(GenericData.get().getDefaultValue(field));
+
+    field = new Schema.Field("myField", Schema.createUnion(Schema.create(Type.NULL), Schema.create(Type.INT)), "doc", 1);
+    assertTrue(field.hasDefaultValue());
+    assertEquals(1, field.defaultVal());
+    assertEquals(1, GenericData.get().getDefaultValue(field));
   }
 
   @Test

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchema.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchema.java
@@ -237,17 +237,26 @@ public class TestSchema {
     // schema string that did not have the child schema inlined.
     assertEquals(parent, parentWithoutInlinedChildReference);
   }
+
   @Test
   void unionDefaultValue() {
-    Schema.Field field = new Schema.Field("myField", Schema.createUnion(Schema.create(Type.NULL), Schema.create(Type.INT)), "doc", null);
-    assertTrue(field.hasDefaultValue());
+    Schema.Field field = new Schema.Field("myField",
+        Schema.createUnion(Schema.create(Type.NULL), Schema.create(Type.INT)), "doc", null);
+    assertFalse(field.hasDefaultValue());
     assertNull(field.defaultVal());
-    assertNull(GenericData.get().getDefaultValue(field));
 
-    field = new Schema.Field("myField", Schema.createUnion(Schema.create(Type.NULL), Schema.create(Type.INT)), "doc", 1);
-    assertTrue(field.hasDefaultValue());
+    field = new Schema.Field("myField", Schema.createUnion(Schema.create(Type.NULL), Schema.create(Type.INT)), "doc",
+        1);
     assertEquals(1, field.defaultVal());
     assertEquals(1, GenericData.get().getDefaultValue(field));
+  }
+
+  @Test
+  void optionalArrayDefaultValue() {
+    Schema.Field field = new Schema.Field("myField",
+        Schema.createUnion(Schema.create(Type.NULL), Schema.createArray(Schema.create(Type.STRING))), "doc", null);
+    assertFalse(field.hasDefaultValue());
+    assertNull(field.defaultVal());
   }
 
   @Test


### PR DESCRIPTION
### What is the purpose of the change
This pull request aims to enhance the functionality of Union types in the Java language by enabling the setting of default values for any type within a Union. Currently, only the first type in a Union can have a default value. This change will make Union types more flexible and versatile in Java programming.

Proposed Changes
Modification of Union Type Declaration

Previously, Union types in Java allowed setting default values only for the first type in the Union. This restriction is being lifted to enable default values for any type within the Union. This change will require modifications to the grammar and type-checking mechanisms.
### Verifying this change

JacksonUtils.java
`  public static Object toObject(JsonNode jsonNode, Schema schema) {
    if (schema != null && schema.getType().equals(Schema.Type.UNION)) {
      for (Schema type : schema.getTypes()) {
        Object o = toObject(jsonNode, type);
        if (o != null) {
          return o;
        }
      }
    }`
Schema.java
`    case UNION: // check against each branch of union
      for (Schema branch : schema.getTypes())
        if (isValidDefault(branch, defaultValue))
          return true;
      return false;`
