### PR TITLE
Fix action/labeler to work with v5

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -18,15 +18,39 @@
 #
 # Pull Request Labeler Github Action Configuration: https://github.com/marketplace/actions/labeler
 
-C: ["lang/c/**/*"]
-C++: ["lang/c++/**/*"]
-C#: ["lang/csharp/**/*"]
-Java: ["lang/java/**/*"]
-Js: ["lang/js/**/*"]
-Perl: ["lang/perl/**/*"]
-Php: ["lang/php/**/*"]
-Python: ["lang/py/**/*"]
-Ruby: ["lang/ruby/**/*"]
-Rust: ["lang/rust/**/*"]
-build: ["**/*Dockerfile*", "**/*.sh", "**/*pom.xml", ".github/**/*"]
-website: ["doc/**/*"]
+C: 
+  - changed-files:
+    - any-glob-to-any-file: "lang/c/**/*"
+C++: 
+  - changed-files:
+    - any-glob-to-any-file: "lang/c++/**/*"
+C#: 
+  - changed-files:
+    - any-glob-to-any-file: "lang/csharp/**/*"
+Java: 
+  - changed-files:
+    - any-glob-to-any-file: "lang/java/**/*"
+Js: 
+  - changed-files:
+    - any-glob-to-any-file: "lang/js/**/*"
+Perl: 
+  - changed-files:
+    - any-glob-to-any-file: "lang/perl/**/*"
+Php: 
+  - changed-files:
+    - any-glob-to-any-file: "lang/php/**/*"
+Python: 
+  - changed-files:
+    - any-glob-to-any-file: "lang/py/**/*"
+Ruby: 
+  - changed-files:
+    - any-glob-to-any-file: "lang/ruby/**/*"
+Rust: 
+  - changed-files:
+    - any-glob-to-any-file: "lang/rust/**/*"
+build: 
+  - changed-files:
+    - any-glob-to-any-file: ["**/*Dockerfile*", "**/*.sh", "**/*pom.xml", ".github/**/*"]
+website: 
+  - changed-files:
+    - any-glob-to-any-file: "doc/**/*"

--- a/lang/rust/README.md
+++ b/lang/rust/README.md
@@ -38,4 +38,3 @@ See [avro_test_helper/README.md](./avro_test_helper/README.md)
 ## WebAssembly demo application
 
 See [wasm-demo/README.md](./wasm-demo/README.md)
-


### PR DESCRIPTION
## What is the purpose of the change

* Fix the `.github/labeler.yml` after the upgrade of action/labeler to v5 (https://github.com/apache/avro/pull/2632)


## Verifying this change

* The labeler workflow should pass without error for the syntax in `.github/labeler.yml`

## Documentation

- Does this pull request introduce a new feature? no