### PR TITLE
[C++] Turn on more compiler warnings

### DIFF
--- a/lang/c++/CMakeLists.txt
+++ b/lang/c++/CMakeLists.txt
@@ -64,7 +64,7 @@ if (WIN32 AND NOT CYGWIN AND NOT MSYS)
 endif()
 
 if (CMAKE_COMPILER_IS_GNUCXX)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -Werror")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -Werror")
 if (AVRO_ADD_PROTECTOR_FLAGS)
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fstack-protector-all -D_GLIBCXX_DEBUG")
     # Unset _GLIBCXX_DEBUG for avrogencpp.cc because using Boost Program Options

--- a/lang/c++/README
+++ b/lang/c++/README
@@ -29,9 +29,9 @@ INSTRUCTIONS
 
 Pre-requisites:
 
-To compile requires boost headers, and the boost regex library. Optionally, it requires Snappy compression library. If Snappy is available, it builds support for Snappy compression and skips it otherwise. (Please see your OS-specific instructions on how to install Boost and Snappy for your OS).
+To compile requires boost headers, the boost regex library and the fmt library. Optionally, it requires Snappy compression library. If Snappy is available, it builds support for Snappy compression and skips it otherwise. (Please see your OS-specific instructions on how to install Boost and Snappy for your OS).
 
-To build one requires cmake 2.6 or later.
+To build one requires cmake 3.5 or later and a compiler which supports at least C++17.
 
 To generate a Makefile under Unix, MacOS (using GNU) or Cygwin use:
 

--- a/lang/c++/api/NodeConcepts.hh
+++ b/lang/c++/api/NodeConcepts.hh
@@ -159,11 +159,11 @@ private:
 template<typename T>
 struct NameIndexConcept {
 
-    bool lookup(const std::string &name, size_t &index) const {
+    bool lookup(const std::string &, size_t &) const {
         throw Exception("Name index does not exist");
     }
 
-    bool add(const ::std::string &name, size_t) {
+    bool add(const ::std::string &, size_t) {
         throw Exception("Name index does not exist");
     }
 };

--- a/lang/c++/api/Validator.hh
+++ b/lang/c++/api/Validator.hh
@@ -32,7 +32,7 @@ namespace avro {
 
 class AVRO_DECL NullValidator : private boost::noncopyable {
 public:
-    explicit NullValidator(const ValidSchema &schema) {}
+    explicit NullValidator(const ValidSchema &) {}
     NullValidator() = default;
 
     void setCount(int64_t) {}
@@ -49,11 +49,11 @@ public:
         return 0;
     }
 
-    static bool getCurrentRecordName(std::string &name) {
+    static bool getCurrentRecordName(std::string &) {
         return true;
     }
 
-    static bool getNextFieldName(std::string &name) {
+    static bool getNextFieldName(std::string &) {
         return true;
     }
 

--- a/lang/c++/impl/Compiler.cc
+++ b/lang/c++/impl/Compiler.cc
@@ -286,8 +286,9 @@ static Field makeField(const Entity &e, SymbolTable &st, const string &ns) {
     const Object &m = e.objectValue();
     string n = getStringField(e, m, "name");
     vector<string> aliases;
-    if (containsField(m, "aliases")) {
-        for (const auto &alias : getArrayField(e, m, "aliases")) {
+    string aliasesName = "aliases";
+    if (containsField(m, aliasesName)) {
+        for (const auto &alias : getArrayField(e, m, aliasesName)) {
             aliases.emplace_back(alias.stringValue());
         }
     }
@@ -313,7 +314,8 @@ static NodePtr makeRecordNode(const Entity &e, const Name &name,
     concepts::MultiAttribute<NodePtr> fieldValues;
     concepts::MultiAttribute<CustomAttributes> customAttributes;
     vector<GenericDatum> defaultValues;
-    for (const auto &it : getArrayField(e, m, "fields")) {
+    string fields = "fields";
+    for (const auto &it : getArrayField(e, m, fields)) {
         Field f = makeField(it, st, ns);
         fieldNames.add(f.name);
         fieldAliases.push_back(f.aliases);
@@ -375,7 +377,8 @@ static LogicalType makeLogicalType(const Entity &e, const Object &m) {
 
 static NodePtr makeEnumNode(const Entity &e,
                             const Name &name, const Object &m) {
-    const Array &v = getArrayField(e, m, "symbols");
+    string symbolsName = "symbols";
+    const Array &v = getArrayField(e, m, symbolsName);
     concepts::MultiAttribute<string> symbols;
     for (const auto &it : v) {
         if (it.type() != json::EntityType::String) {
@@ -447,8 +450,9 @@ static Name getName(const Entity &e, const Object &m, const string &ns) {
         }
     }
 
-    if (containsField(m, "aliases")) {
-        for (const auto &alias : getArrayField(e, m, "aliases")) {
+    std::string aliases = "aliases";
+    if (containsField(m, aliases)) {
+        for (const auto &alias : getArrayField(e, m, aliases)) {
             result.addAlias(alias.stringValue());
         }
     }
@@ -502,7 +506,7 @@ static NodePtr makeNode(const Entity &e, const Object &m,
     throw Exception("Unknown type definition: %1%", e.toString());
 }
 
-static NodePtr makeNode(const Entity &e, const Array &m,
+static NodePtr makeNode(const Entity &, const Array &m,
                         SymbolTable &st, const string &ns) {
     concepts::MultiAttribute<NodePtr> mm;
     for (const auto &it : m) {

--- a/lang/c++/impl/NodeImpl.cc
+++ b/lang/c++/impl/NodeImpl.cc
@@ -113,7 +113,7 @@ NodePrimitive::resolve(const Node &reader) const {
                 return RESOLVE_PROMOTABLE_TO_LONG;
             }
 
-            // fall-through intentional
+            [[fallthrough]];
 
         case AVRO_LONG:
 
@@ -121,7 +121,7 @@ NodePrimitive::resolve(const Node &reader) const {
                 return RESOLVE_PROMOTABLE_TO_FLOAT;
             }
 
-            // fall-through intentional
+            [[fallthrough]];
 
         case AVRO_FLOAT:
 
@@ -334,7 +334,7 @@ void NodeRecord::printJson(std::ostream &os, size_t depth) const {
 }
 
 void NodePrimitive::printDefaultToJson(const GenericDatum &g, std::ostream &os,
-                                       size_t depth) const {
+                                       size_t) const {
     assert(isPrimitive(g.type()));
 
     switch (g.type()) {
@@ -375,13 +375,13 @@ void NodePrimitive::printDefaultToJson(const GenericDatum &g, std::ostream &os,
 }
 
 void NodeEnum::printDefaultToJson(const GenericDatum &g, std::ostream &os,
-                                  size_t depth) const {
+                                  size_t) const {
     assert(g.type() == AVRO_ENUM);
     os << "\"" << g.value<GenericEnum>().symbol() << "\"";
 }
 
 void NodeFixed::printDefaultToJson(const GenericDatum &g, std::ostream &os,
-                                   size_t depth) const {
+                                   size_t) const {
     assert(g.type() == AVRO_FIXED);
     // ex: "\uOOff"
     // Convert to a string

--- a/lang/c++/impl/Resolver.cc
+++ b/lang/c++/impl/Resolver.cc
@@ -51,7 +51,7 @@ class PrimitiveSkipper : public Resolver {
 public:
     PrimitiveSkipper() : Resolver() {}
 
-    void parse(Reader &reader, uint8_t *address) const final {
+    void parse(Reader &reader, uint8_t *) const final {
         T val;
         reader.readValue(val);
         DEBUG_OUT("Skipping " << val);
@@ -93,7 +93,7 @@ private:
         DEBUG_OUT("Promoting " << val);
     }
 
-    void parseIt(Reader &reader, uint8_t *, const std::false_type &) const {}
+    void parseIt(Reader &, uint8_t *, const std::false_type &) const {}
 
     template<typename T>
     void parseIt(Reader &reader, uint8_t *address) const {
@@ -108,7 +108,7 @@ class PrimitiveSkipper<std::vector<uint8_t>> : public Resolver {
 public:
     PrimitiveSkipper() : Resolver() {}
 
-    void parse(Reader &reader, uint8_t *address) const final {
+    void parse(Reader &reader, uint8_t *) const final {
         std::vector<uint8_t> val;
         reader.readBytes(val);
         DEBUG_OUT("Skipping bytes");
@@ -276,9 +276,9 @@ protected:
 
 class EnumSkipper : public Resolver {
 public:
-    EnumSkipper(ResolverFactory &factory, const NodePtr &writer) : Resolver() {}
+    EnumSkipper(ResolverFactory &, const NodePtr &) : Resolver() {}
 
-    void parse(Reader &reader, uint8_t *address) const final {
+    void parse(Reader &reader, uint8_t *) const final {
         int64_t val = reader.readEnum();
         DEBUG_OUT("Skipping enum" << val);
     }
@@ -290,9 +290,9 @@ public:
         VAL
     };
 
-    EnumParser(ResolverFactory &factory, const NodePtr &writer, const NodePtr &reader, const CompoundLayout &offsets) : Resolver(),
-                                                                                                                        offset_(offsets.at(0).offset()),
-                                                                                                                        readerSize_(reader->names()) {
+    EnumParser(ResolverFactory &, const NodePtr &writer, const NodePtr &reader, const CompoundLayout &offsets) : Resolver(),
+                                                                                                                 offset_(offsets.at(0).offset()),
+                                                                                                                 readerSize_(reader->names()) {
         const size_t writerSize = writer->names();
 
         mapping_.reserve(writerSize);
@@ -413,11 +413,11 @@ protected:
 
 class FixedSkipper : public Resolver {
 public:
-    FixedSkipper(ResolverFactory &factory, const NodePtr &writer) : Resolver() {
+    FixedSkipper(ResolverFactory &, const NodePtr &writer) : Resolver() {
         size_ = writer->fixedSize();
     }
 
-    void parse(Reader &reader, uint8_t *address) const final {
+    void parse(Reader &reader, uint8_t *) const final {
         DEBUG_OUT("Skipping fixed");
         std::unique_ptr<uint8_t[]> val(new uint8_t[size_]);
         reader.readFixed(&val[0], size_);
@@ -429,7 +429,7 @@ protected:
 
 class FixedParser : public Resolver {
 public:
-    FixedParser(ResolverFactory &factory, const NodePtr &writer, const NodePtr &reader, const CompoundLayout &offsets) : Resolver() {
+    FixedParser(ResolverFactory &, const NodePtr &writer, const NodePtr &, const CompoundLayout &offsets) : Resolver() {
         size_ = writer->fixedSize();
         offset_ = offsets.at(0).offset();
     }
@@ -449,7 +449,7 @@ class ResolverFactory : private boost::noncopyable {
 
     template<typename T>
     unique_ptr<Resolver>
-    constructPrimitiveSkipper(const NodePtr &writer) {
+    constructPrimitiveSkipper(const NodePtr &) {
         return unique_ptr<Resolver>(new PrimitiveSkipper<T>());
     }
 

--- a/lang/c++/impl/parsing/ValidatingCodec.cc
+++ b/lang/c++/impl/parsing/ValidatingCodec.cc
@@ -152,7 +152,7 @@ ProductionPtr ValidatingGrammarGenerator::doGenerate(const NodePtr &n,
 }
 
 struct DummyHandler {
-    static size_t handle(const Symbol &s) {
+    static size_t handle(const Symbol &) {
         return 0;
     }
 };

--- a/lang/c++/test/AvrogencppTests.cc
+++ b/lang/c++/test/AvrogencppTests.cc
@@ -219,16 +219,16 @@ void testNamespace() {
     twPoint.set_AvroPoint(point);
 }
 
-void setRecord(uau::r1 &r) {
+void setRecord(uau::r1 &) {
 }
 
-void check(const uau::r1 &r1, const uau::r1 &r2) {
+void check(const uau::r1 &, const uau::r1 &) {
 }
 
-void setRecord(umu::r1 &r) {
+void setRecord(umu::r1 &) {
 }
 
-void check(const umu::r1 &r1, const umu::r1 &r2) {
+void check(const umu::r1 &, const umu::r1 &) {
 }
 
 template<typename T>

--- a/lang/c++/test/CodecTests.cc
+++ b/lang/c++/test/CodecTests.cc
@@ -25,7 +25,7 @@
 #include "Specific.hh"
 #include "ValidSchema.hh"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <cstdint>
 #include <functional>
 #include <stack>
@@ -335,7 +335,7 @@ struct StackElement {
 };
 } // namespace
 
-static vector<string>::const_iterator skipCalls(Scanner &sc, Decoder &d,
+static vector<string>::const_iterator skipCalls(Scanner &sc, Decoder &,
                                                 vector<string>::const_iterator it, bool isArray) {
     char end = isArray ? ']' : '}';
     int level = 0;
@@ -364,7 +364,7 @@ static vector<string>::const_iterator skipCalls(Scanner &sc, Decoder &d,
             case 'K':
             case 'b':
             case 'f':
-            case 'e': ++it; // Fall through.
+            case 'e': ++it; [[fallthrough]];
             case 'c':
             case 'U':
                 sc.extractInt();
@@ -594,7 +594,6 @@ struct TestData4 {
     const char *readerCalls;
     const char *readerValues[100];
     unsigned int depth;
-    size_t recordCount;
 };
 
 void appendSentinel(OutputStream &os) {
@@ -1345,8 +1344,7 @@ static const TestData4 data4[] = {
         })",
         "RS10S10RS10S10",
         {"s1", "s2", "t1", "t2", nullptr},
-        1,
-        2},
+        1},
 
     // Reordered fields
     {
@@ -1370,7 +1368,6 @@ static const TestData4 data4[] = {
         })",
         "RLS10",
         {"10", "hello", nullptr},
-        1,
         1},
 
     // Default values
@@ -1385,7 +1382,6 @@ static const TestData4 data4[] = {
         })",
         "RI",
         {"100", nullptr},
-        1,
         1},
 
     {R"({"type": "record", "name": "r", "fields": [{"name": "f2", "type": "int"}]})",
@@ -1401,7 +1397,6 @@ static const TestData4 data4[] = {
         })",
      "RII",
      {"10", "101", nullptr},
-     1,
      1},
 
     {
@@ -1446,7 +1441,6 @@ static const TestData4 data4[] = {
         })",
         "RRIIL",
         {"10", "101", "11", nullptr},
-        1,
         1},
 
     // Default value for a record.
@@ -1503,7 +1497,6 @@ static const TestData4 data4[] = {
         })",
         "RRLILRLI",
         {"10", "12", "13", "15", "101", nullptr},
-        1,
         1},
 
     {
@@ -1552,7 +1545,6 @@ static const TestData4 data4[] = {
         })",
         "RRLILRLI",
         {"10", "12", "13", "15", "101", nullptr},
-        1,
         1},
 
     // TODO mkmkme HERE
@@ -1577,7 +1569,6 @@ static const TestData4 data4[] = {
         })",
         "[c1sI]",
         {"100", nullptr},
-        1,
         1},
 
     {
@@ -1601,7 +1592,6 @@ static const TestData4 data4[] = {
         })",
         "[Rc1sI]",
         {"100", nullptr},
-        1,
         1},
 
     // Record of array of record with deleted field as last field
@@ -1647,8 +1637,7 @@ static const TestData4 data4[] = {
         })",
         "R[c1sI]",
         {"10", nullptr},
-        2,
-        1},
+        2},
 
     // Enum resolution
     {
@@ -1658,7 +1647,6 @@ static const TestData4 data4[] = {
         R"({"type": "enum", "name": "e", "symbols": ["y", "z"]})",
         "e1",
         {nullptr},
-        1,
         1},
 
     {R"({"type": "enum", "name": "e", "symbols": ["x", "y"]})",
@@ -1667,7 +1655,6 @@ static const TestData4 data4[] = {
      R"({"type": "enum", "name": "e", "symbols": ["y", "z"]})",
      "e0",
      {nullptr},
-     1,
      1},
 
     // Union
@@ -1678,7 +1665,6 @@ static const TestData4 data4[] = {
         R"(["long", "int"])",
         "U1I",
         {"100", nullptr},
-        1,
         1},
 
     {R"(["long", "int"])",
@@ -1687,7 +1673,6 @@ static const TestData4 data4[] = {
      R"("int")",
      "I",
      {"100", nullptr},
-     1,
      1},
 
     // Arrray of unions
@@ -1698,8 +1683,7 @@ static const TestData4 data4[] = {
         R"({"type":"array", "items": "int"})",
         "[c2sIsI]",
         {"100", "100", nullptr},
-        2,
-        1},
+        2},
 
     // Map of unions
     {
@@ -1709,8 +1693,7 @@ static const TestData4 data4[] = {
         R"({"type":"map", "values": "int"})",
         "{c2sS10IsS10I}",
         {"k1", "100", "k2", "100", nullptr},
-        2,
-        1},
+        2},
 
     // Union + promotion
     {
@@ -1720,7 +1703,6 @@ static const TestData4 data4[] = {
         R"(["long", "string"])",
         "U0L",
         {"100", nullptr},
-        1,
         1},
 
     {R"(["int", "string"])",
@@ -1729,7 +1711,6 @@ static const TestData4 data4[] = {
      R"("long")",
      "L",
      {"100", nullptr},
-     1,
      1},
 
     // Record where union field is skipped.
@@ -1757,7 +1738,6 @@ static const TestData4 data4[] = {
         })",
         "BLD",
         {"1", "100", "10.75", nullptr},
-        1,
         1},
 };
 
@@ -1801,13 +1781,13 @@ Test testWithData(const Test &test, const Data &) {
         testWithData(&testFunc<Factory>, data), data, data + COUNTOF(data)))
 
 struct BinaryEncoderFactory {
-    static EncoderPtr newEncoder(const ValidSchema &schema) {
+    static EncoderPtr newEncoder(const ValidSchema &) {
         return binaryEncoder();
     }
 };
 
 struct BinaryDecoderFactory {
-    static DecoderPtr newDecoder(const ValidSchema &schema) {
+    static DecoderPtr newDecoder(const ValidSchema &) {
         return binaryDecoder();
     }
 };
@@ -2068,7 +2048,7 @@ static void testByteCount() {
 } // namespace avro
 
 boost::unit_test::test_suite *
-init_unit_test_suite(int argc, char *argv[]) {
+init_unit_test_suite(int, char *[]) {
     using namespace boost::unit_test;
 
     auto *ts = BOOST_TEST_SUITE("Avro C++ unit tests for codecs");

--- a/lang/c++/test/CommonsSchemasTests.cc
+++ b/lang/c++/test/CommonsSchemasTests.cc
@@ -45,8 +45,7 @@ void testCommonSchema(const std::filesystem::path &dir_path) {
     DataFileWriter<GenericDatum> writer(outputDataFile.c_str(), schema);
 
     while (reader.read(datum)) {
-        avro::GenericRecord &rec = datum.value<avro::GenericRecord>();
-        BOOST_CHECK(rec.fieldCount() >= 0);
+        datum.value<avro::GenericRecord>();
         writer.write(datum);
     }
     writer.close();

--- a/lang/c++/test/DataFileTests.cc
+++ b/lang/c++/test/DataFileTests.cc
@@ -217,7 +217,7 @@ public:
 #endif
 
     void testWriteWithCodec(avro::Codec codec) {
-        avro::DataFileWriter<ComplexInteger> df(filename, writerSchema, 100);
+        avro::DataFileWriter<ComplexInteger> df(filename, writerSchema, 100, codec);
         int64_t re = 3;
         int64_t im = 5;
         for (int i = 0; i < count; ++i, re *= im, im += 3) {
@@ -1004,7 +1004,7 @@ void testReadRecordEfficientlyUsingLastSyncSnappyCodec() {
 #endif
 
 test_suite *
-init_unit_test_suite(int argc, char *argv[]) {
+init_unit_test_suite(int, char *[]) {
     {
         auto *ts = BOOST_TEST_SUITE("DataFile tests: test0.df");
         shared_ptr<DataFileTest> t1(new DataFileTest("test1.d0", sch, isch, 0));

--- a/lang/c++/test/buffertest.cc
+++ b/lang/c++/test/buffertest.cc
@@ -18,7 +18,7 @@
 
 #include <boost/test/included/unit_test.hpp>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #ifdef HAVE_BOOST_ASIO
 #include <boost/asio.hpp>

--- a/lang/c++/test/unittest.cc
+++ b/lang/c++/test/unittest.cc
@@ -274,7 +274,7 @@ struct TestSchema {
         out << is.rdbuf();
     }
 
-    void printNext(Parser<Reader> &p) {
+    void printNext(Parser<Reader> &) {
         // no-op printer
     }
 


### PR DESCRIPTION
## What is the purpose of the change

`-Wall` is a good start, but really not sufficient, as it doesn't turn on many compiler warnings which help catch bugs. Turning on `-Wextra` lets the compiler check more things, reducing potential bugs.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Documentation

- Does this pull request introduce a new feature? No
- If yes, how is the feature documented? N/A
