### PR TITLE
AVRO-3991 [C++] Fix undefined behavior in Compiler.cc

### DIFF
--- a/lang/c++/impl/Compiler.cc
+++ b/lang/c++/impl/Compiler.cc
@@ -338,7 +338,7 @@ static LogicalType makeLogicalType(const Entity &e, const Object &m) {
         return LogicalType(LogicalType::NONE);
     }
 
-    const std::string &typeField = getStringField(e, m, "logicalType");
+    string typeField = getStringField(e, m, "logicalType");
 
     if (typeField == "decimal") {
         LogicalType decimalType(LogicalType::DECIMAL);
@@ -428,7 +428,7 @@ static NodePtr makeMapNode(const Entity &e, const Object &m,
 }
 
 static Name getName(const Entity &e, const Object &m, const string &ns) {
-    const string &name = getStringField(e, m, "name");
+    string name = getStringField(e, m, "name");
 
     Name result;
     if (isFullName(name)) {
@@ -458,7 +458,7 @@ static Name getName(const Entity &e, const Object &m, const string &ns) {
 
 static NodePtr makeNode(const Entity &e, const Object &m,
                         SymbolTable &st, const string &ns) {
-    const string &type = getStringField(e, m, "type");
+    string type = getStringField(e, m, "type");
     NodePtr result;
     if (type == "record" || type == "error" || type == "enum" || type == "fixed") {
         Name nm = getName(e, m, ns);


### PR DESCRIPTION
## What is the purpose of the change

Fix [AVRO-3991](https://issues.apache.org/jira/browse/AVRO-3991), which is a potential security vulnerability.

`getStringField` returns a value, not a reference, so saving its result to a `const std::string&` results in undefined behavior as we point to a temporary which has been cleaned up.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Documentation

- Does this pull request introduce a new feature? No
- If yes, how is the feature documented? N/A
