### PR TITLE
AVRO-3990 [C++] Fix invalid code generation for union with reserved name

### DIFF
--- a/lang/c++/CMakeLists.txt
+++ b/lang/c++/CMakeLists.txt
@@ -154,7 +154,7 @@ macro (gen file ns)
         COMMAND avrogencpp
             -p -
             -i ${CMAKE_CURRENT_SOURCE_DIR}/jsonschemas/${file}
-            -o ${file}.hh -n ${ns} -U
+            -o ${file}.hh -n ${ns}
         DEPENDS avrogencpp ${CMAKE_CURRENT_SOURCE_DIR}/jsonschemas/${file})
     add_custom_target (${file}_hh DEPENDS ${file}.hh)
 endmacro (gen)
@@ -175,6 +175,7 @@ gen (tree2 tr2)
 gen (crossref cr)
 gen (primitivetypes pt)
 gen (cpp_reserved_words cppres)
+gen (cpp_reserved_words_union_typedef cppres_union)
 
 add_executable (avrogencpp impl/avrogencpp.cc)
 target_link_libraries (avrogencpp avrocpp_s ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES})
@@ -208,7 +209,7 @@ add_dependencies (AvrogencppTests bigrecord_hh bigrecord_r_hh bigrecord2_hh
     tweet_hh
     union_array_union_hh union_map_union_hh union_conflict_hh
     recursive_hh reuse_hh circulardep_hh tree1_hh tree2_hh crossref_hh
-    primitivetypes_hh empty_record_hh)
+    primitivetypes_hh empty_record_hh cpp_reserved_words_union_typedef_hh)
 
 include (InstallRequiredSystemLibraries)
 

--- a/lang/c++/impl/avrogencpp.cc
+++ b/lang/c++/impl/avrogencpp.cc
@@ -254,6 +254,7 @@ string CodeGen::generateRecordType(const NodePtr &n) {
             if (n->leafAt(i)->type() == avro::AVRO_UNION) {
                 os_ << "    typedef " << types[i]
                     << ' ' << n->nameAt(i) << "_t;\n";
+                types[i] = n->nameAt(i) + "_t";
             }
         }
     }
@@ -261,11 +262,7 @@ string CodeGen::generateRecordType(const NodePtr &n) {
         // the nameAt(i) does not take c++ reserved words into account
         // so we need to call decorate on it
         std::string decoratedNameAt = decorate(n->nameAt(i));
-        if (!noUnion_ && n->leafAt(i)->type() == avro::AVRO_UNION) {
-            os_ << "    " << decoratedNameAt << "_t";
-        } else {
-            os_ << "    " << types[i];
-        }
+        os_ << "    " << types[i];
         os_ << ' ' << decoratedNameAt << ";\n";
     }
 
@@ -279,13 +276,7 @@ string CodeGen::generateRecordType(const NodePtr &n) {
         // so we need to call decorate on it
         std::string decoratedNameAt = decorate(n->nameAt(i));
         os_ << "        " << decoratedNameAt << "(";
-        if (!noUnion_ && n->leafAt(i)->type() == avro::AVRO_UNION) {
-            // the nameAt(i) does not take c++ reserved words into account
-            // so we need to call decorate on it
-            os_ << decoratedNameAt << "_t";
-        } else {
-            os_ << types[i];
-        }
+        os_ << types[i];
         os_ << "())";
         if (i != (c - 1)) {
             os_ << ',';

--- a/lang/c++/jsonschemas/cpp_reserved_words_union_typedef
+++ b/lang/c++/jsonschemas/cpp_reserved_words_union_typedef
@@ -1,0 +1,13 @@
+{
+  "type": "record",
+  "name": "Record",
+  "fields": [
+    {
+      "name": "void",
+      "type": [
+        "int",
+        "double"
+      ]
+    }
+  ]
+}

--- a/lang/c++/test/AvrogencppTestReservedWords.cc
+++ b/lang/c++/test/AvrogencppTestReservedWords.cc
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 #include "cpp_reserved_words.hh"
+#include "cpp_reserved_words_union_typedef.hh"
 
 #include "Compiler.hh"
 


### PR DESCRIPTION
## What is the purpose of the change

Fix [AVRO-3990](https://issues.apache.org/jira/browse/AVRO-3990)

## Verifying this change

*(Please pick one of the following options)*

This change adds a schema which previously resulted in compilation errors to AvrogencppTestReservedWords, which ensures it compiles.

## Documentation

- Does this pull request introduce a new feature? No
- If yes, how is the feature documented? N/A
