### PR TITLE
AVRO-3966: [Java] Fix default value serialisation for fixed and bytes

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/generic/GenericData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/generic/GenericData.java
@@ -21,7 +21,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.time.temporal.Temporal;
 import java.util.AbstractList;
 import java.util.Arrays;
@@ -744,7 +743,7 @@ public class GenericData {
     } else if (isBytes(datum)) {
       buffer.append("\"");
       ByteBuffer bytes = ((ByteBuffer) datum).duplicate();
-      writeEscapedString(StandardCharsets.ISO_8859_1.decode(bytes), buffer);
+      writeBytesAsJsonString(bytes, buffer);
       buffer.append("\"");
     } else if (isNanOrInfinity(datum) || isTemporal(datum) || datum instanceof UUID) {
       buffer.append("\"");
@@ -770,6 +769,20 @@ public class GenericData {
   private boolean isNanOrInfinity(Object datum) {
     return ((datum instanceof Float) && (((Float) datum).isInfinite() || ((Float) datum).isNaN()))
         || ((datum instanceof Double) && (((Double) datum).isInfinite() || ((Double) datum).isNaN()));
+  }
+
+  private static void writeBytesAsJsonString(ByteBuffer buffer, StringBuilder builder) {
+    byte[] bytes = new byte[buffer.remaining()];
+    buffer.get(bytes);
+
+    for (byte b : bytes) {
+      String hex = Integer.toHexString(b);
+
+      builder.append("\\u");
+      for (int j = 0; j < 4 - hex.length(); j++)
+        builder.append('0');
+      builder.append(hex.toUpperCase());
+    }
   }
 
   /* Adapted from https://code.google.com/p/json-simple */

--- a/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericData.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericData.java
@@ -550,11 +550,10 @@ public class TestGenericData {
   }
 
   @Test
-  void toStringEscapesControlCharsInBytes() throws Exception {
+  void toStringWritesBytesAsUEscapedSequence() throws Exception {
     GenericData data = GenericData.get();
     ByteBuffer bytes = ByteBuffer.wrap(new byte[] { 'a', '\n', 'b' });
-    assertEquals("\"a\\nb\"", data.toString(bytes));
-    assertEquals("\"a\\nb\"", data.toString(bytes));
+    assertEquals("\"\\u0061\\u000A\\u0062\"", data.toString(bytes));
   }
 
   @Test


### PR DESCRIPTION
<!--

*Thank you very much for contributing to Apache Avro - we are happy that you want to help us improve Avro. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Avro a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/AVRO/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "AVRO-XXXX: [component] Title of the pull request", where *AVRO-XXXX* should be replaced by the actual issue number. 
    The *component* is optional, but can help identify the correct reviewers faster: either the language ("java", "python") or subsystem such as "build" or "doc" are good candidates.  

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests. You can [build the entire project](https://github.com/apache/avro/blob/main/BUILD.md) or just the [language-specific SDK](https://avro.apache.org/project/how-to-contribute/#unit-tests).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Every commit message references Jira issues in their subject lines. In addition, commits follow the guidelines from [How to write a good git commit message](https://chris.beams.io/posts/git-commit/)
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

-->

## What is the purpose of the change

Default value for fixed and bytes schemas is converted to JSON in the wrong (according to docs) way.

Also, it's possible to store any unicode string as default for bytes, like:

```json
{
  "type" : "record",
  "name" : "TestRecord",
  "fields" : [ {
    "name" : "testFixed",
    "type" : {
      "type" : "fixed",
      "name" : "Code",
      "size" : 3
    },
    "default" : "Привет"
  } ]
}
```

The above example would be serialised into Avro format as "?????".

In this PR:

 - added explicit conversion from `String` to `byte[]` using `ISO_8859_1` charset (the one that used during `byte[]` to JSON conversion and during reading Avro into Java objects);
 - explicitly stated in doc-blocks of methods `bytesDefault` and `fixedDefault` that this conversion is performed;
 - `byte[]` to JSON conversion itself now is done according to doc: by translating bytes to u-escaped sequences (e.g. `2F0011FF` into `\u002F\u0000\u0011\u00FF`)

## Verifying this change

This change is already covered by existing tests, such as:
 - org.apache.avro.generic.TestGenericData
 - org.apache.avro.TestFixed

# DISCUSSION IS NEEDED

In the test `TestGenericData` I've had to rewrite test `toStringEscapesControlCharsInBytes`. The new behaviour encodes `"a\nb"` as `"\u0061\u000A\u0062"`, thus breaking some compatibility (kinda, more like breaking readability).

It is possible still to not encode ASCII characters (from `U+0020` to `U+007E`) and persist full compatibility with previous version, but then the behaviour would differ from one described in the documentation.

## Documentation

- Does this pull request introduce a new feature? No, it just makes old feature work exactly how it's documented.