### PR TITLE
AVRO-3867: [Python][Build] Fix the broken link to the Python API doc in the web site

### DIFF
--- a/lang/py/build.sh
+++ b/lang/py/build.sh
@@ -84,7 +84,10 @@ main() {
   for target; do
     case "$target" in
       clean) clean;;
-      dist) dist;;
+      dist)
+        dist
+        doc
+        ;;
       doc) doc;;
       interop-data-generate) interop-data-generate;;
       interop-data-test) interop-data-test;;


### PR DESCRIPTION
AVRO-3867

## What is the purpose of the change
This PR fixes an issue that the link to the Python API doc in the web site is broken.
I built the website by `./build.sh` dist and then tried to access to the Python API doc but the link seems broken.

The cause is `py/build.sh dist` doesn't generate the document.
So this PR includes a fix to generate the document when we run `py/build.sh dist`.

## Verifying this change
Built the web site and confirmed the link is available.

## Documentation

- Does this pull request introduce a new feature? (no)
