### PR TITLE
AVRO 3979: Fix schema compatibility location for type mismatch with w…

### DIFF
--- a/lang/py/avro/compatibility.py
+++ b/lang/py/avro/compatibility.py
@@ -231,8 +231,8 @@ class ReaderWriterCompatibilityChecker:
             raise AvroRuntimeException(f"Unknown schema type: {reader.type}")
         if writer.type == SchemaType.UNION:
             writer = cast(UnionSchema, writer)
-            for s in writer.schemas:
-                result = merge(result, self.get_compatibility(reader, s))
+            for i in range(len(writer.schemas)):
+                result = merge(result, self.get_compatibility(reader, writer.schemas[i], str(i), location))
             return result
         if reader.type in {SchemaType.NULL, SchemaType.BOOLEAN, SchemaType.INT}:
             return merge(result, type_mismatch(reader, writer, location))

--- a/lang/py/avro/test/test_compatibility.py
+++ b/lang/py/avro/test/test_compatibility.py
@@ -198,6 +198,17 @@ A_DINT_RECORD1 = parse(
         }
     )
 )
+A_DINT_OPTIONAL_RECORD1 = parse(
+    json.dumps(
+        {
+            "type": SchemaType.RECORD,
+            "name": "Record1",
+            "fields": [
+                {"name": "a", "type": [SchemaType.NULL, SchemaType.INT], "default": None},
+            ],
+        }
+    )
+)
 A_INT_B_DINT_RECORD1 = parse(
     json.dumps(
         {
@@ -1041,19 +1052,19 @@ class TestCompatibility(unittest.TestCase):
                 FLOAT_SCHEMA,
                 INT_LONG_FLOAT_DOUBLE_UNION_SCHEMA,
                 "reader type: float not compatible with writer type: double",
-                "/",
+                "/3",
             ),
             (
                 LONG_SCHEMA,
                 INT_FLOAT_UNION_SCHEMA,
                 "reader type: long not compatible with writer type: float",
-                "/",
+                "/1",
             ),
             (
                 INT_SCHEMA,
                 INT_FLOAT_UNION_SCHEMA,
                 "reader type: int not compatible with writer type: float",
-                "/",
+                "/1",
             ),
             # (INT_LIST_RECORD, LONG_LIST_RECORD, "reader type: int not compatible with writer type: long", "/fields/0/type"),
             (
@@ -1062,6 +1073,18 @@ class TestCompatibility(unittest.TestCase):
                 "reader type: null not compatible with writer type: int",
                 "/",
             ),
+            (
+                INT_SCHEMA,
+                INT_STRING_UNION_SCHEMA,
+                "reader type: int not compatible with writer type: string",
+                "/1"
+            ),
+            (
+                A_DINT_RECORD1,
+                A_DINT_OPTIONAL_RECORD1,
+                "reader type: int not compatible with writer type: null",
+                "/fields/0/type/0"
+            )
         ]
         for reader, writer, message, location in incompatible_pairs:
             result = ReaderWriterCompatibilityChecker().get_compatibility(reader, writer)


### PR DESCRIPTION
<!--

*Thank you very much for contributing to Apache Avro - we are happy that you want to help us improve Avro. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Avro a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/AVRO/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "AVRO-XXXX: [component] Title of the pull request", where *AVRO-XXXX* should be replaced by the actual issue number. 
    The *component* is optional, but can help identify the correct reviewers faster: either the language ("java", "python") or subsystem such as "build" or "doc" are good candidates.  

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests. You can [build the entire project](https://github.com/apache/avro/blob/main/BUILD.md) or just the [language-specific SDK](https://avro.apache.org/project/how-to-contribute/#unit-tests).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Every commit message references Jira issues in their subject lines. In addition, commits follow the guidelines from [How to write a good git commit message](https://chris.beams.io/posts/git-commit/)
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

-->

## What is the purpose of the change

Fixes [AVRO-3979](https://issues.apache.org/jira/browse/AVRO-3979), fixing the returned incompatibility location information from schema compatibility when there is a type mismatch between a primitive reader type and a union writer type. Previously the incompatibility location returned was always `/`. Now the location to the type field is accurately returned.


## Verifying this change


This is verified by the following existing tests that were previously expecting incompatibility location `/` failing:
| **Reader Schema** | **Writer Schema** | **Previous Location** | **New Location** |
| ------------- | ------------- | ------------- | ------------- |
| `FLOAT_SCHEMA`  | `INT_LONG_FLOAT_DOUBLE_UNION_SCHEMA`  | `/` | `/3` |
| `LONG_SCHEMA`  | `INT_FLOAT_UNION_SCHEMA`  | `/` | `/1` |
| `INT_SCHEMA`  | `INT_FLOAT_UNION_SCHEMA`  | `/` | `/1` |

and also by the follow added tests:
| **Reader Schema** | **Writer Schema** | **Expected Location** |
| ------------- | ------------- | ------------- |
| `INT_SCHEMA`  | `INT_STRING_UNION_SCHEMA`  | `/1` |
| `A_DINT_RECORD1`  | `A_DINT_OPTIONAL_RECORD1`  | `/fields/type/0` |

## Documentation

- Does this pull request introduce a new feature? (yes / **no**)
- If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
