### PR TITLE
AVRO-3921: [ruby] Test against Ruby 3.3

### DIFF
--- a/.github/workflows/test-lang-ruby.yml
+++ b/.github/workflows/test-lang-ruby.yml
@@ -43,6 +43,7 @@ jobs:
         - '3.0'
         - '3.1'
         - '3.2'
+        - '3.3'
     steps:
       - uses: actions/checkout@v4
 
@@ -83,6 +84,7 @@ jobs:
         - '3.0'
         - '3.1'
         - '3.2'
+        - '3.3'
     steps:
       - uses: actions/checkout@v4
 

--- a/lang/ruby/test/test_logical_types.rb
+++ b/lang/ruby/test/test_logical_types.rb
@@ -141,7 +141,7 @@ class TestLogicalTypes < Test::Unit::TestCase
                     "null"
                 ],
                 "default": "\u0000"
-            }  
+            }
         ]
     }')
 
@@ -215,7 +215,7 @@ class TestLogicalTypes < Test::Unit::TestCase
     sales_tax_record = {
       "sales" => BigDecimal("12.34"),
       "tax" => BigDecimal("0.000"),
-      "invoice_date" => Time.at(0).to_date,
+      "invoice_date" => Date.new(1970, 1, 1),
       # time-millis is not supported
       "invoice_time" => 0,
       "created_at" => Time.at(0).utc,


### PR DESCRIPTION
## What is the purpose of the change

Verify that Avro works with the latest version of Ruby, v3.3, to resolve [AVRO-3921](https://issues.apache.org/jira/browse/AVRO-3921).

## Verifying this change

- The change adds a version to the testing matrix.
- A test that was unstable in local testing with different Ruby versions is updated to use a more stable equivalent, specifying a Date directly instead of converting from Time to a Date

## Documentation

- Does this pull request introduce a new feature? **no**
