### PR TITLE
[C++] Run clang-format on all files

### DIFF
--- a/lang/c++/api/CustomAttributes.hh
+++ b/lang/c++/api/CustomAttributes.hh
@@ -19,11 +19,11 @@
 #ifndef avro_CustomAttributes_hh__
 #define avro_CustomAttributes_hh__
 
+#include "Config.hh"
 #include <boost/optional.hpp>
 #include <iostream>
 #include <map>
 #include <string>
-#include "Config.hh"
 
 namespace avro {
 
@@ -31,7 +31,7 @@ namespace avro {
 // Each attribute is represented by a unique name and value.
 // User is supposed to create CustomAttributes object and then add it to Schema.
 class AVRO_DECL CustomAttributes {
-  public:
+public:
     // Retrieves the custom attribute json entity for that attributeName, returns an
     // null if the attribute doesn't exist.
     boost::optional<std::string> getAttribute(const std::string &name) const;
@@ -45,12 +45,12 @@ class AVRO_DECL CustomAttributes {
     }
 
     // Prints the attribute value for the specific attribute.
-    void printJson(std::ostream& os, const std::string &name) const;
+    void printJson(std::ostream &os, const std::string &name) const;
 
-  private:
+private:
     std::map<std::string, std::string> attributes_;
 };
 
-}  // namespace avro
+} // namespace avro
 
 #endif

--- a/lang/c++/api/Exception.hh
+++ b/lang/c++/api/Exception.hh
@@ -20,8 +20,8 @@
 #define avro_Exception_hh__
 
 #include "Config.hh"
-#include <stdexcept>
 #include <fmt/core.h>
+#include <stdexcept>
 
 namespace avro {
 
@@ -32,9 +32,9 @@ class AVRO_DECL Exception : public virtual std::runtime_error {
 public:
     explicit Exception(const std::string &msg) : std::runtime_error(msg) {}
 
-    template <typename... Args>
-    Exception(fmt::format_string<Args...> fmt, Args&&... args)
-        : std::runtime_error(fmt::format(fmt, std::forward<Args>(args)...) ) {}
+    template<typename... Args>
+    Exception(fmt::format_string<Args...> fmt, Args &&...args)
+        : std::runtime_error(fmt::format(fmt, std::forward<Args>(args)...)) {}
 };
 
 } // namespace avro

--- a/lang/c++/api/GenericDatum.hh
+++ b/lang/c++/api/GenericDatum.hh
@@ -553,11 +553,13 @@ inline Type GenericDatum::type() const {
 inline LogicalType GenericDatum::logicalType() const {
     return (type_ == AVRO_UNION) ?
 #if __cplusplus >= 201703L
-        std::any_cast<GenericUnion>(&value_)->datum().logicalType() :
+                                 std::any_cast<GenericUnion>(&value_)->datum().logicalType()
+                                 :
 #else
-        boost::any_cast<GenericUnion>(&value_)->datum().logicalType() :
+                                 boost::any_cast<GenericUnion>(&value_)->datum().logicalType()
+                                 :
 #endif
-        logicalType_;
+                                 logicalType_;
 }
 
 template<typename T>

--- a/lang/c++/api/Node.hh
+++ b/lang/c++/api/Node.hh
@@ -50,10 +50,10 @@ public:
     Name();
     explicit Name(const std::string &name);
     Name(std::string simpleName, std::string ns);
-    Name(const Name& other);
-    Name& operator=(const Name& other);
-    Name(Name&& other);
-    Name& operator=(Name&& other);
+    Name(const Name &other);
+    Name &operator=(const Name &other);
+    Name(Name &&other);
+    Name &operator=(Name &&other);
     ~Name();
 
     std::string fullname() const;
@@ -162,7 +162,7 @@ public:
     }
     virtual size_t fixedSize() const = 0;
 
-    void addCustomAttributesForField(const CustomAttributes& customAttributes) {
+    void addCustomAttributesForField(const CustomAttributes &customAttributes) {
         checkLock();
         doAddCustomAttribute(customAttributes);
     }
@@ -199,7 +199,7 @@ protected:
     virtual void doAddLeaf(const NodePtr &newLeaf) = 0;
     virtual void doAddName(const std::string &name) = 0;
     virtual void doSetFixedSize(size_t size) = 0;
-    virtual void doAddCustomAttribute(const CustomAttributes& customAttributes) = 0;
+    virtual void doAddCustomAttribute(const CustomAttributes &customAttributes) = 0;
 
 private:
     const Type type_;
@@ -216,8 +216,9 @@ inline std::ostream &operator<<(std::ostream &os, const avro::Node &n) {
 }
 } // namespace std
 
-template <> struct fmt::formatter<avro::Name> : fmt::formatter<std::string> {
-    template <typename FormatContext>
+template<>
+struct fmt::formatter<avro::Name> : fmt::formatter<std::string> {
+    template<typename FormatContext>
     auto format(const avro::Name &n, FormatContext &ctx) {
         return fmt::formatter<std::string>::format(n.fullname(), ctx);
     }

--- a/lang/c++/api/NodeImpl.hh
+++ b/lang/c++/api/NodeImpl.hh
@@ -30,9 +30,9 @@
 #include <sstream>
 #include <utility>
 
+#include "CustomAttributes.hh"
 #include "Node.hh"
 #include "NodeConcepts.hh"
-#include "CustomAttributes.hh"
 
 namespace avro {
 
@@ -161,7 +161,7 @@ protected:
     void setLeafToSymbolic(size_t index, const NodePtr &node) override;
 
     void doAddCustomAttribute(const CustomAttributes &customAttributes) override {
-      customAttributes_.add(customAttributes);
+        customAttributes_.add(customAttributes);
     }
 
     SchemaResolution furtherResolution(const Node &reader) const {
@@ -325,10 +325,7 @@ public:
     void printJson(std::ostream &os, size_t depth) const override;
 
     bool isValid() const override {
-        return ((nameAttribute_.size() == 1) &&
-            (leafAttributes_.size() == leafNameAttributes_.size()) &&
-            (customAttributes_.size() == 0 ||
-            customAttributes_.size() == leafAttributes_.size()));
+        return ((nameAttribute_.size() == 1) && (leafAttributes_.size() == leafNameAttributes_.size()) && (customAttributes_.size() == 0 || customAttributes_.size() == leafAttributes_.size()));
     }
 
     const GenericDatum &defaultValueAt(size_t index) override {

--- a/lang/c++/api/Reader.hh
+++ b/lang/c++/api/Reader.hh
@@ -84,7 +84,7 @@ public:
         union {
             double d;
             uint64_t i;
-        } v = { 0 };
+        } v = {0};
         reader_.read(v.i);
         val = v.d;
     }

--- a/lang/c++/api/Schema.hh
+++ b/lang/c++/api/Schema.hh
@@ -20,8 +20,8 @@
 #define avro_Schema_hh__
 
 #include "Config.hh"
-#include "NodeImpl.hh"
 #include "CustomAttributes.hh"
+#include "NodeImpl.hh"
 #include <string>
 
 /// \file

--- a/lang/c++/api/Types.hh
+++ b/lang/c++/api/Types.hh
@@ -19,8 +19,8 @@
 #ifndef avro_Types_hh__
 #define avro_Types_hh__
 
-#include <iostream>
 #include <fmt/format.h>
+#include <iostream>
 
 #include "Config.hh"
 
@@ -110,8 +110,9 @@ std::ostream &operator<<(std::ostream &os, const Null &null);
 
 } // namespace avro
 
-template <> struct fmt::formatter<avro::Type> : fmt::formatter<std::string> {
-    template <typename FormatContext>
+template<>
+struct fmt::formatter<avro::Type> : fmt::formatter<std::string> {
+    template<typename FormatContext>
     auto format(avro::Type t, FormatContext &ctx) {
         return fmt::formatter<std::string>::format(avro::toString(t), ctx);
     }

--- a/lang/c++/examples/cpx.hh
+++ b/lang/c++/examples/cpx.hh
@@ -16,14 +16,12 @@
  * limitations under the License.
  */
 
-
 #ifndef CPX_HH_1278398428__H_
 #define CPX_HH_1278398428__H_
 
-
-#include "avro/Specific.hh"
-#include "avro/Encoder.hh"
 #include "avro/Decoder.hh"
+#include "avro/Encoder.hh"
+#include "avro/Specific.hh"
 
 namespace c {
 struct cpx {
@@ -31,18 +29,19 @@ struct cpx {
     double im;
 };
 
-}
+} // namespace c
 namespace avro {
-template<> struct codec_traits<c::cpx> {
-    static void encode(Encoder& e, const c::cpx& v) {
+template<>
+struct codec_traits<c::cpx> {
+    static void encode(Encoder &e, const c::cpx &v) {
         avro::encode(e, v.re);
         avro::encode(e, v.im);
     }
-    static void decode(Decoder& d, c::cpx& v) {
+    static void decode(Decoder &d, c::cpx &v) {
         avro::decode(d, v.re);
         avro::decode(d, v.im);
     }
 };
 
-}
+} // namespace avro
 #endif

--- a/lang/c++/examples/custom.cc
+++ b/lang/c++/examples/custom.cc
@@ -18,19 +18,19 @@
 
 #include <complex>
 
-#include "avro/Encoder.hh"
 #include "avro/Decoder.hh"
+#include "avro/Encoder.hh"
 #include "avro/Specific.hh"
 
 namespace avro {
 template<typename T>
-struct codec_traits<std::complex<T> > {
-    static void encode(Encoder& e, const std::complex<T>& c) {
+struct codec_traits<std::complex<T>> {
+    static void encode(Encoder &e, const std::complex<T> &c) {
         avro::encode(e, std::real(c));
         avro::encode(e, std::imag(c));
     }
 
-    static void decode(Decoder& d, std::complex<T>& c) {
+    static void decode(Decoder &d, std::complex<T> &c) {
         T re, im;
         avro::decode(d, re);
         avro::decode(d, im);
@@ -38,10 +38,8 @@ struct codec_traits<std::complex<T> > {
     }
 };
 
-}
-int
-main()
-{
+} // namespace avro
+int main() {
     std::unique_ptr<avro::OutputStream> out = avro::memoryOutputStream();
     avro::EncoderPtr e = avro::binaryEncoder();
     e->init(*out);

--- a/lang/c++/examples/datafile.cc
+++ b/lang/c++/examples/datafile.cc
@@ -18,25 +18,21 @@
 
 #include <fstream>
 
-#include "cpx.hh"
-#include "avro/Encoder.hh"
-#include "avro/Decoder.hh"
-#include "avro/ValidSchema.hh"
 #include "avro/Compiler.hh"
 #include "avro/DataFile.hh"
+#include "avro/Decoder.hh"
+#include "avro/Encoder.hh"
+#include "avro/ValidSchema.hh"
+#include "cpx.hh"
 
-
-avro::ValidSchema loadSchema(const char* filename)
-{
+avro::ValidSchema loadSchema(const char *filename) {
     std::ifstream ifs(filename);
     avro::ValidSchema result;
     avro::compileJsonSchema(ifs, result);
     return result;
 }
 
-int
-main()
-{
+int main() {
     avro::ValidSchema cpxSchema = loadSchema("cpx.json");
 
     {
@@ -59,4 +55,3 @@ main()
     }
     return 0;
 }
-

--- a/lang/c++/examples/generated.cc
+++ b/lang/c++/examples/generated.cc
@@ -16,14 +16,11 @@
  * limitations under the License.
  */
 
-#include "cpx.hh"
-#include "avro/Encoder.hh"
 #include "avro/Decoder.hh"
+#include "avro/Encoder.hh"
+#include "cpx.hh"
 
-
-int
-main()
-{
+int main() {
     std::unique_ptr<avro::OutputStream> out = avro::memoryOutputStream();
     avro::EncoderPtr e = avro::binaryEncoder();
     e->init(*out);
@@ -41,4 +38,3 @@ main()
     std::cout << '(' << c2.re << ", " << c2.im << ')' << std::endl;
     return 0;
 }
-

--- a/lang/c++/examples/generic.cc
+++ b/lang/c++/examples/generic.cc
@@ -16,20 +16,18 @@
  * limitations under the License.
  */
 
-#include <fstream>
 #include <complex>
+#include <fstream>
 
 #include "cpx.hh"
 
 #include "avro/Compiler.hh"
-#include "avro/Encoder.hh"
 #include "avro/Decoder.hh"
-#include "avro/Specific.hh"
+#include "avro/Encoder.hh"
 #include "avro/Generic.hh"
+#include "avro/Specific.hh"
 
-int
-main()
-{
+int main() {
     std::ifstream ifs("cpx.json");
 
     avro::ValidSchema cpxSchema;
@@ -51,14 +49,14 @@ main()
     avro::decode(*d, datum);
     std::cout << "Type: " << datum.type() << std::endl;
     if (datum.type() == avro::AVRO_RECORD) {
-        const avro::GenericRecord& r = datum.value<avro::GenericRecord>();
+        const avro::GenericRecord &r = datum.value<avro::GenericRecord>();
         std::cout << "Field-count: " << r.fieldCount() << std::endl;
         if (r.fieldCount() == 2) {
-            const avro::GenericDatum& f0 = r.fieldAt(0);
+            const avro::GenericDatum &f0 = r.fieldAt(0);
             if (f0.type() == avro::AVRO_DOUBLE) {
                 std::cout << "Real: " << f0.value<double>() << std::endl;
             }
-            const avro::GenericDatum& f1 = r.fieldAt(1);
+            const avro::GenericDatum &f1 = r.fieldAt(1);
             if (f1.type() == avro::AVRO_DOUBLE) {
                 std::cout << "Imaginary: " << f1.value<double>() << std::endl;
             }

--- a/lang/c++/examples/imaginary.hh
+++ b/lang/c++/examples/imaginary.hh
@@ -16,31 +16,30 @@
  * limitations under the License.
  */
 
-
 #ifndef IMAGINARY_HH_3460301992__H_
 #define IMAGINARY_HH_3460301992__H_
 
-
-#include "boost/any.hpp"
-#include "avro/Specific.hh"
-#include "avro/Encoder.hh"
 #include "avro/Decoder.hh"
+#include "avro/Encoder.hh"
+#include "avro/Specific.hh"
+#include "boost/any.hpp"
 
 namespace i {
 struct cpx {
     double im;
 };
 
-}
+} // namespace i
 namespace avro {
-template<> struct codec_traits<i::cpx> {
-    static void encode(Encoder& e, const i::cpx& v) {
+template<>
+struct codec_traits<i::cpx> {
+    static void encode(Encoder &e, const i::cpx &v) {
         avro::encode(e, v.im);
     }
-    static void decode(Decoder& d, i::cpx& v) {
+    static void decode(Decoder &d, i::cpx &v) {
         avro::decode(d, v.im);
     }
 };
 
-}
+} // namespace avro
 #endif

--- a/lang/c++/examples/resolving.cc
+++ b/lang/c++/examples/resolving.cc
@@ -22,24 +22,19 @@
 #include "imaginary.hh"
 
 #include "avro/Compiler.hh"
-#include "avro/Encoder.hh"
 #include "avro/Decoder.hh"
-#include "avro/Specific.hh"
+#include "avro/Encoder.hh"
 #include "avro/Generic.hh"
+#include "avro/Specific.hh"
 
-
-
-avro::ValidSchema load(const char* filename)
-{
+avro::ValidSchema load(const char *filename) {
     std::ifstream ifs(filename);
     avro::ValidSchema result;
     avro::compileJsonSchema(ifs, result);
     return result;
 }
 
-int
-main()
-{
+int main() {
     avro::ValidSchema cpxSchema = load("cpx.json");
     avro::ValidSchema imaginarySchema = load("imaginary.json");
 
@@ -53,11 +48,10 @@ main()
 
     std::unique_ptr<avro::InputStream> in = avro::memoryInputStream(*out);
     avro::DecoderPtr d = avro::resolvingDecoder(cpxSchema, imaginarySchema,
-        avro::binaryDecoder());
+                                                avro::binaryDecoder());
     d->init(*in);
 
     i::cpx c2;
     avro::decode(*d, c2);
     std::cout << "Imaginary: " << c2.im << std::endl;
-
 }

--- a/lang/c++/examples/schemaload.cc
+++ b/lang/c++/examples/schemaload.cc
@@ -18,13 +18,10 @@
 
 #include <fstream>
 
-#include "avro/ValidSchema.hh"
 #include "avro/Compiler.hh"
+#include "avro/ValidSchema.hh"
 
-
-int
-main()
-{
+int main() {
     std::ifstream in("cpx.json");
 
     avro::ValidSchema cpxSchema;

--- a/lang/c++/examples/validating.cc
+++ b/lang/c++/examples/validating.cc
@@ -16,23 +16,23 @@
  * limitations under the License.
  */
 
-#include <fstream>
 #include <complex>
+#include <fstream>
 
 #include "avro/Compiler.hh"
-#include "avro/Encoder.hh"
 #include "avro/Decoder.hh"
+#include "avro/Encoder.hh"
 #include "avro/Specific.hh"
 
 namespace avro {
 template<typename T>
-struct codec_traits<std::complex<T> > {
-    static void encode(Encoder& e, const std::complex<T>& c) {
+struct codec_traits<std::complex<T>> {
+    static void encode(Encoder &e, const std::complex<T> &c) {
         avro::encode(e, std::real(c));
         avro::encode(e, std::imag(c));
     }
 
-    static void decode(Decoder& d, std::complex<T>& c) {
+    static void decode(Decoder &d, std::complex<T> &c) {
         T re, im;
         avro::decode(d, re);
         avro::decode(d, im);
@@ -40,10 +40,8 @@ struct codec_traits<std::complex<T> > {
     }
 };
 
-}
-int
-main()
-{
+} // namespace avro
+int main() {
     std::ifstream ifs("cpx.json");
 
     avro::ValidSchema cpxSchema;
@@ -51,14 +49,14 @@ main()
 
     std::unique_ptr<avro::OutputStream> out = avro::memoryOutputStream();
     avro::EncoderPtr e = avro::validatingEncoder(cpxSchema,
-        avro::binaryEncoder());
+                                                 avro::binaryEncoder());
     e->init(*out);
     std::complex<double> c1(1.0, 2.0);
     avro::encode(*e, c1);
 
     std::unique_ptr<avro::InputStream> in = avro::memoryInputStream(*out);
     avro::DecoderPtr d = avro::validatingDecoder(cpxSchema,
-        avro::binaryDecoder());
+                                                 avro::binaryDecoder());
     d->init(*in);
 
     std::complex<double> c2;

--- a/lang/c++/impl/Compiler.cc
+++ b/lang/c++/impl/Compiler.cc
@@ -152,15 +152,15 @@ struct Field {
     const GenericDatum defaultValue;
     const CustomAttributes customAttributes;
 
-    Field(string n, vector<string> a, NodePtr v, GenericDatum dv, const CustomAttributes& ca)
+    Field(string n, vector<string> a, NodePtr v, GenericDatum dv, const CustomAttributes &ca)
         : name(std::move(n)), aliases(std::move(a)), schema(std::move(v)), defaultValue(std::move(dv)), customAttributes(ca) {}
 };
 
 static void assertType(const Entity &e, EntityType et) {
     if (e.type() != et) {
         throw Exception(
-                "Unexpected type for default value: Expected {}, but found {} in line {}",
-                json::typeToString(et), json::typeToString(e.type()), e.line());
+            "Unexpected type for default value: Expected {}, but found {} in line {}",
+            json::typeToString(et), json::typeToString(e.type()), e.line());
     }
 }
 
@@ -220,8 +220,8 @@ static GenericDatum makeGenericDatum(NodePtr n,
                 auto it = v.find(n->nameAt(i));
                 if (it == v.end()) {
                     throw Exception(
-                            "No value found in default for {}",
-                            n->nameAt(i));
+                        "No value found in default for {}",
+                        n->nameAt(i));
                 }
                 result.setFieldAt(i,
                                   makeGenericDatum(n->leafAt(i), it->second, st));
@@ -263,24 +263,23 @@ static GenericDatum makeGenericDatum(NodePtr n,
     }
 }
 
-static const std::unordered_set<std::string>& getKnownFields() {
+static const std::unordered_set<std::string> &getKnownFields() {
     // return known fields
     static const std::unordered_set<std::string> kKnownFields =
         {"name", "type", "aliases", "default", "doc", "size", "logicalType",
          "values", "precision", "scale", "namespace"};
-      return kKnownFields;
+    return kKnownFields;
 }
 
-static void getCustomAttributes(const Object& m, CustomAttributes &customAttributes)
-{
-  // Don't add known fields on primitive type and fixed type into custom
-  // fields.
-  const std::unordered_set<std::string>& kKnownFields = getKnownFields();
-  for (const auto &entry : m) {
-    if (kKnownFields.find(entry.first) == kKnownFields.end()) {
-      customAttributes.addAttribute(entry.first, entry.second.stringValue());
+static void getCustomAttributes(const Object &m, CustomAttributes &customAttributes) {
+    // Don't add known fields on primitive type and fixed type into custom
+    // fields.
+    const std::unordered_set<std::string> &kKnownFields = getKnownFields();
+    for (const auto &entry : m) {
+        if (kKnownFields.find(entry.first) == kKnownFields.end()) {
+            customAttributes.addAttribute(entry.first, entry.second.stringValue());
+        }
     }
-  }
 }
 
 static Field makeField(const Entity &e, SymbolTable &st, const string &ns) {
@@ -439,8 +438,8 @@ static Name getName(const Entity &e, const Object &m, const string &ns) {
         if (it != m.end()) {
             if (it->second.type() != json::type_traits<string>::type()) {
                 throw Exception(
-                        "Json field \"namespace\" is not a string: {}",
-                        it->second.toString());
+                    "Json field \"namespace\" is not a string: {}",
+                    it->second.toString());
             }
             result = Name(name, it->second.stringValue());
         } else {

--- a/lang/c++/impl/CustomAttributes.cc
+++ b/lang/c++/impl/CustomAttributes.cc
@@ -17,9 +17,9 @@
  * limitations under the License.
  */
 #include "CustomAttributes.hh"
+#include "Exception.hh"
 #include <map>
 #include <memory>
-#include "Exception.hh"
 
 namespace avro {
 
@@ -28,26 +28,26 @@ boost::optional<std::string> CustomAttributes::getAttribute(const std::string &n
     std::map<std::string, std::string>::const_iterator iter =
         attributes_.find(name);
     if (iter == attributes_.end()) {
-      return result;
+        return result;
     }
     result = iter->second;
     return result;
 }
 
-void CustomAttributes::addAttribute(const std::string& name,
-                                    const std::string& value) {
-  auto iter_and_find =
-      attributes_.insert(std::pair<std::string, std::string>(name, value));
-  if (!iter_and_find.second) {
-    throw Exception(name + " already exists and cannot be added");
-  }
+void CustomAttributes::addAttribute(const std::string &name,
+                                    const std::string &value) {
+    auto iter_and_find =
+        attributes_.insert(std::pair<std::string, std::string>(name, value));
+    if (!iter_and_find.second) {
+        throw Exception(name + " already exists and cannot be added");
+    }
 }
 
-void CustomAttributes::printJson(std::ostream& os,
-                                  const std::string& name) const {
+void CustomAttributes::printJson(std::ostream &os,
+                                 const std::string &name) const {
     if (attributes().find(name) == attributes().end()) {
         throw Exception(name + " doesn't exist");
     }
     os << "\"" << name << "\": \"" << attributes().at(name) << "\"";
 }
-}  // namespace avro
+} // namespace avro

--- a/lang/c++/impl/DataFile.cc
+++ b/lang/c++/impl/DataFile.cc
@@ -94,8 +94,8 @@ DataFileWriterBase::DataFileWriterBase(std::unique_ptr<OutputStream> outputStrea
 void DataFileWriterBase::init(const ValidSchema &schema, size_t syncInterval, const Codec &codec) {
     if (syncInterval < minSyncInterval || syncInterval > maxSyncInterval) {
         throw Exception(
-                "Invalid sync interval: {}. Should be between {} and {}",
-                syncInterval, minSyncInterval, maxSyncInterval);
+            "Invalid sync interval: {}. Should be between {} and {}",
+            syncInterval, minSyncInterval, maxSyncInterval);
     }
     setMetadata(AVRO_CODEC_KEY, AVRO_NULL_CODEC);
 
@@ -118,12 +118,11 @@ void DataFileWriterBase::init(const ValidSchema &schema, size_t syncInterval, co
     lastSync_ = stream_->byteCount();
 }
 
-DataFileWriterBase::~DataFileWriterBase()
-{
+DataFileWriterBase::~DataFileWriterBase() {
     if (stream_) {
         try {
             close();
-        } catch(...) {}
+        } catch (...) {}
     }
 }
 
@@ -412,8 +411,8 @@ void DataFileReaderBase::readDataBlock() {
         uint32_t c = crc();
         if (checksum != c) {
             throw Exception(
-                    "Checksum did not match for Snappy compression: Expected: {}, computed: {}",
-                    checksum, c);
+                "Checksum did not match for Snappy compression: Expected: {}, computed: {}",
+                checksum, c);
         }
         os_.reset(new boost::iostreams::filtering_istream());
         os_->push(

--- a/lang/c++/impl/Node.cc
+++ b/lang/c++/impl/Node.cc
@@ -42,11 +42,11 @@ Name::Name(std::string simpleName, std::string ns) : ns_(std::move(ns)), simpleN
     check();
 }
 
-Name::Name(const Name& other) {
+Name::Name(const Name &other) {
     *this = other;
 }
 
-Name& Name::operator=(const Name& other) {
+Name &Name::operator=(const Name &other) {
     if (this != &other) {
         ns_ = other.ns_;
         simpleName_ = other.simpleName_;
@@ -57,9 +57,9 @@ Name& Name::operator=(const Name& other) {
     return *this;
 }
 
-Name::Name(Name&& other) = default;
+Name::Name(Name &&other) = default;
 
-Name& Name::operator=(Name&& other) = default;
+Name &Name::operator=(Name &&other) = default;
 
 Name::~Name() = default;
 
@@ -79,7 +79,7 @@ void Name::fullname(const string &name) {
     check();
 }
 
-const std::vector<std::string>& Name::aliases() const {
+const std::vector<std::string> &Name::aliases() const {
     static const std::vector<std::string> emptyAliases;
     return aliases_ ? aliases_->raw : emptyAliases;
 }
@@ -149,10 +149,10 @@ void Node::setLogicalType(LogicalType logicalType) {
                 long maxPrecision = floor(log10(2.0) * (8.0 * fixedSize() - 1));
                 if (logicalType.precision() > maxPrecision) {
                     throw Exception(
-                            "DECIMAL precision {} is too large for the "
-                            "FIXED type of size {}, precision cannot be "
-                            "larger than {}",
-                            logicalType.precision(), fixedSize(), maxPrecision);
+                        "DECIMAL precision {} is too large for the "
+                        "FIXED type of size {}, precision cannot be "
+                        "larger than {}",
+                        logicalType.precision(), fixedSize(), maxPrecision);
                 }
             }
             if (logicalType.scale() > logicalType.precision()) {

--- a/lang/c++/impl/NodeImpl.cc
+++ b/lang/c++/impl/NodeImpl.cc
@@ -83,14 +83,15 @@ std::ostream &operator<<(std::ostream &os, indent x) {
     return os;
 }
 
-void printCustomAttributes(const CustomAttributes& customAttributes, int depth,
-                       std::ostream &os) {
+void printCustomAttributes(const CustomAttributes &customAttributes, int depth,
+                           std::ostream &os) {
     std::map<std::string, std::string>::const_iterator iter =
         customAttributes.attributes().begin();
     while (iter != customAttributes.attributes().end()) {
-      os << ",\n" << indent(depth);
-      customAttributes.printJson(os, iter->first);
-      ++iter;
+        os << ",\n"
+           << indent(depth);
+        customAttributes.printJson(os, iter->first);
+        ++iter;
     }
 }
 
@@ -302,10 +303,10 @@ void NodeRecord::printJson(std::ostream &os, size_t depth) const {
                     os << ',';
                 }
                 os << '\n'
-                << indent(depth) << "\"" << fieldsAliases_[i][j] << "\"";
+                   << indent(depth) << "\"" << fieldsAliases_[i][j] << "\"";
             }
             os << '\n'
-            << indent(--depth) << ']';
+               << indent(--depth) << ']';
         }
 
         // Serialize "default" field:
@@ -320,8 +321,8 @@ void NodeRecord::printJson(std::ostream &os, size_t depth) const {
             }
         }
 
-        if(customAttributes_.size() == fields) {
-          printCustomAttributes(customAttributes_.get(i), depth, os);
+        if (customAttributes_.size() == fields) {
+            printCustomAttributes(customAttributes_.get(i), depth, os);
         }
 
         os << '\n';

--- a/lang/c++/impl/Schema.cc
+++ b/lang/c++/impl/Schema.cc
@@ -18,8 +18,8 @@
 
 #include <utility>
 
-#include "Schema.hh"
 #include "CustomAttributes.hh"
+#include "Schema.hh"
 
 namespace avro {
 

--- a/lang/c++/impl/Stream.cc
+++ b/lang/c++/impl/Stream.cc
@@ -129,7 +129,7 @@ public:
     ~MemoryOutputStream() final {
         for (std::vector<uint8_t *>::const_iterator it = data_.begin();
              it != data_.end(); ++it) {
-            delete[] * it;
+            delete[] *it;
         }
     }
 

--- a/lang/c++/impl/Validator.cc
+++ b/lang/c++/impl/Validator.cc
@@ -106,7 +106,7 @@ void Validator::unionAdvance() {
         } else {
             throw Exception(
                 "Union selection out of range, got {}, expecting 0-{}",
-                            count_, node->leaves() - 1);
+                count_, node->leaves() - 1);
         }
     }
 }

--- a/lang/c++/impl/avrogencpp.cc
+++ b/lang/c++/impl/avrogencpp.cc
@@ -111,11 +111,10 @@ public:
             std::string schemaFile, std::string headerFile,
             std::string guardString,
             std::string includePrefix, bool noUnion, bool useCpp17) : unionNumber_(0), os_(os), inNamespace_(false), ns_(std::move(ns)),
-                                                       schemaFile_(std::move(schemaFile)), headerFile_(std::move(headerFile)),
-                                                       includePrefix_(std::move(includePrefix)), noUnion_(noUnion), useCpp17_(useCpp17),
-                                                       guardString_(std::move(guardString)),
-                                                       random_(static_cast<uint32_t>(::time(nullptr)))
-    {
+                                                                      schemaFile_(std::move(schemaFile)), headerFile_(std::move(headerFile)),
+                                                                      includePrefix_(std::move(includePrefix)), noUnion_(noUnion), useCpp17_(useCpp17),
+                                                                      guardString_(std::move(guardString)),
+                                                                      random_(static_cast<uint32_t>(::time(nullptr))) {
 #if __cplusplus >= 201703L
         anyNs = "std";
 #else
@@ -323,7 +322,7 @@ string CodeGen::unionName() {
 
 static void generateGetterAndSetter(ostream &os,
                                     const string &structName, const string &type, const string &name,
-                                    size_t idx, const std::string& anyNs) {
+                                    size_t idx, const std::string &anyNs) {
     string sn = " " + structName + "::";
 
     os << "inline\n";
@@ -823,14 +822,7 @@ int main(int argc, char **argv) {
     const string NO_UNION_TYPEDEF("no-union-typedef");
 
     po::options_description desc("Allowed options");
-    desc.add_options()("help,h", "produce help message")
-        ("version,V", "produce version information")
-        ("include-prefix,p", po::value<string>()->default_value("avro"), "prefix for include headers, - for none, default: avro")
-        ("no-union-typedef,U", "do not generate typedefs for unions in records")
-        ("namespace,n", po::value<string>(), "set namespace for generated code")
-        ("cpp17", "use c++17 instead of boost")
-        ("input,i", po::value<string>(), "input file")
-        ("output,o", po::value<string>(), "output file to generate");
+    desc.add_options()("help,h", "produce help message")("version,V", "produce version information")("include-prefix,p", po::value<string>()->default_value("avro"), "prefix for include headers, - for none, default: avro")("no-union-typedef,U", "do not generate typedefs for unions in records")("namespace,n", po::value<string>(), "set namespace for generated code")("cpp17", "use c++17 instead of boost")("input,i", po::value<string>(), "input file")("output,o", po::value<string>(), "output file to generate");
 
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);

--- a/lang/c++/impl/json/JsonIO.cc
+++ b/lang/c++/impl/json/JsonIO.cc
@@ -55,7 +55,8 @@ void JsonParser::expectToken(Token tk) {
             if (cur() == Token::String
                 && (sv == "Infinity" || sv == "-Infinity" || sv == "NaN")) {
                 curToken = Token::Double;
-                dv = sv == "Infinity" ? std::numeric_limits<double>::infinity() : sv == "-Infinity" ? -std::numeric_limits<double>::infinity() : std::numeric_limits<double>::quiet_NaN();
+                dv = sv == "Infinity" ? std::numeric_limits<double>::infinity() : sv == "-Infinity" ? -std::numeric_limits<double>::infinity()
+                                                                                                    : std::numeric_limits<double>::quiet_NaN();
                 return;
             } else if (cur() == Token::Long) {
                 dv = double(lv);
@@ -146,7 +147,8 @@ JsonParser::Token JsonParser::tryNumber(char ch) {
     sv.push_back(ch);
 
     hasNext = false;
-    int state = (ch == '-') ? 0 : (ch == '0') ? 1 : 2;
+    int state = (ch == '-') ? 0 : (ch == '0') ? 1
+                                              : 2;
     for (;;) {
         switch (state) {
             case 0:
@@ -313,7 +315,6 @@ JsonParser::Token JsonParser::tryString() {
         }
     }
 }
-
 
 // Decode the given string and return contents as UTF8-encoded bytes.
 // The input does not have the enclosing double-quotes.

--- a/lang/c++/impl/parsing/ResolvingDecoder.cc
+++ b/lang/c++/impl/parsing/ResolvingDecoder.cc
@@ -366,7 +366,9 @@ ProductionPtr ResolvingGrammarGenerator::doGenerate2(
                 if (writerType == AVRO_INT || writerType == AVRO_LONG
                     || writerType == AVRO_FLOAT) {
                     return make_shared<Production>(1,
-                                                   Symbol::resolveSymbol(writerType == AVRO_INT ? Symbol::Kind::Int : writerType == AVRO_LONG ? Symbol::Kind::Long : Symbol::Kind::Float, Symbol::Kind::Double));
+                                                   Symbol::resolveSymbol(writerType == AVRO_INT ? Symbol::Kind::Int : writerType == AVRO_LONG ? Symbol::Kind::Long
+                                                                                                                                              : Symbol::Kind::Float,
+                                                                         Symbol::Kind::Double));
                 }
                 break;
 
@@ -511,13 +513,16 @@ int64_t ResolvingDecoderImpl<P>::decodeLong() {
 template<typename P>
 float ResolvingDecoderImpl<P>::decodeFloat() {
     Symbol::Kind k = parser_.advance(Symbol::Kind::Float);
-    return k == Symbol::Kind::Int ? base_->decodeInt() : k == Symbol::Kind::Long ? base_->decodeLong() : base_->decodeFloat();
+    return k == Symbol::Kind::Int ? base_->decodeInt() : k == Symbol::Kind::Long ? base_->decodeLong()
+                                                                                 : base_->decodeFloat();
 }
 
 template<typename P>
 double ResolvingDecoderImpl<P>::decodeDouble() {
     Symbol::Kind k = parser_.advance(Symbol::Kind::Double);
-    return k == Symbol::Kind::Int ? base_->decodeInt() : k == Symbol::Kind::Long ? base_->decodeLong() : k == Symbol::Kind::Float ? base_->decodeFloat() : base_->decodeDouble();
+    return k == Symbol::Kind::Int ? base_->decodeInt() : k == Symbol::Kind::Long ? base_->decodeLong()
+        : k == Symbol::Kind::Float                                               ? base_->decodeFloat()
+                                                                                 : base_->decodeDouble();
 }
 
 template<typename P>

--- a/lang/c++/test/CodecTests.cc
+++ b/lang/c++/test/CodecTests.cc
@@ -1286,7 +1286,7 @@ static const TestData3 data3[] = {
         {"name": "f1", "type": "boolean"},
         {"name": "f2", "type": "double"}]})",
      "IBD",
-    R"({"type":"record", "name":"s", "aliases":["r"], "fields":[
+     R"({"type":"record", "name":"s", "aliases":["r"], "fields":[
         {"name":"g0", "type":"int", "aliases":["f0"]},
         {"name":"g1", "type":"boolean", "aliases":["f1"]},
         {"name":"f2", "type":"double", "aliases":["g2"]}]})",
@@ -1346,8 +1346,7 @@ static const TestData4 data4[] = {
         "RS10S10RS10S10",
         {"s1", "s2", "t1", "t2", nullptr},
         1,
-        2
-    },
+        2},
 
     // Reordered fields
     {
@@ -1372,8 +1371,7 @@ static const TestData4 data4[] = {
         "RLS10",
         {"10", "hello", nullptr},
         1,
-        1
-    },
+        1},
 
     // Default values
     {
@@ -1388,14 +1386,12 @@ static const TestData4 data4[] = {
         "RI",
         {"100", nullptr},
         1,
-        1
-    },
+        1},
 
-    {
-        R"({"type": "record", "name": "r", "fields": [{"name": "f2", "type": "int"}]})",
-        "I",
-        {"10", nullptr},
-        R"({
+    {R"({"type": "record", "name": "r", "fields": [{"name": "f2", "type": "int"}]})",
+     "I",
+     {"10", nullptr},
+     R"({
             "type": "record",
             "name": "r",
             "fields": [
@@ -1403,11 +1399,10 @@ static const TestData4 data4[] = {
                 {"name": "f2", "type": "int"}
             ]
         })",
-        "RII",
-        {"10", "101", nullptr},
-        1,
-        1
-    },
+     "RII",
+     {"10", "101", nullptr},
+     1,
+     1},
 
     {
         R"({
@@ -1452,8 +1447,7 @@ static const TestData4 data4[] = {
         "RRIIL",
         {"10", "101", "11", nullptr},
         1,
-        1
-    },
+        1},
 
     // Default value for a record.
     {
@@ -1510,8 +1504,7 @@ static const TestData4 data4[] = {
         "RRLILRLI",
         {"10", "12", "13", "15", "101", nullptr},
         1,
-        1
-    },
+        1},
 
     {
         R"({
@@ -1560,10 +1553,9 @@ static const TestData4 data4[] = {
         "RRLILRLI",
         {"10", "12", "13", "15", "101", nullptr},
         1,
-        1
-    },
+        1},
 
-// TODO mkmkme HERE
+    // TODO mkmkme HERE
     {
         R"({
             "type": "record",
@@ -1586,8 +1578,7 @@ static const TestData4 data4[] = {
         "[c1sI]",
         {"100", nullptr},
         1,
-        1
-    },
+        1},
 
     {
         R"({
@@ -1611,8 +1602,7 @@ static const TestData4 data4[] = {
         "[Rc1sI]",
         {"100", nullptr},
         1,
-        1
-    },
+        1},
 
     // Record of array of record with deleted field as last field
     {
@@ -1658,8 +1648,7 @@ static const TestData4 data4[] = {
         "R[c1sI]",
         {"10", nullptr},
         2,
-        1
-    },
+        1},
 
     // Enum resolution
     {
@@ -1670,19 +1659,16 @@ static const TestData4 data4[] = {
         "e1",
         {nullptr},
         1,
-        1
-    },
+        1},
 
-    {
-        R"({"type": "enum", "name": "e", "symbols": ["x", "y"]})",
-        "e1",
-        {nullptr},
-        R"({"type": "enum", "name": "e", "symbols": ["y", "z"]})",
-        "e0",
-        {nullptr},
-        1,
-        1
-    },
+    {R"({"type": "enum", "name": "e", "symbols": ["x", "y"]})",
+     "e1",
+     {nullptr},
+     R"({"type": "enum", "name": "e", "symbols": ["y", "z"]})",
+     "e0",
+     {nullptr},
+     1,
+     1},
 
     // Union
     {
@@ -1693,19 +1679,16 @@ static const TestData4 data4[] = {
         "U1I",
         {"100", nullptr},
         1,
-        1
-    },
+        1},
 
-    {
-        R"(["long", "int"])",
-        "U1I",
-        {"100", nullptr},
-        R"("int")",
-        "I",
-        {"100", nullptr},
-        1,
-        1
-    },
+    {R"(["long", "int"])",
+     "U1I",
+     {"100", nullptr},
+     R"("int")",
+     "I",
+     {"100", nullptr},
+     1,
+     1},
 
     // Arrray of unions
     {
@@ -1716,8 +1699,7 @@ static const TestData4 data4[] = {
         "[c2sIsI]",
         {"100", "100", nullptr},
         2,
-        1
-    },
+        1},
 
     // Map of unions
     {
@@ -1728,8 +1710,7 @@ static const TestData4 data4[] = {
         "{c2sS10IsS10I}",
         {"k1", "100", "k2", "100", nullptr},
         2,
-        1
-    },
+        1},
 
     // Union + promotion
     {
@@ -1740,19 +1721,16 @@ static const TestData4 data4[] = {
         "U0L",
         {"100", nullptr},
         1,
-        1
-    },
+        1},
 
-    {
-        R"(["int", "string"])",
-        "U0I",
-        {"100", nullptr},
-        R"("long")",
-        "L",
-        {"100", nullptr},
-        1,
-        1
-    },
+    {R"(["int", "string"])",
+     "U0I",
+     {"100", nullptr},
+     R"("long")",
+     "L",
+     {"100", nullptr},
+     1,
+     1},
 
     // Record where union field is skipped.
     {
@@ -1780,8 +1758,7 @@ static const TestData4 data4[] = {
         "BLD",
         {"1", "100", "10.75", nullptr},
         1,
-        1
-    },
+        1},
 };
 
 static const TestData4 data4BinaryOnly[] = {
@@ -1796,8 +1773,7 @@ static const TestData4 data4BinaryOnly[] = {
         R"({"type":"array", "items": "int"})",
         "[c1sIc1sI]",
         {"100", "100", nullptr},
-        2
-    },
+        2},
 
     // Map of unions
     {
@@ -1807,8 +1783,7 @@ static const TestData4 data4BinaryOnly[] = {
         R"({"type":"map", "values": "int"})",
         "{c1sS10Ic1sS10I}",
         {"k1", "100", "k2", "100", nullptr},
-        2
-    },
+        2},
 };
 
 #define COUNTOF(x) sizeof(x) / sizeof(x[0])

--- a/lang/c++/test/CommonsSchemasTests.cc
+++ b/lang/c++/test/CommonsSchemasTests.cc
@@ -15,79 +15,71 @@
  * permissions and limitations under the License.
  */
 
+#include "Compiler.hh"
+#include "DataFile.hh"
+#include "Generic.hh"
+#include "ValidSchema.hh"
 #include <boost/test/included/unit_test.hpp>
 #include <boost/test/unit_test.hpp>
 #include <filesystem>
-#include "DataFile.hh"
-#include "Compiler.hh"
-#include "ValidSchema.hh"
-#include "Generic.hh"
 
-
-using avro::validatingDecoder;
-using avro::GenericReader;
 using avro::DataFileReader;
 using avro::DataFileWriter;
 using avro::GenericDatum;
+using avro::GenericReader;
+using avro::validatingDecoder;
 
+void testCommonSchema(const std::filesystem::path &dir_path) {
+    const std::filesystem::path &schemaFile = dir_path / "schema.json";
+    std::ifstream in(schemaFile.c_str());
 
-void testCommonSchema(const std::filesystem::path &dir_path)
-{
-	const std::filesystem::path& schemaFile = dir_path / "schema.json";
-	std::ifstream in(schemaFile.c_str());
+    avro::ValidSchema schema;
+    avro::compileJsonSchema(in, schema);
 
-	avro::ValidSchema schema;
-	avro::compileJsonSchema(in, schema);
+    const std::filesystem::path &dataFile = dir_path / "data.avro";
 
-	const std::filesystem::path& dataFile = dir_path / "data.avro";
+    GenericDatum datum(schema);
+    const std::filesystem::path &outputDataFile = dir_path / "data_out.avro";
 
+    DataFileReader<GenericDatum> reader(dataFile.c_str());
+    DataFileWriter<GenericDatum> writer(outputDataFile.c_str(), schema);
 
-	GenericDatum datum(schema);
-	const std::filesystem::path& outputDataFile = dir_path / "data_out.avro";
-
-
-	DataFileReader<GenericDatum> reader(dataFile.c_str());
-	DataFileWriter<GenericDatum> writer(outputDataFile.c_str(), schema);
-
-	while (reader.read(datum)) {
-        avro::GenericRecord& rec =  datum.value<avro::GenericRecord>();
+    while (reader.read(datum)) {
+        avro::GenericRecord &rec = datum.value<avro::GenericRecord>();
         BOOST_CHECK(rec.fieldCount() >= 0);
         writer.write(datum);
-	}
-	writer.close();
-	reader.close();
+    }
+    writer.close();
+    reader.close();
 
-	GenericDatum datumOrig(schema);
-	GenericDatum datumNew(schema);
+    GenericDatum datumOrig(schema);
+    GenericDatum datumNew(schema);
 
-	DataFileReader<GenericDatum> readerOrig(dataFile.c_str());
-	DataFileReader<GenericDatum> readerNew(outputDataFile.c_str());
-	while (readerOrig.read(datumOrig)) {
-	    BOOST_CHECK(readerNew.read(datumNew));
-        avro::GenericRecord& rec1 =  datumOrig.value<avro::GenericRecord>();
-        avro::GenericRecord& rec2 =  datumNew.value<avro::GenericRecord>();
+    DataFileReader<GenericDatum> readerOrig(dataFile.c_str());
+    DataFileReader<GenericDatum> readerNew(outputDataFile.c_str());
+    while (readerOrig.read(datumOrig)) {
+        BOOST_CHECK(readerNew.read(datumNew));
+        avro::GenericRecord &rec1 = datumOrig.value<avro::GenericRecord>();
+        avro::GenericRecord &rec2 = datumNew.value<avro::GenericRecord>();
         BOOST_CHECK_EQUAL(rec1.fieldCount(), rec2.fieldCount());
-	}
-	BOOST_CHECK(!readerNew.read(datumNew));
+    }
+    BOOST_CHECK(!readerNew.read(datumNew));
 
-
-	std::filesystem::remove(outputDataFile);
+    std::filesystem::remove(outputDataFile);
 }
 
-
-
-void testCommonsSchemas()
-{
-	const std::filesystem::path commons_schemas{"../../share/test/data/schemas"};
-	if (!std::filesystem::exists(commons_schemas)) {
-        std::cout << "\nWarn: Can't access share test folder '../../share/test/data/schemas'\n" << std::endl;
+void testCommonsSchemas() {
+    const std::filesystem::path commons_schemas{"../../share/test/data/schemas"};
+    if (!std::filesystem::exists(commons_schemas)) {
+        std::cout << "\nWarn: Can't access share test folder '../../share/test/data/schemas'\n"
+                  << std::endl;
         return;
-	}
-	for (auto const& dir_entry : std::filesystem::directory_iterator{commons_schemas}) {
+    }
+    for (auto const &dir_entry : std::filesystem::directory_iterator{commons_schemas}) {
         if (std::filesystem::is_directory(dir_entry)) {
-		    testCommonSchema(dir_entry.path());
+            testCommonSchema(dir_entry.path());
         }
-	}
+    }
 }
 
 boost::unit_test::test_suite *

--- a/lang/c++/test/SchemaTests.cc
+++ b/lang/c++/test/SchemaTests.cc
@@ -108,11 +108,10 @@ const char *basicSchemas[] = {
 
     // Custom attribute(s) for field in record
     "{\"type\": \"record\",\"name\": \"Test\",\"fields\": "
-        "[{\"name\": \"f1\",\"type\": \"long\",\"extra field\": \"1\"}]}",
+    "[{\"name\": \"f1\",\"type\": \"long\",\"extra field\": \"1\"}]}",
     "{\"type\": \"record\",\"name\": \"Test\",\"fields\": "
-        "[{\"name\": \"f1\",\"type\": \"long\","
-        "\"extra field1\": \"1\",\"extra field2\": \"2\"}]}"
-};
+    "[{\"name\": \"f1\",\"type\": \"long\","
+    "\"extra field1\": \"1\",\"extra field2\": \"2\"}]}"};
 
 const char *basicSchemaErrors[] = {
     // Record
@@ -227,12 +226,12 @@ const char *roundTripSchemas[] = {
 
     // Custom fields
     "{\"type\":\"record\",\"name\":\"Test\",\"fields\":"
-        "[{\"name\":\"f1\",\"type\":\"long\",\"extra_field\":\"1\"},"
-        "{\"name\":\"f2\",\"type\":\"int\"}]}",
+    "[{\"name\":\"f1\",\"type\":\"long\",\"extra_field\":\"1\"},"
+    "{\"name\":\"f2\",\"type\":\"int\"}]}",
     "{\"type\":\"record\",\"name\":\"Test\",\"fields\":"
-        "[{\"name\":\"f1\",\"type\":\"long\",\"extra_field\":\"1\"},"
-        "{\"name\":\"f2\",\"type\":\"int\","
-        "\"extra_field1\":\"21\",\"extra_field2\":\"22\"}]}",
+    "[{\"name\":\"f1\",\"type\":\"long\",\"extra_field\":\"1\"},"
+    "{\"name\":\"f2\",\"type\":\"int\","
+    "\"extra_field1\":\"21\",\"extra_field2\":\"22\"}]}",
 };
 
 const char *malformedLogicalTypes[] = {
@@ -368,7 +367,7 @@ static void testLogicalTypes() {
         \"logicalType\": \"uuid\"\n\
     }";
     // AVRO-2923 Union with LogicalType
-    const char* unionType = "[\n\
+    const char *unionType = "[\n\
         {\"type\":\"string\", \"logicalType\":\"uuid\"},\"null\"\n\
     ]";
     {

--- a/lang/c++/test/unittest.cc
+++ b/lang/c++/test/unittest.cc
@@ -43,7 +43,6 @@
 #include "NodeImpl.hh"
 #include "Types.hh"
 
-
 using namespace avro;
 
 static const uint8_t fixeddata[16] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
@@ -80,8 +79,7 @@ struct TestSchema {
         bool caught = false;
         try {
             customAttributeLong.addAttribute("extra_info_mylong", std::string("duplicate"));
-        }
-        catch(Exception &e) {
+        } catch (Exception &e) {
             std::cout << "(intentional) exception: " << e.what() << '\n';
             caught = true;
         }
@@ -143,9 +141,9 @@ struct TestSchema {
 
         CustomAttributes customAttributeLong2;
         customAttributeLong2.addAttribute("extra_info_mylong2",
-        std::string("it's a long field"));
+                                          std::string("it's a long field"));
         customAttributeLong2.addAttribute("more_info_mylong2",
-        std::string("it's still a long field"));
+                                          std::string("it's still a long field"));
         record.addField("mylong2", LongSchema(), customAttributeLong2);
 
         record.addField("anotherint", intSchema);
@@ -413,27 +411,27 @@ struct TestSchema {
     }
 
     void testNodeRecord(const NodeRecord &nodeRecord,
-                    const std::string &expectedJson)
-    {
+                        const std::string &expectedJson) {
         BOOST_CHECK_EQUAL(nodeRecord.isValid(), true);
 
         std::ostringstream oss;
         nodeRecord.printJson(oss, 0);
         std::string actual = oss.str();
         actual.erase(std::remove_if(actual.begin(), actual.end(),
-                                    ::isspace), actual.end());
+                                    ::isspace),
+                     actual.end());
 
         std::string expected = expectedJson;
         expected.erase(std::remove_if(expected.begin(), expected.end(),
-                                    ::isspace), expected.end());
+                                      ::isspace),
+                       expected.end());
 
         BOOST_CHECK_EQUAL(actual, expected);
     }
 
     // Create NodeRecord with custom attributes at field level
     // validate json serialization
-    void checkNodeRecordWithCustomAttribute()
-    {
+    void checkNodeRecordWithCustomAttribute() {
         Name recordName("Test");
         HasName nameConcept(recordName);
         concepts::MultiAttribute<std::string> fieldNames;
@@ -450,30 +448,29 @@ struct TestSchema {
         cf.addAttribute("arrayField", std::string("[1]"));
         cf.addAttribute("mapField", std::string("{\\\"key1\\\":\\\"value1\\\", \\\"key2\\\":\\\"value2\\\"}"));
         fieldNames.add("f1");
-        fieldValues.add(NodePtr( new NodePrimitive(Type::AVRO_LONG)));
+        fieldValues.add(NodePtr(new NodePrimitive(Type::AVRO_LONG)));
         customAttributes.add(cf);
 
         NodeRecord nodeRecordWithCustomAttribute(nameConcept, fieldValues,
-                                            fieldNames, fieldAliases, defaultValues,
-                                            customAttributes);
+                                                 fieldNames, fieldAliases, defaultValues,
+                                                 customAttributes);
         std::string expectedJsonWithCustomAttribute =
-        "{\"type\": \"record\", \"name\": \"Test\",\"fields\": "
-        "[{\"name\": \"f1\", \"type\": \"long\", "
-        "\"arrayField\": \"[1]\", "
-        "\"booleanField\": \"true\", "
-        "\"mapField\": \"{\\\"key1\\\":\\\"value1\\\", \\\"key2\\\":\\\"value2\\\"}\", "
-        "\"nullField\": \"null\", "
-        "\"numberField\": \"1.23\", "
-        "\"stringField\": \"\\\"field value with \\\"double quotes\\\"\\\"\""
-        "}]}";
+            "{\"type\": \"record\", \"name\": \"Test\",\"fields\": "
+            "[{\"name\": \"f1\", \"type\": \"long\", "
+            "\"arrayField\": \"[1]\", "
+            "\"booleanField\": \"true\", "
+            "\"mapField\": \"{\\\"key1\\\":\\\"value1\\\", \\\"key2\\\":\\\"value2\\\"}\", "
+            "\"nullField\": \"null\", "
+            "\"numberField\": \"1.23\", "
+            "\"stringField\": \"\\\"field value with \\\"double quotes\\\"\\\"\""
+            "}]}";
         testNodeRecord(nodeRecordWithCustomAttribute,
-                    expectedJsonWithCustomAttribute);
+                       expectedJsonWithCustomAttribute);
     }
 
     // Create NodeRecord without custom attributes at field level
     // validate json serialization
-    void checkNodeRecordWithoutCustomAttribute()
-    {
+    void checkNodeRecordWithoutCustomAttribute() {
         Name recordName("Test");
         HasName nameConcept(recordName);
         concepts::MultiAttribute<std::string> fieldNames;
@@ -481,19 +478,18 @@ struct TestSchema {
         std::vector<GenericDatum> defaultValues;
 
         fieldNames.add("f1");
-        fieldValues.add(NodePtr( new NodePrimitive(Type::AVRO_LONG)));
+        fieldValues.add(NodePtr(new NodePrimitive(Type::AVRO_LONG)));
 
         NodeRecord nodeRecordWithoutCustomAttribute(nameConcept, fieldValues,
-                                            fieldNames, defaultValues);
+                                                    fieldNames, defaultValues);
         std::string expectedJsonWithoutCustomAttribute =
-        "{\"type\": \"record\", \"name\": \"Test\",\"fields\": "
-        "[{\"name\": \"f1\", \"type\": \"long\"}]}";
+            "{\"type\": \"record\", \"name\": \"Test\",\"fields\": "
+            "[{\"name\": \"f1\", \"type\": \"long\"}]}";
         testNodeRecord(nodeRecordWithoutCustomAttribute,
-                    expectedJsonWithoutCustomAttribute);
+                       expectedJsonWithoutCustomAttribute);
     }
 
-    void checkCustomAttributes_getAttribute()
-    {
+    void checkCustomAttributes_getAttribute() {
         CustomAttributes cf;
         cf.addAttribute("field1", std::string("1"));
 


### PR DESCRIPTION
## What is the purpose of the change

There is a .clang-format file in the repository, indicating that files should be formatted with this standard, but they have drifted out of conformance over time, which makes it easy to accidentally introduce unrelated differences when submitting changes. This formats the entire c++ directory.

Ideally, format compliance should be checked when a pull request is made, I'm open to creating a PR which adds this workflow if desired.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Documentation

- Does this pull request introduce a new feature? No
- If yes, how is the feature documented? N/A
