### PR TITLE
Bump maven-core to 3.9.6 and drop needless plexus-utils

### DIFF
--- a/lang/java/maven-plugin/pom.xml
+++ b/lang/java/maven-plugin/pom.xml
@@ -72,14 +72,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <!-- Bump this to a higher version while maven 3.3.9 still uses 3.0.22 with a -->
-    <!-- XML injection vulnerability. -->
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-utils</artifactId>
-      <version>3.5.1</version>
-      <scope>provided</scope>
-    </dependency>
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>file-management</artifactId>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -49,7 +49,7 @@
     <jetty.version>9.4.53.v20231009</jetty.version>
     <jopt-simple.version>5.0.4</jopt-simple.version>
     <junit5.version>5.10.2</junit5.version>
-    <maven-core.version>3.3.9</maven-core.version>
+    <maven-core.version>3.9.6</maven-core.version>
     <mockito.version>5.10.0</mockito.version>
     <netty.version>4.1.106.Final</netty.version>
     <protobuf.version>3.25.2</protobuf.version>


### PR DESCRIPTION
Updating to the latest maven-core makes we can drop the plexus-utils dependency
(see also https://github.com/apache/avro/pull/2619 )