### PR TITLE
AVRO-3856: [C#] Hardcode MaxDepth property to 192 when using Newtonsoft JsonReader to load Avro schema up to 64 depth levels

### DIFF
--- a/lang/csharp/src/apache/main/Schema/Schema.cs
+++ b/lang/csharp/src/apache/main/Schema/Schema.cs
@@ -248,34 +248,43 @@ namespace Avro
             // Refer to https://github.com/JamesNK/Newtonsoft.Json/pull/2904
             // Newtonsoft author advised to use JObject.Load/JArray.Load instead of JObject.Parse()/JArray.Parse()
             // The reason is we can set the MaxDepth property on the JsonReader.
-            JsonReader reader = new JsonTextReader(new StringReader(json));
-            // Another issue discovered is Avro schema depth level is not counted the same as in JsonReader.
-            // The default depth level limit of 64 in JsonReader can only support around 20 levels of Avro schema.
-            // When putting break point in JsonReader Push methods with various Avro schema depth levels,
-            // here is my observation:
-            //
-            // Avro Schema Depth	JsonReader Depth Level Count
-            // 4	                11
-            // 16                   44
-            // 32	                92
-            // 64	                188
-            //
-            // So, roughly speaking, the depth level count is about 2.75 times of Avro schema depth.
-            // Below is the hard-coded value to compensate over-counting of depth level in Newtonsoft
-            // to support Avro schema depth level to 64 slightly beyond.
-            reader.MaxDepth = 192;
-
-            try
+            using (var reader = new JsonTextReader(new StringReader(json)))
             {
-                bool IsArray = json.StartsWith("[", StringComparison.Ordinal)
-                    && json.EndsWith("]", StringComparison.Ordinal);
-                JContainer j = IsArray ? (JContainer)JArray.Load(reader) : (JContainer)JObject.Load(reader);
+                // Another issue discovered is Avro schema depth level is not counted the same as in JsonReader.
+                // The default depth level limit of 64 in JsonReader can only support around 20 levels of Avro schema.
+                // When putting break point in JsonReader Push methods with various Avro schema depth levels,
+                // here is my observation:
+                //
+                // Avro Schema Depth	JsonReader Depth Level Count
+                // 4	                11
+                // 16                   44
+                // 32	                92
+                // 64	                188
+                //
+                // So, roughly speaking, the depth level count is about 2.75 times of Avro schema depth.
+                // Below is the hard-coded value to compensate over-counting of depth level in Newtonsoft
+                // to support Avro schema depth level to 64 slightly beyond.
+                reader.MaxDepth = 192;
 
-                return ParseJson(j, names, encspace);
-            }
-            catch (Newtonsoft.Json.JsonSerializationException ex)
-            {
-                throw new SchemaParseException("Could not parse. " + ex.Message + Environment.NewLine + json);
+                try
+                {
+                    bool IsArray = json.StartsWith("[", StringComparison.Ordinal)
+                        && json.EndsWith("]", StringComparison.Ordinal);
+                    JContainer j = IsArray ? (JContainer)JArray.Load(reader) : (JContainer)JObject.Load(reader);
+
+                    // When replacing JArray.Parse and JObject.Parse with JArray.Load and JObject.Load,
+                    // we will need this check following what Newtonsoft.Json does.
+                    while (reader.Read())
+                    {
+                        // Any content encountered here other than a comment will throw in the reader.
+                    }
+
+                    return ParseJson(j, names, encspace);
+                }
+                catch (Newtonsoft.Json.JsonSerializationException ex)
+                {
+                    throw new SchemaParseException("Could not parse. " + ex.Message + Environment.NewLine + json);
+                }
             }
         }
 

--- a/lang/csharp/src/apache/main/Schema/Schema.cs
+++ b/lang/csharp/src/apache/main/Schema/Schema.cs
@@ -244,6 +244,7 @@ namespace Avro
             Schema sc = PrimitiveSchema.NewInstance(json);
             if (null != sc) return sc;
 
+            // Refer to https://issues.apache.org/jira/browse/AVRO-3856
             // Refer to https://github.com/JamesNK/Newtonsoft.Json/pull/2904
             // Newtonsoft author advised to use JObject.Load/JArray.Load instead of JObject.Parse()/JArray.Parse()
             // The reason is we can set the MaxDepth property on the JsonReader.

--- a/lang/csharp/src/apache/main/Schema/Schema.cs
+++ b/lang/csharp/src/apache/main/Schema/Schema.cs
@@ -249,13 +249,17 @@ namespace Avro
             // Newtonsoft author advised to use JObject.Load/JArray.Load instead of JObject.Parse()/JArray.Parse()
             // The reason is we can set the MaxDepth property on the JsonReader.
             JsonReader reader = new JsonTextReader(new StringReader(json));
-            // Another issue discovered is JsonReader.Push(JsonContainerType value) method overcounting the depth
-            // level of Avro schema.  Here are the observation of over-counting depth level in Newtonsoft's JsonReader:
+            // Another issue discovered is Avro schema depth level is not counted the same as in JsonReader.
+            // The default depth level limit of 64 in JsonReader can only support around 20 levels of Avro schema.
+            // When putting break point in JsonReader Push methods with various Avro schema depth levels,
+            // here is my observation:
+            //
             // Avro Schema Depth	JsonReader Depth Level Count
             // 4	                11
             // 16                   44
             // 32	                92
             // 64	                188
+            //
             // So, roughly speaking, the depth level count is about 2.75 times of Avro schema depth.
             // Below is the hard-coded value to compensate over-counting of depth level in Newtonsoft
             // to support Avro schema depth level to 64 slightly beyond.

--- a/lang/csharp/src/apache/test/Schema/SchemaTests.cs
+++ b/lang/csharp/src/apache/test/Schema/SchemaTests.cs
@@ -1701,6 +1701,5362 @@ namespace Avro.Test
             var schema = Schema.Parse(json);
         }
 
+       [TestCase]
+        public void ParseRealWorldSchemaTest()
+        {
+            var json = @"
+{
+  ""type"": ""record"",
+  ""name"": ""IcaInstructionSchema"",
+  ""namespace"": ""com.capgroup.casa"",
+  ""fields"": [
+    {
+      ""name"": ""ICAINSTRUCTIONDOWNLOAD"",
+      ""type"": [
+        ""null"",
+        {
+          ""type"": ""record"",
+          ""name"": ""ICAINSTRUCTIONDOWNLOAD"",
+          ""fields"": [
+            {
+              ""name"": ""Header"",
+              ""type"": [
+                ""null"",
+                {
+                  ""type"": ""record"",
+                  ""name"": ""Header"",
+                  ""fields"": [
+                    {
+                      ""name"": ""FileName"",
+                      ""type"": [
+                        ""null"",
+                        ""string""
+                      ],
+                      ""default"": null
+                    },
+                    {
+                      ""name"": ""CreationDate"",
+                      ""type"": [
+                        ""null"",
+                        ""string""
+                      ],
+                      ""default"": null
+                    },
+                    {
+                      ""name"": ""Reference"",
+                      ""type"": [
+                        ""null"",
+                        ""string""
+                      ],
+                      ""default"": null
+                    },
+                    {
+                      ""name"": ""VersionNo"",
+                      ""type"": [
+                        ""null"",
+                        ""string""
+                      ],
+                      ""default"": null
+                    },
+                    {
+                      ""name"": ""MessageType"",
+                      ""type"": [
+                        ""null"",
+                        ""string""
+                      ],
+                      ""default"": null
+                    },
+                    {
+                      ""name"": ""NoOfRecords"",
+                      ""type"": [
+                        ""null"",
+                        ""int""
+                      ],
+                      ""default"": null
+                    },
+                    {
+                      ""name"": ""StatusIndicator"",
+                      ""type"": [
+                        ""null"",
+                        ""int""
+                      ],
+                      ""default"": null
+                    },
+                    {
+                      ""name"": ""RelatedRef"",
+                      ""type"": [
+                        ""null"",
+                        ""int""
+                      ],
+                      ""default"": null
+                    },
+                    {
+                      ""name"": ""To"",
+                      ""type"": [
+                        ""null"",
+                        ""string""
+                      ],
+                      ""default"": null
+                    },
+                    {
+                      ""name"": ""From"",
+                      ""type"": [
+                        ""null"",
+                        ""string""
+                      ],
+                      ""default"": null
+                    },
+                    {
+                      ""name"": ""FromIndicator"",
+                      ""type"": [
+                        ""null"",
+                        ""string""
+                      ],
+                      ""default"": null
+                    },
+                    {
+                      ""name"": ""Direction"",
+                      ""type"": [
+                        ""null"",
+                        ""string""
+                      ],
+                      ""default"": null
+                    }
+                  ]
+                }
+              ],
+              ""default"": null
+            },
+            {
+              ""name"": ""CorporateAction"",
+              ""type"": [
+                ""null"",
+                {
+                  ""type"": ""record"",
+                  ""name"": ""CorporateAction"",
+                  ""fields"": [
+                    {
+                      ""name"": ""TotalBlockNo"",
+                      ""type"": [
+                        ""null"",
+                        ""long""
+                      ],
+                      ""default"": null
+                    },
+                    {
+                      ""name"": ""BlockNo"",
+                      ""type"": [
+                        ""null"",
+                        ""long""
+                      ],
+                      ""default"": null
+                    },
+                    {
+                      ""name"": ""FIBic"",
+                      ""type"": [
+                        ""null"",
+                        ""string""
+                      ],
+                      ""default"": null
+                    },
+                    {
+                      ""name"": ""CorporateActionId"",
+                      ""type"": [
+                        ""null"",
+                        ""long""
+                      ],
+                      ""default"": null
+                    },
+                    {
+                      ""name"": ""ActionType"",
+                      ""type"": [
+                        ""null"",
+                        ""string""
+                      ],
+                      ""default"": null
+                    },
+                    {
+                      ""name"": ""ActionIndicator"",
+                      ""type"": [
+                        ""null"",
+                        ""string""
+                      ],
+                      ""default"": null
+                    },
+                    {
+                      ""name"": ""CAStatusCd"",
+                      ""type"": [
+                        ""null"",
+                        ""string""
+                      ],
+                      ""default"": null
+                    },
+                    {
+                      ""name"": ""EffectiveDate"",
+                      ""type"": [
+                        ""null"",
+                        ""string""
+                      ],
+                      ""default"": null
+                    },
+                    {
+                      ""name"": ""ClientEntitlementBasisDate"",
+                      ""type"": [
+                        ""null"",
+                        ""string""
+                      ],
+                      ""default"": null
+                    },
+                    {
+                      ""name"": ""MarketEntitlementBasisDate"",
+                      ""type"": [
+                        ""null"",
+                        ""string""
+                      ],
+                      ""default"": null
+                    },
+                    {
+                      ""name"": ""Dates"",
+                      ""type"": [
+                        ""null"",
+                        {
+                          ""type"": ""record"",
+                          ""name"": ""Dates"",
+                          ""namespace"": ""com.capgroup.dates"",
+                          ""fields"": [
+                            {
+                              ""name"": ""Date"",
+                              ""type"": [
+                                ""null"",
+                                {
+                                  ""type"": ""array"",
+                                  ""items"": [
+                                    ""null"",
+                                    {
+                                      ""type"": ""record"",
+                                      ""name"": ""Date"",
+                                      ""fields"": [
+                                        {
+                                          ""name"": ""DateQualifierCd"",
+                                          ""type"": [
+                                            ""null"",
+                                            ""string""
+                                          ],
+                                          ""default"": null
+                                        },
+                                        {
+                                          ""name"": ""DateValue"",
+                                          ""type"": [
+                                            ""null"",
+                                            ""double""
+                                          ],
+                                          ""default"": null
+                                        },
+                                        {
+                                          ""name"": ""DateCd"",
+                                          ""type"": [
+                                            ""null"",
+                                            ""string""
+                                          ],
+                                          ""default"": null
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ],
+                              ""default"": null
+                            }
+                          ]
+                        }
+                      ],
+                      ""default"": null
+                    },
+                    {
+                      ""name"": ""CouponNumber"",
+                      ""type"": [
+                        ""null"",
+                        ""string""
+                      ],
+                      ""default"": null
+                    },
+                    {
+                      ""name"": ""ExpectedSettlementDate"",
+                      ""type"": [
+                        ""null"",
+                        ""string""
+                      ],
+                      ""default"": null
+                    },
+                    {
+                      ""name"": ""PriceFactorCurrencyCd"",
+                      ""type"": [
+                        ""null"",
+                        ""string""
+                      ],
+                      ""default"": null
+                    },
+                    {
+                      ""name"": ""PriceFactor"",
+                      ""type"": [
+                        ""null"",
+                        ""double""
+                      ],
+                      ""default"": null
+                    },
+                    {
+                      ""name"": ""SecurityDetails"",
+                      ""type"": [
+                        ""null"",
+                        {
+                          ""type"": ""record"",
+                          ""name"": ""SecurityDetails"",
+                          ""fields"": [
+                            {
+                              ""name"": ""IssueCountryCd"",
+                              ""type"": [
+                                ""null"",
+                                ""string""
+                              ],
+                              ""default"": null
+                            },
+                            {
+                              ""name"": ""IssueCurrencyCd"",
+                              ""type"": [
+                                ""null"",
+                                ""string""
+                              ],
+                              ""default"": null
+                            },
+                            {
+                              ""name"": ""SecurityExternalReferences"",
+                              ""type"": [
+                                ""null"",
+                                {
+                                  ""type"": ""record"",
+                                  ""name"": ""SecurityExternalReferences"",
+                                  ""fields"": [
+                                    {
+                                      ""name"": ""SecurityExternalReference"",
+                                      ""type"": {
+                                        ""type"": ""array"",
+                                        ""items"": {
+                                          ""type"": ""record"",
+                                          ""name"": ""SecurityExternalReference"",
+                                          ""fields"": [
+                                            {
+                                              ""name"": ""SecurityIdentifierTypeCd"",
+                                              ""type"": [
+                                                ""null"",
+                                                ""string""
+                                              ],
+                                              ""default"": null
+                                            },
+                                            {
+                                              ""name"": ""SecurityIdentifierValue"",
+                                              ""type"": [
+                                                ""null"",
+                                                ""string""
+                                              ],
+                                              ""default"": null
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              ],
+                              ""default"": null
+                            },
+                            {
+                              ""name"": ""ReportingClassificationGroups"",
+                              ""type"": [
+                                ""null"",
+                                {
+                                  ""type"": ""record"",
+                                  ""name"": ""ReportingClassificationGroups"",
+                                  ""fields"": [
+                                    {
+                                      ""name"": ""ReportingClassificationGroup"",
+                                      ""type"": {
+                                        ""type"": ""array"",
+                                        ""items"": {
+                                          ""type"": ""record"",
+                                          ""name"": ""ReportingClassificationGroup"",
+                                          ""fields"": [
+                                            {
+                                              ""name"": ""ReportingClassificationGroupId"",
+                                              ""type"": [
+                                                ""null"",
+                                                ""long""
+                                              ],
+                                              ""default"": null
+                                            },
+                                            {
+                                              ""name"": ""ReportingClassificationGroupName"",
+                                              ""type"": [
+                                                ""null"",
+                                                ""string""
+                                              ],
+                                              ""default"": null
+                                            },
+                                            {
+                                              ""name"": ""ValueId"",
+                                              ""type"": [
+                                                ""null"",
+                                                ""long""
+                                              ],
+                                              ""default"": null
+                                            },
+                                            {
+                                              ""name"": ""ValueName"",
+                                              ""type"": [
+                                                ""null"",
+                                                ""string""
+                                              ],
+                                              ""default"": null
+                                            },
+                                            {
+                                              ""name"": ""ValueCode"",
+                                              ""type"": [
+                                                ""null"",
+                                                ""string""
+                                              ],
+                                              ""default"": null
+                                            },
+                                            {
+                                              ""name"": ""ValueSequence"",
+                                              ""type"": [
+                                                ""null"",
+                                                ""string""
+                                              ],
+                                              ""default"": null
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              ],
+                              ""default"": null
+                            }
+                          ]
+                        }
+                      ],
+                      ""default"": null
+                    },
+                    {
+                      ""name"": ""Options"",
+                      ""type"": [
+                        ""null"",
+                        {
+                          ""type"": ""record"",
+                          ""name"": ""Options"",
+                          ""fields"": [
+                            {
+                              ""name"": ""Option"",
+                              ""type"": {
+                                ""type"": ""array"",
+                                ""items"": {
+                                  ""type"": ""record"",
+                                  ""name"": ""Option"",
+                                  ""fields"": [
+                                    {
+                                      ""name"": ""OptionId"",
+                                      ""type"": [
+                                        ""null"",
+                                        ""long""
+                                      ],
+                                      ""default"": null
+                                    },
+                                    {
+                                      ""name"": ""OptionNumber"",
+                                      ""type"": [
+                                        ""null"",
+                                        ""string""
+                                      ],
+                                      ""default"": null
+                                    },
+                                    {
+                                      ""name"": ""OptionCd"",
+                                      ""type"": [
+                                        ""null"",
+                                        ""string""
+                                      ],
+                                      ""default"": null
+                                    },
+                                    {
+                                      ""name"": ""OptionTemplateId"",
+                                      ""type"": [
+                                        ""null"",
+                                        ""int""
+                                      ],
+                                      ""default"": null
+                                    },
+                                    {
+                                      ""name"": ""LotLevelProcessingFlag"",
+                                      ""type"": [
+                                        ""null"",
+                                        ""int""
+                                      ],
+                                      ""default"": null
+                                    },
+                                    {
+                                      ""name"": ""AccountingMethodBasedFlag"",
+                                      ""type"": [
+                                        ""null"",
+                                        ""int""
+                                      ],
+                                      ""default"": null
+                                    },
+                                    {
+                                      ""name"": ""ParentLineBookcostPercentage"",
+                                      ""type"": [
+                                        ""null"",
+                                        ""string""
+                                      ],
+                                      ""default"": null
+                                    },
+                                    {
+                                      ""name"": ""Rates"",
+                                      ""type"": [
+                                        ""null"",
+                                        {
+                                          ""type"": ""record"",
+                                          ""name"": ""Rates"",
+                                          ""namespace"": ""com.capgroup.option.rates"",
+                                          ""fields"": [
+                                            {
+                                              ""name"": ""Rate"",
+                                              ""type"": {
+                                                ""type"": ""array"",
+                                                ""items"": {
+                                                  ""type"": ""record"",
+                                                  ""name"": ""Rate"",
+                                                  ""fields"": [
+                                                    {
+                                                      ""name"": ""RateQualifierCd"",
+                                                      ""type"": [
+                                                        ""null"",
+                                                        ""string""
+                                                      ],
+                                                      ""default"": null
+                                                    },
+                                                    {
+                                                      ""name"": ""RateValue"",
+                                                      ""type"": [
+                                                        ""null"",
+                                                        ""double""
+                                                      ],
+                                                      ""default"": null
+                                                    },
+                                                    {
+                                                      ""name"": ""RateTypeCd"",
+                                                      ""type"": [
+                                                        ""null"",
+                                                        ""string""
+                                                      ],
+                                                      ""default"": null
+                                                    },
+                                                    {
+                                                      ""name"": ""CurrencyCd"",
+                                                      ""type"": [
+                                                        ""null"",
+                                                        ""string""
+                                                      ],
+                                                      ""default"": null
+                                                    },
+                                                    {
+                                                      ""name"": ""Amount1"",
+                                                      ""type"": [
+                                                        ""null"",
+                                                        ""double""
+                                                      ],
+                                                      ""default"": null
+                                                    },
+                                                    {
+                                                      ""name"": ""RateStatusCd"",
+                                                      ""type"": [
+                                                        ""null"",
+                                                        ""string""
+                                                      ],
+                                                      ""default"": null
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      ""default"": null
+                                    },
+                                    {
+                                      ""name"": ""Dates"",
+                                      ""type"": [
+                                        ""null"",
+                                        {
+                                          ""type"": ""record"",
+                                          ""name"": ""Dates"",
+                                          ""namespace"": ""com.capgroup.option.dates"",
+                                          ""fields"": [
+                                            {
+                                              ""name"": ""Date"",
+                                              ""type"": {
+                                                ""type"": ""array"",
+                                                ""items"": {
+                                                  ""type"": ""record"",
+                                                  ""name"": ""Date"",
+                                                  ""fields"": [
+                                                    {
+                                                      ""name"": ""DateQualifierCd"",
+                                                      ""type"": [
+                                                        ""null"",
+                                                        ""string""
+                                                      ],
+                                                      ""default"": null
+                                                    },
+                                                    {
+                                                      ""name"": ""DateValue"",
+                                                      ""type"": [
+                                                        ""null"",
+                                                        ""double""
+                                                      ],
+                                                      ""default"": null
+                                                    },
+                                                    {
+                                                      ""name"": ""DateCd"",
+                                                      ""type"": [
+                                                        ""null"",
+                                                        ""string""
+                                                      ],
+                                                      ""default"": null
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      ""default"": null
+                                    },
+                                    {
+                                      ""name"": ""CashMovements"",
+                                      ""type"": [
+                                        ""null"",
+                                        {
+                                          ""type"": ""record"",
+                                          ""name"": ""CashMovements"",
+                                          ""fields"": [
+                                            {
+                                              ""name"": ""CashMovement"",
+                                              ""type"": [
+                                                ""null"",
+                                                {
+                                                  ""type"": ""array"",
+                                                  ""items"": [
+                                                    ""null"",
+                                                    {
+                                                      ""type"": ""record"",
+                                                      ""name"": ""CashMovement"",
+                                                      ""fields"": [
+                                                        {
+                                                          ""name"": ""CashMovementId"",
+                                                          ""type"": [
+                                                            ""null"",
+                                                            ""long""
+                                                          ],
+                                                          ""default"": null
+                                                        },
+                                                        {
+                                                          ""name"": ""Rates"",
+                                                          ""type"": [
+                                                            ""null"",
+                                                            {
+                                                              ""type"": ""record"",
+                                                              ""name"": ""Rates"",
+                                                              ""namespace"": ""com.capgroup.option.cashmove.rates"",
+                                                              ""fields"": [
+                                                                {
+                                                                  ""name"": ""Rate"",
+                                                                  ""type"": {
+                                                                    ""type"": ""array"",
+                                                                    ""items"": {
+                                                                      ""type"": ""record"",
+                                                                      ""name"": ""Rate"",
+                                                                      ""fields"": [
+                                                                        {
+                                                                          ""name"": ""RateQualifierCd"",
+                                                                          ""type"": [
+                                                                            ""null"",
+                                                                            ""string""
+                                                                          ],
+                                                                          ""default"": null
+                                                                        },
+                                                                        {
+                                                                          ""name"": ""RateValue"",
+                                                                          ""type"": [
+                                                                            ""null"",
+                                                                            ""double""
+                                                                          ],
+                                                                          ""default"": null
+                                                                        },
+                                                                        {
+                                                                          ""name"": ""RateTypeCd"",
+                                                                          ""type"": [
+                                                                            ""null"",
+                                                                            ""string""
+                                                                          ],
+                                                                          ""default"": null
+                                                                        },
+                                                                        {
+                                                                          ""name"": ""CurrencyCd"",
+                                                                          ""type"": [
+                                                                            ""null"",
+                                                                            ""string""
+                                                                          ],
+                                                                          ""default"": null
+                                                                        },
+                                                                        {
+                                                                          ""name"": ""Amount1"",
+                                                                          ""type"": [
+                                                                            ""null"",
+                                                                            ""double""
+                                                                          ],
+                                                                          ""default"": null
+                                                                        },
+                                                                        {
+                                                                          ""name"": ""RateStatusCd"",
+                                                                          ""type"": [
+                                                                            ""null"",
+                                                                            ""string""
+                                                                          ],
+                                                                          ""default"": null
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  }
+                                                                }
+                                                              ]
+                                                            }
+                                                          ],
+                                                          ""default"": null
+                                                        },
+                                                        {
+                                                          ""name"": ""Places"",
+                                                          ""type"": [
+                                                            ""null"",
+                                                            {
+                                                              ""type"": ""record"",
+                                                              ""name"": ""Places"",
+                                                              ""namespace"": ""com.capgroup.option.cashmove.place"",
+                                                              ""fields"": [
+                                                                {
+                                                                  ""name"": ""Place"",
+                                                                  ""type"": {
+                                                                    ""type"": ""array"",
+                                                                    ""items"": {
+                                                                      ""type"": ""record"",
+                                                                      ""name"": ""Place"",
+                                                                      ""fields"": [
+                                                                        {
+                                                                          ""name"": ""PlaceQualifierCd"",
+                                                                          ""type"": [
+                                                                            ""null"",
+                                                                            ""string""
+                                                                          ],
+                                                                          ""default"": null
+                                                                        },
+                                                                        {
+                                                                          ""name"": ""PlaceValue"",
+                                                                          ""type"": [
+                                                                            ""null"",
+                                                                            ""string""
+                                                                          ],
+                                                                          ""default"": null
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  }
+                                                                }
+                                                              ]
+                                                            }
+                                                          ],
+                                                          ""default"": null
+                                                        },
+                                                        {
+                                                          ""name"": ""Dates"",
+                                                          ""type"": [
+                                                            ""null"",
+                                                            {
+                                                              ""type"": ""record"",
+                                                              ""name"": ""Dates"",
+                                                              ""namespace"": ""com.capgroup.option.cashmove.dates"",
+                                                              ""fields"": [
+                                                                {
+                                                                  ""name"": ""Date"",
+                                                                  ""type"": {
+                                                                    ""type"": ""array"",
+                                                                    ""items"": {
+                                                                      ""type"": ""record"",
+                                                                      ""name"": ""Date"",
+                                                                      ""fields"": [
+                                                                        {
+                                                                          ""name"": ""DateQualifierCd"",
+                                                                          ""type"": [
+                                                                            ""null"",
+                                                                            ""string""
+                                                                          ],
+                                                                          ""default"": null
+                                                                        },
+                                                                        {
+                                                                          ""name"": ""DateValue"",
+                                                                          ""type"": [
+                                                                            ""null"",
+                                                                            ""double""
+                                                                          ],
+                                                                          ""default"": null
+                                                                        },
+                                                                        {
+                                                                          ""name"": ""DateCd"",
+                                                                          ""type"": [
+                                                                            ""null"",
+                                                                            ""string""
+                                                                          ],
+                                                                          ""default"": null
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  }
+                                                                }
+                                                              ]
+                                                            }
+                                                          ],
+                                                          ""default"": null
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ],
+                                              ""default"": null
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      ""default"": null
+                                    },
+                                    {
+                                      ""name"": ""SecurityMovements"",
+                                      ""type"": [
+                                        ""null"",
+                                        {
+                                          ""type"": ""record"",
+                                          ""name"": ""SecurityMovements"",
+                                          ""namespace"": ""com.capgroup.security.movement"",
+                                          ""fields"": [
+                                            {
+                                              ""name"": ""SecurityMovement"",
+                                              ""type"": [
+                                                ""null"",
+                                                {
+                                                  ""type"": ""array"",
+                                                  ""items"": [
+                                                    ""null"",
+                                                    {
+                                                      ""type"": ""record"",
+                                                      ""name"": ""SecurityMovement"",
+                                                      ""fields"": [
+                                                        {
+                                                          ""name"": ""SecurityMovementId"",
+                                                          ""type"": [
+                                                            ""null"",
+                                                            ""long""
+                                                          ],
+                                                          ""default"": null
+                                                        },
+                                                        {
+                                                          ""name"": ""SecurityDetails"",
+                                                          ""type"": [
+                                                            ""null"",
+                                                            {
+                                                              ""type"": ""record"",
+                                                              ""name"": ""SecurityDetails"",
+                                                              ""fields"": [
+                                                                {
+                                                                  ""name"": ""IssueCountryCd"",
+                                                                  ""type"": [
+                                                                    ""null"",
+                                                                    ""string""
+                                                                  ],
+                                                                  ""default"": null
+                                                                },
+                                                                {
+                                                                  ""name"": ""IssueCurrencyCd"",
+                                                                  ""type"": [
+                                                                    ""null"",
+                                                                    ""string""
+                                                                  ],
+                                                                  ""default"": null
+                                                                },
+                                                                {
+                                                                  ""name"": ""SecurityExternalReferences"",
+                                                                  ""type"": [
+                                                                    ""null"",
+                                                                    {
+                                                                      ""type"": ""record"",
+                                                                      ""name"": ""SecurityExternalReferences"",
+                                                                      ""fields"": [
+                                                                        {
+                                                                          ""name"": ""SecurityExternalReference"",
+                                                                          ""type"": {
+                                                                            ""type"": ""array"",
+                                                                            ""items"": {
+                                                                              ""type"": ""record"",
+                                                                              ""name"": ""SecurityExternalReference"",
+                                                                              ""fields"": [
+                                                                                {
+                                                                                  ""name"": ""SecurityIdentifierTypeCd"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    ""string""
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                },
+                                                                                {
+                                                                                  ""name"": ""SecurityIdentifierValue"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    ""string""
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  ],
+                                                                  ""default"": null
+                                                                },
+                                                                {
+                                                                  ""name"": ""ReportingClassificationGroups"",
+                                                                  ""type"": [
+                                                                    ""null"",
+                                                                    {
+                                                                      ""type"": ""record"",
+                                                                      ""name"": ""ReportingClassificationGroups"",
+                                                                      ""namespace"": ""com.capgroup.option.secmove.ReportingClassificationGroups"",
+                                                                      ""fields"": [
+                                                                        {
+                                                                          ""name"": ""ReportingClassificationGroup"",
+                                                                          ""type"": {
+                                                                            ""type"": ""array"",
+                                                                            ""items"": {
+                                                                              ""type"": ""record"",
+                                                                              ""name"": ""ReportingClassificationGroup"",
+                                                                              ""fields"": [
+                                                                                {
+                                                                                  ""name"": ""ReportingClassificationGroupId"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    ""long""
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                },
+                                                                                {
+                                                                                  ""name"": ""ReportingClassificationGroupName"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    ""string""
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                },
+                                                                                {
+                                                                                  ""name"": ""ValueId"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    ""long""
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                },
+                                                                                {
+                                                                                  ""name"": ""ValueName"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    ""string""
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                },
+                                                                                {
+                                                                                  ""name"": ""ValueCode"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    ""string""
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                },
+                                                                                {
+                                                                                  ""name"": ""ValueSequence"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    ""string""
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  ],
+                                                                  ""default"": null
+                                                                }
+                                                              ]
+                                                            }
+                                                          ],
+                                                          ""default"": null
+                                                        },
+                                                        {
+                                                          ""name"": ""Rates"",
+                                                          ""type"": [
+                                                            ""null"",
+                                                            {
+                                                              ""type"": ""record"",
+                                                              ""name"": ""Rates"",
+                                                              ""namespace"": ""com.capgroup.option.secmove.rates"",
+                                                              ""fields"": [
+                                                                {
+                                                                  ""name"": ""Rate"",
+                                                                  ""type"": [
+                                                                    ""null"",
+                                                                    {
+                                                                      ""type"": ""array"",
+                                                                      ""items"": [
+                                                                        ""null"",
+                                                                        {
+                                                                          ""type"": ""record"",
+                                                                          ""name"": ""Rate"",
+                                                                          ""fields"": [
+                                                                            {
+                                                                              ""name"": ""RateQualifierCd"",
+                                                                              ""type"": [
+                                                                                ""null"",
+                                                                                ""string""
+                                                                              ],
+                                                                              ""default"": null
+                                                                            },
+                                                                            {
+                                                                              ""name"": ""Description"",
+                                                                              ""type"": [
+                                                                                ""null"",
+                                                                                ""string""
+                                                                              ],
+                                                                              ""default"": null
+                                                                            },
+                                                                            {
+                                                                              ""name"": ""RateValue"",
+                                                                              ""type"": [
+                                                                                ""null"",
+                                                                                ""double""
+                                                                              ],
+                                                                              ""default"": null
+                                                                            },
+                                                                            {
+                                                                              ""name"": ""ExchangeFromCurrencyCd"",
+                                                                              ""type"": [
+                                                                                ""null"",
+                                                                                ""double""
+                                                                              ],
+                                                                              ""default"": null
+                                                                            },
+                                                                            {
+                                                                              ""name"": ""ExchangeToCurrencyCd"",
+                                                                              ""type"": [
+                                                                                ""null"",
+                                                                                ""double""
+                                                                              ],
+                                                                              ""default"": null
+                                                                            },
+                                                                            {
+                                                                              ""name"": ""RateTypeCd"",
+                                                                              ""type"": [
+                                                                                ""null"",
+                                                                                ""string""
+                                                                              ],
+                                                                              ""default"": null
+                                                                            },
+                                                                            {
+                                                                              ""name"": ""CurrencyCd"",
+                                                                              ""type"": [
+                                                                                ""null"",
+                                                                                ""string""
+                                                                              ],
+                                                                              ""default"": null
+                                                                            },
+                                                                            {
+                                                                              ""name"": ""Amount1"",
+                                                                              ""type"": [
+                                                                                ""null"",
+                                                                                ""double""
+                                                                              ],
+                                                                              ""default"": null
+                                                                            },
+                                                                            {
+                                                                              ""name"": ""Amount2"",
+                                                                              ""type"": [
+                                                                                ""null"",
+                                                                                ""double""
+                                                                              ],
+                                                                              ""default"": null
+                                                                            },
+                                                                            {
+                                                                              ""name"": ""RateStatusCd"",
+                                                                              ""type"": [
+                                                                                ""null"",
+                                                                                ""string""
+                                                                              ],
+                                                                              ""default"": null
+                                                                            },
+                                                                            {
+                                                                              ""name"": ""Quantity1"",
+                                                                              ""type"": [
+                                                                                ""null"",
+                                                                                ""double""
+                                                                              ],
+                                                                              ""default"": null
+                                                                            },
+                                                                            {
+                                                                              ""name"": ""Quantity2"",
+                                                                              ""type"": [
+                                                                                ""null"",
+                                                                                ""double""
+                                                                              ],
+                                                                              ""default"": null
+                                                                            },
+                                                                            {
+                                                                              ""name"": ""CurrencyCd1"",
+                                                                              ""type"": [
+                                                                                ""null"",
+                                                                                ""string""
+                                                                              ],
+                                                                              ""default"": null
+                                                                            },
+                                                                            {
+                                                                              ""name"": ""CurrencyCd2"",
+                                                                              ""type"": [
+                                                                                ""null"",
+                                                                                ""string""
+                                                                              ],
+                                                                              ""default"": null
+                                                                            },
+                                                                            {
+                                                                              ""name"": ""IndexPoint"",
+                                                                              ""type"": [
+                                                                                ""null"",
+                                                                                ""double""
+                                                                              ],
+                                                                              ""default"": null
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  ],
+                                                                  ""default"": null
+                                                                }
+                                                              ]
+                                                            }
+                                                          ],
+                                                          ""default"": null
+                                                        },
+                                                        {
+                                                          ""name"": ""Places"",
+                                                          ""type"": [
+                                                            ""null"",
+                                                            {
+                                                              ""type"": ""record"",
+                                                              ""name"": ""Places"",
+                                                              ""namespace"": ""com.capgroup.option.secmove.places"",
+                                                              ""fields"": [
+                                                                {
+                                                                  ""name"": ""Place"",
+                                                                  ""type"": [
+                                                                    ""null"",
+                                                                    {
+                                                                      ""type"": ""array"",
+                                                                      ""items"": [
+                                                                        ""null"",
+                                                                        {
+                                                                          ""type"": ""record"",
+                                                                          ""name"": ""Place"",
+                                                                          ""fields"": [
+                                                                            {
+                                                                              ""name"": ""PlaceQualifierCd"",
+                                                                              ""type"": [
+                                                                                ""null"",
+                                                                                ""string""
+                                                                              ],
+                                                                              ""default"": null
+                                                                            },
+                                                                            {
+                                                                              ""name"": ""PlaceValue"",
+                                                                              ""type"": [
+                                                                                ""null"",
+                                                                                ""string""
+                                                                              ],
+                                                                              ""default"": null
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  ],
+                                                                  ""default"": null
+                                                                }
+                                                              ]
+                                                            }
+                                                          ],
+                                                          ""default"": null
+                                                        },
+                                                        {
+                                                          ""name"": ""StockDirectionInd"",
+                                                          ""type"": [
+                                                            ""null"",
+                                                            ""string""
+                                                          ],
+                                                          ""default"": null
+                                                        },
+                                                        {
+                                                          ""name"": ""PDEFPrerefundedSecurityFlag"",
+                                                          ""type"": [
+                                                            ""null"",
+                                                            ""string""
+                                                          ],
+                                                          ""default"": null
+                                                        },
+                                                        {
+                                                          ""name"": ""CostBasisAllocationPercentage"",
+                                                          ""type"": [
+                                                            ""null"",
+                                                            ""double""
+                                                          ],
+                                                          ""default"": null
+                                                        },
+                                                        {
+                                                          ""name"": ""Dates"",
+                                                          ""type"": [
+                                                            ""null"",
+                                                            {
+                                                              ""type"": ""record"",
+                                                              ""name"": ""Dates"",
+                                                              ""namespace"": ""com.capgroup.option.secmove.dates"",
+                                                              ""fields"": [
+                                                                {
+                                                                  ""name"": ""Date"",
+                                                                  ""type"": [
+                                                                    ""null"",
+                                                                    {
+                                                                      ""type"": ""array"",
+                                                                      ""items"": [
+                                                                        ""null"",
+                                                                        {
+                                                                          ""type"": ""record"",
+                                                                          ""name"": ""Date"",
+                                                                          ""fields"": [
+                                                                            {
+                                                                              ""name"": ""DateQualifierCd"",
+                                                                              ""type"": [
+                                                                                ""null"",
+                                                                                ""string""
+                                                                              ],
+                                                                              ""default"": null
+                                                                            },
+                                                                            {
+                                                                              ""name"": ""DateValue"",
+                                                                              ""type"": [
+                                                                                ""null"",
+                                                                                ""double""
+                                                                              ],
+                                                                              ""default"": null
+                                                                            },
+                                                                            {
+                                                                              ""name"": ""DateCd"",
+                                                                              ""type"": [
+                                                                                ""null"",
+                                                                                ""string""
+                                                                              ],
+                                                                              ""default"": null
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  ],
+                                                                  ""default"": null
+                                                                }
+                                                              ]
+                                                            }
+                                                          ],
+                                                          ""default"": null
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ],
+                                              ""default"": null
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      ""default"": null
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      ""default"": null
+                    },
+                    {
+                      ""name"": ""IcaInstructions"",
+                      ""type"": [
+                        ""null"",
+                        {
+                          ""type"": ""record"",
+                          ""name"": ""IcaInstructions"",
+                          ""namespace"": ""com.capgroup.ica.instructions"",
+                          ""fields"": [
+                            {
+                              ""name"": ""IcaInstruction"",
+                              ""type"": [
+                                ""null"",
+                                {
+                                  ""type"": ""array"",
+                                  ""items"": [
+                                    ""null"",
+                                    {
+                                      ""type"": ""record"",
+                                      ""name"": ""IcaInstruction"",
+                                      ""fields"": [
+                                        {
+                                          ""name"": ""CustodyAccount"",
+                                          ""type"": [
+                                            ""null"",
+                                            {
+                                              ""type"": ""record"",
+                                              ""name"": ""CustodyAccount"",
+                                              ""fields"": [
+                                                {
+                                                  ""name"": ""AccountExternalReference"",
+                                                  ""type"": [
+                                                    ""null"",
+                                                    {
+                                                      ""type"": ""record"",
+                                                      ""name"": ""AccountExternalReference"",
+                                                      ""fields"": [
+                                                        {
+                                                          ""name"": ""ExternalRefType"",
+                                                          ""type"": [
+                                                            ""null"",
+                                                            ""string""
+                                                          ],
+                                                          ""default"": null
+                                                        },
+                                                        {
+                                                          ""name"": ""ExternalRefValue"",
+                                                          ""type"": [
+                                                            ""null"",
+                                                            ""string""
+                                                          ],
+                                                          ""default"": null
+                                                        }
+                                                      ]
+                                                    }
+                                                  ],
+                                                  ""default"": null
+                                                }
+                                              ]
+                                            }
+                                          ],
+                                          ""default"": null
+                                        },
+                                        {
+                                          ""name"": ""Option"",
+                                          ""type"": [
+                                            {
+                                              ""type"": ""array"",
+                                              ""items"": {
+                                                ""type"": ""record"",
+                                                ""name"": ""Option"",
+                                                ""fields"": [
+                                                  {
+                                                    ""name"": ""OptionId"",
+                                                    ""type"": [
+                                                      ""null"",
+                                                      ""long""
+                                                    ],
+                                                    ""default"": null
+                                                  },
+                                                  {
+                                                    ""name"": ""OptionNumber"",
+                                                    ""type"": [
+                                                      ""null"",
+                                                      ""string""
+                                                    ],
+                                                    ""default"": null
+                                                  },
+                                                  {
+                                                    ""name"": ""OptionCd"",
+                                                    ""type"": [
+                                                      ""null"",
+                                                      ""string""
+                                                    ],
+                                                    ""default"": null
+                                                  },
+                                                  {
+                                                    ""name"": ""OptionTemplateId"",
+                                                    ""type"": [
+                                                      ""null"",
+                                                      ""string""
+                                                    ],
+                                                    ""default"": null
+                                                  },
+                                                  {
+                                                    ""name"": ""CustodyAccountIcaInstruction"",
+                                                    ""type"": [
+                                                      ""null"",
+                                                      {
+                                                        ""type"": ""record"",
+                                                        ""name"": ""CustodyAccountIcaInstruction"",
+                                                        ""fields"": [
+                                                          {
+                                                            ""name"": ""CashAccount"",
+                                                            ""type"": [
+                                                              ""null"",
+                                                              {
+                                                                ""type"": ""array"",
+                                                                ""items"": [
+                                                                  ""null"",
+                                                                  {
+                                                                    ""type"": ""record"",
+                                                                    ""name"": ""CashAccount"",
+                                                                    ""namespace"": ""com.capgroup.custInst.cashaccount"",
+                                                                    ""fields"": [
+                                                                      {
+                                                                        ""name"": ""AccountExternalReference"",
+                                                                        ""type"": [
+                                                                          ""null"",
+                                                                          {
+                                                                            ""type"": ""record"",
+                                                                            ""name"": ""AccountExternalReference"",
+                                                                            ""fields"": [
+                                                                              {
+                                                                                ""name"": ""ExternalRefType"",
+                                                                                ""type"": [
+                                                                                  ""null"",
+                                                                                  ""string""
+                                                                                ],
+                                                                                ""default"": null
+                                                                              },
+                                                                              {
+                                                                                ""name"": ""ExternalRefValue"",
+                                                                                ""type"": [
+                                                                                  ""null"",
+                                                                                  ""string""
+                                                                                ],
+                                                                                ""default"": null
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ],
+                                                                        ""default"": null
+                                                                      },
+                                                                      {
+                                                                        ""name"": ""CashAccountType"",
+                                                                        ""type"": [
+                                                                          ""null"",
+                                                                          ""string""
+                                                                        ],
+                                                                        ""default"": null
+                                                                      },
+                                                                      {
+                                                                        ""name"": ""CashAccountCurrencyCd"",
+                                                                        ""type"": [
+                                                                          ""null"",
+                                                                          ""string""
+                                                                        ],
+                                                                        ""default"": null
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ],
+                                                            ""default"": null
+                                                          },
+                                                          {
+                                                            ""name"": ""Allocation"",
+                                                            ""type"": [
+                                                              {
+                                                                ""type"": ""array"",
+                                                                ""items"": {
+                                                                  ""type"": ""record"",
+                                                                  ""name"": ""Allocation"",
+                                                                  ""fields"": [
+                                                                    {
+                                                                      ""name"": ""AllocationReferences"",
+                                                                      ""type"": [
+                                                                        ""null"",
+                                                                        {
+                                                                          ""type"": ""record"",
+                                                                          ""name"": ""AllocationReferences"",
+                                                                          ""fields"": [
+                                                                            {
+                                                                              ""name"": ""AllocationReference"",
+                                                                              ""type"": [
+                                                                                {
+                                                                                  ""type"": ""array"",
+                                                                                  ""items"": {
+                                                                                    ""type"": ""record"",
+                                                                                    ""name"": ""AllocationReference"",
+                                                                                    ""fields"": [
+                                                                                      {
+                                                                                        ""name"": ""ReferenceTypeCd"",
+                                                                                        ""type"": [
+                                                                                          ""null"",
+                                                                                          ""string""
+                                                                                        ],
+                                                                                        ""default"": null
+                                                                                      },
+                                                                                      {
+                                                                                        ""name"": ""ReferenceValue"",
+                                                                                        ""type"": [
+                                                                                          ""null"",
+                                                                                          ""string""
+                                                                                        ],
+                                                                                        ""default"": null
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      ],
+                                                                      ""default"": null
+                                                                    },
+                                                                    {
+                                                                      ""name"": ""SequenceNumber"",
+                                                                      ""type"": [
+                                                                        ""null"",
+                                                                        ""long""
+                                                                      ],
+                                                                      ""default"": null
+                                                                    },
+                                                                    {
+                                                                      ""name"": ""AllocationStatusCd"",
+                                                                      ""type"": [
+                                                                        ""null"",
+                                                                        ""string""
+                                                                      ],
+                                                                      ""default"": null
+                                                                    },
+                                                                    {
+                                                                      ""name"": ""Source"",
+                                                                      ""type"": [
+                                                                        ""null"",
+                                                                        ""string""
+                                                                      ],
+                                                                      ""default"": null
+                                                                    },
+                                                                    {
+                                                                      ""name"": ""AllocationKeyValues"",
+                                                                      ""type"": [
+                                                                        ""null"",
+                                                                        {
+                                                                          ""type"": ""record"",
+                                                                          ""name"": ""AllocationKeyValues"",
+                                                                          ""namespace"": ""com.capgroup.allocation.keyvalue"",
+                                                                          ""fields"": [
+                                                                            {
+                                                                              ""name"": ""AllocationKeyValue"",
+                                                                              ""type"": [
+                                                                                ""null"",
+                                                                                {
+                                                                                  ""type"": ""array"",
+                                                                                  ""items"": [
+                                                                                    ""null"",
+                                                                                    {
+                                                                                      ""type"": ""record"",
+                                                                                      ""name"": ""AllocationKeyValue"",
+                                                                                      ""fields"": [
+                                                                                        {
+                                                                                          ""name"": ""Key"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""string""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""Value"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""string""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""Value2"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""double""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""Value3"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""double""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        }
+                                                                                      ]
+                                                                                    }
+                                                                                  ]
+                                                                                }
+                                                                              ],
+                                                                              ""default"": null
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      ],
+                                                                      ""default"": null
+                                                                    },
+                                                                    {
+                                                                      ""name"": ""ContractualCashSettlementFlag"",
+                                                                      ""type"": [
+                                                                        ""null"",
+                                                                        ""string""
+                                                                      ],
+                                                                      ""default"": null
+                                                                    },
+                                                                    {
+                                                                      ""name"": ""ContractualStockSettlementFlag"",
+                                                                      ""type"": [
+                                                                        ""null"",
+                                                                        ""string""
+                                                                      ],
+                                                                      ""default"": null
+                                                                    },
+                                                                    {
+                                                                      ""name"": ""TransactionTypeCd"",
+                                                                      ""type"": [
+                                                                        ""null"",
+                                                                        ""string""
+                                                                      ],
+                                                                      ""default"": null
+                                                                    },
+                                                                    {
+                                                                      ""name"": ""ExpectedSettlementDate"",
+                                                                      ""type"": [
+                                                                        ""null"",
+                                                                        ""string""
+                                                                      ],
+                                                                      ""default"": null
+                                                                    },
+                                                                    {
+                                                                      ""name"": ""OverrideSettlementDate"",
+                                                                      ""type"": [
+                                                                        ""null"",
+                                                                        ""string""
+                                                                      ],
+                                                                      ""default"": null
+                                                                    },
+                                                                    {
+                                                                      ""name"": ""ElectionId"",
+                                                                      ""type"": [
+                                                                        ""null"",
+                                                                        ""long""
+                                                                      ],
+                                                                      ""default"": null
+                                                                    },
+                                                                    {
+                                                                      ""name"": ""ElectionDetails"",
+                                                                      ""type"": [
+                                                                        ""null"",
+                                                                        {
+                                                                          ""type"": ""record"",
+                                                                          ""name"": ""ElectionDetails"",
+                                                                          ""namespace"": ""com.capgroup.allocation.electiondetails"",
+                                                                          ""fields"": [
+                                                                            {
+                                                                              ""name"": ""ElectionDetail"",
+                                                                              ""type"": [
+                                                                                ""null"",
+                                                                                {
+                                                                                  ""type"": ""array"",
+                                                                                  ""items"": [
+                                                                                    ""null"",
+                                                                                    {
+                                                                                      ""type"": ""record"",
+                                                                                      ""name"": ""ElectionDetail"",
+                                                                                      ""fields"": [
+                                                                                        {
+                                                                                          ""name"": ""ElectionDetailId"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""long""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""ElectionQuantity"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""double""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        }
+                                                                                      ]
+                                                                                    }
+                                                                                  ]
+                                                                                }
+                                                                              ],
+                                                                              ""default"": null
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      ],
+                                                                      ""default"": null
+                                                                    },
+                                                                    {
+                                                                      ""name"": ""BlockingPositionId"",
+                                                                      ""type"": [
+                                                                        ""null"",
+                                                                        ""long""
+                                                                      ],
+                                                                      ""default"": null
+                                                                    },
+                                                                    {
+                                                                      ""name"": ""FXRequestId"",
+                                                                      ""type"": [
+                                                                        ""null"",
+                                                                        ""long""
+                                                                      ],
+                                                                      ""default"": null
+                                                                    },
+                                                                    {
+                                                                      ""name"": ""ApportionedPosition"",
+                                                                      ""type"": [
+                                                                        ""null"",
+                                                                        ""double""
+                                                                      ],
+                                                                      ""default"": null
+                                                                    },
+                                                                    {
+                                                                      ""name"": ""PositionType"",
+                                                                      ""type"": [
+                                                                        ""null"",
+                                                                        ""double""
+                                                                      ],
+                                                                      ""default"": null
+                                                                    },
+                                                                    {
+                                                                      ""name"": ""ClaimAssociation"",
+                                                                      ""type"": [
+                                                                        ""null"",
+                                                                        ""string""
+                                                                      ],
+                                                                      ""default"": null
+                                                                    },
+                                                                    {
+                                                                      ""name"": ""TradeReference"",
+                                                                      ""type"": [
+                                                                        ""null"",
+                                                                        {
+                                                                          ""type"": ""array"",
+                                                                          ""items"": [
+                                                                            ""null"",
+                                                                            {
+                                                                              ""type"": ""record"",
+                                                                              ""name"": ""TradeReference"",
+                                                                              ""fields"": [
+                                                                                {
+                                                                                  ""name"": ""ReferenceTypeCd"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    ""string""
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                },
+                                                                                {
+                                                                                  ""name"": ""ReferenceValue"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    ""string""
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      ],
+                                                                      ""default"": null
+                                                                    },
+                                                                    {
+                                                                      ""name"": ""Counterparty"",
+                                                                      ""type"": [
+                                                                        ""null"",
+                                                                        {
+                                                                          ""type"": ""array"",
+                                                                          ""items"": [
+                                                                            ""null"",
+                                                                            {
+                                                                              ""type"": ""record"",
+                                                                              ""name"": ""Counterparty"",
+                                                                              ""fields"": [
+                                                                                {
+                                                                                  ""name"": ""ExternalRefType"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    ""string""
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                },
+                                                                                {
+                                                                                  ""name"": ""ExternalRefValue"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    ""string""
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      ],
+                                                                      ""default"": null
+                                                                    },
+                                                                    {
+                                                                      ""name"": ""CashMovement"",
+                                                                      ""type"": [
+                                                                        ""null"",
+                                                                        {
+                                                                          ""type"": ""array"",
+                                                                          ""items"": [
+                                                                            ""null"",
+                                                                            {
+                                                                              ""type"": ""record"",
+                                                                              ""name"": ""CashMovement"",
+                                                                              ""fields"": [
+                                                                                {
+                                                                                  ""name"": ""CashMovementId"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    ""long""
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                },
+                                                                                {
+                                                                                  ""name"": ""Rate"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    ""double""
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                },
+                                                                                {
+                                                                                  ""name"": ""CreditDebitIndicator"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    ""string""
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                },
+                                                                                {
+                                                                                  ""name"": ""CashAmounts"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    {
+                                                                                      ""type"": ""record"",
+                                                                                      ""name"": ""CashAmounts"",
+                                                                                      ""namespace"": ""com.capgroup.custaccount.cashmove.cashmmounts"",
+                                                                                      ""fields"": [
+                                                                                        {
+                                                                                          ""name"": ""TradeAmount"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            {
+                                                                                              ""type"": ""record"",
+                                                                                              ""name"": ""TradeAmount"",
+                                                                                              ""fields"": [
+                                                                                                {
+                                                                                                  ""name"": ""CustodianNetAmount"",
+                                                                                                  ""type"": [
+                                                                                                    ""null"",
+                                                                                                    ""double""
+                                                                                                  ],
+                                                                                                  ""default"": null
+                                                                                                },
+                                                                                                {
+                                                                                                  ""name"": ""NetAmount"",
+                                                                                                  ""type"": [
+                                                                                                    ""null"",
+                                                                                                    ""double""
+                                                                                                  ],
+                                                                                                  ""default"": null
+                                                                                                },
+                                                                                                {
+                                                                                                  ""name"": ""GrossAmount"",
+                                                                                                  ""type"": [
+                                                                                                    ""null"",
+                                                                                                    ""double""
+                                                                                                  ],
+                                                                                                  ""default"": null
+                                                                                                },
+                                                                                                {
+                                                                                                  ""name"": ""Currency"",
+                                                                                                  ""type"": [
+                                                                                                    ""null"",
+                                                                                                    ""string""
+                                                                                                  ],
+                                                                                                  ""default"": null
+                                                                                                }
+                                                                                              ]
+                                                                                            }
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""TradeToSettlementFxRate"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""double""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""CustodianPaymentAmount"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            {
+                                                                                              ""type"": ""array"",
+                                                                                              ""items"": [
+                                                                                                ""null"",
+                                                                                                {
+                                                                                                  ""type"": ""record"",
+                                                                                                  ""name"": ""CustodianPaymentAmount"",
+                                                                                                  ""fields"": [
+                                                                                                    {
+                                                                                                      ""name"": ""CustodianPaymentCurrency"",
+                                                                                                      ""type"": [
+                                                                                                        ""null"",
+                                                                                                        ""string""
+                                                                                                      ],
+                                                                                                      ""default"": null
+                                                                                                    },
+                                                                                                    {
+                                                                                                      ""name"": ""SettlementAmountInCustodianCurrency"",
+                                                                                                      ""type"": [
+                                                                                                        ""null"",
+                                                                                                        ""string""
+                                                                                                      ],
+                                                                                                      ""default"": null
+                                                                                                    },
+                                                                                                    {
+                                                                                                      ""name"": ""CustodianPaymentToSettlementFxRate"",
+                                                                                                      ""type"": [
+                                                                                                        ""null"",
+                                                                                                        ""string""
+                                                                                                      ],
+                                                                                                      ""default"": null
+                                                                                                    },
+                                                                                                    {
+                                                                                                      ""name"": ""CustodianPaymentToTradeFxRate"",
+                                                                                                      ""type"": [
+                                                                                                        ""null"",
+                                                                                                        ""string""
+                                                                                                      ],
+                                                                                                      ""default"": null
+                                                                                                    }
+                                                                                                  ]
+                                                                                                }
+                                                                                              ]
+                                                                                            }
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""SettlementAmount"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            {
+                                                                                              ""type"": ""record"",
+                                                                                              ""name"": ""SettlementAmount"",
+                                                                                              ""fields"": [
+                                                                                                {
+                                                                                                  ""name"": ""NetAmount"",
+                                                                                                  ""type"": [
+                                                                                                    ""null"",
+                                                                                                    ""double""
+                                                                                                  ],
+                                                                                                  ""default"": null
+                                                                                                },
+                                                                                                {
+                                                                                                  ""name"": ""AggregatedSettledAmount"",
+                                                                                                  ""type"": [
+                                                                                                    ""null"",
+                                                                                                    ""double""
+                                                                                                  ],
+                                                                                                  ""default"": null
+                                                                                                },
+                                                                                                {
+                                                                                                  ""name"": ""RemainingSettlementAmount"",
+                                                                                                  ""type"": [
+                                                                                                    ""null"",
+                                                                                                    ""double""
+                                                                                                  ],
+                                                                                                  ""default"": null
+                                                                                                },
+                                                                                                {
+                                                                                                  ""name"": ""Currency"",
+                                                                                                  ""type"": [
+                                                                                                    ""null"",
+                                                                                                    ""string""
+                                                                                                  ],
+                                                                                                  ""default"": null
+                                                                                                },
+                                                                                                {
+                                                                                                  ""name"": ""SettlementAmountDifference"",
+                                                                                                  ""type"": [
+                                                                                                    ""null"",
+                                                                                                    ""double""
+                                                                                                  ],
+                                                                                                  ""default"": null
+                                                                                                }
+                                                                                              ]
+                                                                                            }
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        }
+                                                                                      ]
+                                                                                    }
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          ],
+                                                                          ""default"": null
+                                                                        }
+                                                                      ],
+                                                                      ""default"": null
+                                                                    },
+                                                                    {
+                                                                      ""name"": ""SecurityMovement"",
+                                                                      ""type"": [
+                                                                        ""null"",
+                                                                        {
+                                                                          ""type"": ""array"",
+                                                                          ""items"": [
+                                                                            ""null"",
+                                                                            {
+                                                                              ""type"": ""record"",
+                                                                              ""name"": ""SecurityMovement"",
+                                                                              ""fields"": [
+                                                                                {
+                                                                                  ""name"": ""SecurityMovementId"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    ""long""
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                },
+                                                                                {
+                                                                                  ""name"": ""StockDirectionInd"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    ""string""
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                },
+                                                                                {
+                                                                                  ""name"": ""SecurityQuantity"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    ""double""
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                },
+                                                                                {
+                                                                                  ""name"": ""AggregatedSettledSecurityQuantity"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    ""double""
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                },
+                                                                                {
+                                                                                  ""name"": ""RemainingSettlementSecurityQuantity"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    ""double""
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                },
+                                                                                {
+                                                                                  ""name"": ""CostPriceSecurityCurrency"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    ""double""
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                },
+                                                                                {
+                                                                                  ""name"": ""PriceInTradeCurrency"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    ""double""
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                },
+                                                                                {
+                                                                                  ""name"": ""SecurityDetails"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    {
+                                                                                      ""type"": ""array"",
+                                                                                      ""items"": [
+                                                                                        ""null"",
+                                                                                        {
+                                                                                          ""type"": ""record"",
+                                                                                          ""name"": ""SecurityDetails"",
+                                                                                          ""fields"": [
+                                                                                            {
+                                                                                              ""name"": ""IssueCountryCd"",
+                                                                                              ""type"": [
+                                                                                                ""null"",
+                                                                                                ""string""
+                                                                                              ],
+                                                                                              ""default"": null
+                                                                                            },
+                                                                                            {
+                                                                                              ""name"": ""IssueCurrencyCd"",
+                                                                                              ""type"": [
+                                                                                                ""null"",
+                                                                                                ""string""
+                                                                                              ],
+                                                                                              ""default"": null
+                                                                                            },
+                                                                                            {
+                                                                                              ""name"": ""SecurityExternalReferences"",
+                                                                                              ""type"": [
+                                                                                                ""null"",
+                                                                                                {
+                                                                                                  ""type"": ""record"",
+                                                                                                  ""name"": ""SecurityExternalReferences"",
+                                                                                                  ""fields"": [
+                                                                                                    {
+                                                                                                      ""name"": ""SecurityExternalReference"",
+                                                                                                      ""type"": [
+                                                                                                        {
+                                                                                                          ""type"": ""array"",
+                                                                                                          ""items"": {
+                                                                                                            ""type"": ""record"",
+                                                                                                            ""name"": ""SecurityExternalReference"",
+                                                                                                            ""fields"": [
+                                                                                                              {
+                                                                                                                ""name"": ""SecurityIdentifierTypeCd"",
+                                                                                                                ""type"": [
+                                                                                                                  ""null"",
+                                                                                                                  ""string""
+                                                                                                                ],
+                                                                                                                ""default"": null
+                                                                                                              },
+                                                                                                              {
+                                                                                                                ""name"": ""SecurityIdentifierValue"",
+                                                                                                                ""type"": [
+                                                                                                                  ""null"",
+                                                                                                                  ""string""
+                                                                                                                ],
+                                                                                                                ""default"": null
+                                                                                                              }
+                                                                                                            ]
+                                                                                                          }
+                                                                                                        }
+                                                                                                      ]
+                                                                                                    }
+                                                                                                  ]
+                                                                                                }
+                                                                                              ],
+                                                                                              ""default"": null
+                                                                                            },
+                                                                                            {
+                                                                                              ""name"": ""ReportingClassificationGroups"",
+                                                                                              ""type"": [
+                                                                                                ""null"",
+                                                                                                {
+                                                                                                  ""type"": ""record"",
+                                                                                                  ""name"": ""ReportingClassificationGroups"",
+                                                                                                  ""fields"": [
+                                                                                                    {
+                                                                                                      ""name"": ""ReportingClassificationGroup"",
+                                                                                                      ""type"": [
+                                                                                                        ""null"",
+                                                                                                        {
+                                                                                                          ""type"": ""array"",
+                                                                                                          ""items"": [
+                                                                                                            {
+                                                                                                              ""type"": ""record"",
+                                                                                                              ""name"": ""ReportingClassificationGroup"",
+                                                                                                              ""fields"": [
+                                                                                                                {
+                                                                                                                  ""name"": ""ReportingClassificationGroupId"",
+                                                                                                                  ""type"": [
+                                                                                                                    ""null"",
+                                                                                                                    ""long""
+                                                                                                                  ],
+                                                                                                                  ""default"": null
+                                                                                                                },
+                                                                                                                {
+                                                                                                                  ""name"": ""ReportingClassificationGroupName"",
+                                                                                                                  ""type"": [
+                                                                                                                    ""null"",
+                                                                                                                    ""string""
+                                                                                                                  ],
+                                                                                                                  ""default"": null
+                                                                                                                },
+                                                                                                                {
+                                                                                                                  ""name"": ""ValueId"",
+                                                                                                                  ""type"": [
+                                                                                                                    ""null"",
+                                                                                                                    ""long""
+                                                                                                                  ],
+                                                                                                                  ""default"": null
+                                                                                                                },
+                                                                                                                {
+                                                                                                                  ""name"": ""ValueName"",
+                                                                                                                  ""type"": [
+                                                                                                                    ""null"",
+                                                                                                                    ""string""
+                                                                                                                  ],
+                                                                                                                  ""default"": null
+                                                                                                                },
+                                                                                                                {
+                                                                                                                  ""name"": ""ValueCode"",
+                                                                                                                  ""type"": [
+                                                                                                                    ""null"",
+                                                                                                                    ""string""
+                                                                                                                  ],
+                                                                                                                  ""default"": null
+                                                                                                                },
+                                                                                                                {
+                                                                                                                  ""name"": ""ValueSequence"",
+                                                                                                                  ""type"": [
+                                                                                                                    ""null"",
+                                                                                                                    ""string""
+                                                                                                                  ],
+                                                                                                                  ""default"": null
+                                                                                                                }
+                                                                                                              ]
+                                                                                                            }
+                                                                                                          ]
+                                                                                                        }
+                                                                                                      ],
+                                                                                                      ""default"": null
+                                                                                                    }
+                                                                                                  ]
+                                                                                                }
+                                                                                              ],
+                                                                                              ""default"": null
+                                                                                            }
+                                                                                          ]
+                                                                                        }
+                                                                                      ]
+                                                                                    }
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                },
+                                                                                {
+                                                                                  ""name"": ""CashAmounts"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    {
+                                                                                      ""type"": ""record"",
+                                                                                      ""name"": ""CashAmounts"",
+                                                                                      ""namespace"": ""com.capgroup.custaccount.secmove.cashmmounts"",
+                                                                                      ""fields"": [
+                                                                                        {
+                                                                                          ""name"": ""TradeAmount"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            {
+                                                                                              ""type"": ""record"",
+                                                                                              ""name"": ""TradeAmount"",
+                                                                                              ""fields"": [
+                                                                                                {
+                                                                                                  ""name"": ""CustodianNetAmount"",
+                                                                                                  ""type"": [
+                                                                                                    ""null"",
+                                                                                                    ""double""
+                                                                                                  ],
+                                                                                                  ""default"": null
+                                                                                                },
+                                                                                                {
+                                                                                                  ""name"": ""NetAmount"",
+                                                                                                  ""type"": [
+                                                                                                    ""null"",
+                                                                                                    ""double""
+                                                                                                  ],
+                                                                                                  ""default"": null
+                                                                                                },
+                                                                                                {
+                                                                                                  ""name"": ""GrossAmount"",
+                                                                                                  ""type"": [
+                                                                                                    ""null"",
+                                                                                                    ""double""
+                                                                                                  ],
+                                                                                                  ""default"": null
+                                                                                                },
+                                                                                                {
+                                                                                                  ""name"": ""Currency"",
+                                                                                                  ""type"": [
+                                                                                                    ""null"",
+                                                                                                    ""string""
+                                                                                                  ],
+                                                                                                  ""default"": null
+                                                                                                }
+                                                                                              ]
+                                                                                            }
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""TradeToSettlementFxRate"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""double""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""CustodianPaymentAmount"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            {
+                                                                                              ""type"": ""array"",
+                                                                                              ""items"": [
+                                                                                                ""null"",
+                                                                                                {
+                                                                                                  ""type"": ""record"",
+                                                                                                  ""name"": ""CustodianPaymentAmount"",
+                                                                                                  ""namespace"": ""com.capgroup.custaccount.custpayamount"",
+                                                                                                  ""fields"": [
+                                                                                                    {
+                                                                                                      ""name"": ""CustodianPaymentCurrency"",
+                                                                                                      ""type"": [
+                                                                                                        ""null"",
+                                                                                                        ""string""
+                                                                                                      ],
+                                                                                                      ""default"": null
+                                                                                                    },
+                                                                                                    {
+                                                                                                      ""name"": ""SettlementAmountInCustodianCurrency"",
+                                                                                                      ""type"": [
+                                                                                                        ""null"",
+                                                                                                        ""double""
+                                                                                                      ],
+                                                                                                      ""default"": null
+                                                                                                    },
+                                                                                                    {
+                                                                                                      ""name"": ""CustodianPaymentToSettlementFxRate"",
+                                                                                                      ""type"": [
+                                                                                                        ""null"",
+                                                                                                        ""double""
+                                                                                                      ],
+                                                                                                      ""default"": null
+                                                                                                    },
+                                                                                                    {
+                                                                                                      ""name"": ""CustodianPaymentToTradeFxRate"",
+                                                                                                      ""type"": [
+                                                                                                        ""null"",
+                                                                                                        ""double""
+                                                                                                      ],
+                                                                                                      ""default"": null
+                                                                                                    }
+                                                                                                  ]
+                                                                                                }
+                                                                                              ]
+                                                                                            }
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""SettlementAmount"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            {
+                                                                                              ""type"": ""record"",
+                                                                                              ""name"": ""SettlementAmount"",
+                                                                                              ""fields"": [
+                                                                                                {
+                                                                                                  ""name"": ""NetAmount"",
+                                                                                                  ""type"": [
+                                                                                                    ""null"",
+                                                                                                    ""double""
+                                                                                                  ],
+                                                                                                  ""default"": null
+                                                                                                },
+                                                                                                {
+                                                                                                  ""name"": ""AggregatedSettledAmount"",
+                                                                                                  ""type"": [
+                                                                                                    ""null"",
+                                                                                                    ""double""
+                                                                                                  ],
+                                                                                                  ""default"": null
+                                                                                                },
+                                                                                                {
+                                                                                                  ""name"": ""RemainingSettlementAmount"",
+                                                                                                  ""type"": [
+                                                                                                    ""null"",
+                                                                                                    ""double""
+                                                                                                  ],
+                                                                                                  ""default"": null
+                                                                                                },
+                                                                                                {
+                                                                                                  ""name"": ""Currency"",
+                                                                                                  ""type"": [
+                                                                                                    ""null"",
+                                                                                                    ""string""
+                                                                                                  ],
+                                                                                                  ""default"": null
+                                                                                                },
+                                                                                                {
+                                                                                                  ""name"": ""SettlementAmountDifference"",
+                                                                                                  ""type"": [
+                                                                                                    ""null"",
+                                                                                                    ""string""
+                                                                                                  ],
+                                                                                                  ""default"": null
+                                                                                                }
+                                                                                              ]
+                                                                                            }
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        }
+                                                                                      ]
+                                                                                    }
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      ],
+                                                                      ""default"": null
+                                                                    },
+                                                                    {
+                                                                      ""name"": ""BookCost"",
+                                                                      ""type"": [
+                                                                        ""null"",
+                                                                        {
+                                                                          ""type"": ""array"",
+                                                                          ""items"": [
+                                                                            ""null"",
+                                                                            {
+                                                                              ""type"": ""record"",
+                                                                              ""name"": ""BookCost"",
+                                                                              ""fields"": [
+                                                                                {
+                                                                                  ""name"": ""BookCostIsEstimateFlag"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    ""string""
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                },
+                                                                                {
+                                                                                  ""name"": ""CleanBookCostInBaseCurr"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    ""double""
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                },
+                                                                                {
+                                                                                  ""name"": ""CleanBookCostInSecCurr"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    ""double""
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                },
+                                                                                {
+                                                                                  ""name"": ""DirtyBookCostInBaseCurr"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    ""double""
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                },
+                                                                                {
+                                                                                  ""name"": ""DirtyBookCostInSecCurr"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    ""double""
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                },
+                                                                                {
+                                                                                  ""name"": ""TradeToSecFxRate"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    ""double""
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                },
+                                                                                {
+                                                                                  ""name"": ""TradeToBaseFxRate"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    ""double""
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                },
+                                                                                {
+                                                                                  ""name"": ""ClientBaseCurrency"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    ""string""
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                },
+                                                                                {
+                                                                                  ""name"": ""BookCostCurr"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    ""string""
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                },
+                                                                                {
+                                                                                  ""name"": ""DirtyBookCostInBookCostCurr"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    ""double""
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                },
+                                                                                {
+                                                                                  ""name"": ""CleanBookCostInBookCostCurr"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    ""double""
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      ],
+                                                                      ""default"": null
+                                                                    },
+                                                                    {
+                                                                      ""name"": ""Charges"",
+                                                                      ""type"": [
+                                                                        ""null"",
+                                                                        {
+                                                                          ""type"": ""record"",
+                                                                          ""name"": ""Charges"",
+                                                                          ""namespace"": ""com.capgroup.option.Charges"",
+                                                                          ""fields"": [
+                                                                            {
+                                                                              ""name"": ""Charge"",
+                                                                              ""type"": [
+                                                                                ""null"",
+                                                                                {
+                                                                                  ""type"": ""array"",
+                                                                                  ""items"": [
+                                                                                    ""null"",
+                                                                                    {
+                                                                                      ""type"": ""record"",
+                                                                                      ""name"": ""Charge"",
+                                                                                      ""fields"": [
+                                                                                        {
+                                                                                          ""name"": ""ChargeId"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""long""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""ChargeClassificationType"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""string""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""ChargeCategoryCd"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""string""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""ChargeCd"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""string""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""ChargeableQuantity"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""double""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""ChargeCurrencyCd"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""string""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""ChargeableAmount"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""double""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""RateCd"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""double""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""ChargeRateTypeCd"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""string""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""ChargeRate"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""double""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""VatRate"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""double""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""VatTypeCd"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""string""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""VatAmount"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""double""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""GrossChargeAmount"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""double""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""ChargeAmount"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""double""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""ChargeSourceCd"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""string""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""ChargeOriginCd"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""string""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""ApplyChargeAsCd"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""string""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""EstimateFlag"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""string""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""ReportableOnly"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""string""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""ReclaimFlag"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""string""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""ReclaimChargeRate"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""double""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""ChargeReference"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""double""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""QualifierCd"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""double""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        }
+                                                                                      ]
+                                                                                    }
+                                                                                  ]
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      ],
+                                                                      ""default"": null
+                                                                    },
+                                                                    {
+                                                                      ""name"": ""SettlementDetails"",
+                                                                      ""type"": [
+                                                                        ""null"",
+                                                                        {
+                                                                          ""type"": ""record"",
+                                                                          ""name"": ""SettlementDetails"",
+                                                                          ""fields"": [
+                                                                            {
+                                                                              ""name"": ""SettlementDetail"",
+                                                                              ""type"": [
+                                                                                ""null"",
+                                                                                {
+                                                                                  ""type"": ""array"",
+                                                                                  ""items"": [
+                                                                                    ""null"",
+                                                                                    {
+                                                                                      ""type"": ""record"",
+                                                                                      ""name"": ""SettlementDetail"",
+                                                                                      ""fields"": [
+                                                                                        {
+                                                                                          ""name"": ""CreationDate"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""string""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""StatusId"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""long""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""AllocationStatusCd"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""string""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""StatusActionCd"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""string""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""CashValueDate"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""string""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""CashPostingDate"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""string""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""SettlementAmount"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""double""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""AggregatedSettledAmount"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""double""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""RemainingSettlementAmount"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""double""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""StockValueDate"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""string""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""StockPostingDate"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""string""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""SettlementSecurityQuantity"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""double""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""AggregatedSettledSecurityQuantity"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""double""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""RemainingSettlementSecurityQuantity"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""double""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""Charges"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            {
+                                                                                              ""type"": ""record"",
+                                                                                              ""name"": ""Charges"",
+                                                                                              ""namespace"": ""com.capgroup.option.settlement.charges"",
+                                                                                              ""fields"": [
+                                                                                                {
+                                                                                                  ""name"": ""Charge"",
+                                                                                                  ""type"": [
+                                                                                                    {
+                                                                                                      ""type"": ""array"",
+                                                                                                      ""items"": {
+                                                                                                        ""type"": ""record"",
+                                                                                                        ""name"": ""Charge"",
+                                                                                                        ""fields"": [
+                                                                                                          {
+                                                                                                            ""name"": ""ChargeId"",
+                                                                                                            ""type"": [
+                                                                                                              ""null"",
+                                                                                                              ""long""
+                                                                                                            ],
+                                                                                                            ""default"": null
+                                                                                                          },
+                                                                                                          {
+                                                                                                            ""name"": ""SettlementChargeAmount"",
+                                                                                                            ""type"": [
+                                                                                                              ""null"",
+                                                                                                              ""double""
+                                                                                                            ],
+                                                                                                            ""default"": null
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      }
+                                                                                                    }
+                                                                                                  ]
+                                                                                                }
+                                                                                              ]
+                                                                                            }
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""ReasonCd"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""double""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""Comments"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""string""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        }
+                                                                                      ]
+                                                                                    }
+                                                                                  ]
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      ],
+                                                                      ""default"": null
+                                                                    },
+                                                                    {
+                                                                      ""name"": ""CashAccount"",
+                                                                      ""type"": [
+                                                                        ""null"",
+                                                                        {
+                                                                          ""type"": ""array"",
+                                                                          ""items"": [
+                                                                            ""null"",
+                                                                            {
+                                                                              ""type"": ""record"",
+                                                                              ""name"": ""CashAccount"",
+                                                                              ""namespace"": ""com.capgroup.custInst.alloc.cashaccount"",
+                                                                              ""fields"": [
+                                                                                {
+                                                                                  ""name"": ""AccountExternalReference"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    {
+                                                                                      ""type"": ""record"",
+                                                                                      ""name"": ""AccountExternalReference"",
+                                                                                      ""fields"": [
+                                                                                        {
+                                                                                          ""name"": ""ExternalRefType"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""string""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        },
+                                                                                        {
+                                                                                          ""name"": ""ExternalRefValue"",
+                                                                                          ""type"": [
+                                                                                            ""null"",
+                                                                                            ""string""
+                                                                                          ],
+                                                                                          ""default"": null
+                                                                                        }
+                                                                                      ]
+                                                                                    }
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                },
+                                                                                {
+                                                                                  ""name"": ""CashAccountType"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    ""string""
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                },
+                                                                                {
+                                                                                  ""name"": ""CashAccountCurrencyCd"",
+                                                                                  ""type"": [
+                                                                                    ""null"",
+                                                                                    ""string""
+                                                                                  ],
+                                                                                  ""default"": null
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      ],
+                                                                      ""default"": null
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ],
+                                                    ""default"": null
+                                                  },
+                                                  {
+                                                    ""name"": ""InvestmentAccountIcaInstructions"",
+                                                    ""type"": [
+                                                      ""null"",
+                                                      {
+                                                        ""type"": ""record"",
+                                                        ""name"": ""InvestmentAccountIcaInstructions"",
+                                                        ""namespace"": ""com.capgroup.inica.instructions.investment.account"",
+                                                        ""fields"": [
+                                                          {
+                                                            ""name"": ""InvestmentAccountIcaInstruction"",
+                                                            ""type"": [
+                                                              ""null"",
+                                                              {
+                                                                ""type"": ""array"",
+                                                                ""items"": [
+                                                                  ""null"",
+                                                                  {
+                                                                    ""type"": ""record"",
+                                                                    ""name"": ""InvestmentAccountIcaInstruction"",
+                                                                    ""fields"": [
+                                                                      {
+                                                                        ""name"": ""InvestmentAccount"",
+                                                                        ""type"": [
+                                                                          ""null"",
+                                                                          {
+                                                                            ""type"": ""record"",
+                                                                            ""name"": ""InvestmentAccount"",
+                                                                            ""fields"": [
+                                                                              {
+                                                                                ""name"": ""AccountExternalReference"",
+                                                                                ""type"": [
+                                                                                  ""null"",
+                                                                                  {
+                                                                                    ""type"": ""record"",
+                                                                                    ""name"": ""AccountExternalReference"",
+                                                                                    ""fields"": [
+                                                                                      {
+                                                                                        ""name"": ""ExternalRefType"",
+                                                                                        ""type"": [
+                                                                                          ""null"",
+                                                                                          ""string""
+                                                                                        ],
+                                                                                        ""default"": null
+                                                                                      },
+                                                                                      {
+                                                                                        ""name"": ""ExternalRefValue"",
+                                                                                        ""type"": [
+                                                                                          ""null"",
+                                                                                          ""string""
+                                                                                        ],
+                                                                                        ""default"": null
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ],
+                                                                                ""default"": null
+                                                                              },
+                                                                              {
+                                                                                ""name"": ""InvestmentAccountType"",
+                                                                                ""type"": [
+                                                                                  ""null"",
+                                                                                  ""string""
+                                                                                ],
+                                                                                ""default"": null
+                                                                              },
+                                                                              {
+                                                                                ""name"": ""TaxResidencies"",
+                                                                                ""type"": [
+                                                                                  ""null"",
+                                                                                  {
+                                                                                    ""type"": ""record"",
+                                                                                    ""name"": ""TaxResidencies"",
+                                                                                    ""namespace"": ""com.capgroup.option.taxresidencies"",
+                                                                                    ""fields"": [
+                                                                                      {
+                                                                                        ""name"": ""TaxResidency"",
+                                                                                        ""type"": [
+                                                                                          ""null"",
+                                                                                          {
+                                                                                            ""type"": ""array"",
+                                                                                            ""items"": [
+                                                                                              ""null"",
+                                                                                              {
+                                                                                                ""type"": ""record"",
+                                                                                                ""name"": ""TaxResidency"",
+                                                                                                ""fields"": [
+                                                                                                  {
+                                                                                                    ""name"": ""TaxResidencyCd"",
+                                                                                                    ""type"": [
+                                                                                                      ""null"",
+                                                                                                      ""string""
+                                                                                                    ],
+                                                                                                    ""default"": null
+                                                                                                  },
+                                                                                                  {
+                                                                                                    ""name"": ""TaxResidencyEffectiveDate"",
+                                                                                                    ""type"": [
+                                                                                                      ""null"",
+                                                                                                      ""string""
+                                                                                                    ],
+                                                                                                    ""default"": null
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ],
+                                                                                ""default"": null
+                                                                              },
+                                                                              {
+                                                                                ""name"": ""ClassificationGroups"",
+                                                                                ""type"": [
+                                                                                  ""null"",
+                                                                                  {
+                                                                                    ""type"": ""record"",
+                                                                                    ""name"": ""ClassificationGroups"",
+                                                                                    ""fields"": [
+                                                                                      {
+                                                                                        ""name"": ""ClassificationGroup"",
+                                                                                        ""type"": [
+                                                                                          {
+                                                                                            ""type"": ""array"",
+                                                                                            ""items"": {
+                                                                                              ""type"": ""record"",
+                                                                                              ""name"": ""ClassificationGroup"",
+                                                                                              ""fields"": [
+                                                                                                {
+                                                                                                  ""name"": ""ClassificationGroupId"",
+                                                                                                  ""type"": [
+                                                                                                    ""null"",
+                                                                                                    ""long""
+                                                                                                  ],
+                                                                                                  ""default"": null
+                                                                                                },
+                                                                                                {
+                                                                                                  ""name"": ""ClassificationGroupName"",
+                                                                                                  ""type"": [
+                                                                                                    ""null"",
+                                                                                                    ""string""
+                                                                                                  ],
+                                                                                                  ""default"": null
+                                                                                                },
+                                                                                                {
+                                                                                                  ""name"": ""ClassificationValueId"",
+                                                                                                  ""type"": [
+                                                                                                    ""null"",
+                                                                                                    ""int""
+                                                                                                  ],
+                                                                                                  ""default"": null
+                                                                                                },
+                                                                                                {
+                                                                                                  ""name"": ""ClassificationValue"",
+                                                                                                  ""type"": [
+                                                                                                    ""null"",
+                                                                                                    ""string""
+                                                                                                  ],
+                                                                                                  ""default"": null
+                                                                                                }
+                                                                                              ]
+                                                                                            }
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ],
+                                                                                ""default"": null
+                                                                              },
+                                                                              {
+                                                                                ""name"": ""EligibleBalance"",
+                                                                                ""type"": [
+                                                                                  ""null"",
+                                                                                  ""double""
+                                                                                ],
+                                                                                ""default"": null
+                                                                              },
+                                                                              {
+                                                                                ""name"": ""TotalPosition"",
+                                                                                ""type"": [
+                                                                                  ""null"",
+                                                                                  ""double""
+                                                                                ],
+                                                                                ""default"": null
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ],
+                                                                        ""default"": null
+                                                                      },
+                                                                      {
+                                                                        ""name"": ""CashAccount"",
+                                                                        ""type"": [
+                                                                          ""null"",
+                                                                          {
+                                                                            ""type"": ""array"",
+                                                                            ""items"": [
+                                                                              ""null"",
+                                                                              {
+                                                                                ""type"": ""record"",
+                                                                                ""name"": ""CashAccount"",
+                                                                                ""namespace"": ""com.capgroup.invinst.allocation.cashaccount"",
+                                                                                ""fields"": [
+                                                                                  {
+                                                                                    ""name"": ""AccountExternalReference"",
+                                                                                    ""type"": [
+                                                                                      ""null"",
+                                                                                      {
+                                                                                        ""type"": ""record"",
+                                                                                        ""name"": ""AccountExternalReference"",
+                                                                                        ""fields"": [
+                                                                                          {
+                                                                                            ""name"": ""ExternalRefType"",
+                                                                                            ""type"": [
+                                                                                              ""null"",
+                                                                                              ""string""
+                                                                                            ],
+                                                                                            ""default"": null
+                                                                                          },
+                                                                                          {
+                                                                                            ""name"": ""ExternalRefValue"",
+                                                                                            ""type"": [
+                                                                                              ""null"",
+                                                                                              ""string""
+                                                                                            ],
+                                                                                            ""default"": null
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ],
+                                                                                    ""default"": null
+                                                                                  },
+                                                                                  {
+                                                                                    ""name"": ""CashAccountType"",
+                                                                                    ""type"": [
+                                                                                      ""null"",
+                                                                                      ""string""
+                                                                                    ],
+                                                                                    ""default"": null
+                                                                                  },
+                                                                                  {
+                                                                                    ""name"": ""CashAccountCurrencyCd"",
+                                                                                    ""type"": [
+                                                                                      ""null"",
+                                                                                      ""string""
+                                                                                    ],
+                                                                                    ""default"": null
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ],
+                                                                        ""default"": null
+                                                                      },
+                                                                      {
+                                                                        ""name"": ""Allocation"",
+                                                                        ""type"": [
+                                                                          ""null"",
+                                                                          {
+                                                                            ""type"": ""array"",
+                                                                            ""items"": [
+                                                                              ""null"",
+                                                                              {
+                                                                                ""type"": ""record"",
+                                                                                ""name"": ""Allocation"",
+                                                                                ""fields"": [
+                                                                                  {
+                                                                                    ""name"": ""AllocationReferences"",
+                                                                                    ""type"": [
+                                                                                      ""null"",
+                                                                                      {
+                                                                                        ""type"": ""record"",
+                                                                                        ""name"": ""AllocationReferences"",
+                                                                                        ""fields"": [
+                                                                                          {
+                                                                                            ""name"": ""AllocationReference"",
+                                                                                            ""type"": {
+                                                                                              ""type"": ""array"",
+                                                                                              ""items"": {
+                                                                                                ""type"": ""record"",
+                                                                                                ""name"": ""AllocationReference"",
+                                                                                                ""fields"": [
+                                                                                                  {
+                                                                                                    ""name"": ""ReferenceTypeCd"",
+                                                                                                    ""type"": [
+                                                                                                      ""null"",
+                                                                                                      ""string""
+                                                                                                    ],
+                                                                                                    ""default"": null
+                                                                                                  },
+                                                                                                  {
+                                                                                                    ""name"": ""ReferenceValue"",
+                                                                                                    ""type"": [
+                                                                                                      ""null"",
+                                                                                                      ""string""
+                                                                                                    ],
+                                                                                                    ""default"": null
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ],
+                                                                                    ""default"": null
+                                                                                  },
+                                                                                  {
+                                                                                    ""name"": ""SequenceNumber"",
+                                                                                    ""type"": [
+                                                                                      ""null"",
+                                                                                      ""long""
+                                                                                    ],
+                                                                                    ""default"": null
+                                                                                  },
+                                                                                  {
+                                                                                    ""name"": ""AllocationStatusCd"",
+                                                                                    ""type"": [
+                                                                                      ""null"",
+                                                                                      ""string""
+                                                                                    ],
+                                                                                    ""default"": null
+                                                                                  },
+                                                                                  {
+                                                                                    ""name"": ""Source"",
+                                                                                    ""type"": [
+                                                                                      ""null"",
+                                                                                      ""string""
+                                                                                    ],
+                                                                                    ""default"": null
+                                                                                  },
+                                                                                  {
+                                                                                    ""name"": ""AllocationKeyValues"",
+                                                                                    ""type"": [
+                                                                                      ""null"",
+                                                                                      {
+                                                                                        ""type"": ""record"",
+                                                                                        ""name"": ""AllocationKeyValues"",
+                                                                                        ""namespace"": ""com.capgroup.inavacc.allocation.keyvalue"",
+                                                                                        ""fields"": [
+                                                                                          {
+                                                                                            ""name"": ""AllocationKeyValue"",
+                                                                                            ""type"": [
+                                                                                              ""null"",
+                                                                                              {
+                                                                                                ""type"": ""array"",
+                                                                                                ""items"": [
+                                                                                                  ""null"",
+                                                                                                  {
+                                                                                                    ""type"": ""record"",
+                                                                                                    ""name"": ""AllocationKeyValue"",
+                                                                                                    ""fields"": [
+                                                                                                      {
+                                                                                                        ""name"": ""Key"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""string""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""Value"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""string""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""Value2"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""double""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""Value3"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""double""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ],
+                                                                                    ""default"": null
+                                                                                  },
+                                                                                  {
+                                                                                    ""name"": ""ContractualCashSettlementFlag"",
+                                                                                    ""type"": [
+                                                                                      ""null"",
+                                                                                      ""string""
+                                                                                    ],
+                                                                                    ""default"": null
+                                                                                  },
+                                                                                  {
+                                                                                    ""name"": ""ContractualStockSettlementFlag"",
+                                                                                    ""type"": [
+                                                                                      ""null"",
+                                                                                      ""string""
+                                                                                    ],
+                                                                                    ""default"": null
+                                                                                  },
+                                                                                  {
+                                                                                    ""name"": ""TransactionTypeCd"",
+                                                                                    ""type"": [
+                                                                                      ""null"",
+                                                                                      ""string""
+                                                                                    ],
+                                                                                    ""default"": null
+                                                                                  },
+                                                                                  {
+                                                                                    ""name"": ""ExpectedSettlementDate"",
+                                                                                    ""type"": [
+                                                                                      ""null"",
+                                                                                      ""string""
+                                                                                    ],
+                                                                                    ""default"": null
+                                                                                  },
+                                                                                  {
+                                                                                    ""name"": ""OverrideSettlementDate"",
+                                                                                    ""type"": [
+                                                                                      ""null"",
+                                                                                      ""string""
+                                                                                    ],
+                                                                                    ""default"": null
+                                                                                  },
+                                                                                  {
+                                                                                    ""name"": ""ElectionId"",
+                                                                                    ""type"": [
+                                                                                      ""null"",
+                                                                                      ""long""
+                                                                                    ],
+                                                                                    ""default"": null
+                                                                                  },
+                                                                                  {
+                                                                                    ""name"": ""ElectionDetails"",
+                                                                                    ""type"": [
+                                                                                      ""null"",
+                                                                                      {
+                                                                                        ""type"": ""record"",
+                                                                                        ""name"": ""ElectionDetails"",
+                                                                                        ""namespace"": ""com.capgroup.inavacc.allocation.electiondetails"",
+                                                                                        ""fields"": [
+                                                                                          {
+                                                                                            ""name"": ""ElectionDetail"",
+                                                                                            ""type"": [
+                                                                                              ""null"",
+                                                                                              {
+                                                                                                ""type"": ""array"",
+                                                                                                ""items"": [
+                                                                                                  ""null"",
+                                                                                                  {
+                                                                                                    ""type"": ""record"",
+                                                                                                    ""name"": ""ElectionDetail"",
+                                                                                                    ""fields"": [
+                                                                                                      {
+                                                                                                        ""name"": ""ElectionDetailId"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""long""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""ElectionQuantity"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""double""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ],
+                                                                                    ""default"": null
+                                                                                  },
+                                                                                  {
+                                                                                    ""name"": ""BlockingPositionId"",
+                                                                                    ""type"": [
+                                                                                      ""null"",
+                                                                                      ""long""
+                                                                                    ],
+                                                                                    ""default"": null
+                                                                                  },
+                                                                                  {
+                                                                                    ""name"": ""FXRequestId"",
+                                                                                    ""type"": [
+                                                                                      ""null"",
+                                                                                      ""long""
+                                                                                    ],
+                                                                                    ""default"": null
+                                                                                  },
+                                                                                  {
+                                                                                    ""name"": ""ApportionedPosition"",
+                                                                                    ""type"": [
+                                                                                      ""null"",
+                                                                                      ""double""
+                                                                                    ],
+                                                                                    ""default"": null
+                                                                                  },
+                                                                                  {
+                                                                                    ""name"": ""PositionType"",
+                                                                                    ""type"": [
+                                                                                      ""null"",
+                                                                                      ""string""
+                                                                                    ],
+                                                                                    ""default"": null
+                                                                                  },
+                                                                                  {
+                                                                                    ""name"": ""ClaimAssociation"",
+                                                                                    ""type"": [
+                                                                                      ""null"",
+                                                                                      ""string""
+                                                                                    ],
+                                                                                    ""default"": null
+                                                                                  },
+                                                                                  {
+                                                                                    ""name"": ""TradeReference"",
+                                                                                    ""type"": [
+                                                                                      ""null"",
+                                                                                      {
+                                                                                        ""type"": ""array"",
+                                                                                        ""items"": [
+                                                                                          ""null"",
+                                                                                          {
+                                                                                            ""type"": ""record"",
+                                                                                            ""name"": ""TradeReference"",
+                                                                                            ""fields"": [
+                                                                                              {
+                                                                                                ""name"": ""ReferenceTypeCd"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  ""string""
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              },
+                                                                                              {
+                                                                                                ""name"": ""ReferenceValue"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  ""string""
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ],
+                                                                                    ""default"": null
+                                                                                  },
+                                                                                  {
+                                                                                    ""name"": ""Counterparty"",
+                                                                                    ""type"": [
+                                                                                      ""null"",
+                                                                                      {
+                                                                                        ""type"": ""array"",
+                                                                                        ""items"": [
+                                                                                          ""null"",
+                                                                                          {
+                                                                                            ""type"": ""record"",
+                                                                                            ""name"": ""Counterparty"",
+                                                                                            ""fields"": [
+                                                                                              {
+                                                                                                ""name"": ""ExternalRefType"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  ""string""
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              },
+                                                                                              {
+                                                                                                ""name"": ""ExternalRefValue"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  ""string""
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ],
+                                                                                    ""default"": null
+                                                                                  },
+                                                                                  {
+                                                                                    ""name"": ""IPExternalReferences"",
+                                                                                    ""type"": [
+                                                                                      ""null"",
+                                                                                      {
+                                                                                        ""type"": ""record"",
+                                                                                        ""name"": ""IPExternalReferences"",
+                                                                                        ""namespace"": ""com.capgroup.option.ipexternalreferences"",
+                                                                                        ""fields"": [
+                                                                                          {
+                                                                                            ""name"": ""ExternalReference"",
+                                                                                            ""type"": [
+                                                                                              ""null"",
+                                                                                              {
+                                                                                                ""type"": ""array"",
+                                                                                                ""items"": [
+                                                                                                  ""null"",
+                                                                                                  {
+                                                                                                    ""type"": ""record"",
+                                                                                                    ""name"": ""ExternalReference"",
+                                                                                                    ""fields"": [
+                                                                                                      {
+                                                                                                        ""name"": ""ExternalReferenceType"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""string""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""ExternalReferenceValue"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""double""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ],
+                                                                                    ""default"": null
+                                                                                  },
+                                                                                  {
+                                                                                    ""name"": ""RoleTypeCd"",
+                                                                                    ""type"": [
+                                                                                      ""null"",
+                                                                                      ""string""
+                                                                                    ],
+                                                                                    ""default"": null
+                                                                                  },
+                                                                                  {
+                                                                                    ""name"": ""CashMovement"",
+                                                                                    ""type"": [
+                                                                                      ""null"",
+                                                                                      {
+                                                                                        ""type"": ""array"",
+                                                                                        ""items"": [
+                                                                                          ""null"",
+                                                                                          {
+                                                                                            ""type"": ""record"",
+                                                                                            ""name"": ""CashMovement"",
+                                                                                            ""fields"": [
+                                                                                              {
+                                                                                                ""name"": ""CashMovementId"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  ""long""
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              },
+                                                                                              {
+                                                                                                ""name"": ""Rate"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  ""double""
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              },
+                                                                                              {
+                                                                                                ""name"": ""CreditDebitIndicator"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  ""string""
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              },
+                                                                                              {
+                                                                                                ""name"": ""CashAmounts"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  {
+                                                                                                    ""type"": ""record"",
+                                                                                                    ""name"": ""CashAmounts"",
+                                                                                                    ""namespace"": ""com.capgroup.invaccount.cashmove.cashmmounts"",
+                                                                                                    ""fields"": [
+                                                                                                      {
+                                                                                                        ""name"": ""TradeAmount"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          {
+                                                                                                            ""type"": ""record"",
+                                                                                                            ""name"": ""TradeAmount"",
+                                                                                                            ""fields"": [
+                                                                                                              {
+                                                                                                                ""name"": ""CustodianNetAmount"",
+                                                                                                                ""type"": [
+                                                                                                                  ""null"",
+                                                                                                                  ""double""
+                                                                                                                ],
+                                                                                                                ""default"": null
+                                                                                                              },
+                                                                                                              {
+                                                                                                                ""name"": ""NetAmount"",
+                                                                                                                ""type"": [
+                                                                                                                  ""null"",
+                                                                                                                  ""double""
+                                                                                                                ],
+                                                                                                                ""default"": null
+                                                                                                              },
+                                                                                                              {
+                                                                                                                ""name"": ""GrossAmount"",
+                                                                                                                ""type"": [
+                                                                                                                  ""null"",
+                                                                                                                  ""double""
+                                                                                                                ],
+                                                                                                                ""default"": null
+                                                                                                              },
+                                                                                                              {
+                                                                                                                ""name"": ""Currency"",
+                                                                                                                ""type"": [
+                                                                                                                  ""null"",
+                                                                                                                  ""string""
+                                                                                                                ],
+                                                                                                                ""default"": null
+                                                                                                              }
+                                                                                                            ]
+                                                                                                          }
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""TradeToSettlementFxRate"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""double""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""CustodianPaymentAmount"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          {
+                                                                                                            ""type"": ""array"",
+                                                                                                            ""items"": [
+                                                                                                              ""null"",
+                                                                                                              {
+                                                                                                                ""type"": ""record"",
+                                                                                                                ""name"": ""CustodianPaymentAmount"",
+                                                                                                                ""namespace"": ""com.capgroup.invaccount.custpayamount"",
+                                                                                                                ""fields"": [
+                                                                                                                  {
+                                                                                                                    ""name"": ""CustodianPaymentCurrency"",
+                                                                                                                    ""type"": [
+                                                                                                                      ""null"",
+                                                                                                                      ""string""
+                                                                                                                    ],
+                                                                                                                    ""default"": null
+                                                                                                                  },
+                                                                                                                  {
+                                                                                                                    ""name"": ""SettlementAmountInCustodianCurrency"",
+                                                                                                                    ""type"": [
+                                                                                                                      ""null"",
+                                                                                                                      ""double""
+                                                                                                                    ],
+                                                                                                                    ""default"": null
+                                                                                                                  },
+                                                                                                                  {
+                                                                                                                    ""name"": ""CustodianPaymentToSettlementFxRate"",
+                                                                                                                    ""type"": [
+                                                                                                                      ""null"",
+                                                                                                                      ""double""
+                                                                                                                    ],
+                                                                                                                    ""default"": null
+                                                                                                                  },
+                                                                                                                  {
+                                                                                                                    ""name"": ""CustodianPaymentToTradeFxRate"",
+                                                                                                                    ""type"": [
+                                                                                                                      ""null"",
+                                                                                                                      ""double""
+                                                                                                                    ],
+                                                                                                                    ""default"": null
+                                                                                                                  }
+                                                                                                                ]
+                                                                                                              }
+                                                                                                            ]
+                                                                                                          }
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""SettlementAmount"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          {
+                                                                                                            ""type"": ""record"",
+                                                                                                            ""name"": ""SettlementAmount"",
+                                                                                                            ""fields"": [
+                                                                                                              {
+                                                                                                                ""name"": ""NetAmount"",
+                                                                                                                ""type"": [
+                                                                                                                  ""null"",
+                                                                                                                  ""double""
+                                                                                                                ],
+                                                                                                                ""default"": null
+                                                                                                              },
+                                                                                                              {
+                                                                                                                ""name"": ""AggregatedSettledAmount"",
+                                                                                                                ""type"": [
+                                                                                                                  ""null"",
+                                                                                                                  ""double""
+                                                                                                                ],
+                                                                                                                ""default"": null
+                                                                                                              },
+                                                                                                              {
+                                                                                                                ""name"": ""RemainingSettlementAmount"",
+                                                                                                                ""type"": [
+                                                                                                                  ""null"",
+                                                                                                                  ""double""
+                                                                                                                ],
+                                                                                                                ""default"": null
+                                                                                                              },
+                                                                                                              {
+                                                                                                                ""name"": ""Currency"",
+                                                                                                                ""type"": [
+                                                                                                                  ""null"",
+                                                                                                                  ""string""
+                                                                                                                ],
+                                                                                                                ""default"": null
+                                                                                                              }
+                                                                                                            ]
+                                                                                                          }
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ],
+                                                                                    ""default"": null
+                                                                                  },
+                                                                                  {
+                                                                                    ""name"": ""SecurityMovement"",
+                                                                                    ""type"": [
+                                                                                      ""null"",
+                                                                                      {
+                                                                                        ""type"": ""array"",
+                                                                                        ""items"": [
+                                                                                          ""null"",
+                                                                                          {
+                                                                                            ""type"": ""record"",
+                                                                                            ""name"": ""SecurityMovement"",
+                                                                                            ""fields"": [
+                                                                                              {
+                                                                                                ""name"": ""SecurityMovementId"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  ""long""
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              },
+                                                                                              {
+                                                                                                ""name"": ""StockDirectionInd"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  ""string""
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              },
+                                                                                              {
+                                                                                                ""name"": ""SecurityQuantity"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  ""double""
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              },
+                                                                                              {
+                                                                                                ""name"": ""AggregatedSettledSecurityQuantity"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  ""double""
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              },
+                                                                                              {
+                                                                                                ""name"": ""RemainingSettlementSecurityQuantity"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  ""double""
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              },
+                                                                                              {
+                                                                                                ""name"": ""CostPriceSecurityCurrency"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  ""double""
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              },
+                                                                                              {
+                                                                                                ""name"": ""PriceInTradeCurrency"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  ""double""
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              },
+                                                                                              {
+                                                                                                ""name"": ""SecurityDetails"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  {
+                                                                                                    ""type"": ""record"",
+                                                                                                    ""name"": ""SecurityDetails"",
+                                                                                                    ""fields"": [
+                                                                                                      {
+                                                                                                        ""name"": ""IssueCountryCd"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""string""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""IssueCurrencyCd"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""string""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""SecurityExternalReferences"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          {
+                                                                                                            ""type"": ""record"",
+                                                                                                            ""name"": ""SecurityExternalReferences"",
+                                                                                                            ""fields"": [
+                                                                                                              {
+                                                                                                                ""name"": ""SecurityExternalReference"",
+                                                                                                                ""type"": [
+                                                                                                                  {
+                                                                                                                    ""type"": ""array"",
+                                                                                                                    ""items"": {
+                                                                                                                      ""type"": ""record"",
+                                                                                                                      ""name"": ""SecurityExternalReference"",
+                                                                                                                      ""fields"": [
+                                                                                                                        {
+                                                                                                                          ""name"": ""SecurityIdentifierTypeCd"",
+                                                                                                                          ""type"": [
+                                                                                                                            ""null"",
+                                                                                                                            ""string""
+                                                                                                                          ],
+                                                                                                                          ""default"": null
+                                                                                                                        },
+                                                                                                                        {
+                                                                                                                          ""name"": ""SecurityIdentifierValue"",
+                                                                                                                          ""type"": [
+                                                                                                                            ""null"",
+                                                                                                                            ""string""
+                                                                                                                          ],
+                                                                                                                          ""default"": null
+                                                                                                                        }
+                                                                                                                      ]
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                ]
+                                                                                                              }
+                                                                                                            ]
+                                                                                                          }
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""ReportingClassificationGroups"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          {
+                                                                                                            ""type"": ""record"",
+                                                                                                            ""name"": ""ReportingClassificationGroups"",
+                                                                                                            ""fields"": [
+                                                                                                              {
+                                                                                                                ""name"": ""ReportingClassificationGroup"",
+                                                                                                                ""type"": [
+                                                                                                                  {
+                                                                                                                    ""type"": ""array"",
+                                                                                                                    ""items"": {
+                                                                                                                      ""type"": ""record"",
+                                                                                                                      ""name"": ""ReportingClassificationGroup"",
+                                                                                                                      ""fields"": [
+                                                                                                                        {
+                                                                                                                          ""name"": ""ReportingClassificationGroupId"",
+                                                                                                                          ""type"": [
+                                                                                                                            ""null"",
+                                                                                                                            ""long""
+                                                                                                                          ],
+                                                                                                                          ""default"": null
+                                                                                                                        },
+                                                                                                                        {
+                                                                                                                          ""name"": ""ReportingClassificationGroupName"",
+                                                                                                                          ""type"": [
+                                                                                                                            ""null"",
+                                                                                                                            ""string""
+                                                                                                                          ],
+                                                                                                                          ""default"": null
+                                                                                                                        },
+                                                                                                                        {
+                                                                                                                          ""name"": ""ValueId"",
+                                                                                                                          ""type"": [
+                                                                                                                            ""null"",
+                                                                                                                            ""long""
+                                                                                                                          ],
+                                                                                                                          ""default"": null
+                                                                                                                        },
+                                                                                                                        {
+                                                                                                                          ""name"": ""ValueName"",
+                                                                                                                          ""type"": [
+                                                                                                                            ""null"",
+                                                                                                                            ""string""
+                                                                                                                          ],
+                                                                                                                          ""default"": null
+                                                                                                                        },
+                                                                                                                        {
+                                                                                                                          ""name"": ""ValueCode"",
+                                                                                                                          ""type"": [
+                                                                                                                            ""null"",
+                                                                                                                            ""string""
+                                                                                                                          ],
+                                                                                                                          ""default"": null
+                                                                                                                        },
+                                                                                                                        {
+                                                                                                                          ""name"": ""ValueSequence"",
+                                                                                                                          ""type"": [
+                                                                                                                            ""null"",
+                                                                                                                            ""string""
+                                                                                                                          ],
+                                                                                                                          ""default"": null
+                                                                                                                        }
+                                                                                                                      ]
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                ]
+                                                                                                              }
+                                                                                                            ]
+                                                                                                          }
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              },
+                                                                                              {
+                                                                                                ""name"": ""CashAmounts"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  {
+                                                                                                    ""type"": ""record"",
+                                                                                                    ""name"": ""CashAmounts"",
+                                                                                                    ""namespace"": ""com.capgroup.custaccount.cashmmounts"",
+                                                                                                    ""fields"": [
+                                                                                                      {
+                                                                                                        ""name"": ""TradeAmount"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          {
+                                                                                                            ""type"": ""record"",
+                                                                                                            ""name"": ""TradeAmount"",
+                                                                                                            ""fields"": [
+                                                                                                              {
+                                                                                                                ""name"": ""CustodianNetAmount"",
+                                                                                                                ""type"": [
+                                                                                                                  ""null"",
+                                                                                                                  ""double""
+                                                                                                                ],
+                                                                                                                ""default"": null
+                                                                                                              },
+                                                                                                              {
+                                                                                                                ""name"": ""NetAmount"",
+                                                                                                                ""type"": [
+                                                                                                                  ""null"",
+                                                                                                                  ""double""
+                                                                                                                ],
+                                                                                                                ""default"": null
+                                                                                                              },
+                                                                                                              {
+                                                                                                                ""name"": ""GrossAmount"",
+                                                                                                                ""type"": [
+                                                                                                                  ""null"",
+                                                                                                                  ""double""
+                                                                                                                ],
+                                                                                                                ""default"": null
+                                                                                                              },
+                                                                                                              {
+                                                                                                                ""name"": ""Currency"",
+                                                                                                                ""type"": [
+                                                                                                                  ""null"",
+                                                                                                                  ""string""
+                                                                                                                ],
+                                                                                                                ""default"": null
+                                                                                                              }
+                                                                                                            ]
+                                                                                                          }
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""TradeToSettlementFxRate"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""double""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""CustodianPaymentAmount"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          {
+                                                                                                            ""type"": ""array"",
+                                                                                                            ""items"": [
+                                                                                                              ""null"",
+                                                                                                              {
+                                                                                                                ""type"": ""record"",
+                                                                                                                ""name"": ""CustodianPaymentAmount"",
+                                                                                                                ""fields"": [
+                                                                                                                  {
+                                                                                                                    ""name"": ""CustodianPaymentCurrency"",
+                                                                                                                    ""type"": [
+                                                                                                                      ""null"",
+                                                                                                                      ""string""
+                                                                                                                    ],
+                                                                                                                    ""default"": null
+                                                                                                                  },
+                                                                                                                  {
+                                                                                                                    ""name"": ""SettlementAmountInCustodianCurrency"",
+                                                                                                                    ""type"": [
+                                                                                                                      ""null"",
+                                                                                                                      ""string""
+                                                                                                                    ],
+                                                                                                                    ""default"": null
+                                                                                                                  },
+                                                                                                                  {
+                                                                                                                    ""name"": ""CustodianPaymentToSettlementFxRate"",
+                                                                                                                    ""type"": [
+                                                                                                                      ""null"",
+                                                                                                                      ""string""
+                                                                                                                    ],
+                                                                                                                    ""default"": null
+                                                                                                                  },
+                                                                                                                  {
+                                                                                                                    ""name"": ""CustodianPaymentToTradeFxRate"",
+                                                                                                                    ""type"": [
+                                                                                                                      ""null"",
+                                                                                                                      ""string""
+                                                                                                                    ],
+                                                                                                                    ""default"": null
+                                                                                                                  }
+                                                                                                                ]
+                                                                                                              }
+                                                                                                            ]
+                                                                                                          }
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""SettlementAmount"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          {
+                                                                                                            ""type"": ""record"",
+                                                                                                            ""name"": ""SettlementAmount"",
+                                                                                                            ""fields"": [
+                                                                                                              {
+                                                                                                                ""name"": ""NetAmount"",
+                                                                                                                ""type"": [
+                                                                                                                  ""null"",
+                                                                                                                  ""double""
+                                                                                                                ],
+                                                                                                                ""default"": null
+                                                                                                              },
+                                                                                                              {
+                                                                                                                ""name"": ""AggregatedSettledAmount"",
+                                                                                                                ""type"": [
+                                                                                                                  ""null"",
+                                                                                                                  ""double""
+                                                                                                                ],
+                                                                                                                ""default"": null
+                                                                                                              },
+                                                                                                              {
+                                                                                                                ""name"": ""RemainingSettlementAmount"",
+                                                                                                                ""type"": [
+                                                                                                                  ""null"",
+                                                                                                                  ""double""
+                                                                                                                ],
+                                                                                                                ""default"": null
+                                                                                                              },
+                                                                                                              {
+                                                                                                                ""name"": ""Currency"",
+                                                                                                                ""type"": [
+                                                                                                                  ""null"",
+                                                                                                                  ""string""
+                                                                                                                ],
+                                                                                                                ""default"": null
+                                                                                                              },
+                                                                                                              {
+                                                                                                                ""name"": ""SettlementAmountDifference"",
+                                                                                                                ""type"": [
+                                                                                                                  ""null"",
+                                                                                                                  ""double""
+                                                                                                                ],
+                                                                                                                ""default"": null
+                                                                                                              }
+                                                                                                            ]
+                                                                                                          }
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ],
+                                                                                    ""default"": null
+                                                                                  },
+                                                                                  {
+                                                                                    ""name"": ""BookCost"",
+                                                                                    ""type"": [
+                                                                                      ""null"",
+                                                                                      {
+                                                                                        ""type"": ""array"",
+                                                                                        ""items"": [
+                                                                                          ""null"",
+                                                                                          {
+                                                                                            ""type"": ""record"",
+                                                                                            ""name"": ""BookCost"",
+                                                                                            ""fields"": [
+                                                                                              {
+                                                                                                ""name"": ""BookCostIsEstimateFlag"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  ""string""
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              },
+                                                                                              {
+                                                                                                ""name"": ""CleanBookCostInBaseCurr"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  ""double""
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              },
+                                                                                              {
+                                                                                                ""name"": ""CleanBookCostInSecCurr"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  ""double""
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              },
+                                                                                              {
+                                                                                                ""name"": ""DirtyBookCostInBaseCurr"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  ""double""
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              },
+                                                                                              {
+                                                                                                ""name"": ""DirtyBookCostInSecCurr"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  ""double""
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              },
+                                                                                              {
+                                                                                                ""name"": ""TradeToSecFxRate"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  ""double""
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              },
+                                                                                              {
+                                                                                                ""name"": ""TradeToBaseFxRate"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  ""double""
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              },
+                                                                                              {
+                                                                                                ""name"": ""ClientBaseCurrency"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  ""string""
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              },
+                                                                                              {
+                                                                                                ""name"": ""BookCostCurr"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  ""string""
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              },
+                                                                                              {
+                                                                                                ""name"": ""DirtyBookCostInBookCostCurr"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  ""double""
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              },
+                                                                                              {
+                                                                                                ""name"": ""CleanBookCostInBookCostCurr"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  ""double""
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ],
+                                                                                    ""default"": null
+                                                                                  },
+                                                                                  {
+                                                                                    ""name"": ""Charges"",
+                                                                                    ""type"": [
+                                                                                      ""null"",
+                                                                                      {
+                                                                                        ""type"": ""record"",
+                                                                                        ""name"": ""Charges"",
+                                                                                        ""namespace"": ""com.capgroup.invacc.Charges"",
+                                                                                        ""fields"": [
+                                                                                          {
+                                                                                            ""name"": ""Charge"",
+                                                                                            ""type"": [
+                                                                                              ""null"",
+                                                                                              {
+                                                                                                ""type"": ""array"",
+                                                                                                ""items"": [
+                                                                                                  ""null"",
+                                                                                                  {
+                                                                                                    ""type"": ""record"",
+                                                                                                    ""name"": ""Charge"",
+                                                                                                    ""fields"": [
+                                                                                                      {
+                                                                                                        ""name"": ""ChargeId"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""long""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""ChargeClassificationType"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""string""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""ChargeCategoryCd"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""string""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""ChargeCd"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""string""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""ChargeableQuantity"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""double""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""ChargeCurrencyCd"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""string""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""ChargeableAmount"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""double""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""RateCd"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""double""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""ChargeRateTypeCd"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""string""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""ChargeRate"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""double""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""VatRate"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""double""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""VatTypeCd"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""string""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""VatAmount"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""double""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""GrossChargeAmount"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""double""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""ChargeAmount"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""double""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""ChargeSourceCd"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""string""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""ChargeOriginCd"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""string""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""ApplyChargeAsCd"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""string""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""EstimateFlag"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""string""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""ReportableOnly"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""string""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""ReclaimFlag"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""string""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""ReclaimChargeRate"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""double""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""ChargeReference"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""string""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""QualifierCd"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""string""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""NationalCurrencyCd"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""string""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""NationalChargeableAmount"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""double""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""NationalChargeAmount"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""double""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""TradeToNationalFxRate"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""double""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""ReclaimableChargeRate"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""double""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""NonReclaimableChargeRate"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""double""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""AppliedNetRate"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""double""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""ReclaimableChargeAmount"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""double""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""NonReclaimableChargeAmount"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""double""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ],
+                                                                                    ""default"": null
+                                                                                  },
+                                                                                  {
+                                                                                    ""name"": ""SettlementDetails"",
+                                                                                    ""type"": [
+                                                                                      ""null"",
+                                                                                      {
+                                                                                        ""type"": ""record"",
+                                                                                        ""name"": ""SettlementDetails"",
+                                                                                        ""fields"": [
+                                                                                          {
+                                                                                            ""name"": ""SettlementDetail"",
+                                                                                            ""type"": [
+                                                                                              ""null"",
+                                                                                              {
+                                                                                                ""type"": ""array"",
+                                                                                                ""items"": [
+                                                                                                  ""null"",
+                                                                                                  {
+                                                                                                    ""type"": ""record"",
+                                                                                                    ""name"": ""SettlementDetail"",
+                                                                                                    ""fields"": [
+                                                                                                      {
+                                                                                                        ""name"": ""CreationDate"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""string""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""StatusId"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""long""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""AllocationStatusCd"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""string""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""StatusActionCd"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""string""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""CashValueDate"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""string""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""CashPostingDate"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""string""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""SettlementAmount"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""double""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""AggregatedSettledAmount"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""double""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""RemainingSettlementAmount"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""double""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""StockValueDate"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""string""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""StockPostingDate"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""string""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""SettlementSecurityQuantity"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""double""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""AggregatedSettledSecurityQuantity"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""double""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""RemainingSettlementSecurityQuantity"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""double""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""Charges"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          {
+                                                                                                            ""type"": ""record"",
+                                                                                                            ""name"": ""Charges"",
+                                                                                                            ""namespace"": ""com.capgroup.option.settlements.charges"",
+                                                                                                            ""fields"": [
+                                                                                                              {
+                                                                                                                ""name"": ""Charge"",
+                                                                                                                ""type"": [
+                                                                                                                  {
+                                                                                                                    ""type"": ""array"",
+                                                                                                                    ""items"": {
+                                                                                                                      ""type"": ""record"",
+                                                                                                                      ""name"": ""Charge"",
+                                                                                                                      ""fields"": [
+                                                                                                                        {
+                                                                                                                          ""name"": ""ChargeId"",
+                                                                                                                          ""type"": [
+                                                                                                                            ""null"",
+                                                                                                                            ""long""
+                                                                                                                          ],
+                                                                                                                          ""default"": null
+                                                                                                                        },
+                                                                                                                        {
+                                                                                                                          ""name"": ""SettlementChargeAmount"",
+                                                                                                                          ""type"": [
+                                                                                                                            ""null"",
+                                                                                                                            ""double""
+                                                                                                                          ],
+                                                                                                                          ""default"": null
+                                                                                                                        }
+                                                                                                                      ]
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                ]
+                                                                                                              }
+                                                                                                            ]
+                                                                                                          }
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""ReasonCd"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""double""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""Comments"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""string""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ],
+                                                                                    ""default"": null
+                                                                                  },
+                                                                                  {
+                                                                                    ""name"": ""CashAccount"",
+                                                                                    ""type"": [
+                                                                                      ""null"",
+                                                                                      {
+                                                                                        ""type"": ""array"",
+                                                                                        ""items"": [
+                                                                                          ""null"",
+                                                                                          {
+                                                                                            ""type"": ""record"",
+                                                                                            ""name"": ""CashAccount"",
+                                                                                            ""namespace"": ""com.capgroup.invinst.cashaccount"",
+                                                                                            ""fields"": [
+                                                                                              {
+                                                                                                ""name"": ""AccountExternalReference"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  {
+                                                                                                    ""type"": ""record"",
+                                                                                                    ""name"": ""AccountExternalReference"",
+                                                                                                    ""fields"": [
+                                                                                                      {
+                                                                                                        ""name"": ""ExternalRefType"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""string""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""ExternalRefValue"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""string""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              },
+                                                                                              {
+                                                                                                ""name"": ""CashAccountType"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  ""string""
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              },
+                                                                                              {
+                                                                                                ""name"": ""CashAccountCurrencyCd"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  ""string""
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ],
+                                                                                    ""default"": null
+                                                                                  },
+                                                                                  {
+                                                                                    ""name"": ""BeneficialOwnerDetail"",
+                                                                                    ""type"": [
+                                                                                      ""null"",
+                                                                                      {
+                                                                                        ""type"": ""array"",
+                                                                                        ""items"": [
+                                                                                          ""null"",
+                                                                                          {
+                                                                                            ""type"": ""record"",
+                                                                                            ""name"": ""BeneficialOwnerDetail"",
+                                                                                            ""fields"": [
+                                                                                              {
+                                                                                                ""name"": ""BeneficialOwnerId"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  ""long""
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              },
+                                                                                              {
+                                                                                                ""name"": ""QuantityOfSecuritiesHeld"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  ""double""
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              },
+                                                                                              {
+                                                                                                ""name"": ""TaxResidency"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  ""double""
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              },
+                                                                                              {
+                                                                                                ""name"": ""TaxRate"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  ""double""
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              },
+                                                                                              {
+                                                                                                ""name"": ""ClientReference"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  ""string""
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              },
+                                                                                              {
+                                                                                                ""name"": ""ClaimTypeCd"",
+                                                                                                ""type"": [
+                                                                                                  ""null"",
+                                                                                                  ""string""
+                                                                                                ],
+                                                                                                ""default"": null
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ],
+                                                                                    ""default"": null
+                                                                                  },
+                                                                                  {
+                                                                                    ""name"": ""SubPosAdjustments"",
+                                                                                    ""type"": [
+                                                                                      ""null"",
+                                                                                      {
+                                                                                        ""type"": ""record"",
+                                                                                        ""name"": ""SubPosAdjustments"",
+                                                                                        ""namespace"": ""com.capgroup.option.subposadjustments"",
+                                                                                        ""fields"": [
+                                                                                          {
+                                                                                            ""name"": ""SubPosAdjustment"",
+                                                                                            ""type"": [
+                                                                                              ""null"",
+                                                                                              {
+                                                                                                ""type"": ""array"",
+                                                                                                ""items"": [
+                                                                                                  ""null"",
+                                                                                                  {
+                                                                                                    ""type"": ""record"",
+                                                                                                    ""name"": ""SubPosAdjustment"",
+                                                                                                    ""fields"": [
+                                                                                                      {
+                                                                                                        ""name"": ""AdjustmentReferences"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          {
+                                                                                                            ""type"": ""record"",
+                                                                                                            ""name"": ""AdjustmentReferences"",
+                                                                                                            ""fields"": [
+                                                                                                              {
+                                                                                                                ""name"": ""AdjustmentReference"",
+                                                                                                                ""type"": [
+                                                                                                                  ""null"",
+                                                                                                                  {
+                                                                                                                    ""type"": ""array"",
+                                                                                                                    ""items"": [
+                                                                                                                      ""null"",
+                                                                                                                      {
+                                                                                                                        ""type"": ""record"",
+                                                                                                                        ""name"": ""AdjustmentReference"",
+                                                                                                                        ""fields"": [
+                                                                                                                          {
+                                                                                                                            ""name"": ""ExternalReferenceType"",
+                                                                                                                            ""type"": [
+                                                                                                                              ""null"",
+                                                                                                                              ""string""
+                                                                                                                            ],
+                                                                                                                            ""default"": null
+                                                                                                                          },
+                                                                                                                          {
+                                                                                                                            ""name"": ""ExternalReferenceValue"",
+                                                                                                                            ""type"": [
+                                                                                                                              ""null"",
+                                                                                                                              ""string""
+                                                                                                                            ],
+                                                                                                                            ""default"": null
+                                                                                                                          }
+                                                                                                                        ]
+                                                                                                                      }
+                                                                                                                    ]
+                                                                                                                  }
+                                                                                                                ]
+                                                                                                              }
+                                                                                                            ]
+                                                                                                          }
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""InterestedPartyDetails"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          {
+                                                                                                            ""type"": ""record"",
+                                                                                                            ""name"": ""InterestedPartyDetails"",
+                                                                                                            ""fields"": [
+                                                                                                              {
+                                                                                                                ""name"": ""ExternalReferences"",
+                                                                                                                ""type"": [
+                                                                                                                  ""null"",
+                                                                                                                  {
+                                                                                                                    ""type"": ""record"",
+                                                                                                                    ""name"": ""ExternalReferences"",
+                                                                                                                    ""fields"": [
+                                                                                                                      {
+                                                                                                                        ""name"": ""ExternalReference"",
+                                                                                                                        ""type"": {
+                                                                                                                          ""type"": ""array"",
+                                                                                                                          ""items"": {
+                                                                                                                            ""type"": ""record"",
+                                                                                                                            ""name"": ""ExternalReference"",
+                                                                                                                            ""fields"": [
+                                                                                                                              {
+                                                                                                                                ""name"": ""ExternalReferenceType"",
+                                                                                                                                ""type"": [
+                                                                                                                                  ""null"",
+                                                                                                                                  ""long""
+                                                                                                                                ],
+                                                                                                                                ""default"": null
+                                                                                                                              },
+                                                                                                                              {
+                                                                                                                                ""name"": ""ExternalReferenceValue"",
+                                                                                                                                ""type"": [
+                                                                                                                                  ""null"",
+                                                                                                                                  ""double""
+                                                                                                                                ],
+                                                                                                                                ""default"": null
+                                                                                                                              }
+                                                                                                                            ]
+                                                                                                                          }
+                                                                                                                        }
+                                                                                                                      }
+                                                                                                                    ]
+                                                                                                                  }
+                                                                                                                ],
+                                                                                                                ""default"": null
+                                                                                                              }
+                                                                                                            ]
+                                                                                                          }
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""RoleTypeCd"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""string""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""SubPositionTypeCd"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""double""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""Quantity"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""double""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""CreditDebitIndicator"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""string""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      },
+                                                                                                      {
+                                                                                                        ""name"": ""EndDate"",
+                                                                                                        ""type"": [
+                                                                                                          ""null"",
+                                                                                                          ""string""
+                                                                                                        ],
+                                                                                                        ""default"": null
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ],
+                                                                                    ""default"": null
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ],
+                                                    ""default"": null
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ],
+                              ""default"": null
+                            }
+                          ]
+                        }
+                      ],
+                      ""default"": null
+                    },
+                    {
+                      ""name"": ""OwnerDetails"",
+                      ""type"": [
+                        ""null"",
+                        {
+                          ""type"": ""record"",
+                          ""name"": ""OwnerDetails"",
+                          ""fields"": [
+                            {
+                              ""name"": ""Team"",
+                              ""type"": [
+                                ""null"",
+                                {
+                                  ""type"": ""record"",
+                                  ""name"": ""Team"",
+                                  ""fields"": [
+                                    {
+                                      ""name"": ""TeamName"",
+                                      ""type"": [
+                                        ""null"",
+                                        ""string""
+                                      ],
+                                      ""default"": null
+                                    }
+                                  ]
+                                }
+                              ],
+                              ""default"": null
+                            },
+                            {
+                              ""name"": ""Executive"",
+                              ""type"": [
+                                ""null"",
+                                {
+                                  ""type"": ""record"",
+                                  ""name"": ""Executive"",
+                                  ""fields"": [
+                                    {
+                                      ""name"": ""LoginName"",
+                                      ""type"": [
+                                        ""null"",
+                                        ""string""
+                                      ],
+                                      ""default"": null
+                                    }
+                                  ]
+                                }
+                              ],
+                              ""default"": null
+                            }
+                          ]
+                        }
+                      ],
+                      ""default"": null
+                    }
+                  ]
+                }
+              ],
+              ""default"": null
+            }
+          ]
+        }
+      ],
+      ""default"": null
+    }
+  ]
+}
+";
+
+            var schema = Schema.Parse(json);
+        }
 
         [TestFixture]
         public class SchemaTypeExtensionsTests

--- a/lang/csharp/src/apache/test/Schema/SchemaTests.cs
+++ b/lang/csharp/src/apache/test/Schema/SchemaTests.cs
@@ -690,6 +690,1018 @@ namespace Avro.Test
             Assert.AreEqual(schema.ToString(), expectedSchemaJson);
         }
 
+        [TestCase]
+        public void Parse16DepthLevelSchemaTest()
+        {
+            var json = @"
+{
+  ""type"": ""record"",
+  ""name"": ""Level1"",
+  ""fields"": [
+    {
+      ""name"": ""level2"",
+      ""type"": {
+        ""type"": ""record"",
+        ""name"": ""Level2"",
+        ""fields"": [
+          {
+            ""name"": ""level3"",
+            ""type"": {
+              ""type"": ""record"",
+              ""name"": ""Level3"",
+              ""fields"": [
+                {
+                  ""name"": ""level4"",
+                  ""type"": {
+                    ""type"": ""record"",
+                    ""name"": ""Level4"",
+                    ""fields"": [
+                      {
+                        ""name"": ""level5"",
+                        ""type"": {
+                          ""type"": ""record"",
+                          ""name"": ""Level5"",
+                          ""fields"": [
+                            {
+                              ""name"": ""level6"",
+                              ""type"": {
+                                ""type"": ""record"",
+                                ""name"": ""Level6"",
+                                ""fields"": [
+                                  {
+                                    ""name"": ""level7"",
+                                    ""type"": {
+                                      ""type"": ""record"",
+                                      ""name"": ""Level7"",
+                                      ""fields"": [
+                                        {
+                                          ""name"": ""level8"",
+                                          ""type"": {
+                                            ""type"": ""record"",
+                                            ""name"": ""Level8"",
+                                            ""fields"": [
+                                              {
+                                                ""name"": ""level9"",
+                                                ""type"": {
+                                                  ""type"": ""record"",
+                                                  ""name"": ""Level9"",
+                                                  ""fields"": [
+                                                    {
+                                                      ""name"": ""level10"",
+                                                      ""type"": {
+                                                        ""type"": ""record"",
+                                                        ""name"": ""Level10"",
+                                                        ""fields"": [
+                                                          {
+                                                            ""name"": ""level11"",
+                                                            ""type"": {
+                                                              ""type"": ""record"",
+                                                              ""name"": ""Level11"",
+                                                              ""fields"": [
+                                                                {
+                                                                  ""name"": ""level12"",
+                                                                  ""type"": {
+                                                                    ""type"": ""record"",
+                                                                    ""name"": ""Level12"",
+                                                                    ""fields"": [
+                                                                      {
+                                                                        ""name"": ""level13"",
+                                                                        ""type"": {
+                                                                          ""type"": ""record"",
+                                                                          ""name"": ""Level13"",
+                                                                          ""fields"": [
+                                                                            {
+                                                                              ""name"": ""level14"",
+                                                                              ""type"": {
+                                                                                ""type"": ""record"",
+                                                                                ""name"": ""Level14"",
+                                                                                ""fields"": [
+                                                                                  {
+                                                                                    ""name"": ""level15"",
+                                                                                    ""type"": {
+                                                                                      ""type"": ""record"",
+                                                                                      ""name"": ""Level15"",
+                                                                                      ""fields"": [
+                                                                                        {
+                                                                                          ""name"": ""level16"",
+                                                                                          ""type"": ""string""
+                                                                                        }
+                                                                                      ]
+                                                                                    }
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                }
+                                                              ]
+                                                            }
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+";
+
+            var schema = Schema.Parse(json);
+
+        }
+
+        [TestCase]
+        public void Parse32DepthLevelSchemaTest()
+        {
+            var json = @"
+{
+  ""type"": ""record"",
+  ""name"": ""Level1"",
+  ""fields"": [
+    {
+      ""name"": ""level2"",
+      ""type"": {
+        ""type"": ""record"",
+        ""name"": ""Level2"",
+        ""fields"": [
+          {
+            ""name"": ""level3"",
+            ""type"": {
+              ""type"": ""record"",
+              ""name"": ""Level3"",
+              ""fields"": [
+                {
+                  ""name"": ""level4"",
+                  ""type"": {
+                    ""type"": ""record"",
+                    ""name"": ""Level4"",
+                    ""fields"": [
+                      {
+                        ""name"": ""level5"",
+                        ""type"": {
+                          ""type"": ""record"",
+                          ""name"": ""Level5"",
+                          ""fields"": [
+                            {
+                              ""name"": ""level6"",
+                              ""type"": {
+                                ""type"": ""record"",
+                                ""name"": ""Level6"",
+                                ""fields"": [
+                                  {
+                                    ""name"": ""level7"",
+                                    ""type"": {
+                                      ""type"": ""record"",
+                                      ""name"": ""Level7"",
+                                      ""fields"": [
+                                        {
+                                          ""name"": ""level8"",
+                                          ""type"": {
+                                            ""type"": ""record"",
+                                            ""name"": ""Level8"",
+                                            ""fields"": [
+                                              {
+                                                ""name"": ""level9"",
+                                                ""type"": {
+                                                  ""type"": ""record"",
+                                                  ""name"": ""Level9"",
+                                                  ""fields"": [
+                                                    {
+                                                      ""name"": ""level10"",
+                                                      ""type"": {
+                                                        ""type"": ""record"",
+                                                        ""name"": ""Level10"",
+                                                        ""fields"": [
+                                                          {
+                                                            ""name"": ""level11"",
+                                                            ""type"": {
+                                                              ""type"": ""record"",
+                                                              ""name"": ""Level11"",
+                                                              ""fields"": [
+                                                                {
+                                                                  ""name"": ""level12"",
+                                                                  ""type"": {
+                                                                    ""type"": ""record"",
+                                                                    ""name"": ""Level12"",
+                                                                    ""fields"": [
+                                                                      {
+                                                                        ""name"": ""level13"",
+                                                                        ""type"": {
+                                                                          ""type"": ""record"",
+                                                                          ""name"": ""Level13"",
+                                                                          ""fields"": [
+                                                                            {
+                                                                              ""name"": ""level14"",
+                                                                              ""type"": {
+                                                                                ""type"": ""record"",
+                                                                                ""name"": ""Level14"",
+                                                                                ""fields"": [
+                                                                                  {
+                                                                                    ""name"": ""level15"",
+                                                                                    ""type"": {
+                                                                                      ""type"": ""record"",
+                                                                                      ""name"": ""Level15"",
+                                                                                      ""fields"": [
+                                                                                        {
+                                                                                          ""name"": ""level16"",
+                                                                                          ""type"": {
+                                                                                            ""type"": ""record"",
+                                                                                            ""name"": ""Level16"",
+                                                                                            ""fields"": [
+                                                                                              {
+                                                                                                ""name"": ""level17"",
+                                                                                                ""type"": {
+                                                                                                  ""type"": ""record"",
+                                                                                                  ""name"": ""Level17"",
+                                                                                                  ""fields"": [
+                                                                                                    {
+                                                                                                      ""name"": ""level18"",
+                                                                                                      ""type"": {
+                                                                                                        ""type"": ""record"",
+                                                                                                        ""name"": ""Level18"",
+                                                                                                        ""fields"": [
+                                                                                                          {
+                                                                                                            ""name"": ""level19"",
+                                                                                                            ""type"": {
+                                                                                                              ""type"": ""record"",
+                                                                                                              ""name"": ""Level19"",
+                                                                                                              ""fields"": [
+                                                                                                                {
+                                                                                                                  ""name"": ""level20"",
+                                                                                                                  ""type"": {
+                                                                                                                    ""type"": ""record"",
+                                                                                                                    ""name"": ""Level20"",
+                                                                                                                    ""fields"": [
+                                                                                                                      {
+                                                                                                                        ""name"": ""level21"",
+                                                                                                                        ""type"": {
+                                                                                                                          ""type"": ""record"",
+                                                                                                                          ""name"": ""Level21"",
+                                                                                                                          ""fields"": [
+                                                                                                                            {
+                                                                                                                              ""name"": ""level22"",
+                                                                                                                              ""type"": {
+                                                                                                                                ""type"": ""record"",
+                                                                                                                                ""name"": ""Level22"",
+                                                                                                                                ""fields"": [
+                                                                                                                                  {
+                                                                                                                                    ""name"": ""level23"",
+                                                                                                                                    ""type"": {
+                                                                                                                                      ""type"": ""record"",
+                                                                                                                                      ""name"": ""Level23"",
+                                                                                                                                      ""fields"": [
+                                                                                                                                        {
+                                                                                                                                          ""name"": ""level24"",
+                                                                                                                                          ""type"": {
+                                                                                                                                            ""type"": ""record"",
+                                                                                                                                            ""name"": ""Level24"",
+                                                                                                                                            ""fields"": [
+                                                                                                                                              {
+                                                                                                                                                ""name"": ""level25"",
+                                                                                                                                                ""type"": {
+                                                                                                                                                  ""type"": ""record"",
+                                                                                                                                                  ""name"": ""Level25"",
+                                                                                                                                                  ""fields"": [
+                                                                                                                                                    {
+                                                                                                                                                      ""name"": ""level26"",
+                                                                                                                                                      ""type"": {
+                                                                                                                                                        ""type"": ""record"",
+                                                                                                                                                        ""name"": ""Level26"",
+                                                                                                                                                        ""fields"": [
+                                                                                                                                                          {
+                                                                                                                                                            ""name"": ""level27"",
+                                                                                                                                                            ""type"": {
+                                                                                                                                                              ""type"": ""record"",
+                                                                                                                                                              ""name"": ""Level27"",
+                                                                                                                                                              ""fields"": [
+                                                                                                                                                                {
+                                                                                                                                                                  ""name"": ""level28"",
+                                                                                                                                                                  ""type"": {
+                                                                                                                                                                    ""type"": ""record"",
+                                                                                                                                                                    ""name"": ""Level28"",
+                                                                                                                                                                    ""fields"": [
+                                                                                                                                                                      {
+                                                                                                                                                                        ""name"": ""level29"",
+                                                                                                                                                                        ""type"": {
+                                                                                                                                                                          ""type"": ""record"",
+                                                                                                                                                                          ""name"": ""Level29"",
+                                                                                                                                                                          ""fields"": [
+                                                                                                                                                                            {
+                                                                                                                                                                              ""name"": ""level30"",
+                                                                                                                                                                              ""type"": {
+                                                                                                                                                                                ""type"": ""record"",
+                                                                                                                                                                                ""name"": ""Level30"",
+                                                                                                                                                                                ""fields"": [
+                                                                                                                                                                                  {
+                                                                                                                                                                                    ""name"": ""level31"",
+                                                                                                                                                                                    ""type"": {
+                                                                                                                                                                                      ""type"": ""record"",
+                                                                                                                                                                                      ""name"": ""Level31"",
+                                                                                                                                                                                      ""fields"": [
+                                                                                                                                                                                        {
+                                                                                                                                                                                          ""name"": ""level32"",
+                                                                                                                                                                                          ""type"": ""string""
+                                                                                                                                                                                        }
+                                                                                                                                                                                      ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                  }
+                                                                                                                                                                                ]
+                                                                                                                                                                              }
+                                                                                                                                                                            }
+                                                                                                                                                                          ]
+                                                                                                                                                                        }
+                                                                                                                                                                      }
+                                                                                                                                                                    ]
+                                                                                                                                                                  }
+                                                                                                                                                                }
+                                                                                                                                                              ]
+                                                                                                                                                            }
+                                                                                                                                                          }
+                                                                                                                                                        ]
+                                                                                                                                                      }
+                                                                                                                                                    }
+                                                                                                                                                  ]
+                                                                                                                                                }
+                                                                                                                                              }
+                                                                                                                                            ]
+                                                                                                                                          }
+                                                                                                                                        }
+                                                                                                                                      ]
+                                                                                                                                    }
+                                                                                                                                  }
+                                                                                                                                ]
+                                                                                                                              }
+                                                                                                                            }
+                                                                                                                          ]
+                                                                                                                        }
+                                                                                                                      }
+                                                                                                                    ]
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              ]
+                                                                                                            }
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      }
+                                                                                                    }
+                                                                                                  ]
+                                                                                                }
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        }
+                                                                                      ]
+                                                                                    }
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                }
+                                                              ]
+                                                            }
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+";
+            var schema = Schema.Parse(json);
+        }
+
+        [TestCase]
+        public void Parse64DepthLevelSchemaTest()
+        {
+            var json = @"
+{
+  ""type"": ""record"",
+  ""name"": ""Level1"",
+  ""fields"": [
+    {
+      ""name"": ""level2"",
+      ""type"": {
+        ""type"": ""record"",
+        ""name"": ""Level2"",
+        ""fields"": [
+          {
+            ""name"": ""level3"",
+            ""type"": {
+              ""type"": ""record"",
+              ""name"": ""Level3"",
+              ""fields"": [
+                {
+                  ""name"": ""level4"",
+                  ""type"": {
+                    ""type"": ""record"",
+                    ""name"": ""Level4"",
+                    ""fields"": [
+                      {
+                        ""name"": ""level5"",
+                        ""type"": {
+                          ""type"": ""record"",
+                          ""name"": ""Level5"",
+                          ""fields"": [
+                            {
+                              ""name"": ""level6"",
+                              ""type"": {
+                                ""type"": ""record"",
+                                ""name"": ""Level6"",
+                                ""fields"": [
+                                  {
+                                    ""name"": ""level7"",
+                                    ""type"": {
+                                      ""type"": ""record"",
+                                      ""name"": ""Level7"",
+                                      ""fields"": [
+                                        {
+                                          ""name"": ""level8"",
+                                          ""type"": {
+                                            ""type"": ""record"",
+                                            ""name"": ""Level8"",
+                                            ""fields"": [
+                                              {
+                                                ""name"": ""level9"",
+                                                ""type"": {
+                                                  ""type"": ""record"",
+                                                  ""name"": ""Level9"",
+                                                  ""fields"": [
+                                                    {
+                                                      ""name"": ""level10"",
+                                                      ""type"": {
+                                                        ""type"": ""record"",
+                                                        ""name"": ""Level10"",
+                                                        ""fields"": [
+                                                          {
+                                                            ""name"": ""level11"",
+                                                            ""type"": {
+                                                              ""type"": ""record"",
+                                                              ""name"": ""Level11"",
+                                                              ""fields"": [
+                                                                {
+                                                                  ""name"": ""level12"",
+                                                                  ""type"": {
+                                                                    ""type"": ""record"",
+                                                                    ""name"": ""Level12"",
+                                                                    ""fields"": [
+                                                                      {
+                                                                        ""name"": ""level13"",
+                                                                        ""type"": {
+                                                                          ""type"": ""record"",
+                                                                          ""name"": ""Level13"",
+                                                                          ""fields"": [
+                                                                            {
+                                                                              ""name"": ""level14"",
+                                                                              ""type"": {
+                                                                                ""type"": ""record"",
+                                                                                ""name"": ""Level14"",
+                                                                                ""fields"": [
+                                                                                  {
+                                                                                    ""name"": ""level15"",
+                                                                                    ""type"": {
+                                                                                      ""type"": ""record"",
+                                                                                      ""name"": ""Level15"",
+                                                                                      ""fields"": [
+                                                                                        {
+                                                                                          ""name"": ""level16"",
+                                                                                          ""type"": {
+                                                                                            ""type"": ""record"",
+                                                                                            ""name"": ""Level16"",
+                                                                                            ""fields"": [
+                                                                                              {
+                                                                                                ""name"": ""level17"",
+                                                                                                ""type"": {
+                                                                                                  ""type"": ""record"",
+                                                                                                  ""name"": ""Level17"",
+                                                                                                  ""fields"": [
+                                                                                                    {
+                                                                                                      ""name"": ""level18"",
+                                                                                                      ""type"": {
+                                                                                                        ""type"": ""record"",
+                                                                                                        ""name"": ""Level18"",
+                                                                                                        ""fields"": [
+                                                                                                          {
+                                                                                                            ""name"": ""level19"",
+                                                                                                            ""type"": {
+                                                                                                              ""type"": ""record"",
+                                                                                                              ""name"": ""Level19"",
+                                                                                                              ""fields"": [
+                                                                                                                {
+                                                                                                                  ""name"": ""level20"",
+                                                                                                                  ""type"": {
+                                                                                                                    ""type"": ""record"",
+                                                                                                                    ""name"": ""Level20"",
+                                                                                                                    ""fields"": [
+                                                                                                                      {
+                                                                                                                        ""name"": ""level21"",
+                                                                                                                        ""type"": {
+                                                                                                                          ""type"": ""record"",
+                                                                                                                          ""name"": ""Level21"",
+                                                                                                                          ""fields"": [
+                                                                                                                            {
+                                                                                                                              ""name"": ""level22"",
+                                                                                                                              ""type"": {
+                                                                                                                                ""type"": ""record"",
+                                                                                                                                ""name"": ""Level22"",
+                                                                                                                                ""fields"": [
+                                                                                                                                  {
+                                                                                                                                    ""name"": ""level23"",
+                                                                                                                                    ""type"": {
+                                                                                                                                      ""type"": ""record"",
+                                                                                                                                      ""name"": ""Level23"",
+                                                                                                                                      ""fields"": [
+                                                                                                                                        {
+                                                                                                                                          ""name"": ""level24"",
+                                                                                                                                          ""type"": {
+                                                                                                                                            ""type"": ""record"",
+                                                                                                                                            ""name"": ""Level24"",
+                                                                                                                                            ""fields"": [
+                                                                                                                                              {
+                                                                                                                                                ""name"": ""level25"",
+                                                                                                                                                ""type"": {
+                                                                                                                                                  ""type"": ""record"",
+                                                                                                                                                  ""name"": ""Level25"",
+                                                                                                                                                  ""fields"": [
+                                                                                                                                                    {
+                                                                                                                                                      ""name"": ""level26"",
+                                                                                                                                                      ""type"": {
+                                                                                                                                                        ""type"": ""record"",
+                                                                                                                                                        ""name"": ""Level26"",
+                                                                                                                                                        ""fields"": [
+                                                                                                                                                          {
+                                                                                                                                                            ""name"": ""level27"",
+                                                                                                                                                            ""type"": {
+                                                                                                                                                              ""type"": ""record"",
+                                                                                                                                                              ""name"": ""Level27"",
+                                                                                                                                                              ""fields"": [
+                                                                                                                                                                {
+                                                                                                                                                                  ""name"": ""level28"",
+                                                                                                                                                                  ""type"": {
+                                                                                                                                                                    ""type"": ""record"",
+                                                                                                                                                                    ""name"": ""Level28"",
+                                                                                                                                                                    ""fields"": [
+                                                                                                                                                                      {
+                                                                                                                                                                        ""name"": ""level29"",
+                                                                                                                                                                        ""type"": {
+                                                                                                                                                                          ""type"": ""record"",
+                                                                                                                                                                          ""name"": ""Level29"",
+                                                                                                                                                                          ""fields"": [
+                                                                                                                                                                            {
+                                                                                                                                                                              ""name"": ""level30"",
+                                                                                                                                                                              ""type"": {
+                                                                                                                                                                                ""type"": ""record"",
+                                                                                                                                                                                ""name"": ""Level30"",
+                                                                                                                                                                                ""fields"": [
+                                                                                                                                                                                  {
+                                                                                                                                                                                    ""name"": ""level31"",
+                                                                                                                                                                                    ""type"": {
+                                                                                                                                                                                      ""type"": ""record"",
+                                                                                                                                                                                      ""name"": ""Level31"",
+                                                                                                                                                                                      ""fields"": [
+                                                                                                                                                                                        {
+                                                                                                                                                                                          ""name"": ""level32"",
+                                                                                                                                                                                          ""type"": {
+                                                                                                                                                                                            ""type"": ""record"",
+                                                                                                                                                                                            ""name"": ""Level32"",
+                                                                                                                                                                                            ""fields"": [
+                                                                                                                                                                                              {
+                                                                                                                                                                                                ""name"": ""level33"",
+                                                                                                                                                                                                ""type"": {
+                                                                                                                                                                                                  ""type"": ""record"",
+                                                                                                                                                                                                  ""name"": ""Level33"",
+                                                                                                                                                                                                  ""fields"": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                      ""name"": ""level34"",
+                                                                                                                                                                                                      ""type"": {
+                                                                                                                                                                                                        ""type"": ""record"",
+                                                                                                                                                                                                        ""name"": ""Level34"",
+                                                                                                                                                                                                        ""fields"": [
+                                                                                                                                                                                                          {
+                                                                                                                                                                                                            ""name"": ""level35"",
+                                                                                                                                                                                                            ""type"": {
+                                                                                                                                                                                                              ""type"": ""record"",
+                                                                                                                                                                                                              ""name"": ""Level35"",
+                                                                                                                                                                                                              ""fields"": [
+                                                                                                                                                                                                                {
+                                                                                                                                                                                                                  ""name"": ""level36"",
+                                                                                                                                                                                                                  ""type"": {
+                                                                                                                                                                                                                    ""type"": ""record"",
+                                                                                                                                                                                                                    ""name"": ""Level36"",
+                                                                                                                                                                                                                    ""fields"": [
+                                                                                                                                                                                                                      {
+                                                                                                                                                                                                                        ""name"": ""level37"",
+                                                                                                                                                                                                                        ""type"": {
+                                                                                                                                                                                                                          ""type"": ""record"",
+                                                                                                                                                                                                                          ""name"": ""Level37"",
+                                                                                                                                                                                                                          ""fields"": [
+                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                              ""name"": ""level38"",
+                                                                                                                                                                                                                              ""type"": {
+                                                                                                                                                                                                                                ""type"": ""record"",
+                                                                                                                                                                                                                                ""name"": ""Level38"",
+                                                                                                                                                                                                                                ""fields"": [
+                                                                                                                                                                                                                                  {
+                                                                                                                                                                                                                                    ""name"": ""level39"",
+                                                                                                                                                                                                                                    ""type"": {
+                                                                                                                                                                                                                                      ""type"": ""record"",
+                                                                                                                                                                                                                                      ""name"": ""Level39"",
+                                                                                                                                                                                                                                      ""fields"": [
+                                                                                                                                                                                                                                        {
+                                                                                                                                                                                                                                          ""name"": ""level40"",
+                                                                                                                                                                                                                                          ""type"": {
+                                                                                                                                                                                                                                            ""type"": ""record"",
+                                                                                                                                                                                                                                            ""name"": ""Level40"",
+                                                                                                                                                                                                                                            ""fields"": [
+                                                                                                                                                                                                                                              {
+                                                                                                                                                                                                                                                ""name"": ""level41"",
+                                                                                                                                                                                                                                                ""type"": {
+                                                                                                                                                                                                                                                  ""type"": ""record"",
+                                                                                                                                                                                                                                                  ""name"": ""Level41"",
+                                                                                                                                                                                                                                                  ""fields"": [
+                                                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                                                      ""name"": ""level42"",
+                                                                                                                                                                                                                                                      ""type"": {
+                                                                                                                                                                                                                                                        ""type"": ""record"",
+                                                                                                                                                                                                                                                        ""name"": ""Level42"",
+                                                                                                                                                                                                                                                        ""fields"": [
+                                                                                                                                                                                                                                                          {
+                                                                                                                                                                                                                                                            ""name"": ""level43"",
+                                                                                                                                                                                                                                                            ""type"": {
+                                                                                                                                                                                                                                                              ""type"": ""record"",
+                                                                                                                                                                                                                                                              ""name"": ""Level43"",
+                                                                                                                                                                                                                                                              ""fields"": [
+                                                                                                                                                                                                                                                                {
+                                                                                                                                                                                                                                                                  ""name"": ""level44"",
+                                                                                                                                                                                                                                                                  ""type"": {
+                                                                                                                                                                                                                                                                    ""type"": ""record"",
+                                                                                                                                                                                                                                                                    ""name"": ""Level44"",
+                                                                                                                                                                                                                                                                    ""fields"": [
+                                                                                                                                                                                                                                                                      {
+                                                                                                                                                                                                                                                                        ""name"": ""level45"",
+                                                                                                                                                                                                                                                                        ""type"": {
+                                                                                                                                                                                                                                                                          ""type"": ""record"",
+                                                                                                                                                                                                                                                                          ""name"": ""Level45"",
+                                                                                                                                                                                                                                                                          ""fields"": [
+                                                                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                                                              ""name"": ""level46"",
+                                                                                                                                                                                                                                                                              ""type"": {
+                                                                                                                                                                                                                                                                                ""type"": ""record"",
+                                                                                                                                                                                                                                                                                ""name"": ""Level46"",
+                                                                                                                                                                                                                                                                                ""fields"": [
+                                                                                                                                                                                                                                                                                  {
+                                                                                                                                                                                                                                                                                    ""name"": ""level47"",
+                                                                                                                                                                                                                                                                                    ""type"": {
+                                                                                                                                                                                                                                                                                      ""type"": ""record"",
+                                                                                                                                                                                                                                                                                      ""name"": ""Level47"",
+                                                                                                                                                                                                                                                                                      ""fields"": [
+                                                                                                                                                                                                                                                                                        {
+                                                                                                                                                                                                                                                                                          ""name"": ""level48"",
+                                                                                                                                                                                                                                                                                          ""type"": {
+                                                                                                                                                                                                                                                                                            ""type"": ""record"",
+                                                                                                                                                                                                                                                                                            ""name"": ""Level48"",
+                                                                                                                                                                                                                                                                                            ""fields"": [
+                                                                                                                                                                                                                                                                                              {
+                                                                                                                                                                                                                                                                                                ""name"": ""level49"",
+                                                                                                                                                                                                                                                                                                ""type"": {
+                                                                                                                                                                                                                                                                                                  ""type"": ""record"",
+                                                                                                                                                                                                                                                                                                  ""name"": ""Level49"",
+                                                                                                                                                                                                                                                                                                  ""fields"": [
+                                                                                                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                                                                                                      ""name"": ""level50"",
+                                                                                                                                                                                                                                                                                                      ""type"": {
+                                                                                                                                                                                                                                                                                                        ""type"": ""record"",
+                                                                                                                                                                                                                                                                                                        ""name"": ""Level50"",
+                                                                                                                                                                                                                                                                                                        ""fields"": [
+                                                                                                                                                                                                                                                                                                          {
+                                                                                                                                                                                                                                                                                                            ""name"": ""level51"",
+                                                                                                                                                                                                                                                                                                            ""type"": {
+                                                                                                                                                                                                                                                                                                              ""type"": ""record"",
+                                                                                                                                                                                                                                                                                                              ""name"": ""Level51"",
+                                                                                                                                                                                                                                                                                                              ""fields"": [
+                                                                                                                                                                                                                                                                                                                {
+                                                                                                                                                                                                                                                                                                                  ""name"": ""level52"",
+                                                                                                                                                                                                                                                                                                                  ""type"": {
+                                                                                                                                                                                                                                                                                                                    ""type"": ""record"",
+                                                                                                                                                                                                                                                                                                                    ""name"": ""Level52"",
+                                                                                                                                                                                                                                                                                                                    ""fields"": [
+                                                                                                                                                                                                                                                                                                                      {
+                                                                                                                                                                                                                                                                                                                        ""name"": ""level53"",
+                                                                                                                                                                                                                                                                                                                        ""type"": {
+                                                                                                                                                                                                                                                                                                                          ""type"": ""record"",
+                                                                                                                                                                                                                                                                                                                          ""name"": ""Level53"",
+                                                                                                                                                                                                                                                                                                                          ""fields"": [
+                                                                                                                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                                                                                                              ""name"": ""level54"",
+                                                                                                                                                                                                                                                                                                                              ""type"": {
+                                                                                                                                                                                                                                                                                                                                ""type"": ""record"",
+                                                                                                                                                                                                                                                                                                                                ""name"": ""Level54"",
+                                                                                                                                                                                                                                                                                                                                ""fields"": [
+                                                                                                                                                                                                                                                                                                                                  {
+                                                                                                                                                                                                                                                                                                                                    ""name"": ""level55"",
+                                                                                                                                                                                                                                                                                                                                    ""type"": {
+                                                                                                                                                                                                                                                                                                                                      ""type"": ""record"",
+                                                                                                                                                                                                                                                                                                                                      ""name"": ""Level55"",
+                                                                                                                                                                                                                                                                                                                                      ""fields"": [
+                                                                                                                                                                                                                                                                                                                                        {
+                                                                                                                                                                                                                                                                                                                                          ""name"": ""level56"",
+                                                                                                                                                                                                                                                                                                                                          ""type"": {
+                                                                                                                                                                                                                                                                                                                                            ""type"": ""record"",
+                                                                                                                                                                                                                                                                                                                                            ""name"": ""Level56"",
+                                                                                                                                                                                                                                                                                                                                            ""fields"": [
+                                                                                                                                                                                                                                                                                                                                              {
+                                                                                                                                                                                                                                                                                                                                                ""name"": ""level57"",
+                                                                                                                                                                                                                                                                                                                                                ""type"": {
+                                                                                                                                                                                                                                                                                                                                                  ""type"": ""record"",
+                                                                                                                                                                                                                                                                                                                                                  ""name"": ""Level57"",
+                                                                                                                                                                                                                                                                                                                                                  ""fields"": [
+                                                                                                                                                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                                                                                                                                                      ""name"": ""level58"",
+                                                                                                                                                                                                                                                                                                                                                      ""type"": {
+                                                                                                                                                                                                                                                                                                                                                        ""type"": ""record"",
+                                                                                                                                                                                                                                                                                                                                                        ""name"": ""Level58"",
+                                                                                                                                                                                                                                                                                                                                                        ""fields"": [
+                                                                                                                                                                                                                                                                                                                                                          {
+                                                                                                                                                                                                                                                                                                                                                            ""name"": ""level59"",
+                                                                                                                                                                                                                                                                                                                                                            ""type"": {
+                                                                                                                                                                                                                                                                                                                                                              ""type"": ""record"",
+                                                                                                                                                                                                                                                                                                                                                              ""name"": ""Level59"",
+                                                                                                                                                                                                                                                                                                                                                              ""fields"": [
+                                                                                                                                                                                                                                                                                                                                                                {
+                                                                                                                                                                                                                                                                                                                                                                  ""name"": ""level60"",
+                                                                                                                                                                                                                                                                                                                                                                  ""type"": {
+                                                                                                                                                                                                                                                                                                                                                                    ""type"": ""record"",
+                                                                                                                                                                                                                                                                                                                                                                    ""name"": ""Level60"",
+                                                                                                                                                                                                                                                                                                                                                                    ""fields"": [
+                                                                                                                                                                                                                                                                                                                                                                      {
+                                                                                                                                                                                                                                                                                                                                                                        ""name"": ""level61"",
+                                                                                                                                                                                                                                                                                                                                                                        ""type"": {
+                                                                                                                                                                                                                                                                                                                                                                          ""type"": ""record"",
+                                                                                                                                                                                                                                                                                                                                                                          ""name"": ""Level61"",
+                                                                                                                                                                                                                                                                                                                                                                          ""fields"": [
+                                                                                                                                                                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                                                                                                                                                              ""name"": ""level62"",
+                                                                                                                                                                                                                                                                                                                                                                              ""type"": {
+                                                                                                                                                                                                                                                                                                                                                                                ""type"": ""record"",
+                                                                                                                                                                                                                                                                                                                                                                                ""name"": ""Level62"",
+                                                                                                                                                                                                                                                                                                                                                                                ""fields"": [
+                                                                                                                                                                                                                                                                                                                                                                                  {
+                                                                                                                                                                                                                                                                                                                                                                                    ""name"": ""level63"",
+                                                                                                                                                                                                                                                                                                                                                                                    ""type"": {
+                                                                                                                                                                                                                                                                                                                                                                                      ""type"": ""record"",
+                                                                                                                                                                                                                                                                                                                                                                                      ""name"": ""Level63"",
+                                                                                                                                                                                                                                                                                                                                                                                      ""fields"": [
+                                                                                                                                                                                                                                                                                                                                                                                        {
+                                                                                                                                                                                                                                                                                                                                                                                          ""name"": ""level64"",
+                                                                                                                                                                                                                                                                                                                                                                                          ""type"": ""string""
+                                                                                                                                                                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                                                                                                                                                                      ]
+                                                                                                                                                                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                                                                                                                                                                  }
+                                                                                                                                                                                                                                                                                                                                                                                ]
+                                                                                                                                                                                                                                                                                                                                                                              }
+                                                                                                                                                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                                                                                                                                                          ]
+                                                                                                                                                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                                                                                                                                                      }
+                                                                                                                                                                                                                                                                                                                                                                    ]
+                                                                                                                                                                                                                                                                                                                                                                  }
+                                                                                                                                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                                                                                                                                              ]
+                                                                                                                                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                                                                                                                                          }
+                                                                                                                                                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                                                                                                                                                      }
+                                                                                                                                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                                                                                                                                  ]
+                                                                                                                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                                                                                                                              }
+                                                                                                                                                                                                                                                                                                                                            ]
+                                                                                                                                                                                                                                                                                                                                          }
+                                                                                                                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                                                                                                                      ]
+                                                                                                                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                                                                                                                  }
+                                                                                                                                                                                                                                                                                                                                ]
+                                                                                                                                                                                                                                                                                                                              }
+                                                                                                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                                                                                                          ]
+                                                                                                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                                                                                                      }
+                                                                                                                                                                                                                                                                                                                    ]
+                                                                                                                                                                                                                                                                                                                  }
+                                                                                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                                                                                              ]
+                                                                                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                                                                                          }
+                                                                                                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                                                                                                      }
+                                                                                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                                                                                  ]
+                                                                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                                                                              }
+                                                                                                                                                                                                                                                                                            ]
+                                                                                                                                                                                                                                                                                          }
+                                                                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                                                                      ]
+                                                                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                                                                  }
+                                                                                                                                                                                                                                                                                ]
+                                                                                                                                                                                                                                                                              }
+                                                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                                                          ]
+                                                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                                                      }
+                                                                                                                                                                                                                                                                    ]
+                                                                                                                                                                                                                                                                  }
+                                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                                              ]
+                                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                                          }
+                                                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                                                      }
+                                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                                  ]
+                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                              }
+                                                                                                                                                                                                                                            ]
+                                                                                                                                                                                                                                          }
+                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                      ]
+                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                  }
+                                                                                                                                                                                                                                ]
+                                                                                                                                                                                                                              }
+                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                          ]
+                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                      }
+                                                                                                                                                                                                                    ]
+                                                                                                                                                                                                                  }
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                              ]
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                          }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                      }
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                  ]
+                                                                                                                                                                                                }
+                                                                                                                                                                                              }
+                                                                                                                                                                                            ]
+                                                                                                                                                                                          }
+                                                                                                                                                                                        }
+                                                                                                                                                                                      ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                  }
+                                                                                                                                                                                ]
+                                                                                                                                                                              }
+                                                                                                                                                                            }
+                                                                                                                                                                          ]
+                                                                                                                                                                        }
+                                                                                                                                                                      }
+                                                                                                                                                                    ]
+                                                                                                                                                                  }
+                                                                                                                                                                }
+                                                                                                                                                              ]
+                                                                                                                                                            }
+                                                                                                                                                          }
+                                                                                                                                                        ]
+                                                                                                                                                      }
+                                                                                                                                                    }
+                                                                                                                                                  ]
+                                                                                                                                                }
+                                                                                                                                              }
+                                                                                                                                            ]
+                                                                                                                                          }
+                                                                                                                                        }
+                                                                                                                                      ]
+                                                                                                                                    }
+                                                                                                                                  }
+                                                                                                                                ]
+                                                                                                                              }
+                                                                                                                            }
+                                                                                                                          ]
+                                                                                                                        }
+                                                                                                                      }
+                                                                                                                    ]
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              ]
+                                                                                                            }
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      }
+                                                                                                    }
+                                                                                                  ]
+                                                                                                }
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        }
+                                                                                      ]
+                                                                                    }
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                }
+                                                              ]
+                                                            }
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+";
+
+            var schema = Schema.Parse(json);
+        }
+
+
         [TestFixture]
         public class SchemaTypeExtensionsTests
         {


### PR DESCRIPTION
<!--

*Thank you very much for contributing to Apache Avro - we are happy that you want to help us improve Avro. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Avro a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/AVRO/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "AVRO-XXXX: [component] Title of the pull request", where *AVRO-XXXX* should be replaced by the actual issue number. 
    The *component* is optional, but can help identify the correct reviewers faster: either the language ("java", "python") or subsystem such as "build" or "doc" are good candidates.  

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests. You can [build the entire project](https://github.com/apache/avro/blob/master/BUILD.md) or just the [language-specific SDK](https://avro.apache.org/project/how-to-contribute/#unit-tests).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Every commit message references Jira issues in their subject lines. In addition, commits follow the guidelines from [How to write a good git commit message](https://chris.beams.io/posts/git-commit/)
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

-->

## What is the purpose of the change

I am an end-user/developer to use Confluent Kafka to consume a Avro message where the number of nested structures is around 20.   The producer/vendor cannot reduce the depth level of the Avro schema.    Confluent support has assisted me to open an issue with Apache Avro project.  The issue is logged in https://issues.apache.org/jira/browse/AVRO-3856.    I am in need of code fix so I can continue.

The current code in Schema.cs parsing Avro schema using JObject.Parse(json), JArray.Parse(json) do not have option to override max depth level.  On https://github.com/JamesNK/Newtonsoft.Json/pull/2904, Newtonsoft Author advised to use JObject.Load(Jsonreader), so we can set the MaxDepth in JsonReader once instantiated.   

In doing so, I also noticed the Avro schema depth level is not counted the same as in JsonReader's.  The default depth level limit of 64 in JsonReader can only support around 20 levels of Avro schema.

When putting break point in JsonReader Push method (called by Load method) with various Avro schema depth levels, here is my observation:

Avro Schema Depth | JsonReader Depth Count
4 | 11
16 | 44
32 | 92
64 | 188

To compensate, I had hardcoded JsonReader MaxDepth to 192 to support parsing of Avro Schema with 64 level depth.

## Verifying this change

This change added tests and can be verified as follows:

I added 3 test cases in SchemaTests.cs:

Parse16DepthLevelSchemaTest
Parse32DepthLevelSchemaTest
Parse64DepthLevelSchemaTest


## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
