### PR TITLE
AVRO-3995 [C++] Require C++17 to compile Avro

### DIFF
--- a/lang/c++/CMakeLists.txt
+++ b/lang/c++/CMakeLists.txt
@@ -24,6 +24,10 @@ if (NOT DEFINED CMAKE_CXX_STANDARD)
     set(CMAKE_CXX_STANDARD 17)
 endif()
 
+if (CMAKE_CXX_STANDARD LESS 17)
+    message(FATAL_ERROR "Avro requires at least C++17")
+endif()
+
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if (APPLE)

--- a/lang/c++/MainPage.dox
+++ b/lang/c++/MainPage.dox
@@ -55,9 +55,9 @@ One should be able to build Avro C++ on (1) any UNIX flavor including cygwin for
 
 In order to build Avro C++, one needs the following:
 <ul>
-    <li>A C++ compiler and runtime libraries.
+    <li>A C++17 or later compiler and runtime libraries.
     <li>Boost library version 1.38 or later. Apart from the header-only libraries of Boost, Avro C++ requires filesystem, iostreams, system and program_options libraries. Please see <a href="https://www.boost.org/">https://www.boost.org</a> or your platform's documentation for details on how to set up Boost for your platform.
-    <li>CMake build tool version 2.6 or later. Please see <a href="https://www.cmake.org">https://www.cmake.org</a> or your platform's documentation for details on how to set up CMake for your system.
+    <li>CMake build tool version 3.5 or later. Please see <a href="https://www.cmake.org">https://www.cmake.org</a> or your platform's documentation for details on how to set up CMake for your system.
     <li>Python. If not already present, please consult your platform-specific documentation on how to install Python on your system.
 </ul>
 

--- a/lang/c++/README
+++ b/lang/c++/README
@@ -29,9 +29,9 @@ INSTRUCTIONS
 
 Pre-requisites:
 
-To compile requires boost headers, the boost regex library and the fmt library. Optionally, it requires Snappy compression library. If Snappy is available, it builds support for Snappy compression and skips it otherwise. (Please see your OS-specific instructions on how to install Boost and Snappy for your OS).
+To compile requires boost headers. Optionally, it requires Snappy compression library. If Snappy is available, it builds support for Snappy compression and skips it otherwise. (Please see your OS-specific instructions on how to install Boost and Snappy for your OS).
 
-To build one requires cmake 3.5 or later and a compiler which supports at least C++17.
+To build one requires cmake 3.5 or later and a compiler supporting C++17 or later.
 
 To generate a Makefile under Unix, MacOS (using GNU) or Cygwin use:
 

--- a/lang/c++/api/GenericDatum.hh
+++ b/lang/c++/api/GenericDatum.hh
@@ -19,16 +19,11 @@
 #ifndef avro_GenericDatum_hh__
 #define avro_GenericDatum_hh__
 
+#include <any>
 #include <cstdint>
 #include <map>
 #include <string>
 #include <vector>
-
-#if __cplusplus >= 201703L
-#include <any>
-#else
-#include "boost/any.hpp"
-#endif
 
 #include "LogicalType.hh"
 #include "Node.hh"
@@ -62,11 +57,7 @@ class AVRO_DECL GenericDatum {
 protected:
     Type type_;
     LogicalType logicalType_;
-#if __cplusplus >= 201703L
     std::any value_;
-#else
-    boost::any value_;
-#endif
 
     explicit GenericDatum(Type t)
         : type_(t), logicalType_(LogicalType::NONE) {}
@@ -192,11 +183,7 @@ public:
     template<typename T>
     GenericDatum(const NodePtr &schema, const T &v) : type_(schema->type()), logicalType_(schema->logicalType()) {
         init(schema);
-#if __cplusplus >= 201703L
         *std::any_cast<T>(&value_) = v;
-#else
-        *boost::any_cast<T>(&value_) = v;
-#endif
     }
 
     /**
@@ -539,67 +526,33 @@ public:
 };
 
 inline Type GenericDatum::type() const {
-    return (type_ == AVRO_UNION) ?
-#if __cplusplus >= 201703L
-                                 std::any_cast<GenericUnion>(&value_)->datum().type()
-                                 :
-#else
-                                 boost::any_cast<GenericUnion>(&value_)->datum().type()
-                                 :
-#endif
-                                 type_;
+    return (type_ == AVRO_UNION) ? std::any_cast<GenericUnion>(&value_)->datum().type()
+                                 : type_;
 }
 
 inline LogicalType GenericDatum::logicalType() const {
-    return (type_ == AVRO_UNION) ?
-#if __cplusplus >= 201703L
-                                 std::any_cast<GenericUnion>(&value_)->datum().logicalType()
-                                 :
-#else
-                                 boost::any_cast<GenericUnion>(&value_)->datum().logicalType()
-                                 :
-#endif
-                                 logicalType_;
+    return (type_ == AVRO_UNION) ? std::any_cast<GenericUnion>(&value_)->datum().logicalType()
+                                 : logicalType_;
 }
 
 template<typename T>
 T &GenericDatum::value() {
-    return (type_ == AVRO_UNION) ?
-#if __cplusplus >= 201703L
-                                 std::any_cast<GenericUnion>(&value_)->datum().value<T>()
+    return (type_ == AVRO_UNION) ? std::any_cast<GenericUnion>(&value_)->datum().value<T>()
                                  : *std::any_cast<T>(&value_);
-#else
-                                 boost::any_cast<GenericUnion>(&value_)->datum().value<T>()
-                                 : *boost::any_cast<T>(&value_);
-#endif
 }
 
 template<typename T>
 const T &GenericDatum::value() const {
-    return (type_ == AVRO_UNION) ?
-#if __cplusplus >= 201703L
-                                 std::any_cast<GenericUnion>(&value_)->datum().value<T>()
+    return (type_ == AVRO_UNION) ? std::any_cast<GenericUnion>(&value_)->datum().value<T>()
                                  : *std::any_cast<T>(&value_);
-#else
-                                 boost::any_cast<GenericUnion>(&value_)->datum().value<T>()
-                                 : *boost::any_cast<T>(&value_);
-#endif
 }
 
 inline size_t GenericDatum::unionBranch() const {
-#if __cplusplus >= 201703L
     return std::any_cast<GenericUnion>(&value_)->currentBranch();
-#else
-    return boost::any_cast<GenericUnion>(&value_)->currentBranch();
-#endif
 }
 
 inline void GenericDatum::selectBranch(size_t branch) {
-#if __cplusplus >= 201703L
     std::any_cast<GenericUnion>(&value_)->selectBranch(branch);
-#else
-    boost::any_cast<GenericUnion>(&value_)->selectBranch(branch);
-#endif
 }
 
 } // namespace avro


### PR DESCRIPTION
## What is the purpose of the change

[AVRO-3995](https://issues.apache.org/jira/browse/AVRO-3995) Update the CMake configuration to provide a useful error message when attempting to compile with an unsupported C++ standard version, and remove code which was `#ifdef`'d to be used only with C++ targets less than C++17.

As discussed in #2431, Avro has effectively required C++17 for nearly a year now, but it wasn't obvious to consumers.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Documentation

- Does this pull request introduce a new feature? No
- If yes, how is the feature documented? N/A
