### PR TITLE
NO-JIRA: [Rust] Fix Clippy errors from Rust 1.79.0

### DIFF
--- a/lang/rust/avro/src/util.rs
+++ b/lang/rust/avro/src/util.rs
@@ -18,7 +18,6 @@
 use crate::{schema::Documentation, AvroResult, Error};
 use serde_json::{Map, Value};
 use std::{
-    i64,
     io::Read,
     sync::{
         atomic::{AtomicBool, AtomicUsize, Ordering},

--- a/lang/rust/avro_derive/src/lib.rs
+++ b/lang/rust/avro_derive/src/lib.rs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// Allow until https://github.com/TedDriggs/darling/pull/292 is resolved
+#![allow(clippy::manual_unwrap_or_default)]
 use darling::FromAttributes;
 use proc_macro2::{Span, TokenStream};
 use quote::quote;

--- a/lang/rust/avro_derive/src/lib.rs
+++ b/lang/rust/avro_derive/src/lib.rs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// for Rust versions older than 1.79.0
+#![allow(unknown_lints)]
 // Allow until https://github.com/TedDriggs/darling/pull/292 is resolved
 #![allow(clippy::manual_unwrap_or_default)]
 use darling::FromAttributes;


### PR DESCRIPTION
## What is the purpose of the change

* Allow a Clippy rule in code generated by Darling library so that the project builds with Rust 1.79.0 (https://github.com/TedDriggs/darling/pull/292)

## Verifying this change

* The build and tests should pass

## Documentation

- Does this pull request introduce a new feature? no