### PR TITLE
AVRO-3868: [Rust][CI] Check consistency between the doc comment in lib.rs and README.md

### DIFF
--- a/.github/workflows/test-lang-rust-ci.yml
+++ b/.github/workflows/test-lang-rust-ci.yml
@@ -80,6 +80,18 @@ jobs:
           components: rustfmt
           targets: ${{ matrix.target }}
 
+      - name: Install cargo-rdme
+        if: matrix.rust == 'stable' && matrix.target == 'x86_64-unknown-linux-gnu'
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: cargo-rdme
+
+      # Check if the doc cumment in avro/src/lib.rs and avro/README.md are in sync.
+      - name: Run cargo-rdme
+        # The result is environment independent so one test pattern is enough.
+        if: matrix.rust == 'stable' && matrix.target == 'x86_64-unknown-linux-gnu'
+        run: cargo rdme --check
+
       - name: Rust Format
         if: matrix.target != 'wasm32-unknown-unknown'
         run: cargo fmt --all -- --check

--- a/.github/workflows/test-lang-rust-ci.yml
+++ b/.github/workflows/test-lang-rust-ci.yml
@@ -80,17 +80,21 @@ jobs:
           components: rustfmt
           targets: ${{ matrix.target }}
 
-      - name: Install cargo-rdme
+      - name: Cache cargo-rdme
         if: matrix.rust == 'stable' && matrix.target == 'x86_64-unknown-linux-gnu'
-        uses: baptiste0928/cargo-install@v2
+        uses: actions/cache@v3
         with:
-          crate: cargo-rdme
+          path: ~/.cargo-${{ matrix.rust }}/cargo-rdme
+          key: cargo-rdme-
 
       # Check if the doc cumment in avro/src/lib.rs and avro/README.md are in sync.
       - name: Run cargo-rdme
         # The result is environment independent so one test pattern is enough.
         if: matrix.rust == 'stable' && matrix.target == 'x86_64-unknown-linux-gnu'
-        run: cargo rdme --check
+        run: |
+          cargo install --root ~/.cargo-${{ matrix.rust }}/cargo-rdme --locked cargo-rdme
+          export PATH=$PATH:~/.cargo-${{ matrix.rust }}/cargo-rdme/bin
+          cargo rdme --check
 
       - name: Rust Format
         if: matrix.target != 'wasm32-unknown-unknown'


### PR DESCRIPTION
AVRO-3868

## What is the purpose of the change
This PR proposes to add a consistency check between the doc comment in `avro/src/lib.rs` and `avro/README.md`.
AVRO-3849 added cargo-rdme so it's nice if we can check the consistency between them.

## Verifying this change
Done by GitHub Actions.

## Documentation

- Does this pull request introduce a new feature? (no)
