### PR TITLE
AVRO-3916: [Rust] Add TimestampNanos types

### DIFF
--- a/lang/rust/avro/README.md
+++ b/lang/rust/avro/README.md
@@ -538,8 +538,10 @@ fn main() -> Result<(), Error> {
     record.put("time_micros", Value::TimeMicros(3));
     record.put("timestamp_millis", Value::TimestampMillis(4));
     record.put("timestamp_micros", Value::TimestampMicros(5));
+    record.put("timestamp_nanos", Value::TimestampNanos(6));
     record.put("local_timestamp_millis", Value::LocalTimestampMillis(4));
     record.put("local_timestamp_micros", Value::LocalTimestampMicros(5));
+    record.put("local_timestamp_nanos", Value::LocalTimestampMicros(6));
     record.put("duration", Duration::new(Months::new(6), Days::new(7), Millis::new(8)));
 
     writer.append(record)?;

--- a/lang/rust/avro/src/decode.rs
+++ b/lang/rust/avro/src/decode.rs
@@ -137,8 +137,10 @@ pub(crate) fn decode_internal<R: Read, S: Borrow<Schema>>(
         Schema::TimeMicros => zag_i64(reader).map(Value::TimeMicros),
         Schema::TimestampMillis => zag_i64(reader).map(Value::TimestampMillis),
         Schema::TimestampMicros => zag_i64(reader).map(Value::TimestampMicros),
+        Schema::TimestampNanos => zag_i64(reader).map(Value::TimestampNanos),
         Schema::LocalTimestampMillis => zag_i64(reader).map(Value::LocalTimestampMillis),
         Schema::LocalTimestampMicros => zag_i64(reader).map(Value::LocalTimestampMicros),
+        Schema::LocalTimestampNanos => zag_i64(reader).map(Value::LocalTimestampNanos),
         Schema::Duration => {
             let mut buf = [0u8; 12];
             reader.read_exact(&mut buf).map_err(Error::ReadDuration)?;

--- a/lang/rust/avro/src/encode.rs
+++ b/lang/rust/avro/src/encode.rs
@@ -90,8 +90,10 @@ pub(crate) fn encode_internal<S: Borrow<Schema>>(
         Value::Long(i)
         | Value::TimestampMillis(i)
         | Value::TimestampMicros(i)
+        | Value::TimestampNanos(i)
         | Value::LocalTimestampMillis(i)
         | Value::LocalTimestampMicros(i)
+        | Value::LocalTimestampNanos(i)
         | Value::TimeMicros(i) => encode_long(*i, buffer),
         Value::Float(x) => buffer.extend_from_slice(&x.to_le_bytes()),
         Value::Double(x) => buffer.extend_from_slice(&x.to_le_bytes()),

--- a/lang/rust/avro/src/error.rs
+++ b/lang/rust/avro/src/error.rs
@@ -154,11 +154,17 @@ pub enum Error {
     #[error("TimestampMicros expected, got {0:?}")]
     GetTimestampMicros(ValueKind),
 
+    #[error("TimestampNanos expected, got {0:?}")]
+    GetTimestampNanos(ValueKind),
+
     #[error("LocalTimestampMillis expected, got {0:?}")]
     GetLocalTimestampMillis(ValueKind),
 
     #[error("LocalTimestampMicros expected, got {0:?}")]
     GetLocalTimestampMicros(ValueKind),
+
+    #[error("LocalTimestampNanos expected, got {0:?}")]
+    GetLocalTimestampNanos(ValueKind),
 
     #[error("Null expected, got {0:?}")]
     GetNull(ValueKind),

--- a/lang/rust/avro/src/lib.rs
+++ b/lang/rust/avro/src/lib.rs
@@ -651,8 +651,10 @@
 //!     record.put("time_micros", Value::TimeMicros(3));
 //!     record.put("timestamp_millis", Value::TimestampMillis(4));
 //!     record.put("timestamp_micros", Value::TimestampMicros(5));
+//!     record.put("timestamp_nanos", Value::TimestampNanos(6));
 //!     record.put("local_timestamp_millis", Value::LocalTimestampMillis(4));
 //!     record.put("local_timestamp_micros", Value::LocalTimestampMicros(5));
+//!     record.put("local_timestamp_nanos", Value::LocalTimestampMicros(6));
 //!     record.put("duration", Duration::new(Months::new(6), Days::new(7), Millis::new(8)));
 //!
 //!     writer.append(record)?;

--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -130,10 +130,14 @@ pub enum Schema {
     TimestampMillis,
     /// An instant in time represented as the number of microseconds after the UNIX epoch.
     TimestampMicros,
+    /// An instant in time represented as the number of nanoseconds after the UNIX epoch.
+    TimestampNanos,
     /// An instant in localtime represented as the number of milliseconds after the UNIX epoch.
     LocalTimestampMillis,
     /// An instant in local time represented as the number of microseconds after the UNIX epoch.
     LocalTimestampMicros,
+    /// An instant in local time represented as the number of nanoseconds after the UNIX epoch.
+    LocalTimestampNanos,
     /// An amount of time defined by a number of months, days and milliseconds.
     Duration,
     /// A reference to another schema.
@@ -199,8 +203,10 @@ impl From<&types::Value> for SchemaKind {
             Value::TimeMicros(_) => Self::TimeMicros,
             Value::TimestampMillis(_) => Self::TimestampMillis,
             Value::TimestampMicros(_) => Self::TimestampMicros,
+            Value::TimestampNanos(_) => Self::TimestampNanos,
             Value::LocalTimestampMillis(_) => Self::LocalTimestampMillis,
             Value::LocalTimestampMicros(_) => Self::LocalTimestampMicros,
+            Value::LocalTimestampNanos(_) => Self::LocalTimestampNanos,
             Value::Duration { .. } => Self::Duration,
         }
     }
@@ -1942,6 +1948,12 @@ impl Serialize for Schema {
                 map.serialize_entry("logicalType", "timestamp-micros")?;
                 map.end()
             }
+            Schema::TimestampNanos => {
+                let mut map = serializer.serialize_map(None)?;
+                map.serialize_entry("type", "long")?;
+                map.serialize_entry("logicalType", "timestamp-nanos")?;
+                map.end()
+            }
             Schema::LocalTimestampMillis => {
                 let mut map = serializer.serialize_map(None)?;
                 map.serialize_entry("type", "long")?;
@@ -1952,6 +1964,12 @@ impl Serialize for Schema {
                 let mut map = serializer.serialize_map(None)?;
                 map.serialize_entry("type", "long")?;
                 map.serialize_entry("logicalType", "local-timestamp-micros")?;
+                map.end()
+            }
+            Schema::LocalTimestampNanos => {
+                let mut map = serializer.serialize_map(None)?;
+                map.serialize_entry("type", "long")?;
+                map.serialize_entry("logicalType", "local-timestamp-nanos")?;
                 map.end()
             }
             Schema::Duration => {


### PR DESCRIPTION
AVRO-3916
## What is the purpose of the change

* Add support for the new logical types:
- `timestamp-nanos`
- `local-timestamp-nanos`

## Verifying this change

* New unit tests are added. All old ones should pass too!

## Documentation

- Does this pull request introduce a new feature? yes
- If yes, how is the feature documented? - the specification is updated