### PR TITLE
AVRO-3855: [Rust] Fix clippy error with Rust 1.65.0

### DIFF
--- a/.github/workflows/test-lang-rust-clippy.yml
+++ b/.github/workflows/test-lang-rust-clippy.yml
@@ -52,6 +52,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: stable
+          rust-version: ${{ matrix.rust }}
+          toolchain: ${{ matrix.rust }}
           components: clippy
       - run: cargo clippy --all-features --all-targets -- -Dclippy::all -Dunused_imports

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -723,7 +723,6 @@ impl RecordField {
                 }
                 _ => {
                     let resolved = avro_value
-                        .to_owned()
                         .resolve_internal(field_schema, names, &field_schema.namespace(), &None)
                         .is_ok();
 
@@ -1635,7 +1634,6 @@ impl Parser {
 
         if let Some(ref value) = default {
             let resolved = types::Value::from(value.clone())
-                .to_owned()
                 .resolve_enum(&symbols, &Some(value.to_string()), &None)
                 .is_ok();
             if !resolved {


### PR DESCRIPTION
AVRO-3855

## What is the purpose of the change
This PR fixes an issue that clippy fails with Rust 1.65.0.
You can reproduce with:
```
cargo +1.65.0 clippy --all-targets --all-features -- -Dclippy::all
```

This PR also modifies `test-lang-rust-clippy.yml` to let the CI verify.

## Verifying this change
The command shown above succeeds.

## Documentation

- Does this pull request introduce a new feature? (no)