### PR TITLE
[AVRO-3944] small CMake fixes

### DIFF
--- a/lang/c++/CMakeLists.txt
+++ b/lang/c++/CMakeLists.txt
@@ -26,7 +26,7 @@ endif()
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.0)
+if (APPLE)
     # Enable MACOSX_RPATH by default
     cmake_policy (SET CMP0042 NEW)
 endif()

--- a/lang/c++/CMakeLists.txt
+++ b/lang/c++/CMakeLists.txt
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-cmake_minimum_required (VERSION 3.1)
+cmake_minimum_required (VERSION 3.5)
 
 set (CMAKE_LEGACY_CYGWIN_WIN32 0)
 


### PR DESCRIPTION
* Bump the minimal supported cmake version to fix the warning
*  Fix the always-true if statement in CMake


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Documentation

- Does this pull request introduce a new feature? **no**
