### PR TITLE
AVRO-3865, AVRO-3866: [Build][Perl][Python] Refer to share/VERSION.txt rather than copy it

### DIFF
--- a/lang/perl/MANIFEST
+++ b/lang/perl/MANIFEST
@@ -41,7 +41,6 @@ META.yml
 LICENSE
 NOTICE
 README
-VERSION.txt
 t/00_compile.t
 t/01_names.t
 t/01_schema.t

--- a/lang/perl/Makefile.PL
+++ b/lang/perl/Makefile.PL
@@ -19,12 +19,7 @@ use Config;
 use inc::Module::Install;
 
 my $version;
-for ('VERSION.txt', '../../share/VERSION.txt') {
-    if (-f) {
-        $version = `cat $_`;
-        last;
-    }
-}
+$version = `cat ../../share/VERSION.txt`;
 chomp $version;
 
 license 'apache';

--- a/lang/perl/build.sh
+++ b/lang/perl/build.sh
@@ -58,7 +58,6 @@ case "$target" in
     ;;
 
   dist)
-    cp ../../share/VERSION.txt .
     perl ./Makefile.PL && make dist
     ;;
 

--- a/lang/py/build.sh
+++ b/lang/py/build.sh
@@ -27,7 +27,6 @@ clean() {
                  '*.avsc' \
                  '*.egg-info' \
                  '*.py[co]' \
-                 'VERSION.txt' \
                  '__pycache__' \
                  '.tox' \
                  'avro/test/interop' \
@@ -53,8 +52,8 @@ dist() (
 
 doc() {
   local doc_dir
-  [[ -s VERSION.txt ]] || cp ../../share/VERSION.txt .
-  doc_dir="../../build/avro-doc-$(<VERSION.txt)/api/py"
+  local version=$(cat ../../share/VERSION.txt)
+  doc_dir="../../build/avro-doc-$version/api/py"
   python3 -m tox -e docs
   mkdir -p "$doc_dir"
   cp -a docs/build/* "$doc_dir"


### PR DESCRIPTION
AVRO-3865
AVRO-3866

## What is the purpose of the change
This PR proposes to change the build process of Perl and Python SDK not to copying `share/VERSION.txt` when we run `lang/perl/build.sh dist` or `lang/py/build.sh doc`.

## Verifying this change
Done by CI.

## Documentation

- Does this pull request introduce a new feature? (no)