### PR TITLE
Minor: Fix an error in running ./build.sh docker

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -311,7 +311,7 @@ do
       } > Dockerfile
       # Include the ruby gemspec for preinstallation.
       # shellcheck disable=SC2086
-      tar -cf- Dockerfile $DOCKER_EXTRA_CONTEXT | docker build $DOCKER_BUILD_XTRA_ARGS -t "$DOCKER_IMAGE_NAME" -
+      tar -cf- Dockerfile $DOCKER_EXTRA_CONTEXT | DOCKER_BUILDKIT=1 docker build $DOCKER_BUILD_XTRA_ARGS -t "$DOCKER_IMAGE_NAME" -
       rm Dockerfile
       # By mapping the .m2 directory you can do an mvn install from
       # within the container and use the result on your normal


### PR DESCRIPTION
## What is the purpose of the change
This PR fixes a minor issue that `./build.sh docker` fails with the following error message.
```
 ---> Running in 24cdd401ee78
/bin/sh: 1: BUILDARCH: parameter not set or null
```

`BUILDARCH` is automatically set by setting an environment variable `DOCKER_BUILDKIT` to `1`.

## Verifying this change
Confirmed `./build.sh docker` succeeded.

## Documentation

- Does this pull request introduce a new feature? (no)