### PR TITLE
AVRO-2825: [csharp] Resolve: C# Logical Types throw exception on unknown logical type

### DIFF
--- a/lang/csharp/src/apache/main/CodeGen/CodeGen.cs
+++ b/lang/csharp/src/apache/main/CodeGen/CodeGen.cs
@@ -893,14 +893,13 @@ namespace Avro
             ctd.Members.Add(cmmPut);
 
             string nspace = recordSchema.Namespace;
-            //if (string.IsNullOrEmpty(nspace))
-            //{
-            //    throw new CodeGenException("Namespace required for record schema " + recordSchema.Name);
-            //}
+            if (string.IsNullOrEmpty(nspace))
+            {
+                throw new CodeGenException("Namespace required for record schema " + recordSchema.Name);
+            }
 
-            // AVRO spec DOES NOT require a Namespace but this code does.
-            // Workaround is to inject a fixed string that will be obvious if required
-            CodeNamespace codens = (!string.IsNullOrEmpty(nspace)) ? AddNamespace(nspace) : AddNamespace(@"SchemaHadNoNamespace");
+            CodeNamespace codens = AddNamespace(nspace);
+
             codens.Types.Add(ctd);
 
             return ctd;

--- a/lang/csharp/src/apache/main/CodeGen/CodeGen.cs
+++ b/lang/csharp/src/apache/main/CodeGen/CodeGen.cs
@@ -893,13 +893,14 @@ namespace Avro
             ctd.Members.Add(cmmPut);
 
             string nspace = recordSchema.Namespace;
-            if (string.IsNullOrEmpty(nspace))
-            {
-                throw new CodeGenException("Namespace required for record schema " + recordSchema.Name);
-            }
+            //if (string.IsNullOrEmpty(nspace))
+            //{
+            //    throw new CodeGenException("Namespace required for record schema " + recordSchema.Name);
+            //}
 
-            CodeNamespace codens = AddNamespace(nspace);
-
+            // AVRO spec DOES NOT require a Namespace but this code does.
+            // Workaround is to inject a fixed string that will be obvious if required
+            CodeNamespace codens = (!string.IsNullOrEmpty(nspace)) ? AddNamespace(nspace) : AddNamespace(@"SchemaHadNoNamespace");
             codens.Types.Add(ctd);
 
             return ctd;

--- a/lang/csharp/src/apache/main/Schema/Schema.cs
+++ b/lang/csharp/src/apache/main/Schema/Schema.cs
@@ -192,9 +192,14 @@ namespace Avro
                         return ArraySchema.NewInstance(jtok, props, names, encspace);
                     if (type.Equals("map", StringComparison.Ordinal))
                         return MapSchema.NewInstance(jtok, props, names, encspace);
-                    if (null != jo["logicalType"]) // logical type based on a primitive
-                        return LogicalSchema.NewInstance(jtok, props, names, encspace);
-
+                    try
+                    {
+                        if (null != jo["logicalType"]) // logical type based on a primitive
+                            return LogicalSchema.NewInstance(jtok, props, names, encspace);
+                    }
+                    // swallow exception from unknown logicalType
+                    catch { }
+                        
                     Schema schema = PrimitiveSchema.NewInstance((string)type, props);
                     if (null != schema)
                         return schema;

--- a/lang/csharp/src/apache/test/AvroGen/AvroGenSchemaTests.cs
+++ b/lang/csharp/src/apache/test/AvroGen/AvroGenSchemaTests.cs
@@ -619,7 +619,9 @@ namespace Avro.Test.AvroGen
                 string schemaFileName = Path.Combine(outputDir, $"{uniqueId}.avsc");
                 System.IO.File.WriteAllText(schemaFileName, schema);
 
-                Assert.That(AvroGenTool.GenSchema(schemaFileName, outputDir, new Dictionary<string, string>(), false), Is.EqualTo(1));
+                // Note: Unknown logical types are now ignored
+                //Assert.That(AvroGenTool.GenSchema(schemaFileName, outputDir, new Dictionary<string, string>(), false), Is.EqualTo(1));
+                Assert.That(AvroGenTool.GenSchema(schemaFileName, outputDir, new Dictionary<string, string>(), false), Is.EqualTo(0));
             }
             finally
             {

--- a/lang/csharp/src/apache/test/Schema/SchemaTests.cs
+++ b/lang/csharp/src/apache/test/Schema/SchemaTests.cs
@@ -548,12 +548,20 @@ namespace Avro.Test
             testToString(sc);
         }
 
+        // Per AVRO Spec (v1.8.0 - v1.11.1) ... Logical Types Section
+        //  Language implementations must ignore unknown logical types when reading, and should use the underlying Avro type.
         [TestCase("{\"type\": \"int\", \"logicalType\": \"unknown\"}", "unknown")]
         public void TestUnknownLogical(string s, string unknownType)
         {
-            var err = Assert.Throws<AvroTypeException>(() => Schema.Parse(s));
+            //var err = Assert.Throws<AvroTypeException>(() => Schema.Parse(s));
+            Assert.DoesNotThrow(() =>
+            {
+                var schema = Schema.Parse(s);
+                // confirm that the schema defaults to the underlying type
+                Assert.IsTrue(schema.Name == @"int");
+            });
 
-            Assert.AreEqual("Logical type '" + unknownType + "' is not supported.", err.Message);
+            //Assert.AreEqual("Logical type '" + unknownType + "' is not supported.", err.Message);
         }
 
         [TestCase("{\"type\": \"map\", \"values\": \"long\"}", "long")]


### PR DESCRIPTION
[AVRO-2825](https://issues.apache.org/jira/browse/AVRO-2825?jql=text%20~%20%22csharp%20logical%22)

## What is the purpose of the change
- This pull request resolves an outstanding issue with the csharp implementation behavior that is **not consistent** with the AVRO spec and the java behavior.
- Per the AVRO Spec:
   - *Language implementations must ignore unknown logical types when reading, and should use the underlying Avro type*
- The current csharp implementation throws an exception for unrecognized Logical Types.

**NOTE:  This PR WILL change the behavior of the current nuget package.  It corrects it to align with the AVRO spec.**

## Verifying this change

This change is already covered by existing tests:
 - test > AvroGen > AvroGenSchemaTests.cs > NotSupportedSchema
    - corrected expected result of Test 

- test > Schema > SchemaTests.cs > TestUnknownLogical
    - corrected expected result of Test 
    
This change added tests and can be verified as follows:
- test > Util > LogicalTypeTests.cs > TestUnknownLogicalType
     - added more complex test to confirm underlying AVRO base type is used.
   
## Documentation

- Does this pull request introduce a new feature? (no)

