### PR TITLE
Minor: [JavaScript] Ignore .nyc_output

### DIFF
--- a/lang/js/.gitignore
+++ b/lang/js/.gitignore
@@ -1,2 +1,3 @@
 coverage/
 node_modules/
+.nyc_output


### PR DESCRIPTION
## What is the purpose of the change
This PR adds an entry `.nyc_output` to `.gitignore` in `lang/js`.
The directory is generated when we run `npm run cover`.

## Verifying this change
Confirmed `git status` ignores `.nyc_output`.

## Documentation

- Does this pull request introduce a new feature? (no)
