### PR TITLE
AVRO-3411: Fix devcontainers build

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,42 +1,36 @@
 {
     "name": "Avro Development",
-
-    "build": { "dockerfile": "../share/docker/Dockerfile" },
-
-    // Use 'settings' to set *default* container specific settings.json values on container create.
-    // You can edit these settings after create using File > Preferences > Settings > Remote.
-    "settings": {
+    "build": {
+        "dockerfile": "../share/docker/Dockerfile",
+        "context": ".."
     },
-
-    // Add the IDs of extensions you want installed when the container is created in the array below.
-    "extensions": [
-        // Python
-        "ms-python.python",
-        "ms-python.vscode-pylance",
-
-         // C/C++
-        "ms-vscode.cpptools",
-
-        // C#
-        "ms-dotnettools.csharp",
-
-        // Rust
-        "vadimcn.vscode-lldb",
-        "mutantdino.resourcemonitor",
-        "matklad.rust-analyzer",
-        "tamasfe.even-better-toml",
-        "serayuzgur.crates",
-
-        // Java
-        "vscjava.vscode-java-pack",
-
-        // Shell script
-        "timonwong.shellcheck",
-
-        // YAML
-        "redhat.vscode-yaml",
-
-        // Git
-        "eamodio.gitlens"
-    ]
+    "customizations": {
+        "vscode": {
+            "settings": {
+            },
+            "extensions": [
+                // Python
+                "ms-python.python",
+                "ms-python.vscode-pylance",
+                // C/C++
+                "ms-vscode.cpptools",
+                // C#
+                "ms-dotnettools.csharp",
+                // Rust
+                "vadimcn.vscode-lldb",
+                "mutantdino.resourcemonitor",
+                "matklad.rust-analyzer",
+                "tamasfe.even-better-toml",
+                "serayuzgur.crates",
+                // Java
+                "vscjava.vscode-java-pack",
+                // Shell script
+                "timonwong.shellcheck",
+                // YAML
+                "redhat.vscode-yaml",
+                // Git
+                "eamodio.gitlens"
+            ]
+        }
+    }
 }

--- a/README.md
+++ b/README.md
@@ -70,3 +70,9 @@ To contribute to Avro, please read:
 [codeql java img]:       https://github.com/apache/avro/actions/workflows/codeql-java-analysis.yml/badge.svg
 [codeql javascript img]: https://github.com/apache/avro/actions/workflows/codeql-js-analysis.yml/badge.svg
 [codeql python img]:     https://github.com/apache/avro/actions/workflows/codeql-py-analysis.yml/badge.svg
+
+You can use devcontainers to develop Avro:
+
+* [![Open in Visual Studio Code](https://img.shields.io/static/v1?label=&message=Open%20in%20Visual%20Studio%20Code&color=blue&logo=visualstudiocode&style=flat)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/apache/avro)
+* [![Open in Github Codespaces](https://img.shields.io/static/v1?label=&message=Open%20in%20Github%20Codespaces&color=2f362d&logo=github)](https://codespaces.new/apache/avro?quickstart=1&hide_repo_select=true)
+


### PR DESCRIPTION
Avro's devcontainers build fails, it misses the context section because of the relative path to the Dockerfile. Also the extensions section showed a warning. All should be good now.

R: @martin-g 
