### PR TITLE
AVRO-3904: [RUST] return a Result when checking schema compatibility so the …

### DIFF
--- a/lang/rust/avro/README.md
+++ b/lang/rust/avro/README.md
@@ -634,7 +634,7 @@ use apache_avro::{Schema, schema_compatibility::SchemaCompatibility};
 
 let writers_schema = Schema::parse_str(r#"{"type": "array", "items":"int"}"#).unwrap();
 let readers_schema = Schema::parse_str(r#"{"type": "array", "items":"long"}"#).unwrap();
-assert_eq!(true, SchemaCompatibility::can_read(&writers_schema, &readers_schema));
+assert!(SchemaCompatibility::can_read(&writers_schema, &readers_schema).is_ok());
 ```
 
 2. Incompatible schemas (a long array schema cannot be read by an int array schema)
@@ -647,7 +647,7 @@ use apache_avro::{Schema, schema_compatibility::SchemaCompatibility};
 
 let writers_schema = Schema::parse_str(r#"{"type": "array", "items":"long"}"#).unwrap();
 let readers_schema = Schema::parse_str(r#"{"type": "array", "items":"int"}"#).unwrap();
-assert_eq!(false, SchemaCompatibility::can_read(&writers_schema, &readers_schema));
+assert!(SchemaCompatibility::can_read(&writers_schema, &readers_schema).is_err());
 ```
 
 <!-- cargo-rdme end -->

--- a/lang/rust/avro/src/error.rs
+++ b/lang/rust/avro/src/error.rs
@@ -478,9 +478,48 @@ pub enum Error {
 
     #[error("Invalid Avro data! Cannot read codec type from value that is not Value::Bytes.")]
     BadCodecMetadata,
+}
 
-    #[error("Schemas are not compatible. '{0}'")]
-    CompatibilityError(String),
+#[derive(thiserror::Error, Debug)]
+pub enum CompatibilityError {
+    #[error("Schemas are not compatible. Writer schema is {writer_schema_type}, but reader schema is {reader_schema_type}")]
+    WrongType {
+        writer_schema_type: String,
+        reader_schema_type: String,
+    },
+
+    #[error("Schemas are not compatible. The {schema_type} should have been {expected_type}")]
+    TypeExpected {
+        schema_type: String,
+        expected_type: String,
+    },
+
+    #[error("Schemas are not compatible. Field '{0}' in reader schema does not match the type in the writer schema")]
+    FieldTypeMismatch(String),
+
+    #[error("Schemas are not compatible. Schemas mismatch")]
+    SchemaMismatch,
+
+    #[error("Schemas are not compatible. Field '{0}' in reader schema must have a default value")]
+    MissingDefaultValue(String),
+
+    #[error("Schemas are not compatible. Reader's symbols must contain all writer's symbols")]
+    MissingSymbols,
+
+    #[error("Schemas are not compatible. All elements in union must match for both schemas")]
+    MissingUnionElements,
+
+    #[error("Schemas are not compatible. Name and size don't match for fixed")]
+    FixedMismatch,
+
+    #[error("Schemas are not compatible. The name must be the same for both schemas. Writer's name {writer_name} and reader's name {reader_name}")]
+    NameMismatch {
+        writer_name: String,
+        reader_name: String,
+    },
+
+    #[error("Schemas are not compatible. Unknown type for '{0}'. Make sure that the type is a valid one")]
+    Inconclusive(String),
 }
 
 impl serde::ser::Error for Error {

--- a/lang/rust/avro/src/error.rs
+++ b/lang/rust/avro/src/error.rs
@@ -478,6 +478,9 @@ pub enum Error {
 
     #[error("Invalid Avro data! Cannot read codec type from value that is not Value::Bytes.")]
     BadCodecMetadata,
+
+    #[error("Schemas are not compatible. '{0}'")]
+    CompatibilityError(String),
 }
 
 impl serde::ser::Error for Error {

--- a/lang/rust/avro/src/lib.rs
+++ b/lang/rust/avro/src/lib.rs
@@ -747,7 +747,7 @@
 //!
 //! let writers_schema = Schema::parse_str(r#"{"type": "array", "items":"int"}"#).unwrap();
 //! let readers_schema = Schema::parse_str(r#"{"type": "array", "items":"long"}"#).unwrap();
-//! assert_eq!(true, SchemaCompatibility::can_read(&writers_schema, &readers_schema));
+//! assert_eq!(true, SchemaCompatibility::can_read(&writers_schema, &readers_schema).is_ok());
 //! ```
 //!
 //! 2. Incompatible schemas (a long array schema cannot be read by an int array schema)
@@ -760,7 +760,7 @@
 //!
 //! let writers_schema = Schema::parse_str(r#"{"type": "array", "items":"long"}"#).unwrap();
 //! let readers_schema = Schema::parse_str(r#"{"type": "array", "items":"int"}"#).unwrap();
-//! assert_eq!(false, SchemaCompatibility::can_read(&writers_schema, &readers_schema));
+//! assert!(SchemaCompatibility::can_read(&writers_schema, &readers_schema).is_err());
 //! ```
 
 mod codec;

--- a/lang/rust/avro/src/lib.rs
+++ b/lang/rust/avro/src/lib.rs
@@ -747,7 +747,7 @@
 //!
 //! let writers_schema = Schema::parse_str(r#"{"type": "array", "items":"int"}"#).unwrap();
 //! let readers_schema = Schema::parse_str(r#"{"type": "array", "items":"long"}"#).unwrap();
-//! assert_eq!(true, SchemaCompatibility::can_read(&writers_schema, &readers_schema).is_ok());
+//! assert!(SchemaCompatibility::can_read(&writers_schema, &readers_schema).is_ok());
 //! ```
 //!
 //! 2. Incompatible schemas (a long array schema cannot be read by an int array schema)

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -206,6 +206,42 @@ impl From<&types::Value> for SchemaKind {
     }
 }
 
+// Implement `Display` for `SchemaKind`.
+impl fmt::Display for Schema {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Schema::Null => write!(f, "Null"),
+            Schema::Boolean => write!(f, "Boolean"),
+            Schema::Int => write!(f, "Int"),
+            Schema::Long => write!(f, "Long"),
+            Schema::Float => write!(f, "Float"),
+            Schema::Double => write!(f, "Double"),
+            Schema::Bytes => write!(f, "Bytes"),
+            Schema::String => write!(f, "String"),
+            Schema::Array(..) => write!(f, "Array"),
+            Schema::Map(..) => write!(f, "Map"),
+            Schema::Union(..) => write!(f, "Union"),
+            Schema::Record(..) => write!(f, "Record"),
+            Schema::Enum(..) => write!(f, "Enum"),
+            Schema::Fixed(..) => write!(f, "Fixed"),
+            Schema::Decimal(..) => write!(f, "Decimal"),
+            Schema::BigDecimal => write!(f, "BigDecimal"),
+            Schema::Uuid => write!(f, "Uuid"),
+            Schema::Date => write!(f, "Date"),
+            Schema::TimeMillis => write!(f, "TimeMillis"),
+            Schema::TimeMicros => write!(f, "TimeMicros"),
+            Schema::TimestampMillis => write!(f, "TimestampMillis"),
+            Schema::TimestampMicros => write!(f, "TimestampMicros"),
+            Schema::LocalTimestampMillis => write!(f, "LocalTimestampMillis"),
+            Schema::LocalTimestampMicros => write!(f, "LocalTimestampMicros"),
+            Schema::Duration => write!(f, "Duration"),
+            Schema::Ref { name } => {
+                write!(f, "{}", name.name)
+            }
+        }
+    }
+}
+
 /// Represents names for `record`, `enum` and `fixed` Avro schemas.
 ///
 /// Each of these `Schema`s have a `fullname` composed of two parts:


### PR DESCRIPTION
## What is the purpose of the change

Do not panic when calculating schemas compatibilities. The return type is a `Result`  which in case of an `error`the user can get feedback about the compatibility issue, otherwise the compatibility will be `Ok()`. Related to [AVRO-3904](https://issues.apache.org/jira/browse/AVRO-3904)


## Verifying this change

This change is partially covered by existing tests, such as `test_union_resolution_no_structure_match, test_missing_field`. WIth the changes I am adding a new test to check the compatibility error and all the existing test will do the same in case of `Err`

## Documentation

- Does this pull request introduce a new feature? (no). The `SchemaCompatibility::can_read` return type has been changed from `bool` to `Result` so this should be in the documentation as well.

