### PR TITLE
[C++] Do not escape solidus in JSON output

### DIFF
--- a/lang/c++/impl/json/JsonIO.hh
+++ b/lang/c++/impl/json/JsonIO.hh
@@ -321,7 +321,6 @@ class AVRO_DECL JsonGenerator {
                 switch (*p) {
                     case '\\':
                     case '"':
-                    case '/':
                         escape(*p, b, p);
                         break;
                     case '\b':

--- a/lang/c++/test/JsonTests.cc
+++ b/lang/c++/test/JsonTests.cc
@@ -65,7 +65,9 @@ TestData<const char *> stringData[] = {
     {R"("\U000a")", EntityType::String, "\n", R"("\n")"},
     {R"("\u000a")", EntityType::String, "\n", R"("\n")"},
     {R"("\"")", EntityType::String, "\"", R"("\"")"},
-    {R"("\/")", EntityType::String, "/", R"("\/")"},
+    // While a solidus may be escaped according to the JSON standard, it need not be escaped.
+    {R"("/\/")", EntityType::String, "//", R"("//")"},
+    {R"("\b\f\n\r\t")", EntityType::String, "\b\f\n\r\t", R"("\b\f\n\r\t")"},
     {R"("\u20ac")", EntityType::String, "\xe2\x82\xac", R"("\u20ac")"},
     {R"("\u03c0")", EntityType::String, "\xcf\x80", R"("\u03c0")"},
     {R"("hello\n")", EntityType::String, "hello\n", R"("hello\n")"},


### PR DESCRIPTION
## What is the purpose of the change

The JSON standard permits a solidus (`/`) to be escaped in strings, but does not require that it be escaped. Most JSON serializers used by other packages/languages do not escape solidus characters, so for consistency it would be nice if Avro also did not perform this useless escape.

## Verifying this change

This change is already covered by existing json tests, I've added additional test cases to ensure full coverage.

## Documentation

- Does this pull request introduce a new feature? No
- If yes, how is the feature documented? N/A
