### PR TITLE
AVRO-3965: [Rust] Default values for fixed can be longer than size

### DIFF
--- a/lang/rust/avro/src/decode.rs
+++ b/lang/rust/avro/src/decode.rs
@@ -149,6 +149,7 @@ pub(crate) fn decode_internal<R: Read, S: Borrow<Schema>>(
                         name: "uuid".into(),
                         aliases: None,
                         doc: None,
+                        default: None,
                         attributes: Default::default(),
                     }),
                     names,
@@ -419,6 +420,7 @@ mod tests {
             doc: None,
             name: Name::new("decimal")?,
             aliases: None,
+            default: None,
             attributes: Default::default(),
         }));
         let schema = Schema::Decimal(DecimalSchema {
@@ -448,6 +450,7 @@ mod tests {
             name: Name::new("decimal")?,
             aliases: None,
             doc: None,
+            default: None,
             attributes: Default::default(),
         }));
         let schema = Schema::Decimal(DecimalSchema {
@@ -893,6 +896,7 @@ mod tests {
             name: "uuid".into(),
             aliases: None,
             doc: None,
+            default: None,
             attributes: Default::default(),
         });
         let value = Value::Uuid(Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000")?);

--- a/lang/rust/avro/src/encode.rs
+++ b/lang/rust/avro/src/encode.rs
@@ -901,6 +901,7 @@ pub(crate) mod tests {
             name: "uuid".into(),
             aliases: None,
             doc: None,
+            default: None,
             attributes: Default::default(),
         });
         let value = Value::Uuid(Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000")?);

--- a/lang/rust/avro/src/error.rs
+++ b/lang/rust/avro/src/error.rs
@@ -370,6 +370,9 @@ pub enum Error {
     #[error("Fixed schema has no `size`")]
     GetFixedSizeField,
 
+    #[error("Fixed schema's default value length ({0}) does not match its size ({1})")]
+    FixedDefaultLenSizeMismatch(usize, u64),
+
     #[error("Failed to compress with flate")]
     DeflateCompress(#[source] std::io::Error),
 

--- a/lang/rust/avro/src/schema_compatibility.rs
+++ b/lang/rust/avro/src/schema_compatibility.rs
@@ -393,6 +393,7 @@ impl SchemaCompatibility {
                         aliases: _,
                         doc: _w_doc,
                         size: w_size,
+                        default: _w_default,
                         attributes: _,
                     }) = writers_schema
                     {
@@ -401,6 +402,7 @@ impl SchemaCompatibility {
                             aliases: _,
                             doc: _r_doc,
                             size: r_size,
+                            default: _r_default,
                             attributes: _,
                         }) = readers_schema
                         {

--- a/lang/rust/avro/src/schema_equality.rs
+++ b/lang/rust/avro/src/schema_equality.rs
@@ -424,6 +424,7 @@ mod tests {
             name: Name::from("fixed"),
             doc: None,
             size: 10,
+            default: None,
             aliases: None,
             attributes: BTreeMap::new(),
         });
@@ -434,6 +435,7 @@ mod tests {
             name: Name::from("fixed"),
             doc: None,
             size: 10,
+            default: None,
             aliases: None,
             attributes: BTreeMap::new(),
         });

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -1367,6 +1367,7 @@ mod tests {
             name: Name::new("some_fixed").unwrap(),
             aliases: None,
             doc: None,
+            default: None,
             attributes: Default::default(),
         });
 
@@ -1722,6 +1723,7 @@ Field with name '"b"' is not a member of the map items"#,
                     aliases: None,
                     size: 20,
                     doc: None,
+                    default: None,
                     attributes: Default::default(),
                 }))
             }))
@@ -3036,6 +3038,7 @@ Field with name '"b"' is not a member of the map items"#,
                 aliases: None,
                 doc: None,
                 size: 3,
+                default: None,
                 attributes: Default::default()
             }))?,
             Value::Fixed(3, vec![97, 98, 99])
@@ -3048,6 +3051,7 @@ Field with name '"b"' is not a member of the map items"#,
                 aliases: None,
                 doc: None,
                 size: 3,
+                default: None,
                 attributes: Default::default()
             }))
             .is_err(),);
@@ -3059,6 +3063,7 @@ Field with name '"b"' is not a member of the map items"#,
                 aliases: None,
                 doc: None,
                 size: 3,
+                default: None,
                 attributes: Default::default()
             }))
             .is_err(),);

--- a/lang/rust/avro/src/writer.rs
+++ b/lang/rust/avro/src/writer.rs
@@ -790,6 +790,7 @@ mod tests {
             aliases: None,
             doc: None,
             size,
+            default: None,
             attributes: Default::default(),
         });
         let value = vec![0u8; size];
@@ -830,6 +831,7 @@ mod tests {
             aliases: None,
             doc: None,
             size: 12,
+            default: None,
             attributes: Default::default(),
         });
         let value = Value::Duration(Duration::new(


### PR DESCRIPTION
## What is the purpose of the change

* Return an error if the default value's length is not the same as the specified size of a Fixed schema

## Verifying this change

* Old and new unit tests should pass

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable 
