### PR TITLE
Minor: [Doc] Fix wrong heading level of Single-object encoding in the doc

### DIFF
--- a/doc/content/en/docs/++version++/Specification/_index.md
+++ b/doc/content/en/docs/++version++/Specification/_index.md
@@ -393,12 +393,12 @@ For example, the union schema `["null","string","Foo"]`, where Foo is a record n
 
 Note that the original schema is still required to correctly process JSON-encoded data. For example, the JSON encoding does not distinguish between _int_ and _long_, _float_ and _double_, records and maps, enums and strings, etc.
 
-#### Single-object encoding
+### Single-object encoding
 In some situations a single Avro serialized object is to be stored for a longer period of time. One very common example is storing Avro records for several weeks in an [Apache Kafka](https://kafka.apache.org/) topic.
 
 In the period after a schema change this persistence system will contain records that have been written with different schemas. So the need arises to know which schema was used to write a record to support schema evolution correctly. In most cases the schema itself is too large to include in the message, so this binary wrapper format supports the use case more effectively.
 
-##### Single object encoding specification
+#### Single object encoding specification
 Single Avro objects are encoded as follows:
 
 1. A two-byte marker, `C3 01`, to show that the message is Avro and uses this single-record format (version 1).


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the heading level of Single-object encoding in the doc.
Currently, `Single-object encoding` is under `JSON Encoding` but it seems wrong.

## Verifying this change

Confirmed the layout is fixed with the following command.
```
docker run --rm -v $(pwd):/src -p 1313:1313 jakejarvis/hugo-extended:latest --source doc/ server     --buildDrafts --buildFuture --bind 0.0.0.0 --navigateToChanged
```

Then, we can find `Single-object encoding` in the table of contents.
![table-of-content](https://github.com/apache/avro/assets/4736016/4a264e63-ef22-47fa-b323-6c298228cd3f)

## Documentation

- Does this pull request introduce a new feature? (no)