### PR TITLE
AVRO-3851: [Rust] Validate default value for record fields and enums on parsing

### DIFF
--- a/lang/rust/avro/src/error.rs
+++ b/lang/rust/avro/src/error.rs
@@ -235,6 +235,9 @@ pub enum Error {
     #[error("One union type {0:?} must match the `default`'s value type {1:?}")]
     GetDefaultUnion(SchemaKind, ValueKind),
 
+    #[error("`default`'s value type of field {0:?} in {1:?} must be {2:?}")]
+    GetDefaultRecordField(String, String, String),
+
     #[error("JSON value {0} claims to be u64 but cannot be converted")]
     GetU64FromJson(serde_json::Number),
 

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -872,7 +872,7 @@ impl Value {
         }
     }
 
-    fn resolve_enum(
+    pub(crate) fn resolve_enum(
         self,
         symbols: &[String],
         enum_default: &Option<String>,


### PR DESCRIPTION
AVRO-3851

## What is the purpose of the change
This PR proposes to improve the functionality of parsing default values for record fields and enums.

Currently, default values for record fields are validated on parsing only if their types are `union`.
It's nice to apply such validation for other types.
Similarly, default values for `enum` are not also validated on parsing now.

So this PR changes parser functionality to validate default values for record fields and enums.

## Verifying this change
Added new tests.

## Documentation

- Does this pull request introduce a new feature? (no)
