### PR TITLE
AVRO-3861: [Build] Add RAT exclusions for python docs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -471,6 +471,7 @@
                 <exclude>lang/py/build/**</exclude>
                 <exclude>lang/py/dist/**</exclude>
                 <exclude>lang/py/userlogs/**</exclude>
+                <exclude>lang/py/docs/build/**</exclude>
                 <exclude>lang/ruby/Manifest</exclude>
                 <!-- text documentation files -->
                 <exclude>CHANGES.txt</exclude>


### PR DESCRIPTION
AVRO-3861

## What is the purpose of the change
This PR fixes an issue that the RAT check fails if Python API docs built are in `lang/py/docs/build`.
You can reproduce this issue by the following steps.

1. Build Python API doc by `cd lang/py && ./build.sh doc`
2. Run `./build.sh dist`

Then, you can see the following error message.
```
[WARNING] Files with unapproved licenses:
  lang/py/docs/build/html/_static/pygments.css
  lang/py/docs/build/html/_static/basic.css
  lang/py/docs/build/html/_static/doctools.js
  lang/py/docs/build/html/_static/documentation_options.js
  lang/py/docs/build/html/_static/language_data.js
  lang/py/docs/build/html/_static/searchtools.js
  lang/py/docs/build/html/_static/sphinx_highlight.js
  lang/py/docs/build/html/_static/alabaster.css
  lang/py/docs/build/html/_static/custom.css
  lang/py/docs/build/html/automodule.html
  lang/py/docs/build/html/index.html
  lang/py/docs/build/html/intro.html
  lang/py/docs/build/html/genindex.html
  lang/py/docs/build/html/py-modindex.html
  lang/py/docs/build/html/search.html
  lang/py/docs/build/html/.buildinfo
  lang/py/docs/build/html/searchindex.js
```

To fix this issue, this PR addes an exclusion rule to `pom.xml` for RAT.

## Verifying this change
Confirmed `./build.sh dist` succeeded even if there are some files in `lang/py/docs/build`

## Documentation

- Does this pull request introduce a new feature? (no)