### PR TITLE
AVRO-3779: [Rust] Fully specify the dependency to bigdecimal crate

### DIFF
--- a/lang/rust/Cargo.lock
+++ b/lang/rust/Cargo.lock
@@ -158,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "bigdecimal"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "454bca3db10617b88b566f205ed190aedb0e0e6dd4cad61d3988a72e8c5594cb"
+checksum = "c06619be423ea5bb86c95f087d5707942791a08a85530df0db2209a3ecfb8bc9"
 dependencies = [
  "autocfg",
  "libm",

--- a/lang/rust/avro/Cargo.toml
+++ b/lang/rust/avro/Cargo.toml
@@ -55,6 +55,7 @@ name = "single"
 
 [dependencies]
 apache-avro-derive = { default-features = false, version = "0.17.0", path = "../avro_derive", optional = true }
+bigdecimal = { default-features = false, version = "0.4.2", features = ["std"] }
 bzip2 = { default-features = false, version = "0.4.4", optional = true }
 crc32fast = { default-features = false, version = "1.3.2", optional = true }
 digest = { default-features = false, version = "0.10.7", features = ["core-api"] }
@@ -73,7 +74,6 @@ typed-builder = { default-features = false, version = "0.16.2" }
 uuid = { default-features = false, version = "1.4.1", features = ["serde", "std"] }
 xz2 = { default-features = false, version = "0.1.7", optional = true }
 zstd = { default-features = false, version = "0.12.4+zstd.1.5.2", optional = true }
-bigdecimal = "0.4"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 quad-rand = { default-features = false, version = "0.2.1" }

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -5155,17 +5155,12 @@ mod tests {
     #[test]
     fn test_avro_3779_bigdecimal_schema() -> TestResult {
         let schema = json!(
-        {
-          "type": "record",
-          "name": "recordWithDecimal",
-          "fields": [
             {
                 "name": "decimal",
                 "type": "bytes",
                 "logicalType": "big-decimal"
             }
-          ]
-        });
+        );
 
         let parse_result = Schema::parse(&schema);
         assert!(
@@ -5173,6 +5168,10 @@ mod tests {
             "parse result must be ok, got: {:?}",
             parse_result
         );
+        match parse_result? {
+            Schema::BigDecimal => (),
+            other => panic!("Expected Schema::BigDecimal but got: {other:?}"),
+        }
 
         Ok(())
     }


### PR DESCRIPTION
AVRO-3779

Depend on full version and only on the `std` feature


## What is the purpose of the change

* Dependency management. 

## Verifying this change

* Build and tests should still pass

## Documentation

- Does this pull request introduce a new feature? no