### PR TITLE
AVRO-3953: Prefixing enum member identifiers instead of throwing

### DIFF
--- a/lang/csharp/src/apache/main/CodeGen/CodeGen.cs
+++ b/lang/csharp/src/apache/main/CodeGen/CodeGen.cs
@@ -496,13 +496,7 @@ namespace Avro
 
             foreach (string symbol in enumschema.Symbols)
             {
-                var effectiveSymbol = symbol;
-                if (CodeGenUtil.Instance.ReservedKeywords.Contains(symbol))
-                {
-                    effectiveSymbol = "@" + symbol;
-                }
-
-                CodeMemberField field = new CodeMemberField(typeof(int), effectiveSymbol);
+                CodeMemberField field = new CodeMemberField(typeof(int), symbol);
                 ctd.Members.Add(field);
             }
 

--- a/lang/csharp/src/apache/main/CodeGen/CodeGen.cs
+++ b/lang/csharp/src/apache/main/CodeGen/CodeGen.cs
@@ -474,8 +474,6 @@ namespace Avro
         /// <exception cref="CodeGenException">
         /// Unable to cast schema into an enum
         /// or
-        /// Enum symbol " + symbol + " is a C# reserved keyword
-        /// or
         /// Namespace required for enum schema " + enumschema.Name.
         /// </exception>
         protected virtual void processEnum(Schema schema)
@@ -498,12 +496,13 @@ namespace Avro
 
             foreach (string symbol in enumschema.Symbols)
             {
+                var effectiveSymbol = symbol;
                 if (CodeGenUtil.Instance.ReservedKeywords.Contains(symbol))
                 {
-                    throw new CodeGenException("Enum symbol " + symbol + " is a C# reserved keyword");
+                    effectiveSymbol = "@" + symbol;
                 }
 
-                CodeMemberField field = new CodeMemberField(typeof(int), symbol);
+                CodeMemberField field = new CodeMemberField(typeof(int), effectiveSymbol);
                 ctd.Members.Add(field);
             }
 

--- a/lang/csharp/src/apache/test/CodGen/CodeGenTest.cs
+++ b/lang/csharp/src/apache/test/CodGen/CodeGenTest.cs
@@ -109,6 +109,33 @@ namespace Avro.Test.CodeGen
                 Assert.That(hasPlanetEnumCode);
                 Assert.That(Regex.Matches(planetEnumCode, "public enum PlanetEnum").Count, Is.EqualTo(1));
             }
+
+            [Test]
+            public void EnumWithKeywordSymbolsShouldHavePrefixedSymbols()
+            {
+                AddSchema(@"{
+    ""type"": ""enum"",
+    ""symbols"": [
+        ""string"",
+        ""integer"",
+        ""float"",
+        ""boolean"",
+        ""list"",
+        ""dict"",
+        ""regex""
+    ],
+    ""name"": ""type"",
+    ""namespace"": ""com.example""
+}");
+                GenerateCode();
+                var types = GetTypes();
+                Assert.That(types.Count, Is.EqualTo(1));
+                bool hasTypeCode = types.TryGetValue("type", out string typeCode);
+                Assert.That(hasTypeCode);
+                Assert.That(Regex.Matches(typeCode, "public enum type").Count, Is.EqualTo(1));
+                Assert.That(Regex.Matches(typeCode, "@string,").Count, Is.EqualTo(1));
+                Assert.That(Regex.Matches(typeCode, "@float,").Count, Is.EqualTo(1));
+            }
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This eliminates a blocking issue where code-gen throws while generating code for this enum:

```json
{
    "type": "enum",
    "symbols": [
        "string",
        "integer",
        "float",
        "boolean",
        "list",
        "dict",
        "regex"
    ],
    "name": "type",
    "namespace": "com.example"
}
```

## Verifying this change

This change is a trivial rework without any test coverage. It eliminates an apparent misunderstanding of C# syntax. The above now correctly yields 

```csharp
public enum type
{
		@string,
		integer,
		@float,
		boolean,
		list,
		dict,
		regex,
}
```

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable
