### PR TITLE
AVRO-3958: [C] Update min cmake version to 3.5

### DIFF
--- a/lang/c/CMakeLists.txt
+++ b/lang/c/CMakeLists.txt
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 project(AvroC C)
 enable_testing()
 


### PR DESCRIPTION
## What is the purpose of the change

We don't use older cmake features and this removes the following warning:

```
  CMake Deprecation Warning at CMakeLists.txt:19 (cmake_minimum_required):
    Compatibility with CMake < 3.5 will be removed from a future version of
    CMake.

    Update the VERSION argument <min> value or use a ...<max> suffix to tell
    CMake that the project does not need compatibility with older versions.
```

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Documentation

No new features are added
