### PR TITLE
AVRO-3970: [Rust] Fix compatibility checks for UUID

### DIFF
--- a/lang/rust/avro/src/schema_compatibility.rs
+++ b/lang/rust/avro/src/schema_compatibility.rs
@@ -65,6 +65,7 @@ impl Checker {
         if w_type != SchemaKind::Union
             && (r_type.is_primitive()
                 || r_type == SchemaKind::Fixed
+                || r_type == SchemaKind::Uuid
                 || r_type == SchemaKind::Date
                 || r_type == SchemaKind::TimeMillis
                 || r_type == SchemaKind::TimeMicros
@@ -400,6 +401,13 @@ impl SchemaCompatibility {
                         }
                     }
                 }
+                SchemaKind::Uuid => {
+                    return check_writer_type(
+                        writers_schema,
+                        readers_schema,
+                        vec![r_type, SchemaKind::String],
+                    );
+                }
                 SchemaKind::Date | SchemaKind::TimeMillis => {
                     return check_writer_type(
                         writers_schema,
@@ -462,8 +470,11 @@ impl SchemaCompatibility {
             SchemaKind::Float => {
                 check_reader_type_multi(r_type, vec![SchemaKind::Float, SchemaKind::Double], w_type)
             }
-            SchemaKind::String => check_reader_type(r_type, SchemaKind::Bytes, w_type),
+            SchemaKind::String => {
+                check_reader_type_multi(r_type, vec![SchemaKind::Bytes, SchemaKind::Uuid], w_type)
+            }
             SchemaKind::Bytes => check_reader_type(r_type, SchemaKind::String, w_type),
+            SchemaKind::Uuid => check_reader_type(r_type, SchemaKind::String, w_type),
             SchemaKind::Date | SchemaKind::TimeMillis => {
                 check_reader_type(r_type, SchemaKind::Int, w_type)
             }
@@ -838,13 +849,21 @@ mod tests {
     #[case(
         r#"{"type": "string"}"#,
         r#"{"type": "int", "logicalType": "date"}"#,
-        CompatibilityError::TypeExpected{schema_type: String::from("readers_schema"), expected_type: vec![SchemaKind::String, SchemaKind::Bytes]}
+        CompatibilityError::TypeExpected{schema_type: String::from("readers_schema"), expected_type: vec![
+            SchemaKind::String,
+            SchemaKind::Bytes,
+            SchemaKind::Uuid,
+        ]}
     )]
     // time-millis type
     #[case(
         r#"{"type": "string"}"#,
         r#"{"type": "int", "logicalType": "time-millis"}"#,
-        CompatibilityError::TypeExpected{schema_type: String::from("readers_schema"), expected_type: vec![SchemaKind::String, SchemaKind::Bytes]}
+        CompatibilityError::TypeExpected{schema_type: String::from("readers_schema"), expected_type: vec![
+            SchemaKind::String,
+            SchemaKind::Bytes,
+            SchemaKind::Uuid,
+        ]}
     )]
     // time-millis type
     #[case(
@@ -970,6 +989,8 @@ mod tests {
             (Schema::String, Schema::Bytes),
             (Schema::Bytes, Schema::String),
             // logical types
+            (Schema::Uuid, Schema::Uuid),
+            (Schema::Uuid, Schema::String),
             (Schema::Date, Schema::Int),
             (Schema::TimeMillis, Schema::Int),
             (Schema::TimeMicros, Schema::Long),
@@ -979,6 +1000,7 @@ mod tests {
             (Schema::LocalTimestampMillis, Schema::Long),
             (Schema::LocalTimestampMicros, Schema::Long),
             (Schema::LocalTimestampNanos, Schema::Long),
+            (Schema::String, Schema::Uuid),
             (Schema::Int, Schema::Date),
             (Schema::Int, Schema::TimeMillis),
             (Schema::Long, Schema::TimeMicros),
@@ -1198,7 +1220,7 @@ mod tests {
                 "field1".to_owned(),
                 Box::new(CompatibilityError::TypeExpected {
                     schema_type: "readers_schema".to_owned(),
-                    expected_type: vec![SchemaKind::String, SchemaKind::Bytes]
+                    expected_type: vec![SchemaKind::String, SchemaKind::Bytes, SchemaKind::Uuid]
                 })
             ),
             SchemaCompatibility::can_read(&string_schema, &int_schema).unwrap_err()


### PR DESCRIPTION
[AVRO-3970](https://issues.apache.org/jira/browse/AVRO-3970)

## What is the purpose of the change

- Allow for proper compatibility checks between schemas featuring the `uuid` `logicalType`


## Verifying this change

This change added tests and can be verified as follows:

- Extended existing compatibility test with `logicalType` `uuid` pairs


## Documentation

- Does this pull request introduce a new feature? no
