### PR TITLE
[C++] do not hardcode Unix Makefiles generator

### DIFF
--- a/lang/c++/build.sh
+++ b/lang/c++/build.sh
@@ -71,10 +71,10 @@ function do_dist() {
   fi
 }
 
-(mkdir -p build; cd build; cmake --version; cmake -G "Unix Makefiles" ..)
 for target in "$@"
 do
 
+cmake -S . -B build
 case "$target" in
   lint)
     # some versions of cppcheck seem to require an explicit
@@ -83,7 +83,7 @@ case "$target" in
     ;;
 
   test)
-    (cd build && cmake -G "Unix Makefiles" -D CMAKE_BUILD_TYPE=Debug -D AVRO_ADD_PROTECTOR_FLAGS=1 .. && make && cd .. \
+    (cmake -S. -Bbuild -D CMAKE_BUILD_TYPE=Debug -D AVRO_ADD_PROTECTOR_FLAGS=1 && cmake --build build \
       && ./build/buffertest \
       && ./build/unittest \
       && ./build/CodecTests \
@@ -105,7 +105,7 @@ case "$target" in
     ;;
 
   dist)
-    (cd build && cmake -G "Unix Makefiles" -D CMAKE_BUILD_TYPE=Release ..)
+    (cd build && cmake -D CMAKE_BUILD_TYPE=Release ..)
     do_dist
     do_doc
     ;;
@@ -119,12 +119,12 @@ case "$target" in
     ;;
 
   clean)
-    (cd build && make clean)
+    (cmake --build build --target clean)
     rm -rf doc test.avro test?.df test??.df test_skip.df test_lastSync.df test_readRecordUsingLastSync.df
     ;;
 
   install)
-    (cd build && cmake -G "Unix Makefiles" -D CMAKE_BUILD_TYPE=Release .. && make install)
+    (cmake -S. -Bbuild -D CMAKE_BUILD_TYPE=Release && cmake --build build --target install)
     ;;
 
   *)


### PR DESCRIPTION
Instead, use `cmake --build`. It has been mentioned at least in cmake 3.2 documentation [1] which has been released in 2015. This will make a build process more flexible to people who want to use different build systems such as Ninja.

[1]: https://cmake.org/cmake/help/v3.2/manual/cmake.1.html

<!--

*Thank you very much for contributing to Apache Avro - we are happy that you want to help us improve Avro. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Avro a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/AVRO/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "AVRO-XXXX: [component] Title of the pull request", where *AVRO-XXXX* should be replaced by the actual issue number. 
    The *component* is optional, but can help identify the correct reviewers faster: either the language ("java", "python") or subsystem such as "build" or "doc" are good candidates.  

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests. You can [build the entire project](https://github.com/apache/avro/blob/main/BUILD.md) or just the [language-specific SDK](https://avro.apache.org/project/how-to-contribute/#unit-tests).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Every commit message references Jira issues in their subject lines. In addition, commits follow the guidelines from [How to write a good git commit message](https://chris.beams.io/posts/git-commit/)
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

-->

## What is the purpose of the change

This change makes the build process slightly more flexible to people who use different build systems.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Documentation

- Does this pull request introduce a new feature? **no**
