### PR TITLE
AVRO-3959: [C] Avoid deprecated OSX atomic ops

### DIFF
--- a/lang/c/src/avro/refcount.h
+++ b/lang/c/src/avro/refcount.h
@@ -86,7 +86,10 @@ avro_refcount_dec(volatile int *refcount)
  * Mac OS X
  */
 
-#elif __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 1050
+#elif __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 1050 \
+  && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 101200
+
+/* macOS 10.12 deprecates OSAtomic* so we'll use the GCC/Clang branch below */
 
 #include <libkern/OSAtomic.h>
 


### PR DESCRIPTION
## What is the purpose of the change

macOS 10.12 deprecated the OSAtomic* functions. This removes the following warnings:

```
  warning: 'OSAtomicIncrement32' is deprecated: first deprecated in macOS 10.12
  warning: 'OSAtomicDecrement32' is deprecated: first deprecated in macOS 10.12
```

## Verifying this change

This change is already covered by existing tests, such as `make test`

## Documentation

No new features are added