### PR TITLE
AVRO-3915: [Rust] Extract dependencies used by more than one member crates into the workspace

### DIFF
--- a/lang/rust/Cargo.toml
+++ b/lang/rust/Cargo.toml
@@ -39,6 +39,13 @@ keywords = ["avro", "data", "serialization"]
 categories = ["encoding"]
 documentation = "https://docs.rs/apache-avro"
 
+# dependencies used by more than one members
+[workspace.dependencies]
+lazy_static = { default-features = false, version = "1.4.0" }
+log = { default-features = false, version = "0.4.20" }
+serde = { default-features = false, version = "1.0.193", features = ["derive"] }
+serde_json = { default-features = false, version = "1.0.108", features = ["std"] }
+
 [profile.release.package.hello-wasm]
 # Tell `rustc` to optimize for small code size.
 opt-level = "s"

--- a/lang/rust/avro/Cargo.toml
+++ b/lang/rust/avro/Cargo.toml
@@ -59,13 +59,13 @@ bigdecimal = { default-features = false, version = "0.4.2", features = ["std"] }
 bzip2 = { default-features = false, version = "0.4.4", optional = true }
 crc32fast = { default-features = false, version = "1.3.2", optional = true }
 digest = { default-features = false, version = "0.10.7", features = ["core-api"] }
-lazy_static = { default-features = false, version = "1.4.0" }
+lazy_static = { workspace = true }
 libflate = { default-features = false, version = "2.0.0", features = ["std"] }
-log = { default-features = false, version = "0.4.20" }
+log = { workspace = true }
 num-bigint = { default-features = false, version = "0.4.4" }
 regex-lite = { default-features = false, version = "0.1.5", features = ["std", "string"] }
-serde = { default-features = false, version = "1.0.193", features = ["derive"] }
-serde_json = { default-features = false, version = "1.0.108", features = ["std"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
 snap = { default-features = false, version = "1.1.0", optional = true }
 strum = { default-features = false, version = "0.25.0" }
 strum_macros = { default-features = false, version = "0.25.3" }
@@ -74,6 +74,7 @@ typed-builder = { default-features = false, version = "0.18.0" }
 uuid = { default-features = false, version = "1.6.1", features = ["serde", "std"] }
 xz2 = { default-features = false, version = "0.1.7", optional = true }
 zstd = { default-features = false, version = "0.13.0", optional = true }
+
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 quad-rand = { default-features = false, version = "0.2.1" }

--- a/lang/rust/avro_derive/Cargo.toml
+++ b/lang/rust/avro_derive/Cargo.toml
@@ -36,7 +36,7 @@ proc-macro = true
 darling = { default-features = false, version = "0.20.3" }
 proc-macro2 = { default-features = false, version = "1.0.70" }
 quote = { default-features = false, version = "1.0.33" }
-serde_json = { default-features = false, version = "1.0.108", features = ["std"] }
+serde_json = { workspace = true }
 syn = { default-features = false, version = "2.0.39", features = ["full", "fold"] }
 
 [dev-dependencies]

--- a/lang/rust/avro_test_helper/Cargo.toml
+++ b/lang/rust/avro_test_helper/Cargo.toml
@@ -35,6 +35,6 @@ anyhow = { default-features = false, version = "1.0.75", features = ["std"] }
 better-panic = { default-features = false, version = "0.3.0" }
 ctor = { default-features = false, version = "0.2.5" }
 env_logger = { default-features = false, version = "0.10.1" }
-lazy_static = { default-features = false, version = "1.4.0" }
-log = { default-features = false, version = "0.4.20" }
+lazy_static = { workspace = true }
+log = { workspace = true }
 ref_thread_local = { default-features = false, version = "0.1.1" }


### PR DESCRIPTION
AVRO-3915

## What is the purpose of the change

* Non functional change. Move dependencies to the parent Cargo.toml

## Verifying this change

* Build and tests should still work

## Documentation

- Does this pull request introduce a new feature? no