### PR TITLE
Minor: [Perl][Test] Suppress warning in interop-data-test for Perl SDK

### DIFF
--- a/lang/perl/xt/interop.t
+++ b/lang/perl/xt/interop.t
@@ -21,8 +21,11 @@ use warnings;
 use Test::More;
 use File::Basename qw(basename);
 use IO::File;
-use_ok 'Avro::DataFile';
-use_ok 'Avro::DataFileReader';
+
+BEGIN {
+    use_ok 'Avro::DataFile';
+    use_ok 'Avro::DataFileReader';
+}
 
 for my $path (glob '../../build/interop/data/*.avro') {
     my $fn = basename($path);


### PR DESCRIPTION
## What is the purpose of the change
This PR aims to suppress a warning in interop-data-test for Perl SDK.

When we run `./build.sh test` or `lang/perl/build.sh interop-data-test`, we get the following message.
```
Name "Avro::DataFile::ValidCodec" used only once: possible typo
```

This warning message sometimes appears in the result of CI.
https://github.com/apache/avro/actions/runs/6255050186

## Verifying this change
Confirmed the warning message is disappeared by running `lang/perl/build.sh interop-data-test`.

## Documentation

- Does this pull request introduce a new feature? (no)
