### PR TITLE
AVRO-3962: [Rust] Add support for field attribute Rustdoc to AvroSchema

### DIFF
--- a/lang/rust/avro_derive/src/lib.rs
+++ b/lang/rust/avro_derive/src/lib.rs
@@ -126,7 +126,8 @@ fn get_data_struct_schema_def(
                 }
                 let field_attrs =
                     FieldOptions::from_attributes(&field.attrs[..]).map_err(darling_to_syn)?;
-                let doc = preserve_optional(field_attrs.doc);
+                let doc =
+                    preserve_optional(field_attrs.doc.or_else(|| extract_outer_doc(&field.attrs)));
                 if let Some(rename) = field_attrs.rename {
                     name = rename
                 }

--- a/lang/rust/avro_derive/tests/derive.rs
+++ b/lang/rust/avro_derive/tests/derive.rs
@@ -1571,4 +1571,28 @@ mod test_derive {
             panic!("Unexpected schema type for {derived_schema:?}")
         }
     }
+
+    #[test]
+    fn avro_3962_fields_documentation() {
+        /// Foo docs
+        #[derive(AvroSchema)]
+        #[allow(dead_code)]
+        struct Foo {
+            /// a's Rustdoc
+            a: i32,
+            /// b's Rustdoc
+            #[avro(doc = "attribute doc has priority over Rustdoc")]
+            b: i32,
+        }
+
+        if let Schema::Record(RecordSchema { fields, .. }) = Foo::get_schema() {
+            assert_eq!(fields[0].doc, Some("a's Rustdoc".to_string()));
+            assert_eq!(
+                fields[1].doc,
+                Some("attribute doc has priority over Rustdoc".to_string())
+            );
+        } else {
+            panic!("Unexpected schema type for Foo")
+        }
+    }
 }


### PR DESCRIPTION
AVRO-3962

## What is the purpose of the change

* Use the struct fields' Rustdoc as a source for Avro Schema fields' `doc`


## Verifying this change

* New IT tests are added

## Documentation

- Does this pull request introduce a new feature? no