### PR TITLE
AVRO-3853: [Rust] Support Local timestamp logical types for Rust SDK

### DIFF
--- a/lang/rust/avro/README.md
+++ b/lang/rust/avro/README.md
@@ -432,6 +432,7 @@ fn main() -> Result<(), Error> {
 1. UUID using the [`uuid`](https://docs.rs/uuid/1.0.0/uuid) crate
 1. Date, Time (milli) as `i32` and Time (micro) as `i64`
 1. Timestamp (milli and micro) as `i64`
+1. Local timestamp (milli and micro) as `i64`
 1. Duration as a custom type with `months`, `days` and `millis` accessor methods each of which returns an `i32`
 
 Note that the on-disk representation is identical to the underlying primitive/complex type.
@@ -500,6 +501,16 @@ fn main() -> Result<(), Error> {
           "logicalType": "timestamp-micros"
         },
         {
+          "name": "local_timestamp_millis",
+          "type": "long",
+          "logicalType": "local-timestamp-millis"
+        },
+        {
+          "name": "local_timestamp_micros",
+          "type": "long",
+          "logicalType": "local-timestamp-micros"
+        },
+        {
           "name": "duration",
           "type": {
             "type": "fixed",
@@ -527,6 +538,8 @@ fn main() -> Result<(), Error> {
     record.put("time_micros", Value::TimeMicros(3));
     record.put("timestamp_millis", Value::TimestampMillis(4));
     record.put("timestamp_micros", Value::TimestampMicros(5));
+    record.put("local_timestamp_millis", Value::LocalTimestampMillis(4));
+    record.put("local_timestamp_micros", Value::LocalTimestampMicros(5));
     record.put("duration", Duration::new(Months::new(6), Days::new(7), Millis::new(8)));
 
     writer.append(record)?;

--- a/lang/rust/avro/src/decode.rs
+++ b/lang/rust/avro/src/decode.rs
@@ -130,6 +130,8 @@ pub(crate) fn decode_internal<R: Read, S: Borrow<Schema>>(
         Schema::TimeMicros => zag_i64(reader).map(Value::TimeMicros),
         Schema::TimestampMillis => zag_i64(reader).map(Value::TimestampMillis),
         Schema::TimestampMicros => zag_i64(reader).map(Value::TimestampMicros),
+        Schema::LocalTimestampMillis => zag_i64(reader).map(Value::LocalTimestampMillis),
+        Schema::LocalTimestampMicros => zag_i64(reader).map(Value::LocalTimestampMicros),
         Schema::Duration => {
             let mut buf = [0u8; 12];
             reader.read_exact(&mut buf).map_err(Error::ReadDuration)?;

--- a/lang/rust/avro/src/encode.rs
+++ b/lang/rust/avro/src/encode.rs
@@ -77,6 +77,8 @@ pub(crate) fn encode_internal<S: Borrow<Schema>>(
         Value::Long(i)
         | Value::TimestampMillis(i)
         | Value::TimestampMicros(i)
+        | Value::LocalTimestampMillis(i)
+        | Value::LocalTimestampMicros(i)
         | Value::TimeMicros(i) => encode_long(*i, buffer),
         Value::Float(x) => buffer.extend_from_slice(&x.to_le_bytes()),
         Value::Double(x) => buffer.extend_from_slice(&x.to_le_bytes()),

--- a/lang/rust/avro/src/error.rs
+++ b/lang/rust/avro/src/error.rs
@@ -151,6 +151,12 @@ pub enum Error {
     #[error("TimestampMicros expected, got {0:?}")]
     GetTimestampMicros(ValueKind),
 
+    #[error("LocalTimestampMillis expected, got {0:?}")]
+    GetLocalTimestampMillis(ValueKind),
+
+    #[error("LocalTimestampMicros expected, got {0:?}")]
+    GetLocalTimestampMicros(ValueKind),
+
     #[error("Null expected, got {0:?}")]
     GetNull(ValueKind),
 

--- a/lang/rust/avro/src/lib.rs
+++ b/lang/rust/avro/src/lib.rs
@@ -545,6 +545,7 @@
 //! 1. UUID using the [`uuid`](https://docs.rs/uuid/1.0.0/uuid) crate
 //! 1. Date, Time (milli) as `i32` and Time (micro) as `i64`
 //! 1. Timestamp (milli and micro) as `i64`
+//! 1. Local timestamp (milli and micro) as `i64`
 //! 1. Duration as a custom type with `months`, `days` and `millis` accessor methods each of which returns an `i32`
 //!
 //! Note that the on-disk representation is identical to the underlying primitive/complex type.
@@ -613,6 +614,16 @@
 //!           "logicalType": "timestamp-micros"
 //!         },
 //!         {
+//!           "name": "local_timestamp_millis",
+//!           "type": "long",
+//!           "logicalType": "local-timestamp-millis"
+//!         },
+//!         {
+//!           "name": "local_timestamp_micros",
+//!           "type": "long",
+//!           "logicalType": "local-timestamp-micros"
+//!         },
+//!         {
 //!           "name": "duration",
 //!           "type": {
 //!             "type": "fixed",
@@ -640,6 +651,8 @@
 //!     record.put("time_micros", Value::TimeMicros(3));
 //!     record.put("timestamp_millis", Value::TimestampMillis(4));
 //!     record.put("timestamp_micros", Value::TimestampMicros(5));
+//!     record.put("local_timestamp_millis", Value::LocalTimestampMillis(4));
+//!     record.put("local_timestamp_micros", Value::LocalTimestampMicros(5));
 //!     record.put("duration", Duration::new(Months::new(6), Days::new(7), Millis::new(8)));
 //!
 //!     writer.append(record)?;

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -127,6 +127,10 @@ pub enum Schema {
     TimestampMillis,
     /// An instant in time represented as the number of microseconds after the UNIX epoch.
     TimestampMicros,
+    /// An instant in localtime represented as the number of milliseconds after the UNIX epoch.
+    LocalTimestampMillis,
+    /// An instant in local time represented as the number of microseconds after the UNIX epoch.
+    LocalTimestampMicros,
     /// An amount of time defined by a number of months, days and milliseconds.
     Duration,
     /// A reference to another schema.
@@ -191,6 +195,8 @@ impl From<&types::Value> for SchemaKind {
             Value::TimeMicros(_) => Self::TimeMicros,
             Value::TimestampMillis(_) => Self::TimestampMillis,
             Value::TimestampMicros(_) => Self::TimestampMicros,
+            Value::LocalTimestampMillis(_) => Self::LocalTimestampMillis,
+            Value::LocalTimestampMicros(_) => Self::LocalTimestampMicros,
             Value::Duration { .. } => Self::Duration,
         }
     }
@@ -1388,6 +1394,26 @@ impl Parser {
                         enclosing_namespace,
                     );
                 }
+                "local-timestamp-millis" => {
+                    return try_logical_type(
+                        "local-timestamp-millis",
+                        complex,
+                        &[SchemaKind::Long],
+                        Schema::LocalTimestampMillis,
+                        self,
+                        enclosing_namespace,
+                    );
+                }
+                "local-timestamp-micros" => {
+                    return try_logical_type(
+                        "local-timestamp-micros",
+                        complex,
+                        &[SchemaKind::Long],
+                        Schema::LocalTimestampMicros,
+                        self,
+                        enclosing_namespace,
+                    );
+                }
                 "duration" => {
                     logical_verify_type(complex, &[SchemaKind::Fixed], self, enclosing_namespace)?;
                     return Ok(Schema::Duration);
@@ -1899,6 +1925,18 @@ impl Serialize for Schema {
                 let mut map = serializer.serialize_map(None)?;
                 map.serialize_entry("type", "long")?;
                 map.serialize_entry("logicalType", "timestamp-micros")?;
+                map.end()
+            }
+            Schema::LocalTimestampMillis => {
+                let mut map = serializer.serialize_map(None)?;
+                map.serialize_entry("type", "long")?;
+                map.serialize_entry("logicalType", "local-timestamp-millis")?;
+                map.end()
+            }
+            Schema::LocalTimestampMicros => {
+                let mut map = serializer.serialize_map(None)?;
+                map.serialize_entry("type", "long")?;
+                map.serialize_entry("logicalType", "local-timestamp-micros")?;
                 map.end()
             }
             Schema::Duration => {

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -108,6 +108,10 @@ pub enum Value {
     TimestampMillis(i64),
     /// Timestamp in microseconds.
     TimestampMicros(i64),
+    /// Local timestamp in milliseconds.
+    LocalTimestampMillis(i64),
+    /// Local timestamp in microseconds.
+    LocalTimestampMicros(i64),
     /// Avro Duration. An amount of time defined by months, days and milliseconds.
     Duration(Duration),
     /// Universally unique identifier.
@@ -327,6 +331,8 @@ impl TryFrom<Value> for JsonValue {
             Value::TimeMicros(t) => Ok(Self::Number(t.into())),
             Value::TimestampMillis(t) => Ok(Self::Number(t.into())),
             Value::TimestampMicros(t) => Ok(Self::Number(t.into())),
+            Value::LocalTimestampMillis(t) => Ok(Self::Number(t.into())),
+            Value::LocalTimestampMicros(t) => Ok(Self::Number(t.into())),
             Value::Duration(d) => Ok(Self::Array(
                 <[u8; 12]>::from(d).iter().map(|&v| v.into()).collect(),
             )),
@@ -409,8 +415,12 @@ impl Value {
             (&Value::Long(_), &Schema::TimeMicros) => None,
             (&Value::Long(_), &Schema::TimestampMillis) => None,
             (&Value::Long(_), &Schema::TimestampMicros) => None,
+            (&Value::Long(_), &Schema::LocalTimestampMillis) => None,
+            (&Value::Long(_), &Schema::LocalTimestampMicros) => None,
             (&Value::TimestampMicros(_), &Schema::TimestampMicros) => None,
             (&Value::TimestampMillis(_), &Schema::TimestampMillis) => None,
+            (&Value::LocalTimestampMicros(_), &Schema::LocalTimestampMicros) => None,
+            (&Value::LocalTimestampMillis(_), &Schema::LocalTimestampMillis) => None,
             (&Value::TimeMicros(_), &Schema::TimeMicros) => None,
             (&Value::TimeMillis(_), &Schema::TimeMillis) => None,
             (&Value::Date(_), &Schema::Date) => None,
@@ -669,6 +679,8 @@ impl Value {
             Schema::TimeMicros => self.resolve_time_micros(),
             Schema::TimestampMillis => self.resolve_timestamp_millis(),
             Schema::TimestampMicros => self.resolve_timestamp_micros(),
+            Schema::LocalTimestampMillis => self.resolve_local_timestamp_millis(),
+            Schema::LocalTimestampMicros => self.resolve_local_timestamp_micros(),
             Schema::Duration => self.resolve_duration(),
             Schema::Uuid => self.resolve_uuid(),
         }
@@ -781,6 +793,22 @@ impl Value {
             Value::TimestampMicros(ts) | Value::Long(ts) => Ok(Value::TimestampMicros(ts)),
             Value::Int(ts) => Ok(Value::TimestampMicros(i64::from(ts))),
             other => Err(Error::GetTimestampMicros(other.into())),
+        }
+    }
+
+    fn resolve_local_timestamp_millis(self) -> Result<Self, Error> {
+        match self {
+            Value::LocalTimestampMillis(ts) | Value::Long(ts) => Ok(Value::LocalTimestampMillis(ts)),
+            Value::Int(ts) => Ok(Value::LocalTimestampMillis(i64::from(ts))),
+            other => Err(Error::GetLocalTimestampMillis(other.into())),
+        }
+    }
+
+    fn resolve_local_timestamp_micros(self) -> Result<Self, Error> {
+        match self {
+            Value::LocalTimestampMicros(ts) | Value::Long(ts) => Ok(Value::LocalTimestampMicros(ts)),
+            Value::Int(ts) => Ok(Value::LocalTimestampMicros(i64::from(ts))),
+            other => Err(Error::GetLocalTimestampMicros(other.into())),
         }
     }
 
@@ -1682,6 +1710,26 @@ Field with name '"b"' is not a member of the map items"#,
     }
 
     #[test]
+    fn test_avro_3853_resolve_timestamp_millis() {
+        let value = Value::LocalTimestampMillis(10);
+        assert!(value.clone().resolve(&Schema::LocalTimestampMillis).is_ok());
+        assert!(value.resolve(&Schema::Float).is_err());
+
+        let value = Value::Float(10.0f32);
+        assert!(value.resolve(&Schema::LocalTimestampMillis).is_err());
+    }
+
+    #[test]
+    fn test_avro_3853_resolve_timestamp_micros() {
+        let value = Value::LocalTimestampMicros(10);
+        assert!(value.clone().resolve(&Schema::LocalTimestampMicros).is_ok());
+        assert!(value.resolve(&Schema::Int).is_err());
+
+        let value = Value::Double(10.0);
+        assert!(value.resolve(&Schema::LocalTimestampMicros).is_err());
+    }
+
+    #[test]
     fn resolve_duration() {
         let value = Value::Duration(Duration::new(
             Months::new(10),
@@ -1884,6 +1932,14 @@ Field with name '"b"' is not a member of the map items"#,
         );
         assert_eq!(
             JsonValue::try_from(Value::TimestampMicros(1))?,
+            JsonValue::Number(1.into())
+        );
+        assert_eq!(
+            JsonValue::try_from(Value::LocalTimestampMillis(1))?,
+            JsonValue::Number(1.into())
+        );
+        assert_eq!(
+            JsonValue::try_from(Value::LocalTimestampMicros(1))?,
             JsonValue::Number(1.into())
         );
         assert_eq!(

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -798,7 +798,9 @@ impl Value {
 
     fn resolve_local_timestamp_millis(self) -> Result<Self, Error> {
         match self {
-            Value::LocalTimestampMillis(ts) | Value::Long(ts) => Ok(Value::LocalTimestampMillis(ts)),
+            Value::LocalTimestampMillis(ts) | Value::Long(ts) => {
+                Ok(Value::LocalTimestampMillis(ts))
+            }
             Value::Int(ts) => Ok(Value::LocalTimestampMillis(i64::from(ts))),
             other => Err(Error::GetLocalTimestampMillis(other.into())),
         }
@@ -806,7 +808,9 @@ impl Value {
 
     fn resolve_local_timestamp_micros(self) -> Result<Self, Error> {
         match self {
-            Value::LocalTimestampMicros(ts) | Value::Long(ts) => Ok(Value::LocalTimestampMicros(ts)),
+            Value::LocalTimestampMicros(ts) | Value::Long(ts) => {
+                Ok(Value::LocalTimestampMicros(ts))
+            }
             Value::Int(ts) => Ok(Value::LocalTimestampMicros(i64::from(ts))),
             other => Err(Error::GetLocalTimestampMicros(other.into())),
         }

--- a/lang/rust/avro/tests/schema.rs
+++ b/lang/rust/avro/tests/schema.rs
@@ -592,6 +592,42 @@ const TIMESTAMPMICROS_LOGICAL_TYPE: &[(&str, bool)] = &[
     ),
 ];
 
+const LOCAL_TIMESTAMPMILLIS_LOGICAL_TYPE: &[(&str, bool)] = &[
+    (
+        r#"{"type": "long", "logicalType": "local-timestamp-millis"}"#,
+        true,
+    ),
+    // this is valid even though its logical type is "local-timestamp-milis" (missing the second "l"), because
+    // unknown logical types are ignored
+    (
+        r#"{"type": "long", "logicalType": "local-timestamp-milis"}"#,
+        true,
+    ),
+    (
+        // this is still valid because unknown logicalType should be ignored
+        r#"{"type": "int", "logicalType": "local-timestamp-millis"}"#,
+        true,
+    ),
+];
+
+const LOCAL_TIMESTAMPMICROS_LOGICAL_TYPE: &[(&str, bool)] = &[
+    (
+        r#"{"type": "long", "logicalType": "local-timestamp-micros"}"#,
+        true,
+    ),
+    // this is valid even though its logical type is "local-timestamp-micro" (missing the last "s"), because
+    // unknown logical types are ignored
+    (
+        r#"{"type": "long", "logicalType": "local-timestamp-micro"}"#,
+        true,
+    ),
+    (
+        // this is still valid because unknown logicalType should be ignored
+        r#"{"type": "int", "logicalType": "local-timestamp-micros"}"#,
+        true,
+    ),
+];
+
 lazy_static! {
     static ref EXAMPLES: Vec<(&'static str, bool)> = Vec::new()
         .iter()
@@ -612,6 +648,8 @@ lazy_static! {
         .chain(TIMEMICROS_LOGICAL_TYPE.iter().copied())
         .chain(TIMESTAMPMILLIS_LOGICAL_TYPE.iter().copied())
         .chain(TIMESTAMPMICROS_LOGICAL_TYPE.iter().copied())
+        .chain(LOCAL_TIMESTAMPMILLIS_LOGICAL_TYPE.iter().copied())
+        .chain(LOCAL_TIMESTAMPMICROS_LOGICAL_TYPE.iter().copied())
         .collect();
     static ref VALID_EXAMPLES: Vec<(&'static str, bool)> =
         EXAMPLES.iter().copied().filter(|s| s.1).collect();


### PR DESCRIPTION
AVRO-3853

## What is the purpose of the change
Local timestamp logical types are missing in the Rust SDK.
It's nice to support them.

## Verifying this change
Added new tests and modified existing tests.

## Documentation

- Does this pull request introduce a new feature? (no)
