### PR TITLE
[AVRO-2397] Use raw string literals in the test

### DIFF
--- a/lang/c++/test/CodecTests.cc
+++ b/lang/c++/test/CodecTests.cc
@@ -1266,42 +1266,42 @@ static const TestData3 data3[] = {
     {R"(["boolean", "int"])", "U1I", R"(["long", "boolean"])", "U0L", 1},
 
     // Aliases
-    {"{\"type\":\"record\", \"name\":\"r\", \"fields\":["
-     "{\"name\":\"f0\", \"type\":\"int\"},"
-     "{\"name\":\"f1\", \"type\":\"boolean\"},"
-     "{\"name\":\"f2\", \"type\":\"double\"}]}",
+    {R"({"type": "record", "name": "r", "fields": [
+        {"name": "f0", "type": "int"},
+        {"name": "f1", "type": "boolean"},
+        {"name": "f2", "type": "double"}]})",
      "IBD",
-     "{\"type\":\"record\", \"name\":\"s\", \"aliases\":[\"r\"], \"fields\":["
-     "{\"name\":\"g0\", \"type\":\"int\", \"aliases\":[\"f0\"]},"
-     "{\"name\":\"g1\", \"type\":\"boolean\", \"aliases\":[\"f1\"]},"
-     "{\"name\":\"f2\", \"type\":\"double\", \"aliases\":[\"g2\"]}]}",
+    R"({"type":"record", "name":"s", "aliases":["r"], "fields":[
+        {"name":"g0", "type":"int", "aliases":["f0"]},
+        {"name":"g1", "type":"boolean", "aliases":["f1"]},
+        {"name":"f2", "type":"double", "aliases":["g2"]}]})",
      "IBD",
      1},
-    {"{\"type\":\"record\", \"name\":\"r\", \"namespace\":\"n\", \"fields\":["
-     "{\"name\":\"f0\", \"type\":\"int\"}]}",
+    {R"({"type": "record", "name": "r", "namespace": "n", "fields": [
+     {"name": "f0", "type": "int"}]})",
      "I",
-     "{\"type\":\"record\", \"name\":\"s\", \"namespace\":\"n2\", \"aliases\":[\"t\", \"n.r\"], \"fields\":["
-     " {\"name\":\"f0\", \"type\":\"int\"}]}",
+     R"({"type": "record", "name": "s", "namespace": "n2", "aliases": ["t", "n.r"], "fields":[
+       {"name": "f0", "type": "int"}]})",
      "I",
      1},
-    {"{\"type\":\"enum\", \"name\":\"e\", \"symbols\":[\"a\", \"b\"]}",
+    {R"({"type": "enum", "name": "e", "symbols": ["a", "b"]})",
      "e1",
-     "{\"type\":\"enum\", \"name\":\"f\", \"aliases\":[\"e\"], \"symbols\":[\"a\", \"b\", \"c\"]}",
-     "e1",
-     1},
-    {"{\"type\":\"enum\", \"name\":\"e\", \"namespace\":\"n\", \"symbols\":[\"a\", \"b\"]}",
-     "e1",
-     "{\"type\":\"enum\", \"name\":\"f\", \"namespace\":\"n2\", \"aliases\":[\"g\", \"n.e\"], \"symbols\":[\"a\", \"b\"]}",
+     R"({"type": "enum", "name": "f", "aliases": ["e"], "symbols":["a", "b", "c"]})",
      "e1",
      1},
-    {"{\"type\":\"fixed\", \"name\":\"f\", \"size\":8}",
+    {R"({"type": "enum", "name": "e", "namespace": "n", "symbols": ["a", "b"]})",
+     "e1",
+     R"({"type": "enum", "name": "f", "namespace": "n2", "aliases": ["g", "n.e"], "symbols": ["a", "b"]})",
+     "e1",
+     1},
+    {R"({"type": "fixed", "name": "f", "size": 8})",
      "f8",
-     "{\"type\":\"fixed\", \"name\":\"g\", \"aliases\":[\"f\"], \"size\":8}",
+     R"({"type": "fixed", "name": "g", "aliases": ["f"], "size": 8})",
      "f8",
      1},
-    {"{\"type\":\"fixed\", \"name\":\"f\", \"namespace\":\"n\", \"size\":8}",
+    {R"({"type": "fixed", "name": "f", "namespace": "n", "size": 8})",
      "f8",
-     "{\"type\":\"fixed\", \"name\":\"g\", \"namespace\":\"n2\", \"aliases\":[\"h\", \"n.f\"], \"size\":8}",
+     R"({"type": "fixed", "name": "g", "namespace": "n2", "aliases": ["h", "n.f"], "size": 8})",
      "f8",
      1},
 };


### PR DESCRIPTION
This should make the test cases a bit more readable.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
## Documentation

- Does this pull request introduce a new feature? **no**
