### PR TITLE
AVRO-3922: [ruby] add timestamp-nanos support

### DIFF
--- a/lang/ruby/lib/avro/logical_types.rb
+++ b/lang/ruby/lib/avro/logical_types.rb
@@ -214,30 +214,50 @@ module Avro
     end
 
     module TimestampMillis
+      SUBUNITS_PER_SECOND = 1000
+
       def self.encode(value)
         return value.to_i if value.is_a?(Numeric)
 
         time = value.to_time
-        time.to_i * 1000 + time.usec / 1000
+        time.to_i * SUBUNITS_PER_SECOND + time.usec / SUBUNITS_PER_SECOND
       end
 
       def self.decode(int)
-        s, ms = int / 1000, int % 1000
-        Time.at(s, ms * 1000).utc
+        s, ms = int.divmod(SUBUNITS_PER_SECOND)
+        Time.at(s, ms, :millisecond).utc
       end
     end
 
     module TimestampMicros
+      SUBUNITS_PER_SECOND = 1000_000
+
       def self.encode(value)
         return value.to_i if value.is_a?(Numeric)
 
         time = value.to_time
-        time.to_i * 1000_000 + time.usec
+        time.to_i * SUBUNITS_PER_SECOND + time.usec
       end
 
       def self.decode(int)
-        s, us = int / 1000_000, int % 1000_000
-        Time.at(s, us).utc
+        s, us = int.divmod(SUBUNITS_PER_SECOND)
+        Time.at(s, us, :microsecond).utc
+      end
+    end
+
+    module TimestampNanos
+      SUBUNITS_PER_SECOND = 1000_000_000
+
+      def self.encode(value)
+        return value.to_i if value.is_a?(Numeric)
+
+        time = value.to_time
+        time.to_i * SUBUNITS_PER_SECOND + time.nsec
+      end
+
+      def self.decode(int)
+        s, ns = int.divmod(SUBUNITS_PER_SECOND)
+        Time.at(s, ns, :nanosecond).utc
       end
     end
 
@@ -260,7 +280,8 @@ module Avro
       },
       "long" => {
         "timestamp-millis" => TimestampMillis,
-        "timestamp-micros" => TimestampMicros
+        "timestamp-micros" => TimestampMicros,
+        "timestamp-nanos"  => TimestampNanos
       },
     }.freeze
 

--- a/lang/ruby/test/random_data.rb
+++ b/lang/ruby/test/random_data.rb
@@ -89,6 +89,8 @@ class RandomData
       Avro::LogicalTypes::TimestampMicros.decode(rand_long)
     when 'timestamp-millis'
       Avro::LogicalTypes::TimestampMillis.decode(rand_long)
+    when 'timestamp-nanos'
+      Avro::LogicalTypes::TimestampNanos.decode(rand_long)
     end
   end
 

--- a/lang/ruby/test/test_io.rb
+++ b/lang/ruby/test/test_io.rb
@@ -94,7 +94,10 @@ EOS
                             "logicalType": "timestamp-micros"}},
                   {"name": "ts2",
                    "type": {"type": "long",
-                            "logicalType": "timestamp-millis"}}]}
+                            "logicalType": "timestamp-millis"}},
+                  {"name": "ts3",
+                   "type": {"type": "long",
+                            "logicalType": "timestamp-nanos"}}]}
 EOS
     check(record_schema)
   end

--- a/lang/ruby/test/test_logical_types.rb
+++ b/lang/ruby/test/test_logical_types.rb
@@ -92,6 +92,28 @@ class TestLogicalTypes < Test::Unit::TestCase
     assert_equal Time.utc(2015, 5, 28, 21, 46, 53, 221843), type.decode(1432849613221843)
   end
 
+  def test_timestamp_nanos_long
+    schema = Avro::Schema.parse <<-SCHEMA
+      { "type": "long", "logicalType": "timestamp-nanos" }
+    SCHEMA
+
+    time = Time.at(628232400, 123456789, :nanosecond)
+    assert_equal 'timestamp-nanos', schema.logical_type
+    assert_encode_and_decode time, schema
+    assert_preencoded Avro::LogicalTypes::TimestampNanos.encode(time), schema, time.utc
+  end
+
+  def test_timestamp_nanos_long_conversion
+    type = Avro::LogicalTypes::TimestampNanos
+
+    now = Time.now.utc
+
+    assert_equal Time.at(now.to_i, now.nsec, :nanosecond).utc, type.decode(type.encode(now))
+    assert_equal 1432849613221843789, type.encode(Time.at(1432849613, 221843789, :nanosecond).utc)
+    assert_equal 1432849613221843789, type.encode(DateTime.new(2015, 5, 28, 21, 46, 53.221843789))
+    assert_equal Time.at(1432849613, 221843789, :nanosecond).utc, type.decode(1432849613221843789)
+  end
+
   def test_parse_fixed_duration
     schema = Avro::Schema.parse <<-SCHEMA
       { "type": "fixed", "size": 12, "name": "fixed_dur", "logicalType": "duration" }


### PR DESCRIPTION
## What is the purpose of the change

Add support for the `timestamp-nanos` logical type to the Avro Ruby component ([AVRO-3922](https://issues.apache.org/jira/browse/AVRO-3922)).

As part of the change, the existing implementation for `timestamp-millis` and `timestamp-micros` is updated to be clearer and more consistent.

## Verifying this change

This change added tests and can be verified as follows:

- Added tests that the follow the pattern of existing `timestamp-*` tests.
- Added support for generating `timestamp-nanos` values as part of random data utilities.
- Ran Ruby test to verify compatibility across supported Ruby versions.

## Documentation

- Does this pull request introduce a new feature? **yes**
  - implements the new `timestamp-nanos` feature for Ruby
- If yes, how is the feature documented? **not applicable**
  - `timestamp-nanos` is already documented
  - AFAIK the documentation does not contain a matrix of which features are supported by each component