### PR TITLE
AVRO-3889: [Java][Build] Maven IDL Generation Modification Check

### DIFF
--- a/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/IDLMojo.java
+++ b/lang/java/maven-plugin/src/main/java/org/apache/avro/mojo/IDLMojo.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -85,7 +86,8 @@ public class IDLMojo extends AbstractAvroMojo {
       Thread.currentThread().setContextClassLoader(projPathLoader);
       try {
         IdlReader parser = new IdlReader();
-        IdlFile idlFile = parser.parse(sourceDirectory.toPath().resolve(filename));
+        Path sourceFilePath = sourceDirectory.toPath().resolve(filename);
+        IdlFile idlFile = parser.parse(sourceFilePath);
         for (String warning : idlFile.getWarnings()) {
           getLog().warn(warning);
         }
@@ -109,7 +111,7 @@ public class IDLMojo extends AbstractAvroMojo {
           compiler.addCustomConversion(projPathLoader.loadClass(customConversion));
         }
         compiler.setOutputCharacterEncoding(project.getProperties().getProperty("project.build.sourceEncoding"));
-        compiler.compileToDestination(null, outputDirectory);
+        compiler.compileToDestination(sourceFilePath.toFile(), outputDirectory);
       } finally {
         Thread.currentThread().setContextClassLoader(contextClassLoader);
       }

--- a/lang/java/maven-plugin/src/test/resources/unit/idl/pom-incremental-compilation.xml
+++ b/lang/java/maven-plugin/src/test/resources/unit/idl/pom-incremental-compilation.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>avro-parent</artifactId>
+    <groupId>org.apache.avro</groupId>
+    <version>1.12.0-SNAPSHOT</version>
+    <relativePath>../../../../../../../../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>avro-maven-plugin-test</artifactId>
+  <packaging>jar</packaging>
+
+  <name>testproject</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>avro-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>idl</id>
+            <goals>
+              <goal>idl-protocol</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <sourceDirectory>${basedir}/src/test</sourceDirectory>
+          <outputDirectory>${basedir}/target/test-harness/idl-incremental</outputDirectory>
+          <stringType>String</stringType>
+          <project implementation="org.apache.maven.plugin.testing.stubs.MavenProjectStub"/>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+      <version>${parent.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+  </dependencies>
+</project>


### PR DESCRIPTION
## What is the purpose of the change
This change adds an up to date check to the maven plugin when generating Java classes from avro IDL. The reason for the change is to prevent unnecessary recompilation of the java source code in projects using the plugin.

## Verifying this change
This change added tests and can be verified as follows:

- Added tests to verify that only missing files are regenerated when processing the avro IDL files.
- Altered existing tests to ensure that files are generated and not used from previous test runs.

Not sure if there are other scenarios that may be affected by this change.

## Documentation
This pull request does not introduce a new feature and is not documented.
