### PR TITLE
AVRO-3960: [C] Fix st ANYARGS warning

### DIFF
--- a/lang/c/src/datum.c
+++ b/lang/c/src/datum.c
@@ -1095,7 +1095,7 @@ static void avro_datum_free(avro_datum_t datum)
 				record = avro_datum_to_record(datum);
 				avro_schema_decref(record->schema);
 				st_foreach(record->fields_byname,
-					   HASH_FUNCTION_CAST char_datum_free_foreach, 0);
+					   (hash_function_foreach) char_datum_free_foreach, 0);
 				st_free_table(record->field_order);
 				st_free_table(record->fields_byname);
 				avro_freet(struct avro_record_datum_t, record);
@@ -1123,7 +1123,7 @@ static void avro_datum_free(avro_datum_t datum)
 				struct avro_map_datum_t *map;
 				map = avro_datum_to_map(datum);
 				avro_schema_decref(map->schema);
-				st_foreach(map->map, HASH_FUNCTION_CAST char_datum_free_foreach,
+				st_foreach(map->map, (hash_function_foreach) char_datum_free_foreach,
 					   0);
 				st_free_table(map->map);
 				st_free_table(map->indices_by_key);
@@ -1135,7 +1135,7 @@ static void avro_datum_free(avro_datum_t datum)
 				struct avro_array_datum_t *array;
 				array = avro_datum_to_array(datum);
 				avro_schema_decref(array->schema);
-				st_foreach(array->els, HASH_FUNCTION_CAST array_free_foreach, 0);
+				st_foreach(array->els, (hash_function_foreach) array_free_foreach, 0);
 				st_free_table(array->els);
 				avro_freet(struct avro_array_datum_t, array);
 			}
@@ -1183,7 +1183,7 @@ avro_datum_reset(avro_datum_t datum)
 		{
 			struct avro_array_datum_t *array;
 			array = avro_datum_to_array(datum);
-			st_foreach(array->els, HASH_FUNCTION_CAST array_free_foreach, 0);
+			st_foreach(array->els, (hash_function_foreach) array_free_foreach, 0);
 			st_free_table(array->els);
 
 			rval = avro_init_array(array);
@@ -1198,7 +1198,7 @@ avro_datum_reset(avro_datum_t datum)
 		{
 			struct avro_map_datum_t *map;
 			map = avro_datum_to_map(datum);
-			st_foreach(map->map, HASH_FUNCTION_CAST char_datum_free_foreach, 0);
+			st_foreach(map->map, (hash_function_foreach) char_datum_free_foreach, 0);
 			st_free_table(map->map);
 			st_free_table(map->indices_by_key);
 			st_free_table(map->keys_by_index);
@@ -1217,7 +1217,7 @@ avro_datum_reset(avro_datum_t datum)
 			record = avro_datum_to_record(datum);
 			rval = 0;
 			st_foreach(record->fields_byname,
-				   HASH_FUNCTION_CAST datum_reset_foreach, (st_data_t) &rval);
+				   (hash_function_foreach) datum_reset_foreach, (st_data_t) &rval);
 			return rval;
 		}
 

--- a/lang/c/src/datum_equal.c
+++ b/lang/c/src/datum_equal.c
@@ -78,7 +78,7 @@ static int map_equal(struct avro_map_datum_t *a, struct avro_map_datum_t *b)
 	if (a->map->num_entries != b->map->num_entries) {
 		return 0;
 	}
-	st_foreach(a->map, HASH_FUNCTION_CAST st_equal_foreach, (st_data_t) & args);
+	st_foreach(a->map, (hash_function_foreach) st_equal_foreach, (st_data_t) & args);
 	return args.rval;
 }
 
@@ -93,7 +93,7 @@ static int record_equal(struct avro_record_datum_t *a,
 	if (a->fields_byname->num_entries != b->fields_byname->num_entries) {
 		return 0;
 	}
-	st_foreach(a->fields_byname, HASH_FUNCTION_CAST st_equal_foreach, (st_data_t) & args);
+	st_foreach(a->fields_byname, (hash_function_foreach) st_equal_foreach, (st_data_t) & args);
 	return args.rval;
 }
 

--- a/lang/c/src/datum_size.c
+++ b/lang/c/src/datum_size.c
@@ -126,7 +126,7 @@ size_map(avro_writer_t writer, const avro_encoding_t * enc,
 	if (datum->map->num_entries) {
 		size_accum(rval, size,
 			   enc->size_long(writer, datum->map->num_entries));
-		st_foreach(datum->map, HASH_FUNCTION_CAST size_map_foreach, (st_data_t) & args);
+		st_foreach(datum->map, (hash_function_foreach) size_map_foreach, (st_data_t) & args);
 		size += args.size;
 	}
 	if (!args.rval) {

--- a/lang/c/src/datum_validate.c
+++ b/lang/c/src/datum_validate.c
@@ -123,7 +123,7 @@ avro_schema_datum_validate(avro_schema_t expected_schema, avro_datum_t datum)
 			    { avro_schema_to_map(expected_schema)->values, 1
 			};
 			st_foreach(avro_datum_to_map(datum)->map,
-				   HASH_FUNCTION_CAST schema_map_validate_foreach,
+				   (hash_function_foreach) schema_map_validate_foreach,
 				   (st_data_t) & vst);
 			return vst.rval;
 		}

--- a/lang/c/src/memoize.c
+++ b/lang/c/src/memoize.c
@@ -52,8 +52,8 @@ avro_memoize_key_hash(avro_memoize_key_t *a)
 
 
 static struct st_hash_type  avro_memoize_hash_type = {
-	HASH_FUNCTION_CAST avro_memoize_key_cmp,
-	HASH_FUNCTION_CAST avro_memoize_key_hash
+	(hash_function_compare) avro_memoize_key_cmp,
+	(hash_function_hash) avro_memoize_key_hash
 };
 
 
@@ -78,7 +78,7 @@ avro_memoize_free_key(avro_memoize_key_t *key, void *result, void *dummy)
 void
 avro_memoize_done(avro_memoize_t *mem)
 {
-	st_foreach((st_table *) mem->cache, HASH_FUNCTION_CAST avro_memoize_free_key, 0);
+	st_foreach((st_table *) mem->cache, (hash_function_foreach) avro_memoize_free_key, 0);
 	st_free_table((st_table *) mem->cache);
 	memset(mem, 0, sizeof(avro_memoize_t));
 }

--- a/lang/c/src/schema.c
+++ b/lang/c/src/schema.c
@@ -137,7 +137,7 @@ static void avro_schema_free(avro_schema_t schema)
 				if (record->space) {
 					avro_str_free(record->space);
 				}
-				st_foreach(record->fields, HASH_FUNCTION_CAST record_free_foreach,
+				st_foreach(record->fields, (hash_function_foreach) record_free_foreach,
 					   0);
 				st_free_table(record->fields_byname);
 				st_free_table(record->fields);
@@ -152,7 +152,7 @@ static void avro_schema_free(avro_schema_t schema)
 				if (enump->space) {
 					avro_str_free(enump->space);
 				}
-				st_foreach(enump->symbols, HASH_FUNCTION_CAST enum_free_foreach,
+				st_foreach(enump->symbols, (hash_function_foreach) enum_free_foreach,
 					   0);
 				st_free_table(enump->symbols);
 				st_free_table(enump->symbols_byname);
@@ -189,7 +189,7 @@ static void avro_schema_free(avro_schema_t schema)
 		case AVRO_UNION:{
 				struct avro_union_schema_t *unionp;
 				unionp = avro_schema_to_union(schema);
-				st_foreach(unionp->branches, HASH_FUNCTION_CAST union_free_foreach,
+				st_foreach(unionp->branches, (hash_function_foreach) union_free_foreach,
 					   0);
 				st_free_table(unionp->branches);
 				st_free_table(unionp->branches_byname);
@@ -1239,7 +1239,7 @@ avro_schema_from_json_root(json_t *root, avro_schema_t *schema)
 	/* json_dumpf(root, stderr, 0); */
 	rval = avro_schema_from_json_t(root, schema, named_schemas, NULL);
 	json_decref(root);
-	st_foreach(named_schemas, HASH_FUNCTION_CAST named_schema_free_foreach, 0);
+	st_foreach(named_schemas, (hash_function_foreach) named_schema_free_foreach, 0);
 	st_free_table(named_schemas);
 	return rval;
 }
@@ -1455,7 +1455,7 @@ avro_schema_t avro_schema_copy(avro_schema_t schema)
 	}
 
 	new_schema = avro_schema_copy_root(schema, named_schemas);
-	st_foreach(named_schemas, HASH_FUNCTION_CAST named_schema_free_foreach, 0);
+	st_foreach(named_schemas, (hash_function_foreach) named_schema_free_foreach, 0);
 	st_free_table(named_schemas);
 	return new_schema;
 }

--- a/lang/c/src/st.h
+++ b/lang/c/src/st.h
@@ -20,26 +20,22 @@ extern "C" {
 
 #pragma GCC visibility push(hidden)
 
-#ifndef ANYARGS
- #ifdef __cplusplus
-   #define ANYARGS ...
- #else
-   #define ANYARGS
- #endif
-#endif
-
 #ifdef _WIN32
-  #define HASH_FUNCTION_CAST (int (__cdecl *)(ANYARGS))
+  typedef int (__cdecl *hash_function_compare)(void*, void*);
+  typedef int (__cdecl *hash_function_hash)(void*);
+  typedef int (__cdecl *hash_function_foreach)(void*, void*, void*);
 #else
-  #define HASH_FUNCTION_CAST
+  typedef int (*hash_function_compare)(void*, void*);
+  typedef int (*hash_function_hash)(void*);
+  typedef int (*hash_function_foreach)(void*, void*, void*);
 #endif
 
 typedef uintptr_t st_data_t;
 typedef struct st_table st_table;
 
 struct st_hash_type {
-  int (*compare) (ANYARGS);
-  int (*hash) (ANYARGS);
+  hash_function_compare compare;
+  hash_function_hash hash;
 };
 
 struct st_table {
@@ -67,7 +63,7 @@ int st_delete _((st_table *, st_data_t *, st_data_t *));
 int st_delete_safe _((st_table *, st_data_t *, st_data_t *, st_data_t));
 int st_insert _((st_table *, st_data_t, st_data_t));
 int st_lookup _((st_table *, st_data_t, st_data_t *));
-int st_foreach _((st_table *, int (*)(ANYARGS), st_data_t));
+int st_foreach _((st_table *, hash_function_foreach, st_data_t));
 void st_add_direct _((st_table *, st_data_t, st_data_t));
 void st_free_table _((st_table *));
 void st_cleanup_safe _((st_table *, st_data_t));


### PR DESCRIPTION
## What is the purpose of the change

This removes the following warning:

```
  avro/lang/c/src/st.c:240:13: warning: passing arguments to a function without a prototype is deprecated in all versions of C and is not
        supported in C2x [-Wdeprecated-non-prototype]
          hash_val = do_hash(key, table);
```

## Verifying this change

This change is already covered by existing tests, such as `make test`

## Documentation

No new features are added