### PR TITLE
[C++] Added support for installing dependencies with Conan

### DIFF
--- a/lang/c++/README
+++ b/lang/c++/README
@@ -41,6 +41,10 @@ cmake -G "Unix Makefiles" ..
 
 If it doesn't work, either you are missing boost package or you need to help
 configure locate it.
+Alternatively, you can use Conan to install the dependencies. To do that, use:
+
+conan install . -u -b missing -s:h build_type=RelWithDebInfo
+cmake -S. -Bbuild -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE=build/RelWithDebInfo/generators/conan_toolchain.cmake
 
 If the Makefile is configured correctly, then you can make and run tests:
 

--- a/lang/c++/conanfile.txt
+++ b/lang/c++/conanfile.txt
@@ -1,0 +1,9 @@
+[requires]
+boost/[^1.84.0]
+
+[generators]
+CMakeDeps
+CMakeToolchain
+
+[layout]
+cmake_layout


### PR DESCRIPTION
## What is the purpose of the change

With this small change, developers of C++ bindings of Avro can build it on a machine with no `boost` installed.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Documentation

- Does this pull request introduce a new feature? **no**
- Although the new possible way of building is documented in `README`