### PR TITLE
[AVRO-3945] Added missing `explicit`

### DIFF
--- a/lang/c++/impl/FileStream.cc
+++ b/lang/c++/impl/FileStream.cc
@@ -49,7 +49,7 @@ struct BufferCopyIn {
 struct FileBufferCopyIn : public BufferCopyIn {
 #ifdef _WIN32
     HANDLE h_;
-    FileBufferCopyIn(const char *filename) : h_(::CreateFileA(filename, GENERIC_READ, 0, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL)) {
+    explicit FileBufferCopyIn(const char *filename) : h_(::CreateFileA(filename, GENERIC_READ, 0, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL)) {
         if (h_ == INVALID_HANDLE_VALUE) {
             throw Exception(boost::format("Cannot open file: %1%") % ::GetLastError());
         }
@@ -232,7 +232,7 @@ struct BufferCopyOut {
 struct FileBufferCopyOut : public BufferCopyOut {
 #ifdef _WIN32
     HANDLE h_;
-    FileBufferCopyOut(const char *filename) : h_(::CreateFileA(filename, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL)) {
+    explicit FileBufferCopyOut(const char *filename) : h_(::CreateFileA(filename, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL)) {
         if (h_ == INVALID_HANDLE_VALUE) {
             throw Exception(boost::format("Cannot open file: %1%") % ::GetLastError());
         }

--- a/lang/c++/impl/json/JsonDom.hh
+++ b/lang/c++/impl/json/JsonDom.hh
@@ -76,22 +76,22 @@ public:
     explicit Entity(size_t line = 0) : type_(EntityType::Null), line_(line) {}
     // Not explicit because do want implicit conversion
     // NOLINTNEXTLINE(google-explicit-constructor)
-    Entity(Bool v, size_t line = 0) : type_(EntityType::Bool), value_(v), line_(line) {}
+    explicit Entity(Bool v, size_t line = 0) : type_(EntityType::Bool), value_(v), line_(line) {}
     // Not explicit because do want implicit conversion
     // NOLINTNEXTLINE(google-explicit-constructor)
-    Entity(Long v, size_t line = 0) : type_(EntityType::Long), value_(v), line_(line) {}
+    explicit Entity(Long v, size_t line = 0) : type_(EntityType::Long), value_(v), line_(line) {}
     // Not explicit because do want implicit conversion
     // NOLINTNEXTLINE(google-explicit-constructor)
-    Entity(Double v, size_t line = 0) : type_(EntityType::Double), value_(v), line_(line) {}
+    explicit Entity(Double v, size_t line = 0) : type_(EntityType::Double), value_(v), line_(line) {}
     // Not explicit because do want implicit conversion
     // NOLINTNEXTLINE(google-explicit-constructor)
-    Entity(const std::shared_ptr<String> &v, size_t line = 0) : type_(EntityType::String), value_(v), line_(line) {}
+    explicit Entity(const std::shared_ptr<String> &v, size_t line = 0) : type_(EntityType::String), value_(v), line_(line) {}
     // Not explicit because do want implicit conversion
     // NOLINTNEXTLINE(google-explicit-constructor)
-    Entity(const std::shared_ptr<Array> &v, size_t line = 0) : type_(EntityType::Arr), value_(v), line_(line) {}
+    explicit Entity(const std::shared_ptr<Array> &v, size_t line = 0) : type_(EntityType::Arr), value_(v), line_(line) {}
     // Not explicit because do want implicit conversion
     // NOLINTNEXTLINE(google-explicit-constructor)
-    Entity(const std::shared_ptr<Object> &v, size_t line = 0) : type_(EntityType::Obj), value_(v), line_(line) {}
+    explicit Entity(const std::shared_ptr<Object> &v, size_t line = 0) : type_(EntityType::Obj), value_(v), line_(line) {}
 
     EntityType type() const { return type_; }
 


### PR DESCRIPTION
This issue is reported by `cppcheck`:

    impl/json/JsonDom.hh:79:5: style: Class 'Entity' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
        Entity(Bool v, size_t line = 0) : type_(EntityType::Bool), value_(v), line_(line) {}
        ^
    impl/json/JsonDom.hh:82:5: style: Class 'Entity' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
        Entity(Long v, size_t line = 0) : type_(EntityType::Long), value_(v), line_(line) {}
        ^
    impl/json/JsonDom.hh:85:5: style: Class 'Entity' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
        Entity(Double v, size_t line = 0) : type_(EntityType::Double), value_(v), line_(line) {}
        ^
    impl/json/JsonDom.hh:88:5: style: Class 'Entity' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
        Entity(const std::shared_ptr<String> &v, size_t line = 0) : type_(EntityType::String), value_(v), line_(line) {}
        ^
    impl/json/JsonDom.hh:91:5: style: Class 'Entity' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
        Entity(const std::shared_ptr<Array> &v, size_t line = 0) : type_(EntityType::Arr), value_(v), line_(line) {}
        ^
    impl/json/JsonDom.hh:94:5: style: Class 'Entity' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
        Entity(const std::shared_ptr<Object> &v, size_t line = 0) : type_(EntityType::Obj), value_(v), line_(line) {}
        ^
    impl/FileStream.cc:52:5: style: Struct 'FileBufferCopyIn' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
        FileBufferCopyIn(const char *filename) : h_(::CreateFileA(filename, GENERIC_READ, 0, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL)) {
        ^
    impl/FileStream.cc:235:5: style: Struct 'FileBufferCopyOut' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
        FileBufferCopyOut(const char *filename) : h_(::CreateFileA(filename, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL)) {
        ^
## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
## Documentation

- Does this pull request introduce a new feature? **no**
