### PR TITLE
AVRO-3999 - Avoid warnings in Perl test suite

### DIFF
--- a/lang/perl/lib/Avro/BinaryDecoder.pm
+++ b/lang/perl/lib/Avro/BinaryDecoder.pm
@@ -67,7 +67,7 @@ sub decode {
     my $type = Avro::Schema->match(
         writer => $writer_schema,
         reader => $reader_schema,
-    ) or throw Avro::Schema::Error::Mismatch;
+    ) or throw Avro::Schema::Error::Mismatch 'schema do not match';
 
     my $meth = "decode_$type";
     return $class->$meth($writer_schema, $reader_schema, $reader);

--- a/lang/perl/xt/schema.t
+++ b/lang/perl/xt/schema.t
@@ -23,7 +23,7 @@ use File::Find;
 use_ok 'Avro::Schema';
 
 sub parse {
-    next unless /\.avsc$/;
+    return unless /\.avsc$/;
     open(my $fh, '<', $_);
     local $/ = undef;
     my $schema = <$fh>;


### PR DESCRIPTION
## What is the purpose of the change

The test suite generated several warnings which could easily be avoided. The changes in this PR make sure the test suite can complete without triggering these scenarios.

Specifically, this PR includes the following changes:

* Do not exit a sub via `next` in `xt/schema.t`
* Add a message to an error raised by Avro::BinaryDecoder which lead to a warning when trying to stringify an undefined value.

Ticket: https://issues.apache.org/jira/browse/AVRO-3999

## Verifying this change

> This change is already covered by existing tests

The change only touches the test suite, and does not change any of the tested behaviours, only the behaviour of the tests.

## Documentation

- Does this pull request introduce a new feature? (yes / **no**)
- If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
