### PR TITLE
AVRO-3859: build.sh clean fails to remove some C# files

### DIFF
--- a/lang/csharp/build.sh
+++ b/lang/csharp/build.sh
@@ -85,7 +85,8 @@ do
       ;;
 
     clean)
-      rm -rf src/apache/{main,test,codegen,ipc,msbuild,perf}/{obj,bin}
+      rm -rf src/apache/{main,test,codegen,ipc,msbuild,perf,benchmark}/{obj,bin}
+      rm -rf src/apache/codec/Avro.File.{BZip2,Snappy,XZ,ZStandard}{,.Test}/{obj,bin}
       rm -rf build
       rm -f  TestResult.xml
       ;;


### PR DESCRIPTION
## What is the purpose of the change

* Make sure that `build.sh clean` removes all bin and obj folders (AVRO-3859)


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)
