### PR TITLE
AVRO-3870: [Rust] Use `git` protocol to fetch dependencies until MSRV is 1.70.0

### DIFF
--- a/.github/workflows/test-lang-rust-ci.yml
+++ b/.github/workflows/test-lang-rust-ci.yml
@@ -66,7 +66,7 @@ jobs:
           # these represent dependencies downloaded by cargo
           # and thus do not depend on the OS, arch nor rust version.
           path: ~/.cargo
-          key: ${{ runner.os }}-cargo-cache1-${{ matrix.target }}-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-cache2-
 
       - name: Cache Rust dependencies
         id: cache-target
@@ -75,12 +75,7 @@ jobs:
           # these represent compiled steps of both dependencies and avro
           # and thus are specific for a particular OS, arch and rust version.
           path: lang/rust/target
-          key: ${{ runner.os }}-target-cache1-${{ matrix.target }}-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Cache hit ?!
-        run: |
-          echo "~/.cargo cache hit: ${{ steps.cache-cargo.outputs.cache-hit }}"
-          echo "lang/rust/target cache hit: ${{ steps.cache-target.outputs.cache-hit }}"
+          key: ${{ runner.os }}-target-cache2-
 
       - name: Rust Toolchain
         uses: dtolnay/rust-toolchain@nightly
@@ -229,7 +224,7 @@ jobs:
           # these represent dependencies downloaded by cargo
           # and thus do not depend on the OS, arch nor rust version.
           path: ~/.cargo
-          key: ${{ runner.os }}-cargo-cache1-web-assembly-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-cache2-
 
       - name: Cache Rust dependencies
         uses: actions/cache@v3
@@ -237,7 +232,7 @@ jobs:
           # these represent compiled steps of both dependencies and avro
           # and thus are specific for a particular OS, arch and rust version.
           path: lang/rust/target
-          key: ${{ runner.os }}-target-cache1-stable-web-assembly-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-target-cache2-
 
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh

--- a/.github/workflows/test-lang-rust-ci.yml
+++ b/.github/workflows/test-lang-rust-ci.yml
@@ -31,6 +31,7 @@ permissions:
 
 env:
   RUSTFLAGS: -Dwarnings
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: 'git' # TODO: remove this env var once MSRV is 1.70.0+
 
 defaults:
   run:
@@ -59,19 +60,27 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Cache Cargo
+        id: cache-cargo
         uses: actions/cache@v3
         with:
           # these represent dependencies downloaded by cargo
           # and thus do not depend on the OS, arch nor rust version.
           path: ~/.cargo
-          key: cargo-cache1-
+          key: ${{ runner.os }}-cargo-cache1-${{ matrix.target }}-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Cache Rust dependencies
+        id: cache-target
         uses: actions/cache@v3
         with:
           # these represent compiled steps of both dependencies and avro
           # and thus are specific for a particular OS, arch and rust version.
-          path: ~/target
-          key: ${{ runner.os }}-target-cache1-${{ matrix.rust }}-
+          path: lang/rust/target
+          key: ${{ runner.os }}-target-cache1-${{ matrix.target }}-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache hit ?!
+        run: |
+          echo "~/.cargo cache hit: ${{ steps.cache-cargo.outputs.cache-hit }}"
+          echo "lang/rust/target cache hit: ${{ steps.cache-target.outputs.cache-hit }}"
 
       - name: Rust Toolchain
         uses: dtolnay/rust-toolchain@nightly
@@ -135,12 +144,13 @@ jobs:
           # and thus do not depend on the OS, arch nor rust version.
           path: ~/.cargo
           key: cargo-cache1-
+
       - name: Cache Rust dependencies
         uses: actions/cache@v3
         with:
           # these represent compiled steps of both dependencies and avro
           # and thus are specific for a particular OS, arch and rust version.
-          path: ~/target
+          path: lang/rust/target
           key: ${{ runner.os }}-target-cache1-stable-
 
       - name: Cache Local Maven Repository
@@ -219,15 +229,15 @@ jobs:
           # these represent dependencies downloaded by cargo
           # and thus do not depend on the OS, arch nor rust version.
           path: ~/.cargo
-          key: cargo-cache1-
+          key: ${{ runner.os }}-cargo-cache1-web-assembly-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache Rust dependencies
         uses: actions/cache@v3
         with:
           # these represent compiled steps of both dependencies and avro
           # and thus are specific for a particular OS, arch and rust version.
-          path: ~/target
-          key: ${{ runner.os }}-target-cache1-stable-
+          path: lang/rust/target
+          key: ${{ runner.os }}-target-cache1-stable-web-assembly-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh


### PR DESCRIPTION
AVRO-3870

## What is the purpose of the change

* Improve the cache keys for the Rust CI jobs

## Verifying this change

The build and tests should still work

## Documentation

- Does this pull request introduce a new feature? no