### PR TITLE
[AVRO-3945] Add missing `override`

### DIFF
--- a/lang/c++/impl/FileStream.cc
+++ b/lang/c++/impl/FileStream.cc
@@ -59,13 +59,13 @@ struct FileBufferCopyIn : public BufferCopyIn {
         ::CloseHandle(h_);
     }
 
-    void seek(size_t len) {
+    void seek(size_t len) override {
         if (::SetFilePointer(h_, len, NULL, FILE_CURRENT) == INVALID_SET_FILE_POINTER && ::GetLastError() != NO_ERROR) {
             throw Exception(boost::format("Cannot skip file: %1%") % ::GetLastError());
         }
     }
 
-    bool read(uint8_t *b, size_t toRead, size_t &actual) {
+    bool read(uint8_t *b, size_t toRead, size_t &actual) override {
         DWORD dw = 0;
         if (!::ReadFile(h_, b, toRead, &dw, NULL)) {
             throw Exception(boost::format("Cannot read file: %1%") % ::GetLastError());
@@ -242,7 +242,7 @@ struct FileBufferCopyOut : public BufferCopyOut {
         ::CloseHandle(h_);
     }
 
-    void write(const uint8_t *b, size_t len) {
+    void write(const uint8_t *b, size_t len) override {
         while (len > 0) {
             DWORD dw = 0;
             if (!::WriteFile(h_, b, len, &dw, NULL)) {


### PR DESCRIPTION
This issue has been reported by `cppcheck`:

    impl/FileStream.cc:52:5: style: Struct 'FileBufferCopyIn' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
        FileBufferCopyIn(const char *filename) : h_(::CreateFileA(filename, GENERIC_READ, 0, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL)) {
        ^
    impl/FileStream.cc:235:5: style: Struct 'FileBufferCopyOut' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
        FileBufferCopyOut(const char *filename) : h_(::CreateFileA(filename, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL)) {
        ^
    impl/FileStream.cc:62:10: style: The function 'seek' overrides a function in a base class but is not marked with a 'override' specifier. [missingOverride]
        void seek(size_t len) {
             ^
    impl/FileStream.cc:45:18: note: Virtual function in base class
        virtual void seek(size_t len) = 0;
                     ^
    impl/FileStream.cc:62:10: note: Function in derived class
        void seek(size_t len) {
             ^
    impl/FileStream.cc:68:10: style: The function 'read' overrides a function in a base class but is not marked with a 'override' specifier. [missingOverride]
        bool read(uint8_t *b, size_t toRead, size_t &actual) {
             ^
    impl/FileStream.cc:46:18: note: Virtual function in base class
        virtual bool read(uint8_t *b, size_t toRead, size_t &actual) = 0;
                     ^
    impl/FileStream.cc:68:10: note: Function in derived class
        bool read(uint8_t *b, size_t toRead, size_t &actual) {
             ^
    impl/FileStream.cc:245:10: style: The function 'write' overrides a function in a base class but is not marked with a 'override' specifier. [missingOverride]
        void write(const uint8_t *b, size_t len) {
             ^
    impl/FileStream.cc:229:18: note: Virtual function in base class
        virtual void write(const uint8_t *b, size_t len) = 0;
                     ^
    impl/FileStream.cc:245:10: note: Function in derived class
        void write(const uint8_t *b, size_t len) {

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
## Documentation

- Does this pull request introduce a new feature? **no**
