### PR TITLE
AVRO-3931 Fix nanosecond timestamps support

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/LogicalTypes.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/LogicalTypes.java
@@ -281,9 +281,9 @@ public class LogicalTypes {
     return LOCAL_TIMESTAMP_MICROS_TYPE;
   }
 
-  private static final LocalTimestampMicros LOCAL_TIMESTAMP_NANOS_TYPE = new LocalTimestampMicros();
+  private static final LocalTimestampNanos LOCAL_TIMESTAMP_NANOS_TYPE = new LocalTimestampNanos();
 
-  public static LocalTimestampMicros localTimestampNanos() {
+  public static LocalTimestampNanos localTimestampNanos() {
     return LOCAL_TIMESTAMP_NANOS_TYPE;
   }
 


### PR DESCRIPTION
Small PR to fix a little error in `LogicalTypes.localTimestampNanos()` method, which wrongly returns the microseconds version.
