### PR TITLE
AVRO-3870: [Rust][Build] Speed up CI for Rust

### DIFF
--- a/.github/workflows/test-lang-rust-ci.yml
+++ b/.github/workflows/test-lang-rust-ci.yml
@@ -31,6 +31,7 @@ permissions:
 
 env:
   RUSTFLAGS: -Dwarnings
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: 'git' # TODO: remove this env var once MSRV is 1.70.0+
 
 defaults:
   run:
@@ -64,14 +65,14 @@ jobs:
           # these represent dependencies downloaded by cargo
           # and thus do not depend on the OS, arch nor rust version.
           path: ~/.cargo
-          key: cargo-cache1-
+          key: ${{ runner.os }}-target-cache1-${{ hashFiles('**/Cargo.lock') }}
       - name: Cache Rust dependencies
         uses: actions/cache@v3
         with:
           # these represent compiled steps of both dependencies and avro
           # and thus are specific for a particular OS, arch and rust version.
-          path: ~/target
-          key: ${{ runner.os }}-target-cache1-${{ matrix.rust }}-
+          path: lang/rust/target
+          key: ${{ runner.os }}-target-cache1-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Rust Toolchain
         uses: dtolnay/rust-toolchain@nightly
@@ -134,14 +135,14 @@ jobs:
           # these represent dependencies downloaded by cargo
           # and thus do not depend on the OS, arch nor rust version.
           path: ~/.cargo
-          key: cargo-cache1-
+          key: ${{ runner.os }}-target-cache1-${{ hashFiles('**/Cargo.lock') }}
       - name: Cache Rust dependencies
         uses: actions/cache@v3
         with:
           # these represent compiled steps of both dependencies and avro
           # and thus are specific for a particular OS, arch and rust version.
-          path: ~/target
-          key: ${{ runner.os }}-target-cache1-stable-
+          path: lang/rust/target
+          key: ${{ runner.os }}-target-cache1-stable-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache Local Maven Repository
         uses: actions/cache@v3
@@ -219,15 +220,15 @@ jobs:
           # these represent dependencies downloaded by cargo
           # and thus do not depend on the OS, arch nor rust version.
           path: ~/.cargo
-          key: cargo-cache1-
+          key: ${{ runner.os }}-target-cache1-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache Rust dependencies
         uses: actions/cache@v3
         with:
           # these represent compiled steps of both dependencies and avro
           # and thus are specific for a particular OS, arch and rust version.
-          path: ~/target
-          key: ${{ runner.os }}-target-cache1-stable-
+          path: lang/rust/target
+          key: ${{ runner.os }}-target-cache1-stable-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh


### PR DESCRIPTION
AVRO-3870

## What is the purpose of the change
This PR aims to make the CI for Rust faster.

In the current master, there are something wrong about actions/cache in `test-lang-rust-ci.yml`.

First, a directory `target` is tend to be cached but the path is wrong. The correct path is `lang/rust/target`, not `~/target`.
https://github.com/apache/avro/actions/runs/6277247580/job/17048599038#step:22:2

Second, as of Rust 1.70.0, Cargo changes the way to download dependencies.
https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html#sparse-by-default-for-cratesio
So, it's better not to share the cache for `~/.cargo`

## Verifying this change

Done by CI.

## Documentation

- Does this pull request introduce a new feature? (no)