### PR TITLE
AVRO-3869 [chsarp] Fix logical fixed schema support

### DIFF
--- a/lang/csharp/src/apache/main/Schema/LogicalSchema.cs
+++ b/lang/csharp/src/apache/main/Schema/LogicalSchema.cs
@@ -47,7 +47,18 @@ namespace Avro
             JToken jtype = jtok["type"];
             if (null == jtype) throw new AvroTypeException("Logical Type does not have 'type'");
 
-            return new LogicalSchema(Schema.ParseJson(jtype, names, encspace), JsonHelper.GetRequiredString(jtok, "logicalType"),  props);
+            Schema baseSchema;
+
+            if (jtype.Type == JTokenType.String && "fixed" == (string)jtype)
+            {
+                baseSchema = FixedSchema.NewInstance(jtok, props, names, encspace);
+            }
+            else
+            {
+                baseSchema = Schema.ParseJson(jtype, names, encspace);
+            }
+
+            return new LogicalSchema(baseSchema, JsonHelper.GetRequiredString(jtok, "logicalType"), props);
         }
 
         private LogicalSchema(Schema baseSchema, string logicalTypeName,  PropertyMap props) : base(Type.Logical, props)

--- a/lang/csharp/src/apache/test/Schema/SchemaTests.cs
+++ b/lang/csharp/src/apache/test/Schema/SchemaTests.cs
@@ -548,6 +548,21 @@ namespace Avro.Test
             testToString(sc);
         }
 
+        [TestCase("{ \"type\": \"fixed\", \"name\": \"LogicalFixed\", \"logicalType\": \"decimal\", \"precision\": 4, \"scale\": 2, \"size\": 10 }", "decimal", 10)]
+        public void TestLogicalFixed(string s, string logicalType, int size)
+        {
+            Schema sc = Schema.Parse(s);
+            Assert.AreEqual(Schema.Type.Logical, sc.Tag);
+            LogicalSchema logsc = sc as LogicalSchema;
+            FixedSchema basesc = logsc.BaseSchema as FixedSchema;
+            Assert.AreEqual(Schema.Type.Fixed, basesc.Tag);
+            Assert.AreEqual(size, basesc.Size);
+            Assert.AreEqual(logicalType, logsc.LogicalType.Name);
+
+            testEquality(s, sc);
+            testToString(sc);
+        }
+
         [TestCase("{\"type\": \"int\", \"logicalType\": \"unknown\"}", "unknown")]
         public void TestUnknownLogical(string s, string unknownType)
         {


### PR DESCRIPTION
<!--

*Thank you very much for contributing to Apache Avro - we are happy that you want to help us improve Avro. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Avro a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/AVRO/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "AVRO-XXXX: [component] Title of the pull request", where *AVRO-XXXX* should be replaced by the actual issue number. 
    The *component* is optional, but can help identify the correct reviewers faster: either the language ("java", "python") or subsystem such as "build" or "doc" are good candidates.  

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests. You can [build the entire project](https://github.com/apache/avro/blob/master/BUILD.md) or just the [language-specific SDK](https://avro.apache.org/project/how-to-contribute/#unit-tests).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Every commit message references Jira issues in their subject lines. In addition, commits follow the guidelines from [How to write a good git commit message](https://chris.beams.io/posts/git-commit/)
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

-->

## What is the purpose of the change

Logical types works only for primitive types, and I can't deserialize an fixed type, like this one:

```javascript
{
 "type": "fixed",
 "name": "LogicalFixed",
 "logicalType": "decimal",
 "precision": 4,
 "scale": 2,
  "size": 10
}
 
``` 

A SchemaParseException is raised ("Undefined name: fixed at 'type'")
This schema is autogenerated by PySpark, from a decimal type, and can't be parsed.
Spark docs: https://spark.apache.org/docs/latest/sql-data-sources-avro.html


## Verifying this change
This change added tests and can be verified as follows:
```csharp
[TestCase("{ \"type\": \"fixed\", \"name\": \"LogicalFixed\", \"logicalType\": \"decimal\", \"precision\": 4, \"scale\": 2, \"size\": 10 }", "decimal", 10)]
public void TestLogicalFixed(string s, string logicalType, int size)
{
    Schema sc = Schema.Parse(s);
    Assert.AreEqual(Schema.Type.Logical, sc.Tag);
    LogicalSchema logsc = sc as LogicalSchema;
    FixedSchema basesc = logsc.BaseSchema as FixedSchema;
    Assert.AreEqual(Schema.Type.Fixed, basesc.Tag);
    Assert.AreEqual(size, basesc.Size);
    Assert.AreEqual(logicalType, logsc.LogicalType.Name);

    testEquality(s, sc);
    testToString(sc);
}
```