### PR TITLE
AVRO-3884: Add `local-timestamp-nanos` and `timestamp-nanos`

### DIFF
--- a/doc/content/en/docs/++version++/Specification/_index.md
+++ b/doc/content/en/docs/++version++/Specification/_index.md
@@ -880,7 +880,7 @@ A `local-timestamp-micros` logical type annotates an Avro `long`, where the long
 ### Local timestamp (nanosecond precision)
 The `local-timestamp-nanos` logical type represents a timestamp in a local timezone, regardless of what specific time zone is considered local, with a precision of one nanosecond.
 
-A `local-timestamp-nanos` logical type annotates an Avro `long`, where the long stores the number of nanoseconds, from 1 January 1970 00:00:00.000000.
+A `local-timestamp-nanos` logical type annotates an Avro `long`, where the long stores the number of nanoseconds, from 1 January 1970 00:00:00.000000000.
 
 ### Duration
 The `duration` logical type represents an amount of time defined by a number of months, days and milliseconds. This is not equivalent to a number of milliseconds, because, depending on the moment in time from which the duration is measured, the number of days in the month and number of milliseconds in a day may differ. Other standard periods such as years, quarters, hours and minutes can be expressed through these basic periods.

--- a/doc/content/en/docs/++version++/Specification/_index.md
+++ b/doc/content/en/docs/++version++/Specification/_index.md
@@ -862,6 +862,11 @@ The `timestamp-micros` logical type represents an instant on the global timeline
 
 A `timestamp-micros` logical type annotates an Avro `long`, where the long stores the number of microseconds from the unix epoch, 1 January 1970 00:00:00.000000 UTC.
 
+### Timestamp (nanosecond precision)
+The `timestamp-nanos` logical type represents an instant on the global timeline, independent of a particular time zone or calendar, with a precision of one nanosecond. Please note that time zone information gets lost in this process. Upon reading a value back, we can only reconstruct the instant, but not the original representation. In practice, such timestamps are typically displayed to users in their local time zones, therefore they may be displayed differently depending on the execution environment.
+
+A `timestamp-nanos` logical type annotates an Avro `long`, where the long stores the number of nanoseconds from the unix epoch, 1 January 1970 00:00:00.000000 UTC.
+
 ### Local timestamp (millisecond precision) {#local_timestamp_ms}
 The `local-timestamp-millis` logical type represents a timestamp in a local timezone, regardless of what specific time zone is considered local, with a precision of one millisecond.
 
@@ -871,6 +876,11 @@ A `local-timestamp-millis` logical type annotates an Avro `long`, where the long
 The `local-timestamp-micros` logical type represents a timestamp in a local timezone, regardless of what specific time zone is considered local, with a precision of one microsecond.
 
 A `local-timestamp-micros` logical type annotates an Avro `long`, where the long stores the number of microseconds, from 1 January 1970 00:00:00.000000.
+
+### Local timestamp (nanosecond precision)
+The `local-timestamp-nanos` logical type represents a timestamp in a local timezone, regardless of what specific time zone is considered local, with a precision of one nanosecond.
+
+A `local-timestamp-nanos` logical type annotates an Avro `long`, where the long stores the number of nanoseconds, from 1 January 1970 00:00:00.000000.
 
 ### Duration
 The `duration` logical type represents an amount of time defined by a number of months, days and milliseconds. This is not equivalent to a number of milliseconds, because, depending on the moment in time from which the duration is measured, the number of days in the month and number of milliseconds in a day may differ. Other standard periods such as years, quarters, hours and minutes can be expressed through these basic periods.

--- a/doc/content/en/docs/++version++/Specification/_index.md
+++ b/doc/content/en/docs/++version++/Specification/_index.md
@@ -865,7 +865,7 @@ A `timestamp-micros` logical type annotates an Avro `long`, where the long store
 ### Timestamp (nanosecond precision)
 The `timestamp-nanos` logical type represents an instant on the global timeline, independent of a particular time zone or calendar, with a precision of one nanosecond. Please note that time zone information gets lost in this process. Upon reading a value back, we can only reconstruct the instant, but not the original representation. In practice, such timestamps are typically displayed to users in their local time zones, therefore they may be displayed differently depending on the execution environment.
 
-A `timestamp-nanos` logical type annotates an Avro `long`, where the long stores the number of nanoseconds from the unix epoch, 1 January 1970 00:00:00.000000 UTC.
+A `timestamp-nanos` logical type annotates an Avro `long`, where the long stores the number of nanoseconds from the unix epoch, 1 January 1970 00:00:00.000000000 UTC.
 
 ### Local timestamp (millisecond precision) {#local_timestamp_ms}
 The `local-timestamp-millis` logical type represents a timestamp in a local timezone, regardless of what specific time zone is considered local, with a precision of one millisecond.

--- a/doc/content/en/docs/++version++/Specification/_index.md
+++ b/doc/content/en/docs/++version++/Specification/_index.md
@@ -870,7 +870,7 @@ The `local-timestamp-{millis,micros,nanos}` logical type represents a timestamp 
 - `local-timestamp-micros`: logical type annotates an Avro `long`, where the long stores the number of microseconds, from 1 January 1970 00:00:00.000000.
 - `local-timestamp-nanos`: logical type annotates an Avro `long`, where the long stores the number of nanoseconds, from 1 January 1970 00:00:00.000000000.
 
-Example: Given an event at noon local time (12:00) on January 1, 2000, in Helsinki where the local time was two hours east of UTC (UTC+2), and then converted to Avro long 946684800000 (milliseconds) and then written.
+Example: Given an event at noon local time (12:00) on January 1, 2000, in Helsinki where the local time was two hours east of UTC (UTC+2), and converted to Avro long 946684800000 (milliseconds) and then written.
 
 ### Duration
 The `duration` logical type represents an amount of time defined by a number of months, days and milliseconds. This is not equivalent to a number of milliseconds, because, depending on the moment in time from which the duration is measured, the number of days in the month and number of milliseconds in a day may differ. Other standard periods such as years, quarters, hours and minutes can be expressed through these basic periods.

--- a/doc/content/en/docs/++version++/Specification/_index.md
+++ b/doc/content/en/docs/++version++/Specification/_index.md
@@ -870,7 +870,7 @@ The `local-timestamp-{millis,micros,nanos}` logical type represents a timestamp 
 - `local-timestamp-micros`: logical type annotates an Avro `long`, where the long stores the number of microseconds, from 1 January 1970 00:00:00.000000.
 - `local-timestamp-nanos`: logical type annotates an Avro `long`, where the long stores the number of nanoseconds, from 1 January 1970 00:00:00.000000000.
 
-Example: Given an event at noon local time (12:00) on January 1, 2000, in Helsinki where the local time was two hours east of UTC (UTC+2), and converted to Avro long 946684800000 (milliseconds) and then written.
+Example: Given an event at noon local time (12:00) on January 1, 2000, in Helsinki where the local time was two hours east of UTC (UTC+2). The timestamp is converted to Avro long 946684800000 (milliseconds) and then written.
 
 ### Duration
 The `duration` logical type represents an amount of time defined by a number of months, days and milliseconds. This is not equivalent to a number of milliseconds, because, depending on the moment in time from which the duration is measured, the number of days in the month and number of milliseconds in a day may differ. Other standard periods such as years, quarters, hours and minutes can be expressed through these basic periods.

--- a/doc/content/en/docs/++version++/Specification/_index.md
+++ b/doc/content/en/docs/++version++/Specification/_index.md
@@ -852,35 +852,25 @@ The `time-micros` logical type represents a time of day, with no reference to a 
 
 A `time-micros` logical type annotates an Avro `long`, where the long stores the number of microseconds after midnight, 00:00:00.000000.
 
-### Timestamp (millisecond precision) {#timestamp_ms}
-The `timestamp-millis` logical type represents an instant on the global timeline, independent of a particular time zone or calendar, with a precision of one millisecond. Please note that time zone information gets lost in this process. Upon reading a value back, we can only reconstruct the instant, but not the original representation. In practice, such timestamps are typically displayed to users in their local time zones, therefore they may be displayed differently depending on the execution environment.
+### Timestamps {#timestamps}
 
-A `timestamp-millis` logical type annotates an Avro `long`, where the long stores the number of milliseconds from the unix epoch, 1 January 1970 00:00:00.000 UTC.
+The `timestamp-{millis,micros,nanos}` logical type represents an instant on the global timeline, independent of a particular time zone or calendar. Upon reading a value back, we can only reconstruct the instant, but not the original representation. In practice, such timestamps are typically displayed to users in their local time zones, therefore they may be displayed differently depending on the execution environment.
 
-### Timestamp (microsecond precision)
-The `timestamp-micros` logical type represents an instant on the global timeline, independent of a particular time zone or calendar, with a precision of one microsecond. Please note that time zone information gets lost in this process. Upon reading a value back, we can only reconstruct the instant, but not the original representation. In practice, such timestamps are typically displayed to users in their local time zones, therefore they may be displayed differently depending on the execution environment.
+- `timestamp-millis`: logical type annotates an Avro `long`, where the long stores the number of milliseconds from the unix epoch, 1 January 1970 00:00:00.000.
+- `timestamp-micros`: logical type annotates an Avro `long`, where the long stores the number of microseconds from the unix epoch, 1 January 1970 00:00:00.000000.
+- `timestamp-nanos`: logical type annotates an Avro `long`, where the long stores the number of nanoseconds from the unix epoch, 1 January 1970 00:00:00.000000000.
 
-A `timestamp-micros` logical type annotates an Avro `long`, where the long stores the number of microseconds from the unix epoch, 1 January 1970 00:00:00.000000 UTC.
+Example: Given an event at noon local time (12:00) on January 1, 2000, in Helsinki where the local time was two hours east of UTC (UTC+2). The timestamp is first shifted to UTC 2000-01-01T10:00:00 and that is then converted to Avro long 946720800000 (milliseconds) and written.
 
-### Timestamp (nanosecond precision)
-The `timestamp-nanos` logical type represents an instant on the global timeline, independent of a particular time zone or calendar, with a precision of one nanosecond. Please note that time zone information gets lost in this process. Upon reading a value back, we can only reconstruct the instant, but not the original representation. In practice, such timestamps are typically displayed to users in their local time zones, therefore they may be displayed differently depending on the execution environment.
+### Local Timestamps {#local_timestamp}
 
-A `timestamp-nanos` logical type annotates an Avro `long`, where the long stores the number of nanoseconds from the unix epoch, 1 January 1970 00:00:00.000000000 UTC.
+The `local-timestamp-{millis,micros,nanos}` logical type represents a timestamp in a local timezone, regardless of what specific time zone is considered local.
 
-### Local timestamp (millisecond precision) {#local_timestamp_ms}
-The `local-timestamp-millis` logical type represents a timestamp in a local timezone, regardless of what specific time zone is considered local, with a precision of one millisecond.
+- `local-timestamp-millis`: logical type annotates an Avro `long`, where the long stores the number of milliseconds, from 1 January 1970 00:00:00.000.
+- `local-timestamp-micros`: logical type annotates an Avro `long`, where the long stores the number of microseconds, from 1 January 1970 00:00:00.000000.
+- `local-timestamp-nanos`: logical type annotates an Avro `long`, where the long stores the number of nanoseconds, from 1 January 1970 00:00:00.000000000.
 
-A `local-timestamp-millis` logical type annotates an Avro `long`, where the long stores the number of milliseconds, from 1 January 1970 00:00:00.000.
-
-### Local timestamp (microsecond precision)
-The `local-timestamp-micros` logical type represents a timestamp in a local timezone, regardless of what specific time zone is considered local, with a precision of one microsecond.
-
-A `local-timestamp-micros` logical type annotates an Avro `long`, where the long stores the number of microseconds, from 1 January 1970 00:00:00.000000.
-
-### Local timestamp (nanosecond precision)
-The `local-timestamp-nanos` logical type represents a timestamp in a local timezone, regardless of what specific time zone is considered local, with a precision of one nanosecond.
-
-A `local-timestamp-nanos` logical type annotates an Avro `long`, where the long stores the number of nanoseconds, from 1 January 1970 00:00:00.000000000.
+Example: Given an event at noon local time (12:00) on January 1, 2000, in Helsinki where the local time was two hours east of UTC (UTC+2), and then converted to Avro long 946684800000 (milliseconds) and then written.
 
 ### Duration
 The `duration` logical type represents an amount of time defined by a number of months, days and milliseconds. This is not equivalent to a number of milliseconds, because, depending on the moment in time from which the duration is measured, the number of days in the month and number of milliseconds in a day may differ. Other standard periods such as years, quarters, hours and minutes can be expressed through these basic periods.


### PR DESCRIPTION
[AVRO-3884](https://issues.apache.org/jira/browse/AVRO-3884)

## What is the purpose of the change

Within certain industries nano timestamps are the common practice (finance for example), therefore I would propose adding this to the Avro spec as well.

Nanosecond datetime precision is needed in various fields and applications for several reasons, particularly in scenarios where extremely precise timing is critical. Here are a few reasons why nanosecond datetime precision is essential:

1. Financial Transactions: In the world of high-frequency trading and financial markets, nanosecond precision is necessary to accurately record and timestamp transactions. Small time differentials can result in significant advantages or losses in trading, making precise timestamps crucial for maintaining fairness and integrity in financial markets.

2. Scientific Research: Many scientific experiments and measurements require extremely high precision in time recording. Fields like particle physics, astronomy, and chemistry may deal with processes that occur at the nanosecond level, where the exact timing of events is vital for accurate data analysis.

3. Telecommunications: In telecommunications, especially for systems operating at high frequencies, nanosecond precision is required to synchronize various network components and ensure the efficient and reliable transfer of data.

4. GPS and Navigation: Global Positioning System (GPS) technology relies on nanosecond precision to calculate the time it takes for signals to travel from satellites to receivers. Accurate timekeeping is crucial for determining precise locations and distances.

5. Aerospace and Defense: In aviation and defense applications, nanosecond precision is needed for tasks such as navigation, missile guidance, and radar systems, where small timing errors can have serious consequences.

6. Data Centers and Distributed Systems: Modern data centers and distributed systems often require nanosecond precision for synchronization and coordination to ensure efficient and reliable operations.

7. Simulation and Modeling: Computer simulations and modeling in various fields, including engineering, climate science, and fluid dynamics, may need nanosecond-level precision to accurately represent real-world processes and interactions.

8. Network Protocols: Some network protocols and technologies, such as Ethernet, use nanosecond precision to time-stamp packets for accurate sequencing and synchronization in communication networks.

9. Cryptography and Security: In cryptographic applications, precise timing can be crucial for ensuring secure authentication and encryption processes, and nanosecond precision can help protect against various timing-based attacks.

10. High-Performance Computing: Supercomputers and other high-performance computing systems require nanosecond precision for tasks like benchmarking, profiling, and optimizing code to improve overall performance.

In these and other applications, nanosecond datetime precision is essential for ensuring accurate data recording, synchronization, and the reliable functioning of systems and processes that rely on precise timing.

## Languages

- **Java**: Supports [nanoseconds using `Instant.ofEpochSecond`](https://docs.oracle.com/javase/8/docs/api/java/time/Instant.html).
- **.Net**: The C# library translates the other timestamp logical types to the [DateTime](https://learn.microsoft.com/dotnet/api/system.datetime?view=netstandard-2.0) and [DateTimeOffset](https://learn.microsoft.com/dotnet/api/system.datetimeoffset?view=netstandard-2.0) types; however, those have a precision of 100 nanoseconds. [details](https://github.com/apache/avro/pull/2554#issuecomment-1765087969).
- **Python**: Python does not support nano's, but pandas and numpy do:
```python
>>> import numpy as np
>>> np.datetime64(1697631171861735496, 'ns')
numpy.datetime64('2023-10-18T12:12:51.861735496')
>>> import pandas as pd
>>> pd.Timestamp(1697631171861735496)  # nano's by default :)
Timestamp('2023-10-18 12:12:51.861735496')
```
- **Rust**: Native support, and [accepts a `i128` using `from_nanos`](https://docs.rs/unix-ts/latest/unix_ts/struct.Timestamp.html#method.from_nanos).
- **Javascript**: Comes with millisecond precision out of the box, but there are third-party libraries available such as [timestamp-nano](https://www.npmjs.com/package/timestamp-nano). It can read from 64-bit byte arrays (both little and big-endian).
- **Perl**: Available through a third-party package [HiRes](https://metacpan.org/pod/Time::HiRes).
- **PHP**: Not available. There is the function [hrtime](https://www.php.net/manual/en/function.hrtime.php) to get the current time in nano's either returns a tuple of (seconds, nanos), or can return an `int64` on 64-bit systems, or a float on 32 bit systems. For languages like this, we could just return the integer value (depending on the physical type).
- **Ruby**: Uses nanoseconds in their own [Time](https://ruby-doc.org/core-2.6.3/Time.html) object.

## Primitive type consideration

- `int64`: Widely available, but limited precision: [1677-09-21 00:12:43.145224193, 2262-04-11 23:47:16.854775807].
- `int128`: Wide range, but might require external libraries, such as GMP for C++, or performance trade-offs because it needs `BigInteger` in Java (as opposed to primitives).
- `decimal(n, 0)`: Arbitrary range, but has the same issue as `int128`.

I'm leaning towards starting with `int64` (and maybe `int128`). We could always promote `int64 → int128` (and that's also binary compatible thanks to the zigzag encoding).

## Verifying this change

*(Please pick one of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
- *Extended interop tests to verify consistent valid schema names between SDKs*
- *Added test that validates that Java throws an AvroRuntimeException on invalid binary data*
- *Manually verified the change by building the website and checking the new redirect*


## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
