### PR TITLE
AVRO-3863: [Java] Delete temporary test data after tests finish

### DIFF
--- a/lang/java/avro/src/test/java/org/apache/avro/TestDataFileReader.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestDataFileReader.java
@@ -91,6 +91,7 @@ public class TestDataFileReader {
         .parse("{\"type\": \"record\", \"name\": \"TestSchema\", \"fields\": "
             + "[ {\"name\": \"id\", \"type\": [\"long\", \"null\"], \"default\": null}]}");
     File f = Files.createTempFile("testThrottledInputStream", ".avro").toFile();
+    f.deleteOnExit();
     try (DataFileWriter<?> w = new DataFileWriter<>(new GenericDatumWriter<>())) {
       w.create(legacySchema, f);
       w.flush();
@@ -150,6 +151,7 @@ public class TestDataFileReader {
           .parse("{\"type\": \"record\", \"name\": \"TestSchema\", \"fields\": "
               + "[ {\"name\": \"id\", \"type\": [\"long\", \"null\"], \"default\": null}]}");
       File f = Files.createTempFile("testInputStreamEOF", ".avro").toFile();
+      f.deleteOnExit();
       try (DataFileWriter<?> w = new DataFileWriter<>(new GenericDatumWriter<>())) {
         w.create(legacySchema, f);
         w.flush();
@@ -201,6 +203,7 @@ public class TestDataFileReader {
 
     // Create a file with the legacy schema.
     File f = Files.createTempFile("testIgnoreSchemaValidationOnRead", ".avro").toFile();
+    f.deleteOnExit();
     try (DataFileWriter<?> w = new DataFileWriter<>(new GenericDatumWriter<>())) {
       w.create(legacySchema, f);
       w.flush();
@@ -215,6 +218,7 @@ public class TestDataFileReader {
   @Test
   void invalidMagicLength() throws IOException {
     File f = Files.createTempFile("testInvalidMagicLength", ".avro").toFile();
+    f.deleteOnExit();
     try (FileWriter w = new FileWriter(f)) {
       w.write("-");
     }
@@ -227,6 +231,7 @@ public class TestDataFileReader {
   @Test
   void invalidMagicBytes() throws IOException {
     File f = Files.createTempFile("testInvalidMagicBytes", ".avro").toFile();
+    f.deleteOnExit();
     try (FileWriter w = new FileWriter(f)) {
       w.write("invalid");
     }

--- a/lang/java/avro/src/test/java/org/apache/avro/TestDataFileReader.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestDataFileReader.java
@@ -38,9 +38,12 @@ import org.apache.avro.file.SeekableInput;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 @SuppressWarnings("restriction")
 public class TestDataFileReader {
+  @TempDir
+  public Path DATA_DIR;
 
   // regression test for bug AVRO-2286
   @Test
@@ -90,8 +93,7 @@ public class TestDataFileReader {
     Schema legacySchema = new Schema.Parser(Schema.NameValidator.NO_VALIDATION).setValidateDefaults(false)
         .parse("{\"type\": \"record\", \"name\": \"TestSchema\", \"fields\": "
             + "[ {\"name\": \"id\", \"type\": [\"long\", \"null\"], \"default\": null}]}");
-    File f = Files.createTempFile("testThrottledInputStream", ".avro").toFile();
-    f.deleteOnExit();
+    File f = DATA_DIR.resolve("testThrottledInputStream.avro").toFile();
     try (DataFileWriter<?> w = new DataFileWriter<>(new GenericDatumWriter<>())) {
       w.create(legacySchema, f);
       w.flush();
@@ -150,8 +152,7 @@ public class TestDataFileReader {
       Schema legacySchema = new Schema.Parser(Schema.NameValidator.NO_VALIDATION).setValidateDefaults(false)
           .parse("{\"type\": \"record\", \"name\": \"TestSchema\", \"fields\": "
               + "[ {\"name\": \"id\", \"type\": [\"long\", \"null\"], \"default\": null}]}");
-      File f = Files.createTempFile("testInputStreamEOF", ".avro").toFile();
-      f.deleteOnExit();
+      File f = DATA_DIR.resolve("testInputStreamEOF.avro").toFile();
       try (DataFileWriter<?> w = new DataFileWriter<>(new GenericDatumWriter<>())) {
         w.create(legacySchema, f);
         w.flush();
@@ -202,8 +203,7 @@ public class TestDataFileReader {
             + "[ {\"name\": \"id\", \"type\": [\"long\", \"null\"], \"default\": null}]}");
 
     // Create a file with the legacy schema.
-    File f = Files.createTempFile("testIgnoreSchemaValidationOnRead", ".avro").toFile();
-    f.deleteOnExit();
+    File f = DATA_DIR.resolve("testIgnoreSchemaValidationOnRead.avro").toFile();
     try (DataFileWriter<?> w = new DataFileWriter<>(new GenericDatumWriter<>())) {
       w.create(legacySchema, f);
       w.flush();
@@ -217,8 +217,7 @@ public class TestDataFileReader {
 
   @Test
   void invalidMagicLength() throws IOException {
-    File f = Files.createTempFile("testInvalidMagicLength", ".avro").toFile();
-    f.deleteOnExit();
+    File f = DATA_DIR.resolve("testInvalidMagicLength.avro").toFile();
     try (FileWriter w = new FileWriter(f)) {
       w.write("-");
     }
@@ -230,8 +229,7 @@ public class TestDataFileReader {
 
   @Test
   void invalidMagicBytes() throws IOException {
-    File f = Files.createTempFile("testInvalidMagicBytes", ".avro").toFile();
-    f.deleteOnExit();
+    File f = DATA_DIR.resolve("testInvalidMagicBytes.avro").toFile();
     try (FileWriter w = new FileWriter(f)) {
       w.write("invalid");
     }

--- a/lang/java/avro/src/test/java/org/apache/avro/TestDataFileReader.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestDataFileReader.java
@@ -43,7 +43,7 @@ import org.junit.jupiter.api.io.TempDir;
 @SuppressWarnings("restriction")
 public class TestDataFileReader {
   @TempDir
-  public Path DATA_DIR;
+  public Path dataDir;
 
   // regression test for bug AVRO-2286
   @Test
@@ -93,7 +93,7 @@ public class TestDataFileReader {
     Schema legacySchema = new Schema.Parser(Schema.NameValidator.NO_VALIDATION).setValidateDefaults(false)
         .parse("{\"type\": \"record\", \"name\": \"TestSchema\", \"fields\": "
             + "[ {\"name\": \"id\", \"type\": [\"long\", \"null\"], \"default\": null}]}");
-    File f = DATA_DIR.resolve("testThrottledInputStream.avro").toFile();
+    File f = dataDir.resolve("testThrottledInputStream.avro").toFile();
     try (DataFileWriter<?> w = new DataFileWriter<>(new GenericDatumWriter<>())) {
       w.create(legacySchema, f);
       w.flush();
@@ -152,7 +152,7 @@ public class TestDataFileReader {
       Schema legacySchema = new Schema.Parser(Schema.NameValidator.NO_VALIDATION).setValidateDefaults(false)
           .parse("{\"type\": \"record\", \"name\": \"TestSchema\", \"fields\": "
               + "[ {\"name\": \"id\", \"type\": [\"long\", \"null\"], \"default\": null}]}");
-      File f = DATA_DIR.resolve("testInputStreamEOF.avro").toFile();
+      File f = dataDir.resolve("testInputStreamEOF.avro").toFile();
       try (DataFileWriter<?> w = new DataFileWriter<>(new GenericDatumWriter<>())) {
         w.create(legacySchema, f);
         w.flush();
@@ -203,7 +203,7 @@ public class TestDataFileReader {
             + "[ {\"name\": \"id\", \"type\": [\"long\", \"null\"], \"default\": null}]}");
 
     // Create a file with the legacy schema.
-    File f = DATA_DIR.resolve("testIgnoreSchemaValidationOnRead.avro").toFile();
+    File f = dataDir.resolve("testIgnoreSchemaValidationOnRead.avro").toFile();
     try (DataFileWriter<?> w = new DataFileWriter<>(new GenericDatumWriter<>())) {
       w.create(legacySchema, f);
       w.flush();
@@ -217,7 +217,7 @@ public class TestDataFileReader {
 
   @Test
   void invalidMagicLength() throws IOException {
-    File f = DATA_DIR.resolve("testInvalidMagicLength.avro").toFile();
+    File f = dataDir.resolve("testInvalidMagicLength.avro").toFile();
     try (FileWriter w = new FileWriter(f)) {
       w.write("-");
     }
@@ -229,7 +229,7 @@ public class TestDataFileReader {
 
   @Test
   void invalidMagicBytes() throws IOException {
-    File f = DATA_DIR.resolve("testInvalidMagicBytes.avro").toFile();
+    File f = dataDir.resolve("testInvalidMagicBytes.avro").toFile();
     try (FileWriter w = new FileWriter(f)) {
       w.write("invalid");
     }

--- a/lang/java/avro/src/test/java/org/apache/avro/io/TestEncoders.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/io/TestEncoders.java
@@ -57,7 +57,7 @@ public class TestEncoders {
   private static EncoderFactory factory = EncoderFactory.get();
 
   @TempDir
-  public Path DIR;
+  public Path dataDir;
 
   @Test
   void binaryEncoderInit() throws IOException {
@@ -261,7 +261,7 @@ public class TestEncoders {
 
   @Test
   void mappedByteBuffer() throws IOException {
-    Path file = DIR.resolve("testMappedByteBuffer.avro");
+    Path file = dataDir.resolve("testMappedByteBuffer.avro");
     Files.write(file, someBytes(EXAMPLE_DATA_SIZE));
     MappedByteBuffer buffer = FileChannel.open(file, StandardOpenOption.READ).map(FileChannel.MapMode.READ_ONLY, 0,
         EXAMPLE_DATA_SIZE);

--- a/lang/java/avro/src/test/java/org/apache/avro/io/TestEncoders.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/io/TestEncoders.java
@@ -262,6 +262,7 @@ public class TestEncoders {
   @Test
   void mappedByteBuffer() throws IOException {
     Path file = Paths.get(DIR.getPath() + "testMappedByteBuffer.avro");
+    file.toFile().deleteOnExit();
     Files.write(file, someBytes(EXAMPLE_DATA_SIZE));
     MappedByteBuffer buffer = FileChannel.open(file, StandardOpenOption.READ).map(FileChannel.MapMode.READ_ONLY, 0,
         EXAMPLE_DATA_SIZE);

--- a/lang/java/avro/src/test/java/org/apache/avro/io/TestEncoders.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/io/TestEncoders.java
@@ -57,7 +57,7 @@ public class TestEncoders {
   private static EncoderFactory factory = EncoderFactory.get();
 
   @TempDir
-  public File DIR;
+  public Path DIR;
 
   @Test
   void binaryEncoderInit() throws IOException {
@@ -261,8 +261,7 @@ public class TestEncoders {
 
   @Test
   void mappedByteBuffer() throws IOException {
-    Path file = Paths.get(DIR.getPath() + "testMappedByteBuffer.avro");
-    file.toFile().deleteOnExit();
+    Path file = DIR.resolve("testMappedByteBuffer.avro");
     Files.write(file, someBytes(EXAMPLE_DATA_SIZE));
     MappedByteBuffer buffer = FileChannel.open(file, StandardOpenOption.READ).map(FileChannel.MapMode.READ_ONLY, 0,
         EXAMPLE_DATA_SIZE);

--- a/lang/java/tools/src/test/java/org/apache/avro/tool/TestCreateRandomFileTool.java
+++ b/lang/java/tools/src/test/java/org/apache/avro/tool/TestCreateRandomFileTool.java
@@ -34,6 +34,7 @@ import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.util.RandomData;
 import org.apache.trevni.TestUtil;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -64,6 +65,11 @@ public class TestCreateRandomFileTool {
   public void after() throws Exception {
     out.close();
     err.close();
+  }
+
+  @AfterAll
+  public static void afterAll() throws Exception {
+    OUT_FILE.delete();
   }
 
   private int run(List<String> args) throws Exception {

--- a/lang/java/tools/src/test/java/org/apache/avro/tool/TestCreateRandomFileTool.java
+++ b/lang/java/tools/src/test/java/org/apache/avro/tool/TestCreateRandomFileTool.java
@@ -47,7 +47,7 @@ public class TestCreateRandomFileTool {
   private static final String COUNT = System.getProperty("test.count", "200");
 
   @TempDir
-  private Path DIR;
+  private Path dataDir;
   private static final File SCHEMA_FILE = new File("../../../share/test/schemas/weather.avsc");
 
   private final Schema.Parser schemaParser = new Schema.Parser();
@@ -86,7 +86,7 @@ public class TestCreateRandomFileTool {
 
   private void check(String... extraArgs) throws Exception {
     ArrayList<String> args = new ArrayList<>();
-    File outFile = DIR.resolve("random.avro").toFile();
+    File outFile = dataDir.resolve("random.avro").toFile();
     args.addAll(Arrays.asList(outFile.toString(), "--count", COUNT, "--schema-file", SCHEMA_FILE.toString(), "--seed",
         Long.toString(SEED)));
     args.addAll(Arrays.asList(extraArgs));
@@ -103,7 +103,7 @@ public class TestCreateRandomFileTool {
 
   private void checkMissingCount(String... extraArgs) throws Exception {
     ArrayList<String> args = new ArrayList<>();
-    File outFile = DIR.resolve("random.avro").toFile();
+    File outFile = dataDir.resolve("random.avro").toFile();
     args.addAll(
         Arrays.asList(outFile.toString(), "--schema-file", SCHEMA_FILE.toString(), "--seed", Long.toString(SEED)));
     args.addAll(Arrays.asList(extraArgs));

--- a/lang/java/tools/src/test/java/org/apache/avro/tool/TestToTrevniTool.java
+++ b/lang/java/tools/src/test/java/org/apache/avro/tool/TestToTrevniTool.java
@@ -30,6 +30,7 @@ import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.util.RandomData;
 import org.apache.trevni.avro.AvroColumnReader;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
 public class TestToTrevniTool {
@@ -40,6 +41,11 @@ public class TestToTrevniTool {
   private static final File AVRO_FILE = new File(DIR, "random.avro");
   private static final File TREVNI_FILE = new File(DIR, "random.trv");
   private static final File SCHEMA_FILE = new File("../../../share/test/schemas/weather.avsc");
+
+  @AfterAll
+  public static void afterAll() throws Exception {
+    AVRO_FILE.delete();
+  }
 
   private String run(String... args) throws Exception {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/lang/java/tools/src/test/java/org/apache/avro/tool/TestToTrevniTool.java
+++ b/lang/java/tools/src/test/java/org/apache/avro/tool/TestToTrevniTool.java
@@ -40,7 +40,7 @@ public class TestToTrevniTool {
   private static final int COUNT = Integer.parseInt(System.getProperty("test.count", "200"));
 
   @TempDir
-  private Path DIR;
+  private Path dataDir;
   private static final File SCHEMA_FILE = new File("../../../share/test/schemas/weather.avsc");
 
   private String run(String... args) throws Exception {
@@ -55,13 +55,13 @@ public class TestToTrevniTool {
     Schema schema = new Schema.Parser().parse(SCHEMA_FILE);
 
     DataFileWriter<Object> writer = new DataFileWriter<>(new GenericDatumWriter<>());
-    File avroFile = DIR.resolve("random.avro").toFile();
+    File avroFile = dataDir.resolve("random.avro").toFile();
     writer.create(schema, avroFile);
     for (Object datum : new RandomData(schema, COUNT, SEED))
       writer.append(datum);
     writer.close();
 
-    File trevniFile = DIR.resolve("random.trv").toFile();
+    File trevniFile = dataDir.resolve("random.trv").toFile();
     run(avroFile.toString(), trevniFile.toString());
 
     AvroColumnReader<Object> reader = new AvroColumnReader<>(new AvroColumnReader.Params(trevniFile));

--- a/lang/java/tools/src/test/java/org/apache/avro/tool/TestToTrevniTool.java
+++ b/lang/java/tools/src/test/java/org/apache/avro/tool/TestToTrevniTool.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.PrintStream;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Iterator;
 
@@ -30,22 +31,17 @@ import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.util.RandomData;
 import org.apache.trevni.avro.AvroColumnReader;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestToTrevniTool {
   private static final long SEED = System.currentTimeMillis();
 
   private static final int COUNT = Integer.parseInt(System.getProperty("test.count", "200"));
-  private static final File DIR = new File("/tmp");
-  private static final File AVRO_FILE = new File(DIR, "random.avro");
-  private static final File TREVNI_FILE = new File(DIR, "random.trv");
-  private static final File SCHEMA_FILE = new File("../../../share/test/schemas/weather.avsc");
 
-  @AfterAll
-  public static void afterAll() throws Exception {
-    AVRO_FILE.delete();
-  }
+  @TempDir
+  private Path DIR;
+  private static final File SCHEMA_FILE = new File("../../../share/test/schemas/weather.avsc");
 
   private String run(String... args) throws Exception {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -59,14 +55,16 @@ public class TestToTrevniTool {
     Schema schema = new Schema.Parser().parse(SCHEMA_FILE);
 
     DataFileWriter<Object> writer = new DataFileWriter<>(new GenericDatumWriter<>());
-    writer.create(schema, Util.createFromFS(AVRO_FILE.toString()));
+    File avroFile = DIR.resolve("random.avro").toFile();
+    writer.create(schema, avroFile);
     for (Object datum : new RandomData(schema, COUNT, SEED))
       writer.append(datum);
     writer.close();
 
-    run(AVRO_FILE.toString(), TREVNI_FILE.toString());
+    File trevniFile = DIR.resolve("random.trv").toFile();
+    run(avroFile.toString(), trevniFile.toString());
 
-    AvroColumnReader<Object> reader = new AvroColumnReader<>(new AvroColumnReader.Params(TREVNI_FILE));
+    AvroColumnReader<Object> reader = new AvroColumnReader<>(new AvroColumnReader.Params(trevniFile));
     Iterator<Object> found = reader.iterator();
     for (Object expected : new RandomData(schema, COUNT, SEED))
       assertEquals(expected, found.next());


### PR DESCRIPTION
AVRO-3863

## What is the purpose of the change
This PR proposes to delete temporary test data generated by tests for Java SDK.
Tests for Java SDK creates some test data, which are left even after tests finish.
```
ls -1 /tmp/*.avro
/tmp/junit1533190586260098046testMappedByteBuffer.avro
/tmp/junit3099644739767498712testMappedByteBuffer.avro
/tmp/junit4466003251314064556testMappedByteBuffer.avro
/tmp/junit4974226498248565286testMappedByteBuffer.avro
/tmp/junit6473921034404349045testMappedByteBuffer.avro
/tmp/junit8662732084083941415testMappedByteBuffer.avro
/tmp/random.avro
/tmp/testIgnoreSchemaValidationOnRead275054571669736256.avro
/tmp/testIgnoreSchemaValidationOnRead4615547521362396523.avro
/tmp/testIgnoreSchemaValidationOnRead4955268403025511495.avro
/tmp/testIgnoreSchemaValidationOnRead5426593551205571746.avro
/tmp/testIgnoreSchemaValidationOnRead7554021276748093417.avro
/tmp/testIgnoreSchemaValidationOnRead8241302423385070851.avro
/tmp/testInputStreamEOF3549506421974960237.avro
/tmp/testInputStreamEOF4423343183305481378.avro
/tmp/testInputStreamEOF7397178073669402143.avro
/tmp/testInputStreamEOF8065492409408481522.avro
/tmp/testInputStreamEOF8087280538995909098.avro
/tmp/testInputStreamEOF8719004614093216771.avro
/tmp/testInvalidMagicBytes1940432228654910095.avro
/tmp/testInvalidMagicBytes2703760186774533143.avro
/tmp/testInvalidMagicBytes5088097518917799234.avro
/tmp/testInvalidMagicBytes863787801374013591.avro
/tmp/testInvalidMagicBytes887543761182735490.avro
/tmp/testInvalidMagicBytes980334707534164945.avro
/tmp/testInvalidMagicLength1346115615984572207.avro
/tmp/testInvalidMagicLength1511998921770126285.avro
/tmp/testInvalidMagicLength1824057536245960603.avro
/tmp/testInvalidMagicLength2005669502062311523.avro
/tmp/testInvalidMagicLength7068591900276715585.avro
/tmp/testInvalidMagicLength8356756206873381473.avro
/tmp/testThrottledInputStream2962195154373996754.avro
/tmp/testThrottledInputStream3610702487927451328.avro
/tmp/testThrottledInputStream4661398720877824185.avro
/tmp/testThrottledInputStream5592809458916764863.avro
/tmp/testThrottledInputStream6489638888793454476.avro
/tmp/testThrottledInputStream8013323018361761899.avro
```

## Verifying this change
The tests still pass even after this change.
Also, test data are deleted.
```
ls /tmp/*.avro
ls: cannot access '/tmp/*.avro': No such file or directory
```

## Documentation

- Does this pull request introduce a new feature? (no)