### PR TITLE
AVRO-3889: [Java][Build] Maven IDL Generation Modification Check

### DIFF
--- a/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/IDLProtocolMojo.java
+++ b/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/IDLProtocolMojo.java
@@ -82,7 +82,8 @@ public class IDLProtocolMojo extends AbstractAvroMojo {
 
       URLClassLoader projPathLoader = new URLClassLoader(runtimeUrls.toArray(new URL[0]),
           Thread.currentThread().getContextClassLoader());
-      try (Idl parser = new Idl(new File(sourceDirectory, filename), projPathLoader)) {
+      File sourceFile = new File(sourceDirectory, filename);
+      try (Idl parser = new Idl(sourceFile, projPathLoader)) {
 
         Protocol p = parser.CompilationUnit();
         for (String warning : parser.getWarningsAfterParsing()) {
@@ -104,7 +105,7 @@ public class IDLProtocolMojo extends AbstractAvroMojo {
           compiler.addCustomConversion(projPathLoader.loadClass(customConversion));
         }
         compiler.setOutputCharacterEncoding(project.getProperties().getProperty("project.build.sourceEncoding"));
-        compiler.compileToDestination(null, outputDirectory);
+        compiler.compileToDestination(sourceFile, outputDirectory);
       }
     } catch (ParseException | ClassNotFoundException | DependencyResolutionRequiredException e) {
       throw new IOException(e);

--- a/lang/java/maven-plugin/src/test/java/org/apache/avro/mojo/TestIDLProtocolMojo.java
+++ b/lang/java/maven-plugin/src/test/java/org/apache/avro/mojo/TestIDLProtocolMojo.java
@@ -17,6 +17,10 @@
  */
 package org.apache.avro.mojo;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.FileTime;
 import org.codehaus.plexus.util.FileUtils;
 import org.junit.Test;
 
@@ -37,6 +41,10 @@ public class TestIDLProtocolMojo extends AbstractAvroMojoTest {
 
   @Test
   public void testIdlProtocolMojo() throws Exception {
+    // Clear output directory to ensure files are recompiled.
+    final File outputDir = new File(getBasedir(), "target/test-harness/idl/test/");
+    FileUtils.deleteDirectory(outputDir);
+
     final IDLProtocolMojo mojo = (IDLProtocolMojo) lookupMojo("idl-protocol", testPom);
     final TestLog log = new TestLog();
     mojo.setLog(log);
@@ -44,7 +52,6 @@ public class TestIDLProtocolMojo extends AbstractAvroMojoTest {
     assertNotNull(mojo);
     mojo.execute();
 
-    final File outputDir = new File(getBasedir(), "target/test-harness/idl/test/");
     final Set<String> generatedFiles = new HashSet<>(Arrays.asList("IdlPrivacy.java", "IdlTest.java", "IdlUser.java",
         "IdlUserWrapper.java", "IdlClasspathImportTest.java"));
     assertFilesExist(outputDir, generatedFiles);
@@ -60,6 +67,10 @@ public class TestIDLProtocolMojo extends AbstractAvroMojoTest {
 
   @Test
   public void testSetCompilerVelocityAdditionalTools() throws Exception {
+    // Clear output directory to ensure files are recompiled.
+    final File outputDir = new File(getBasedir(), "target/test-harness/idl-inject/test");
+    FileUtils.deleteDirectory(outputDir);
+
     final IDLProtocolMojo mojo = (IDLProtocolMojo) lookupMojo("idl-protocol", injectingVelocityToolsTestPom);
     final TestLog log = new TestLog();
     mojo.setLog(log);
@@ -67,7 +78,6 @@ public class TestIDLProtocolMojo extends AbstractAvroMojoTest {
     assertNotNull(mojo);
     mojo.execute();
 
-    final File outputDir = new File(getBasedir(), "target/test-harness/idl-inject/test");
     final Set<String> generatedFiles = new HashSet<>(Arrays.asList("IdlPrivacy.java", "IdlTest.java", "IdlUser.java",
         "IdlUserWrapper.java", "IdlClasspathImportTest.java"));
 
@@ -78,5 +88,38 @@ public class TestIDLProtocolMojo extends AbstractAvroMojoTest {
 
     // The previous test already verifies the warnings.
     assertFalse(log.getLogEntries().isEmpty());
+  }
+
+  @Test
+  public void testIdlProtocolMojoDoesntReplaceUpToDateFiles() throws Exception {
+    // Ensure that the IDL files have already been compiled once.
+    final IDLProtocolMojo mojo = (IDLProtocolMojo) lookupMojo("idl-protocol", testPom);
+    final TestLog log = new TestLog();
+    mojo.setLog(log);
+
+    assertNotNull(mojo);
+    mojo.execute();
+
+    // Remove one file to ensure it is recreated and the others are not.
+    final Path outputDirPath = Paths.get(getBasedir(), "target/test-harness/idl/test/");
+    final File outputDir = outputDirPath.toFile();
+
+    final Path idlPrivacyFilePath = outputDirPath.resolve("IdlPrivacy.java");
+    final FileTime idpPrivacyModificationTime = Files.getLastModifiedTime(idlPrivacyFilePath);
+    Files.delete(idlPrivacyFilePath);
+
+    final Path idlUserFilePath = outputDirPath.resolve("IdlUser.java");
+    final FileTime idlUserModificationTime = Files.getLastModifiedTime(idlUserFilePath);
+
+    mojo.execute();
+
+    // Asserting contents is done in previous tests so just assert existence.
+    final Set<String> generatedFiles = new HashSet<>(Arrays.asList("IdlPrivacy.java", "IdlTest.java", "IdlUser.java",
+        "IdlUserWrapper.java", "IdlClasspathImportTest.java"));
+    assertFilesExist(outputDir, generatedFiles);
+
+    assertTrue(idlPrivacyFilePath.toFile().exists());
+    assertEquals(Files.getLastModifiedTime(idlUserFilePath), idlUserModificationTime);
+    assertTrue(Files.getLastModifiedTime(idlPrivacyFilePath).compareTo(idpPrivacyModificationTime) > 0);
   }
 }


### PR DESCRIPTION
## What is the purpose of the change

This change adds an up to date check to the maven plugin when generating Java classes from avro IDL. The reason for the change is to prevent unnecessary recompilation of the java source code in projects using the plugin. 

## Verifying this change

This change added tests and can be verified as follows:
- Added tests to verify that only missing files are regenerated when processing the avro IDL files.
- Altered existing tests to ensure that files are generated and not used from previous test runs.

Not sure if there are other scenarios that may be affected by this change.

## Documentation

This pull request does not introduce a new feature and is not documented.
