### PR TITLE
Reflect data get fields support not order by property name.

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectData.java
@@ -71,6 +71,8 @@ public class ReflectData extends SpecificData {
 
   private static final String STRING_OUTER_PARENT_REFERENCE = "this$0";
 
+  private static final boolean ORDER_REFLECT_FIELDS =
+      Boolean.parseBoolean(System.getProperty("org.apache.avro.reflect.fields.order", "true"));
   /**
    * Always false since custom coders are not available for {@link ReflectData}.
    */
@@ -858,7 +860,9 @@ public class ReflectData extends SpecificData {
       if (excludeJava && c.getPackage() != null && c.getPackage().getName().startsWith("java."))
         break; // skip java built-in classes
       Field[] declaredFields = c.getDeclaredFields();
-      Arrays.sort(declaredFields, Comparator.comparing(Field::getName));
+      if (ORDER_REFLECT_FIELDS) {
+        Arrays.sort(declaredFields, Comparator.comparing(Field::getName));
+      }
       for (Field field : declaredFields)
         if ((field.getModifiers() & (Modifier.TRANSIENT | Modifier.STATIC)) == 0)
           if (fields.put(field.getName(), field) != null)


### PR DESCRIPTION
In some cases, we hope that the reflect fields order maintain the original order.


```
class Pojo {
String f2;
String f1;
}
```
 At client, it create Pojo and serialize it using JSON format.  
The json: 
```
{"f2":"a", "f1":"b"}
```

And then, create the schema using refelct data, the fields will be ordered. 

The schema:
```
[{"name":"f1", "type":"string"},
{"name":"f2", "type":"string"}]
```

Then push the payload and schema to server, the server store the json payload as k,v format, and store the schema to the schema registry.

At another client, it want to read the data. Then the server read the k,v format data, then decode it according the schema from schema registry. But the fields order is not match the origin. So the decode json will be like
```
{"f1":"b", "f2":"a"}
```

I want to make the json fields order maintain the original order, when creating the schema using ReflectData, not order the fields.