### PR TITLE
Minor: [Rust] Fix the dependency version of apache-avro-test-helper

### DIFF
--- a/lang/rust/Cargo.lock
+++ b/lang/rust/Cargo.lock
@@ -63,7 +63,7 @@ checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "apache-avro"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "apache-avro-derive",
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "apache-avro-derive"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "apache-avro",
  "darling",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "apache-avro-test-helper"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "color-backtrace",

--- a/lang/rust/avro/Cargo.toml
+++ b/lang/rust/avro/Cargo.toml
@@ -82,7 +82,7 @@ rand = { default-features = false, version = "0.8.5", features = ["default"] }
 
 [dev-dependencies]
 anyhow = { default-features = false, version = "1.0.75", features = ["std"] }
-apache-avro-test-helper = { default-features = false, version = "0.16.0", path = "../avro_test_helper" }
+apache-avro-test-helper = { default-features = false, version = "0.17.0", path = "../avro_test_helper" }
 criterion = { default-features = false, version = "0.5.1" }
 hex-literal = { default-features = false, version = "0.4.1" }
 md-5 = { default-features = false, version = "0.10.6" }


### PR DESCRIPTION
## What is the purpose of the change

This is a follow-up PR for [this](https://github.com/apache/avro/commit/b7b7cb96713dd8b54246db416c37e4f5641debd3).
That PR forgot to modify the version of `apache-avro-test-helper`.

## Verifying this change
Done by CI.

## Documentation

- Does this pull request introduce a new feature? (no)
