### PR TITLE
AVRO-3950: [Rust] tests added for match_schemas in schema_compatibility

### DIFF
--- a/lang/rust/Cargo.lock
+++ b/lang/rust/Cargo.lock
@@ -84,6 +84,7 @@ dependencies = [
  "quad-rand",
  "rand",
  "regex-lite",
+ "rstest",
  "serde",
  "serde_json",
  "serial_test",
@@ -553,6 +554,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,6 +577,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,6 +591,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -607,6 +626,12 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "half"
@@ -1051,16 +1076,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
+name = "relative-path"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
+
+[[package]]
 name = "rle-decode-fast"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
+name = "rstest"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97eeab2f3c0a199bc4be135c36c924b6590b88c377d416494288c14f2db30199"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d428f8247852f894ee1be110b375111b586d4fa431f6c46e64ba5a0dcccbe605"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -1107,6 +1176,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"

--- a/lang/rust/Cargo.lock
+++ b/lang/rust/Cargo.lock
@@ -554,17 +554,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
-name = "futures-macro"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "futures-sink"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,12 +566,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
-
-[[package]]
 name = "futures-util"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -591,7 +574,6 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-io",
- "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1093,8 +1075,6 @@ version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97eeab2f3c0a199bc4be135c36c924b6590b88c377d416494288c14f2db30199"
 dependencies = [
- "futures",
- "futures-timer",
  "rstest_macros",
  "rustc_version",
 ]

--- a/lang/rust/avro/Cargo.toml
+++ b/lang/rust/avro/Cargo.toml
@@ -91,6 +91,7 @@ pretty_assertions = { default-features = false, version = "1.4.0", features = ["
 serial_test = "3.0.0"
 sha2 = { default-features = false, version = "0.10.8" }
 paste = { default-features = false, version = "1.0.14" }
+rstest = "0.18.2"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/lang/rust/avro/Cargo.toml
+++ b/lang/rust/avro/Cargo.toml
@@ -91,7 +91,7 @@ pretty_assertions = { default-features = false, version = "1.4.0", features = ["
 serial_test = "3.0.0"
 sha2 = { default-features = false, version = "0.10.8" }
 paste = { default-features = false, version = "1.0.14" }
-rstest = "0.18.2"
+rstest = { default-features = false, version = "0.18.2" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/lang/rust/avro/src/schema_compatibility.rs
+++ b/lang/rust/avro/src/schema_compatibility.rs
@@ -557,6 +557,7 @@ mod tests {
         Codec, Reader, Writer,
     };
     use apache_avro_test_helper::TestResult;
+    use rstest::*;
 
     fn int_array_schema() -> Schema {
         Schema::parse_str(r#"{"type":"array", "items":"int"}"#).unwrap()
@@ -766,6 +767,257 @@ mod tests {
         assert!(incompatible_schemas
             .iter()
             .any(|(reader, writer)| SchemaCompatibility::can_read(writer, reader).is_err()));
+    }
+
+    #[rstest]
+    // Record type test
+    #[case(
+        r#"{"type": "record", "name": "record_a", "fields": [{"type": "long", "name": "date"}]}"#,
+        r#"{"type": "record", "name": "record_a", "fields": [{"type": "long", "name": "date", "default": 18181}]}"#
+    )]
+    // Fixed type test
+    #[case(
+        r#"{"type": "fixed", "name": "EmployeeId", "size": 16}"#,
+        r#"{"type": "fixed", "name": "EmployeeId", "size": 16, "default": "u00ffffffffffffx"}"#
+    )]
+    // Enum type test
+    #[case(
+        r#"{"type": "enum", "name":"Enum1", "symbols": ["A","B"]}"#,
+        r#"{"type": "enum", "name":"Enum1", "symbols": ["A","B", "C"], "default": "C"}"#
+    )]
+    // Map type test
+    #[case(
+        r#"{"type": "map", "values": "int"}"#,
+        r#"{"type": "map", "values": "long"}"#
+    )]
+    // Date type
+    #[case(r#"{"type": "int"}"#, r#"{"type": "int", "logicalType": "date"}"#)]
+    // time-millis type
+    #[case(
+        r#"{"type": "int"}"#,
+        r#"{"type": "int", "logicalType": "time-millis"}"#
+    )]
+    // time-millis type
+    #[case(
+        r#"{"type": "long"}"#,
+        r#"{"type": "long", "logicalType": "time-micros"}"#
+    )]
+    // timetimestamp-nanos type
+    #[case(
+        r#"{"type": "long"}"#,
+        r#"{"type": "long", "logicalType": "timestamp-nanos"}"#
+    )]
+    // timestamp-millis type
+    #[case(
+        r#"{"type": "long"}"#,
+        r#"{"type": "long", "logicalType": "timestamp-millis"}"#
+    )]
+    // timestamp-micros type
+    #[case(
+        r#"{"type": "long"}"#,
+        r#"{"type": "long", "logicalType": "timestamp-micros"}"#
+    )]
+    // local-timestamp-millis type
+    #[case(
+        r#"{"type": "long"}"#,
+        r#"{"type": "long", "logicalType": "local-timestamp-millis"}"#
+    )]
+    // local-timestamp-micros type
+    #[case(
+        r#"{"type": "long"}"#,
+        r#"{"type": "long", "logicalType": "local-timestamp-micros"}"#
+    )]
+    // local-timestamp-nanos type
+    #[case(
+        r#"{"type": "long"}"#,
+        r#"{"type": "long", "logicalType": "local-timestamp-nanos"}"#
+    )]
+    // Array type test
+    #[case(
+        r#"{"type": "array", "items": "int"}"#,
+        r#"{"type": "array", "items": "long"}"#
+    )]
+    fn test_match_schemas_ok(#[case] writer_schema_str: &str, #[case] reader_schema_str: &str) {
+        let writer_schema = Schema::parse_str(writer_schema_str).unwrap();
+        let reader_schema = Schema::parse_str(reader_schema_str).unwrap();
+
+        assert!(SchemaCompatibility::match_schemas(&writer_schema, &reader_schema).is_ok());
+    }
+
+    #[rstest]
+    // Record type test
+    #[case(
+        r#"{"type": "record", "name":"record_a", "fields": [{"type": "long", "name": "date"}]}"#,
+        r#"{"type": "record", "name":"record_b", "fields": [{"type": "long", "name": "date"}]}"#,
+        CompatibilityError::NameMismatch{writer_name: String::from("record_a"), reader_name: String::from("record_b")}
+    )]
+    // Fixed type test
+    #[case(
+        r#"{"type": "fixed", "name": "EmployeeId", "size": 16}"#,
+        r#"{"type": "fixed", "name": "EmployeeId", "size": 20}"#,
+        CompatibilityError::FixedMismatch
+    )]
+    // Enum type test
+    #[case(
+        r#"{"type": "enum", "name": "Enum1", "symbols": ["A","B"]}"#,
+        r#"{"type": "enum", "name": "Enum2", "symbols": ["A","B"]}"#,
+        CompatibilityError::NameMismatch{writer_name: String::from("Enum1"), reader_name: String::from("Enum2")}
+    )]
+    // Map type test
+    #[case(
+        r#"{"type":"map", "values": "long"}"#,
+        r#"{"type":"map", "values": "int"}"#,
+        CompatibilityError::TypeExpected {schema_type: String::from("readers_schema"), expected_type: vec![
+            SchemaKind::Long,
+            SchemaKind::Float,
+            SchemaKind::Double,
+            SchemaKind::TimeMicros,
+            SchemaKind::TimestampMillis,
+            SchemaKind::TimestampMicros,
+            SchemaKind::TimestampNanos,
+            SchemaKind::LocalTimestampMillis,
+            SchemaKind::LocalTimestampMicros,
+            SchemaKind::LocalTimestampNanos,
+        ]}
+    )]
+    // Array type test
+    #[case(
+        r#"{"type": "array", "items": "long"}"#,
+        r#"{"type": "array", "items": "int"}"#,
+        CompatibilityError::TypeExpected {schema_type: String::from("readers_schema"), expected_type: vec![
+            SchemaKind::Long,
+            SchemaKind::Float,
+            SchemaKind::Double,
+            SchemaKind::TimeMicros,
+            SchemaKind::TimestampMillis,
+            SchemaKind::TimestampMicros,
+            SchemaKind::TimestampNanos,
+            SchemaKind::LocalTimestampMillis,
+            SchemaKind::LocalTimestampMicros,
+            SchemaKind::LocalTimestampNanos,
+        ]}
+    )]
+    // Date type test
+    #[case(
+        r#"{"type": "string"}"#,
+        r#"{"type": "int", "logicalType": "date"}"#,
+        CompatibilityError::TypeExpected{schema_type: String::from("readers_schema"), expected_type: vec![SchemaKind::String, SchemaKind::Bytes]}
+    )]
+    // time-millis type
+    #[case(
+        r#"{"type": "string"}"#,
+        r#"{"type": "int", "logicalType": "time-millis"}"#,
+        CompatibilityError::TypeExpected{schema_type: String::from("readers_schema"), expected_type: vec![SchemaKind::String, SchemaKind::Bytes]}
+    )]
+    // time-millis type
+    #[case(
+        r#"{"type": "int"}"#,
+        r#"{"type": "long", "logicalType": "time-micros"}"#,
+        CompatibilityError::TypeExpected{schema_type: String::from("readers_schema"), expected_type: vec![
+            SchemaKind::Int,
+            SchemaKind::Long,
+            SchemaKind::Float,
+            SchemaKind::Double,
+            SchemaKind::Date,
+            SchemaKind::TimeMillis
+        ]}
+    )]
+    // timestamp-nanos type. This test should fail because it is not supported on schema parse_complex
+    // #[case(
+    //     r#"{"type": "string"}"#,
+    //     r#"{"type": "long", "logicalType": "timestamp-nanos"}"#,
+    //     CompatibilityError::TypeExpected{schema_type: String::from("readers_schema"), expected_type: vec![
+    //         SchemaKind::Int,
+    //         SchemaKind::Long,
+    //         SchemaKind::Float,
+    //         SchemaKind::Double,
+    //         SchemaKind::Date,
+    //         SchemaKind::TimeMillis
+    //     ]}
+    // )]
+    // timestamp-millis type
+    #[case(
+        r#"{"type": "int"}"#,
+        r#"{"type": "long", "logicalType": "timestamp-millis"}"#,
+        CompatibilityError::TypeExpected{schema_type: String::from("readers_schema"), expected_type: vec![
+            SchemaKind::Int,
+            SchemaKind::Long,
+            SchemaKind::Float,
+            SchemaKind::Double,
+            SchemaKind::Date,
+            SchemaKind::TimeMillis
+        ]}
+    )]
+    // timestamp-micros type
+    #[case(
+        r#"{"type": "int"}"#,
+        r#"{"type": "long", "logicalType": "timestamp-micros"}"#,
+        CompatibilityError::TypeExpected{schema_type: String::from("readers_schema"), expected_type: vec![
+            SchemaKind::Int,
+            SchemaKind::Long,
+            SchemaKind::Float,
+            SchemaKind::Double,
+            SchemaKind::Date,
+            SchemaKind::TimeMillis
+        ]}
+    )]
+    // local-timestamp-millis type
+    #[case(
+        r#"{"type": "int"}"#,
+        r#"{"type": "long", "logicalType": "local-timestamp-millis"}"#,
+        CompatibilityError::TypeExpected{schema_type: String::from("readers_schema"), expected_type: vec![
+            SchemaKind::Int,
+            SchemaKind::Long,
+            SchemaKind::Float,
+            SchemaKind::Double,
+            SchemaKind::Date,
+            SchemaKind::TimeMillis
+        ]}
+    )]
+    // local-timestamp-micros type
+    #[case(
+        r#"{"type": "int"}"#,
+        r#"{"type": "long", "logicalType": "local-timestamp-micros"}"#,
+        CompatibilityError::TypeExpected{schema_type: String::from("readers_schema"), expected_type: vec![
+            SchemaKind::Int,
+            SchemaKind::Long,
+            SchemaKind::Float,
+            SchemaKind::Double,
+            SchemaKind::Date,
+            SchemaKind::TimeMillis
+        ]}
+    )]
+    // local-timestamp-nanos type. This test should fail because it is not supported on schema parse_complex
+    // #[case(
+    //     r#"{"type": "int"}"#,
+    //     r#"{"type": "long", "logicalType": "local-timestamp-nanos"}"#,
+    //     CompatibilityError::TypeExpected{schema_type: String::from("readers_schema"), expected_type: vec![
+    //         SchemaKind::Int,
+    //         SchemaKind::Long,
+    //         SchemaKind::Float,
+    //         SchemaKind::Double,
+    //         SchemaKind::Date,
+    //         SchemaKind::TimeMillis
+    //     ]}
+    // )]
+    // When compating different types we always get Inconclusive
+    #[case(
+        r#"{"type": "record", "name":"record_b", "fields": [{"type": "long", "name": "date"}]}"#,
+        r#"{"type": "fixed", "name": "EmployeeId", "size": 16}"#,
+        CompatibilityError::Inconclusive(String::from("writers_schema"))
+    )]
+    fn test_match_schemas_error(
+        #[case] writer_schema_str: &str,
+        #[case] reader_schema_str: &str,
+        #[case] expected_error: CompatibilityError,
+    ) {
+        let writer_schema = Schema::parse_str(writer_schema_str).unwrap();
+        let reader_schema = Schema::parse_str(reader_schema_str).unwrap();
+
+        assert_eq!(
+            expected_error,
+            SchemaCompatibility::match_schemas(&writer_schema, &reader_schema).unwrap_err()
+        )
     }
 
     #[test]

--- a/lang/rust/avro/src/schema_compatibility.rs
+++ b/lang/rust/avro/src/schema_compatibility.rs
@@ -837,7 +837,10 @@ mod tests {
         r#"{"type": "array", "items": "int"}"#,
         r#"{"type": "array", "items": "long"}"#
     )]
-    fn test_match_schemas_ok(#[case] writer_schema_str: &str, #[case] reader_schema_str: &str) {
+    fn test_avro_3950_match_schemas_ok(
+        #[case] writer_schema_str: &str,
+        #[case] reader_schema_str: &str,
+    ) {
         let writer_schema = Schema::parse_str(writer_schema_str).unwrap();
         let reader_schema = Schema::parse_str(reader_schema_str).unwrap();
 
@@ -1000,13 +1003,13 @@ mod tests {
     //         SchemaKind::TimeMillis
     //     ]}
     // )]
-    // When compating different types we always get Inconclusive
+    // When comparing different types we always get Inconclusive
     #[case(
         r#"{"type": "record", "name":"record_b", "fields": [{"type": "long", "name": "date"}]}"#,
         r#"{"type": "fixed", "name": "EmployeeId", "size": 16}"#,
         CompatibilityError::Inconclusive(String::from("writers_schema"))
     )]
-    fn test_match_schemas_error(
+    fn test_avro_3950_match_schemas_error(
         #[case] writer_schema_str: &str,
         #[case] reader_schema_str: &str,
         #[case] expected_error: CompatibilityError,


### PR DESCRIPTION
## What is the purpose of the change

This pull request add tests for `match_schemas` in schema_compatibility `AVRO-3950`

## Verifying this change

- This change is a trivial rework / code cleanup without any test coverage.
- Added test that validates `match_schemas
- This PR also shows that some code is never called in the funcion `match_schemas` as pointed in [AVRO-3950](https://issues.apache.org/jira/browse/AVRO-3950)
- This PR also shows that `nanos` types implementation are missing in [schema parse_complex](https://github.com/apache/avro/blob/main/lang/rust/avro/src/schema.rs#L1387), which is also not documented in the [avro spec](https://avro.apache.org/docs/1.11.1/specification/#logical-types)

## Documentation

- Does this pull request introduce a new feature? (no)
