### PR TITLE
AVRO-3948: [Rust] Re-export bigdecimal::BigDecimal as apache_avro::BigDecimal

### DIFF
--- a/lang/rust/avro/src/bigdecimal.rs
+++ b/lang/rust/avro/src/bigdecimal.rs
@@ -21,7 +21,7 @@ use crate::{
     types::Value,
     Error,
 };
-use bigdecimal::BigDecimal;
+pub use bigdecimal::BigDecimal;
 use num_bigint::BigInt;
 use std::io::Read;
 

--- a/lang/rust/avro/src/lib.rs
+++ b/lang/rust/avro/src/lib.rs
@@ -820,6 +820,7 @@ pub mod schema_equality;
 pub mod types;
 pub mod validator;
 
+pub use crate::bigdecimal::BigDecimal;
 pub use codec::Codec;
 pub use de::from_value;
 pub use decimal::Decimal;

--- a/lang/rust/avro/tests/avro-3786.rs
+++ b/lang/rust/avro/tests/avro-3786.rs
@@ -127,15 +127,15 @@ fn avro_3786_deserialize_union_with_different_enum_order() -> TestResult {
         bar_init: Bar::Bar1,
         bar_use_parent: Some(BarUseParent { bar_use: Bar::Bar1 }),
     };
-    let avro_value = crate::to_value(foo1)?;
+    let avro_value = to_value(foo1)?;
     assert!(
         avro_value.validate(&writer_schema),
         "value is valid for schema",
     );
-    let datum = crate::to_avro_datum(&writer_schema, avro_value)?;
+    let datum = to_avro_datum(&writer_schema, avro_value)?;
     let mut x = &datum[..];
     let reader_schema = Schema::parse_str(reader_schema)?;
-    let deser_value = crate::from_avro_datum(&writer_schema, &mut x, Some(&reader_schema))?;
+    let deser_value = from_avro_datum(&writer_schema, &mut x, Some(&reader_schema))?;
     match deser_value {
         types::Value::Record(fields) => {
             assert_eq!(fields.len(), 2);
@@ -251,15 +251,15 @@ fn avro_3786_deserialize_union_with_different_enum_order_defined_in_record() -> 
     let foo1 = Foo {
         bar_parent: Some(BarParent { bar: Bar::Bar0 }),
     };
-    let avro_value = crate::to_value(foo1)?;
+    let avro_value = to_value(foo1)?;
     assert!(
         avro_value.validate(&writer_schema),
         "value is valid for schema",
     );
-    let datum = crate::to_avro_datum(&writer_schema, avro_value)?;
+    let datum = to_avro_datum(&writer_schema, avro_value)?;
     let mut x = &datum[..];
     let reader_schema = Schema::parse_str(reader_schema)?;
-    let deser_value = crate::from_avro_datum(&writer_schema, &mut x, Some(&reader_schema))?;
+    let deser_value = from_avro_datum(&writer_schema, &mut x, Some(&reader_schema))?;
     match deser_value {
         types::Value::Record(fields) => {
             assert_eq!(fields.len(), 1);
@@ -364,15 +364,15 @@ fn test_avro_3786_deserialize_union_with_different_enum_order_defined_in_record_
     let foo1 = Foo {
         bar_parent: Some(BarParent { bar: Bar::Bar1 }),
     };
-    let avro_value = crate::to_value(foo1)?;
+    let avro_value = to_value(foo1)?;
     assert!(
         avro_value.validate(&writer_schema),
         "value is valid for schema",
     );
-    let datum = crate::to_avro_datum(&writer_schema, avro_value)?;
+    let datum = to_avro_datum(&writer_schema, avro_value)?;
     let mut x = &datum[..];
     let reader_schema = Schema::parse_str(reader_schema)?;
-    let deser_value = crate::from_avro_datum(&writer_schema, &mut x, Some(&reader_schema))?;
+    let deser_value = from_avro_datum(&writer_schema, &mut x, Some(&reader_schema))?;
     match deser_value {
         types::Value::Record(fields) => {
             assert_eq!(fields.len(), 1);
@@ -477,15 +477,15 @@ fn test_avro_3786_deserialize_union_with_different_enum_order_defined_in_record_
     let foo1 = Foo {
         bar_parent: Some(BarParent { bar: Bar::Bar1 }),
     };
-    let avro_value = crate::to_value(foo1)?;
+    let avro_value = to_value(foo1)?;
     assert!(
         avro_value.validate(&writer_schema),
         "value is valid for schema",
     );
-    let datum = crate::to_avro_datum(&writer_schema, avro_value)?;
+    let datum = to_avro_datum(&writer_schema, avro_value)?;
     let mut x = &datum[..];
     let reader_schema = Schema::parse_str(reader_schema)?;
-    let deser_value = crate::from_avro_datum(&writer_schema, &mut x, Some(&reader_schema))?;
+    let deser_value = from_avro_datum(&writer_schema, &mut x, Some(&reader_schema))?;
     match deser_value {
         types::Value::Record(fields) => {
             assert_eq!(fields.len(), 1);
@@ -590,15 +590,15 @@ fn deserialize_union_with_different_enum_order_defined_in_record() -> TestResult
     let foo1 = Foo {
         bar_parent: Some(BarParent { bar: Bar::Bar2 }),
     };
-    let avro_value = crate::to_value(foo1)?;
+    let avro_value = to_value(foo1)?;
     assert!(
         avro_value.validate(&writer_schema),
         "value is valid for schema",
     );
-    let datum = crate::to_avro_datum(&writer_schema, avro_value)?;
+    let datum = to_avro_datum(&writer_schema, avro_value)?;
     let mut x = &datum[..];
     let reader_schema = Schema::parse_str(reader_schema)?;
-    let deser_value = crate::from_avro_datum(&writer_schema, &mut x, Some(&reader_schema))?;
+    let deser_value = from_avro_datum(&writer_schema, &mut x, Some(&reader_schema))?;
     match deser_value {
         types::Value::Record(fields) => {
             assert_eq!(fields.len(), 1);
@@ -864,15 +864,15 @@ fn deserialize_union_with_record_with_enum_defined_inline_reader_has_different_i
             defined_in_record: DefinedInRecord::Val1,
         }),
     };
-    let avro_value = crate::to_value(foo1)?;
+    let avro_value = to_value(foo1)?;
     assert!(
         avro_value.validate(&writer_schema),
         "value is valid for schema",
     );
-    let datum = crate::to_avro_datum(&writer_schema, avro_value)?;
+    let datum = to_avro_datum(&writer_schema, avro_value)?;
     let mut x = &datum[..];
     let reader_schema = Schema::parse_str(reader_schema)?;
-    let deser_value = crate::from_avro_datum(&writer_schema, &mut x, Some(&reader_schema))?;
+    let deser_value = from_avro_datum(&writer_schema, &mut x, Some(&reader_schema))?;
     match deser_value {
         types::Value::Record(fields) => {
             assert_eq!(fields.len(), 3);

--- a/lang/rust/avro/tests/big_decimal.rs
+++ b/lang/rust/avro/tests/big_decimal.rs
@@ -1,0 +1,23 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use apache_avro::BigDecimal;
+
+#[test]
+fn avro_3948_use_apache_avro_big_decimal() {
+    let _ = BigDecimal::from(1234567890123456789_i64);
+}


### PR DESCRIPTION
AVRO-3948

## What is the purpose of the change

* Re-export `bigdecimal::BigDecimal` as `apache_avro::BigDecimal`. This way the dependency (`bigdecimal`) could be replaced with another if needed without breaking the API 

## Verifying this change

* Use `apache_avro::BigDecimal` in a new crate, i.e. in a IT test

## Documentation

- Does this pull request introduce a new feature? no
