### PR TITLE
modernize example python

### DIFF
--- a/doc/examples/example.py
+++ b/doc/examples/example.py
@@ -16,18 +16,28 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+from pathlib import Path
+
 import avro.schema
 from avro.datafile import DataFileReader, DataFileWriter
 from avro.io import DatumReader, DatumWriter
 
-schema = avro.schema.parse(open("user.avsc").read())
+# read in the schema file
+schema_text = Path("user.avsc").read_text()
+# then parse it
+schema = avro.schema.parse(schema_text)
 
-writer = DataFileWriter(open("/tmp/users.avro", "w"), DatumWriter(), schema)
-writer.append({"name": "Alyssa", "favorite_number": 256, "WTF": 2})
-writer.append({"name": "Ben", "favorite_number": 7, "favorite_color": "red"})
-writer.close()
+# create a DataFileWriter to write data to a file
+users_file = Path("/tmp/users.avro")
+with users_file.open("wb") as users_fh, DataFileWriter(
+    users_fh, DatumWriter(), schema
+) as writer:
+    writer.append({"name": "Alyssa", "favorite_number": 256})
+    writer.append({"name": "Ben", "favorite_number": 7, "favorite_color": "red"})
 
-reader = DataFileReader(open("/tmp/users.avro", "r"), DatumReader())
-for user in reader:
-    print(user)
-reader.close()
+# create a DataFileReader to read data from a file
+with users_file.open("rb") as users_fh, DataFileReader(
+    users_fh, DatumReader()
+) as reader:
+    for user in reader:
+        print(user)


### PR DESCRIPTION
https://github.com/apache/avro/pull/2932 fixed one problem, but there were others:

1. The existence of a "WTF" field in the record that is not in the schema, causing the code to fail. It's not reflected in [the actual docs](https://avro.apache.org/docs/1.11.1/getting-started-python/#serializing-and-deserializing-without-code-generation).
2. The use of text mode for writing binary data. (This is also correct in the Getting Started docs.)
3. Using strings for paths instead of Path objects. This is a minor thing, but a tidy practice.
4. The possibility of a crash causing a resource leak because our example doesn't use context managers to close the file. (This is also _incorrect_ in the Getting Started docs.)
