### PR TITLE
AVRO-3881: [rust] Writer should write user metadata even if the body is empty

### DIFF
--- a/lang/rust/avro/src/writer.rs
+++ b/lang/rust/avro/src/writer.rs
@@ -1142,7 +1142,7 @@ mod tests {
     }
 
     #[test]
-    fn test_empty_body() -> TestResult {
+    fn test_avro_3881_metadata_empty_body() -> TestResult {
         let schema = Schema::parse_str(SCHEMA)?;
         let mut writer = Writer::new(&schema, Vec::new());
         writer.add_user_metadata("a".to_string(), "b")?;

--- a/lang/rust/avro/src/writer.rs
+++ b/lang/rust/avro/src/writer.rs
@@ -323,6 +323,7 @@ impl<'a, W: Write> Writer<'a, W> {
     /// **NOTE** This function forces the written data to be flushed (an implicit
     /// call to [`flush`](struct.Writer.html#method.flush) is performed).
     pub fn into_inner(mut self) -> AvroResult<W> {
+        self.maybe_write_header()?;
         self.flush()?;
         Ok(self.writer)
     }
@@ -635,6 +636,7 @@ mod tests {
         schema::{DecimalSchema, FixedSchema, Name},
         types::Record,
         util::zig_i64,
+        Reader,
     };
     use pretty_assertions::assert_eq;
     use serde::{Deserialize, Serialize};
@@ -1135,6 +1137,22 @@ mod tests {
         let result = writer.into_inner()?;
 
         assert_eq!(result.len(), 260);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_empty_body() -> TestResult {
+        let schema = Schema::parse_str(SCHEMA)?;
+        let mut writer = Writer::new(&schema, Vec::new());
+        writer.add_user_metadata("a".to_string(), "b")?;
+        let result = writer.into_inner()?;
+
+        let reader = Reader::with_schema(&schema, &result[..])?;
+        let mut expected = HashMap::new();
+        expected.insert("a".to_string(), vec![b'b']);
+        assert_eq!(reader.user_metadata(), &expected);
+        assert_eq!(reader.into_iter().count(), 0);
 
         Ok(())
     }


### PR DESCRIPTION

## What is the purpose of the change

Fix AVRO-3881


## Verifying this change

This change added test that `Writer` always write user metadata even if the body is empty.


## Documentation

- Does this pull request introduce a new feature? (no)

