### PR TITLE
AVRO-3949: [Rust]: Add support for serde to apache_avro::Decimal

### DIFF
--- a/lang/rust/Cargo.lock
+++ b/lang/rust/Cargo.lock
@@ -821,6 +821,7 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]

--- a/lang/rust/avro/Cargo.toml
+++ b/lang/rust/avro/Cargo.toml
@@ -61,7 +61,7 @@ crc32fast = { default-features = false, version = "1.4.0", optional = true }
 digest = { default-features = false, version = "0.10.7", features = ["core-api"] }
 libflate = { default-features = false, version = "2.0.0", features = ["std"] }
 log = { workspace = true }
-num-bigint = { default-features = false, version = "0.4.4" }
+num-bigint = { default-features = false, version = "0.4.4", features = ["std", "serde"] }
 regex-lite = { default-features = false, version = "0.1.5", features = ["std", "string"] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/lang/rust/avro/src/decimal.rs
+++ b/lang/rust/avro/src/decimal.rs
@@ -18,7 +18,7 @@
 use crate::{AvroResult, Error};
 use num_bigint::{BigInt, Sign};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Decimal {
     value: BigInt,
     len: usize,
@@ -129,6 +129,17 @@ mod tests {
 
         let output = <Vec<u8>>::try_from(d)?;
         assert_eq!(output, input);
+
+        Ok(())
+    }
+
+    #[test]
+    fn avro_3949_decimal_serde() -> TestResult {
+        let decimal = Decimal::from(&[1, 2, 3]);
+
+        let ser = serde_json::to_string(&decimal)?;
+        let de = serde_json::from_str(&ser)?;
+        std::assert_eq!(decimal, de);
 
         Ok(())
     }


### PR DESCRIPTION
AVRO-3949

## What is the purpose of the change

* Make it possible to (de)serialize `apache_avro::Decimal`

## Verifying this change

* Add new unit test

## Documentation

- Does this pull request introduce a new feature? no