### PR TITLE
AVRO-3957: [C] Fix typos in docs and examples

### DIFF
--- a/lang/c/docs/index.txt
+++ b/lang/c/docs/index.txt
@@ -178,7 +178,7 @@ different versions of the Avro library.  That means that it's really
 only safe to use these hash values internally within the context of a
 single execution of a single application.
 
-The +reset+ method “clears out” an +avro_value_t instance, making sure
+The +reset+ method “clears out” an +avro_value_t+ instance, making sure
 that it's ready to accept the contents of a new value.  For scalars,
 this is usually a no-op, since the new value will just overwrite the old
 one.  For arrays and maps, this removes any existing elements from the

--- a/lang/c/examples/quickstop.c
+++ b/lang/c/examples/quickstop.c
@@ -107,7 +107,7 @@ int print_person(avro_file_reader_t db, avro_schema_t reader_schema)
 	if (rval == 0) {
 		int64_t id;
 		int32_t age;
-		int32_t *p;
+		const char *p;
 		size_t size;
 		avro_value_t id_value;
 		avro_value_t first_value;


### PR DESCRIPTION
## What is the purpose of the change

This fixes typos in docs and examples

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Documentation

No new features are added