### PR TITLE
AVRO-3609: [Rust] Remove wrong collection of custom attributes

### DIFF
--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -751,7 +751,6 @@ impl RecordField {
                 "type" | "name" | "doc" | "default" | "order" | "position" => continue,
                 _ => custom_attributes.insert(key.clone(), value.clone()),
             };
-            custom_attributes.insert(key.to_string(), value.clone());
         }
         custom_attributes
     }


### PR DESCRIPTION
AVRO-3609

## What is the purpose of the change

* The collection of the custom attributes was wrong. It should collect only attributes which names are not in the predefined list
Found the bug while reviewing the code for AVRO-3886

## Verifying this change

* The old unit tests should still pass

## Documentation

- Does this pull request introduce a new feature? no