### PR TITLE
AVRO-3998: Switch Perl library from JSON::XS to JSON::MaybeXS

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -14,7 +14,7 @@ The following packages must be installed before Avro can be built:
  - Ruby: Ruby 2.7 or greater, ruby-dev, gem, bundler, snappy
  - Perl: Perl 5.24.1 or greater, gmake, Module::Install,
    Module::Install::ReadmeFromPod, Module::Install::Repository,
-   Math::BigInt, JSON::XS, Try::Tiny, Regexp::Common, Encode,
+   Math::BigInt, JSON::MaybeXS, Try::Tiny, Regexp::Common, Encode,
    IO::String, Object::Tiny, Compress::ZLib, Error::Simple,
    Test::More, Test::Exception, Test::Pod
  - Rust: rustc and Cargo 1.65.0 or greater

--- a/lang/perl/Changes
+++ b/lang/perl/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension Avro
 
+        - Switch from JSON::XS to JSON::MaybeXS to support
+          multiple JSON backends
+
 1.00  Fri Jan 17 15:00:00 2014
         - Relicense under apache license 2.0
 

--- a/lang/perl/Makefile.PL
+++ b/lang/perl/Makefile.PL
@@ -35,7 +35,7 @@ requires 'Compress::Zstd';
 requires 'Encode';
 requires 'Error::Simple';
 requires 'IO::String';
-requires 'JSON::XS';
+requires 'JSON::MaybeXS';
 requires 'Object::Tiny';
 requires 'Regexp::Common';
 requires 'Try::Tiny';

--- a/lang/perl/bin/avro-to-json
+++ b/lang/perl/bin/avro-to-json
@@ -23,9 +23,9 @@ use warnings;
 use Avro::DataFileReader;
 use Carp;
 use IO::File;
-use JSON::XS;
+use JSON::MaybeXS ();
 
-my $j = JSON::XS->new->allow_nonref;
+my $j = JSON::MaybeXS->new->allow_nonref;
 
 my $fh = IO::File->new(shift || croak "specify a file");
 my $reader = Avro::DataFileReader->new(

--- a/lang/perl/lib/Avro/Protocol.pm
+++ b/lang/perl/lib/Avro/Protocol.pm
@@ -20,7 +20,7 @@ use strict;
 use warnings;
 
 use Carp;
-use JSON::XS();
+use JSON::MaybeXS ();
 use Try::Tiny;
 use Avro::Protocol::Message;
 use Avro::Schema;
@@ -35,7 +35,7 @@ use Object::Tiny qw{
 
 our $VERSION = '++MODULE_VERSION++';
 
-my $json = JSON::XS->new->allow_nonref;
+my $json = JSON::MaybeXS->new->allow_nonref;
 
 sub parse {
     my $class     = shift;

--- a/lang/perl/lib/Avro/Schema.pm
+++ b/lang/perl/lib/Avro/Schema.pm
@@ -20,12 +20,12 @@ use strict;
 use warnings;
 
 use Carp;
-use JSON::XS();
+use JSON::MaybeXS ();
 use Try::Tiny;
 
 our $VERSION = '++MODULE_VERSION++';
 
-my $json = JSON::XS->new->allow_nonref;
+my $json = JSON::MaybeXS->new->allow_nonref;
 
 sub parse {
     my $schema      = shift;


### PR DESCRIPTION
## What is the purpose of the change

The JSON::MaybeXS library serves as a compatibility layer to allow users to select the JSON backend that matches their stack, rather than forcing them to install a specific one, while still benefiting from the performance boost of XS libraries if they are available.

Ticket: https://issues.apache.org/jira/browse/AVRO-3998

## Verifying this change

> This change is already covered by existing tests

This change changes one dependency for a different one with the same interface that serves as an intermediate layer. Existing tests that exercise JSON encoding / decoding verify that this is the case.

In particular, these tests exercise the modified code:
* `t/01_schema.t`
* `t/05_protocol.t`

The only part of the code that changed that is not covered by tests is the `avro-to-json` utility under `bin`.

## Documentation

- Does this pull request introduce a new feature? (yes / **no**)
- If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
