### PR TITLE
AVRO-3905: [Rust] Fix clippy error with Rust 1.74.0

### DIFF
--- a/lang/rust/avro_derive/tests/derive.rs
+++ b/lang/rust/avro_derive/tests/derive.rs
@@ -68,8 +68,8 @@ mod test_derive {
     {
         assert!(!encoded.is_empty());
         let schema = T::get_schema();
-        let reader = Reader::with_schema(&schema, &encoded[..]).unwrap();
-        for res in reader {
+        let mut reader = Reader::with_schema(&schema, &encoded[..]).unwrap();
+        if let Some(res) = reader.next() {
             match res {
                 Ok(value) => {
                     return from_value::<T>(&value).unwrap();


### PR DESCRIPTION
AVRO-3905

## What is the purpose of the change

* Fix the build with Rust 1.74.0

## Verifying this change

* The build and tests should pass

## Documentation

- Does this pull request introduce a new feature? no