### PR TITLE
AVRO-3899: [Rust] Invalid logical types should be ignored and treatedas the underlying type

### DIFF
--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -1324,12 +1324,17 @@ impl Parser {
                         parse_as_native_complex(complex, self, enclosing_namespace)?,
                         &[SchemaKind::Fixed, SchemaKind::Bytes],
                         |inner| -> AvroResult<Schema> {
-                            let (precision, scale) = Self::parse_precision_and_scale(complex)?;
-                            Ok(Schema::Decimal(DecimalSchema {
-                                precision,
-                                scale,
-                                inner: Box::new(inner),
-                            }))
+                            match Self::parse_precision_and_scale(complex) {
+                                Ok((precision, scale)) => Ok(Schema::Decimal(DecimalSchema {
+                                    precision,
+                                    scale,
+                                    inner: Box::new(inner),
+                                })),
+                                Err(err) => {
+                                    warn!("Ignoring invalid decimal logical type: {}", err);
+                                    Ok(inner)
+                                }
+                            }
                         },
                     );
                 }

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -6316,4 +6316,51 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_avro_3899_parse_decimal_type() -> TestResult {
+        use apache_avro_test_helper::logger::{assert_logged, assert_not_logged};
+
+        let schema = Schema::parse_str(
+            r#"{
+             "name": "InvalidDecimal",
+             "type": "fixed",
+             "size": 16,
+             "logicalType": "decimal",
+             "precision": 2,
+             "scale": 3
+         }"#,
+        )?;
+        match schema {
+            Schema::Fixed(fixed_schema) => {
+                let attrs = fixed_schema.attributes;
+                let precision = attrs
+                    .get("precision")
+                    .expect("The 'precision' attribute is missing");
+                let scale = attrs
+                    .get("scale")
+                    .expect("The 'scale' attribute is missing");
+                assert_logged(&format!("Ignoring invalid decimal logical type: The decimal precision ({}) must be bigger or equal to the scale ({})", precision, scale));
+            }
+            _ => unreachable!("Expected Schema::Fixed, got {:?}", schema),
+        }
+
+        let schema = Schema::parse_str(
+            r#"{
+            "name": "ValidDecimal",
+             "type": "bytes",
+             "logicalType": "decimal",
+             "precision": 3,
+             "scale": 2
+         }"#,
+        )?;
+        match schema {
+            Schema::Decimal(_) => {
+                assert_not_logged("Ignoring invalid decimal logical type: The decimal precision (2) must be bigger or equal to the scale (3)");
+            }
+            _ => unreachable!("Expected Schema::Decimal, got {:?}", schema),
+        }
+
+        Ok(())
+    }
 }

--- a/lang/rust/avro/tests/schema.rs
+++ b/lang/rust/avro/tests/schema.rs
@@ -431,7 +431,7 @@ const DECIMAL_LOGICAL_TYPE: &[(&str, bool)] = &[
             "logicalType": "decimal",
             "precision": 0
         }"#,
-        false,
+        true,
     ),
     (
         r#"{
@@ -449,7 +449,7 @@ const DECIMAL_LOGICAL_TYPE: &[(&str, bool)] = &[
              "precision": 2,
              "scale": -2
          }"#,
-        false,
+        true,
     ),
     (
         r#"{
@@ -458,7 +458,7 @@ const DECIMAL_LOGICAL_TYPE: &[(&str, bool)] = &[
              "precision": -2,
              "scale": 2
          }"#,
-        false,
+        true,
     ),
     (
         r#"{
@@ -467,7 +467,7 @@ const DECIMAL_LOGICAL_TYPE: &[(&str, bool)] = &[
              "precision": 2,
              "scale": 3
          }"#,
-        false,
+        true,
     ),
     (
         r#"{
@@ -478,7 +478,7 @@ const DECIMAL_LOGICAL_TYPE: &[(&str, bool)] = &[
              "scale": 2,
              "size": 5
          }"#,
-        false,
+        true,
     ),
     (
         r#"{
@@ -489,7 +489,7 @@ const DECIMAL_LOGICAL_TYPE: &[(&str, bool)] = &[
              "scale": 3,
              "size": 2
          }"#,
-        false,
+        true,
     ),
     (
         r#"{


### PR DESCRIPTION
AVRO-3899

Log a warning for invalid logical (decimal) schema and use the underlying (base) schema


## What is the purpose of the change

* Fix behavior while parsing a logical schema to behave as expected by the specification

## Verifying this change

* Update the existing unit tests 

## Documentation

- Does this pull request introduce a new feature? no