### PR TITLE
AVRO-3874: Bump minimum Newtonsoft version

### DIFF
--- a/lang/csharp/versions.props
+++ b/lang/csharp/versions.props
@@ -45,9 +45,12 @@
     latest and greatest of a particularly dependency.
     !!! ONLY UPDATE IF FUNCTIONALITY REQUIRES IT !!!
     See https://github.com/apache/avro/pull/1126 & https://github.com/apache/avro/pull/981 for more details
+    NOTE:
+       1. Newtonsoft versions prior to 13.0.1 have severe vulnerability issues.
+          See https://github.com/advisories/GHSA-5crp-9r3c-p9vr for more details
   -->
   <PropertyGroup Label="Minimum Package Versions">
-    <NewtonsoftJsonMinimumVersion>10.0.3</NewtonsoftJsonMinimumVersion>
+    <NewtonsoftJsonMinimumVersion>13.0.1</NewtonsoftJsonMinimumVersion>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
## What is the purpose of the change

* Bump Newtonsoft version to fix vulnerabity issues (AVRO-3874)*
https://github.com/advisories/GHSA-5crp-9r3c-p9vr

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)
