### PR TITLE
fix CVE-2023-42503 by using Apache Commons Compress 1.24.0

### DIFF
--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -39,7 +39,7 @@
     <!-- version properties for dependencies -->
     <ant.version>1.10.14</ant.version>
     <commons-cli.version>1.5.0</commons-cli.version>
-    <commons-compress.version>1.22</commons-compress.version>
+    <commons-compress.version>1.24.0</commons-compress.version>
     <commons-text.version>1.10.0</commons-text.version>
     <grpc.version>1.58.0</grpc.version>
     <hadoop.version>3.3.5</hadoop.version>


### PR DESCRIPTION
Apache Commons Compress 1.22 is vulnerable to CVE-2023-42503. Fix by using version 1.24.0.