### PR TITLE
AVRO-3964: [Rust] Fix out-of-bounds panic

### DIFF
--- a/lang/rust/avro/src/decode.rs
+++ b/lang/rust/avro/src/decode.rs
@@ -323,7 +323,7 @@ pub(crate) fn decode_internal<R: Read, S: Borrow<Schema>>(
             Ok(if let Value::Int(raw_index) = decode_int(reader)? {
                 let index = usize::try_from(raw_index)
                     .map_err(|e| Error::ConvertI32ToUsize(e, raw_index))?;
-                if (0..=symbols.len()).contains(&index) {
+                if (0..symbols.len()).contains(&index) {
                     let symbol = symbols[index].clone();
                     Value::Enum(raw_index as u32, symbol)
                 } else {


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes AVRO-3964, changing panic to error.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Documentation

- Does this pull request introduce a new feature? - No.
- If yes, how is the feature documented? - Not applicable.
