### PR TITLE
AVRO-3897: [Rust] Disallow invalid namespace in fully qualified name for Rust SDK

### DIFF
--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -6216,4 +6216,16 @@ mod tests {
 
         Ok(())
     }
+
+    /// A test cases showing that names and namespaces can be constructed
+    /// entirely by underscores.
+    #[test]
+    fn test_avro_3897_funny_valid_names_and_namespaces() -> TestResult {
+        for funny_name in ["_", "_._", "__._", "_.__", "_._._"] {
+            let name = Name::new(funny_name);
+            assert!(name.is_ok());
+        }
+
+        Ok(())
+    }
 }

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -6198,24 +6198,20 @@ mod tests {
 
     #[test]
     fn test_avro_3897_disallow_invalid_namespaces_in_fully_qualified_name() -> TestResult {
-        let name = Name::new("ns.0.record1");
-        assert!(name.is_err());
-        let expected = Error::InvalidSchemaName("ns.0.record1".to_string(), SCHEMA_NAME_R.as_str())
-            .to_string();
-        let err = name
-            .map_err(|e| e.to_string())
-            .err()
-            .unwrap_or_else(|| "unexpected".to_string());
-        assert_eq!(expected, err);
-
-        let name = Name::new("ns..record1");
+        let full_name = "ns.0.record1";
+        let name = Name::new(full_name);
         assert!(name.is_err());
         let expected =
-            Error::InvalidSchemaName("ns..record1".to_string(), SCHEMA_NAME_R.as_str()).to_string();
-        let err = name
-            .map_err(|e| e.to_string())
-            .err()
-            .unwrap_or_else(|| "unexpected".to_string());
+            Error::InvalidSchemaName(full_name.to_string(), SCHEMA_NAME_R.as_str()).to_string();
+        let err = name.map_err(|e| e.to_string()).err().unwrap();
+        assert_eq!(expected, err);
+
+        let full_name = "ns..record1";
+        let name = Name::new(full_name);
+        assert!(name.is_err());
+        let expected =
+            Error::InvalidSchemaName(full_name.to_string(), SCHEMA_NAME_R.as_str()).to_string();
+        let err = name.map_err(|e| e.to_string()).err().unwrap();
         assert_eq!(expected, err);
 
         Ok(())


### PR DESCRIPTION
AVRO-3897

## What is the purpose of the change
This change aims to fix an issue that the current Rust SDK accidentally allows invalid namespace in fully qualified name with `Name::new()`.

[The specification](https://avro.apache.org/docs/1.11.1/specification/#names) says about `Names` as follows

```
The name portion of the fullname of named types, record field names, and enum symbols must:

start with [A-Za-z_]
subsequently contain only [A-Za-z0-9_]
```
```
The null namespace may not be used in a dot-separated sequence of names. So the grammar for a namespace is:

  <empty> | <name>[(<dot><name>)*]
```

So the following usages of `Name:::new()` should return a kind of `Err` but actually return `Ok`.
```
Name::new("ns.0.record1");
Name::new("ns..record1");
```
The root cause is that the regex `SCHEMA_NAME_R` is not correct.
So this PR fixes the regex.

## Verifying this change
New tests are added.

## Documentation

- Does this pull request introduce a new feature? (no)
