### PR TITLE
AVRO-3857: [BUILD] Automate dist build

### DIFF
--- a/lang/py/build.sh
+++ b/lang/py/build.sh
@@ -84,7 +84,10 @@ main() {
   for target; do
     case "$target" in
       clean) clean;;
-      dist) dist;;
+      dist)
+        dist
+        doc
+        ;;
       doc) doc;;
       interop-data-generate) interop-data-generate;;
       interop-data-test) interop-data-test;;

--- a/share/docker/make-dist.sh
+++ b/share/docker/make-dist.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+function build_doc() {
+  ( cd build/staging-web && npm install )
+  npx -p hugo-extended \
+      -p postcss \
+      -p postcss-cli \
+      hugo --source build/staging-web/ --gc --minify
+}
+export -f build_doc
+
+cd ~/avro
+
+git config --global --add safe.directory ~/avro
+git config --global --add safe.directory ~/avro/doc/themes/docsy
+git config --global --add safe.directory ~/avro/doc/themes/docsy/assets/vendor/Font-Awesome
+git config --global --add safe.directory ~/avro/doc/themes/docsy/assets/vendor/bootstrap
+
+./build.sh dist


### PR DESCRIPTION
AVRO-3857

## What is the purpose of the change
This PR aims to automate dist build.
Currently, the dist build process is not fully automated especially the document.

With this change, you can build dist like as follows.
```
./build.sh docker-dist
```

Also, this PR includes a fix for building the document.
You can confirm the document built by the command above like as follows.
```
# 1. Serve the doc
docker run -p 8080:80 --rm -v $(pwd)/build/staging-web/public:/usr/local/apache2/htdocs/ httpd:2.4
# 2. Then, access http://localhost:8080
```

## Verifying this change
Artifacts seem to be built successfully and stored in `dist`

## Documentation

- Does this pull request introduce a new feature? (no)
