### PR TITLE
AVRO-1514: Clean up Perl dependencies

### DIFF
--- a/.github/workflows/test-lang-perl-ARM.yml
+++ b/.github/workflows/test-lang-perl-ARM.yml
@@ -49,27 +49,17 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          sudo apt-get -qqy install --no-install-recommends libjansson-dev \
-                                                            libcompress-raw-zlib-perl \
-                                                            libcpan-uploader-perl \
-                                                            libencode-perl \
-                                                            libio-string-perl \
-                                                            libjson-xs-perl \
-                                                            libmodule-install-perl \
-                                                            libmodule-install-readmefrompod-perl \
-                                                            libobject-tiny-perl \
-                                                            libperl-critic-perl \
-                                                            libsnappy-dev \
-                                                            libtest-exception-perl \
-                                                            libtest-pod-perl
           cpanm --mirror https://www.cpan.org/ install Compress::Zstd \
+                                                       Encode \
                                                        Error::Simple \
                                                        IO::String \
                                                        Module::Install::ReadmeFromPod \
                                                        Module::Install::Repository \
                                                        Object::Tiny \
+                                                       Perl::Critic \
                                                        Regexp::Common \
                                                        Test::Exception \
+                                                       Test::Pod \
                                                        Try::Tiny \
                                                        inc::Module::Install
 
@@ -95,23 +85,20 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          sudo apt-get -qqy install --no-install-recommends libcompress-raw-zlib-perl \
-                                                            libcpan-uploader-perl \
-                                                            libencode-perl \
-                                                            libio-string-perl \
-                                                            libjansson-dev \
-                                                            libjson-xs-perl \
-                                                            libmodule-install-perl \
-                                                            libmodule-install-readmefrompod-perl \
-                                                            libobject-tiny-perl \
-                                                            libsnappy-dev \
-                                                            libtest-exception-perl \
-                                                            libtest-pod-perl
-          cpanm --mirror https://www.cpan.org/ install Compress::Zstd \
+          sudo apt-get -qqy install --no-install-recommends libjansson-dev \
+                                                            libsnappy-dev
+          cpanm --mirror https://www.cpan.org/ install CPAN::Uploader \
+                                                       Compress::Zstd \
+                                                       Encode \
                                                        Error::Simple \
+                                                       IO::String \
+                                                       Module::Install::ReadmeFromPod \
                                                        Module::Install::Repository \
                                                        Object::Tiny \
+                                                       Perl::Critic \
                                                        Regexp::Common \
+                                                       Test::Exception \
+                                                       Test::Pod \
                                                        Try::Tiny \
                                                        inc::Module::Install
 

--- a/.github/workflows/test-lang-perl-ARM.yml
+++ b/.github/workflows/test-lang-perl-ARM.yml
@@ -52,6 +52,7 @@ jobs:
           cpanm --mirror https://www.cpan.org/ install Compress::Zstd \
                                                        Encode \
                                                        Error::Simple \
+                                                       Module::Install \
                                                        Module::Install::ReadmeFromPod \
                                                        Object::Tiny \
                                                        Perl::Critic \
@@ -59,8 +60,7 @@ jobs:
                                                        Test::Exception \
                                                        Test::More \
                                                        Test::Pod \
-                                                       Try::Tiny \
-                                                       inc::Module::Install
+                                                       Try::Tiny
 
       - name: Lint
         run: ./build.sh lint
@@ -90,6 +90,7 @@ jobs:
                                                        Compress::Zstd \
                                                        Encode \
                                                        Error::Simple \
+                                                       Module::Install \
                                                        Module::Install::ReadmeFromPod \
                                                        Object::Tiny \
                                                        Perl::Critic \
@@ -97,8 +98,7 @@ jobs:
                                                        Test::Exception \
                                                        Test::More \
                                                        Test::Pod \
-                                                       Try::Tiny \
-                                                       inc::Module::Install
+                                                       Try::Tiny
 
       - name: Cache Local Maven Repository
         uses: actions/cache@v4

--- a/.github/workflows/test-lang-perl-ARM.yml
+++ b/.github/workflows/test-lang-perl-ARM.yml
@@ -57,6 +57,7 @@ jobs:
                                                        Perl::Critic \
                                                        Regexp::Common \
                                                        Test::Exception \
+                                                       Test::More \
                                                        Test::Pod \
                                                        Try::Tiny \
                                                        inc::Module::Install
@@ -94,6 +95,7 @@ jobs:
                                                        Perl::Critic \
                                                        Regexp::Common \
                                                        Test::Exception \
+                                                       Test::More \
                                                        Test::Pod \
                                                        Try::Tiny \
                                                        inc::Module::Install

--- a/.github/workflows/test-lang-perl-ARM.yml
+++ b/.github/workflows/test-lang-perl-ARM.yml
@@ -54,7 +54,6 @@ jobs:
                                                        Error::Simple \
                                                        IO::String \
                                                        Module::Install::ReadmeFromPod \
-                                                       Module::Install::Repository \
                                                        Object::Tiny \
                                                        Perl::Critic \
                                                        Regexp::Common \
@@ -93,7 +92,6 @@ jobs:
                                                        Error::Simple \
                                                        IO::String \
                                                        Module::Install::ReadmeFromPod \
-                                                       Module::Install::Repository \
                                                        Object::Tiny \
                                                        Perl::Critic \
                                                        Regexp::Common \

--- a/.github/workflows/test-lang-perl-ARM.yml
+++ b/.github/workflows/test-lang-perl-ARM.yml
@@ -52,7 +52,6 @@ jobs:
           cpanm --mirror https://www.cpan.org/ install Compress::Zstd \
                                                        Encode \
                                                        Error::Simple \
-                                                       IO::String \
                                                        Module::Install::ReadmeFromPod \
                                                        Object::Tiny \
                                                        Perl::Critic \
@@ -90,7 +89,6 @@ jobs:
                                                        Compress::Zstd \
                                                        Encode \
                                                        Error::Simple \
-                                                       IO::String \
                                                        Module::Install::ReadmeFromPod \
                                                        Object::Tiny \
                                                        Perl::Critic \

--- a/.github/workflows/test-lang-perl-ARM.yml
+++ b/.github/workflows/test-lang-perl-ARM.yml
@@ -64,14 +64,14 @@ jobs:
                                                             libtest-pod-perl
           cpanm --mirror https://www.cpan.org/ install Compress::Zstd \
                                                        Error::Simple \
-                                                       Module::Install::Repository \
-                                                       Regexp::Common \
-                                                       Try::Tiny \
-                                                       inc::Module::Install \
-                                                       Module::Install::ReadmeFromPod \
-                                                       Test::Exception \
                                                        IO::String \
-                                                       Object::Tiny
+                                                       Module::Install::ReadmeFromPod \
+                                                       Module::Install::Repository \
+                                                       Object::Tiny \
+                                                       Regexp::Common \
+                                                       Test::Exception \
+                                                       Try::Tiny \
+                                                       inc::Module::Install
 
       - name: Lint
         run: ./build.sh lint

--- a/.github/workflows/test-lang-perl-ARM.yml
+++ b/.github/workflows/test-lang-perl-ARM.yml
@@ -52,6 +52,7 @@ jobs:
           cpanm --mirror https://www.cpan.org/ install Compress::Zstd \
                                                        Encode \
                                                        Error::Simple \
+                                                       JSON::MaybeXS \
                                                        Module::Install \
                                                        Module::Install::ReadmeFromPod \
                                                        Object::Tiny \
@@ -90,6 +91,7 @@ jobs:
                                                        Compress::Zstd \
                                                        Encode \
                                                        Error::Simple \
+                                                       JSON::MaybeXS \
                                                        Module::Install \
                                                        Module::Install::ReadmeFromPod \
                                                        Object::Tiny \

--- a/.github/workflows/test-lang-perl.yml
+++ b/.github/workflows/test-lang-perl.yml
@@ -64,14 +64,14 @@ jobs:
                                                             libtest-pod-perl
           cpanm --mirror https://www.cpan.org/ install Compress::Zstd \
                                                        Error::Simple \
-                                                       Module::Install::Repository \
-                                                       Regexp::Common \
-                                                       Try::Tiny \
-                                                       inc::Module::Install \
-                                                       Module::Install::ReadmeFromPod \
-                                                       Test::Exception \
                                                        IO::String \
-                                                       Object::Tiny
+                                                       Module::Install::ReadmeFromPod \
+                                                       Module::Install::Repository \
+                                                       Object::Tiny \
+                                                       Regexp::Common \
+                                                       Test::Exception \
+                                                       Try::Tiny \
+                                                       inc::Module::Install
 
       - name: Lint
         run: ./build.sh lint

--- a/.github/workflows/test-lang-perl.yml
+++ b/.github/workflows/test-lang-perl.yml
@@ -52,6 +52,7 @@ jobs:
           cpanm --mirror https://www.cpan.org/ install Compress::Zstd \
                                                        Encode \
                                                        Error::Simple \
+                                                       JSON::MaybeXS \
                                                        Module::Install \
                                                        Module::Install::ReadmeFromPod \
                                                        Object::Tiny \
@@ -90,6 +91,7 @@ jobs:
                                                        Compress::Zstd \
                                                        Encode \
                                                        Error::Simple \
+                                                       JSON::MaybeXS \
                                                        Module::Install \
                                                        Module::Install::ReadmeFromPod \
                                                        Object::Tiny \

--- a/.github/workflows/test-lang-perl.yml
+++ b/.github/workflows/test-lang-perl.yml
@@ -52,6 +52,7 @@ jobs:
           cpanm --mirror https://www.cpan.org/ install Compress::Zstd \
                                                        Encode \
                                                        Error::Simple \
+                                                       Module::Install \
                                                        Module::Install::ReadmeFromPod \
                                                        Object::Tiny \
                                                        Perl::Critic \
@@ -59,8 +60,7 @@ jobs:
                                                        Test::Exception \
                                                        Test::More \
                                                        Test::Pod \
-                                                       Try::Tiny \
-                                                       inc::Module::Install
+                                                       Try::Tiny
 
       - name: Lint
         run: ./build.sh lint
@@ -90,14 +90,14 @@ jobs:
                                                        Compress::Zstd \
                                                        Encode \
                                                        Error::Simple \
+                                                       Module::Install \
                                                        Module::Install::ReadmeFromPod \
                                                        Object::Tiny \
                                                        Regexp::Common \
                                                        Test::Exception \
                                                        Test::More \
                                                        Test::Pod \
-                                                       Try::Tiny \
-                                                       inc::Module::Install
+                                                       Try::Tiny
 
       - name: Cache Local Maven Repository
         uses: actions/cache@v4

--- a/.github/workflows/test-lang-perl.yml
+++ b/.github/workflows/test-lang-perl.yml
@@ -57,6 +57,7 @@ jobs:
                                                        Perl::Critic \
                                                        Regexp::Common \
                                                        Test::Exception \
+                                                       Test::More \
                                                        Test::Pod \
                                                        Try::Tiny \
                                                        inc::Module::Install
@@ -93,6 +94,7 @@ jobs:
                                                        Object::Tiny \
                                                        Regexp::Common \
                                                        Test::Exception \
+                                                       Test::More \
                                                        Test::Pod \
                                                        Try::Tiny \
                                                        inc::Module::Install

--- a/.github/workflows/test-lang-perl.yml
+++ b/.github/workflows/test-lang-perl.yml
@@ -57,6 +57,7 @@ jobs:
                                                        Perl::Critic \
                                                        Regexp::Common \
                                                        Test::Exception \
+                                                       Test::Pod \
                                                        Try::Tiny \
                                                        inc::Module::Install
 
@@ -92,6 +93,7 @@ jobs:
                                                        Object::Tiny \
                                                        Regexp::Common \
                                                        Test::Exception \
+                                                       Test::Pod \
                                                        Try::Tiny \
                                                        inc::Module::Install
 

--- a/.github/workflows/test-lang-perl.yml
+++ b/.github/workflows/test-lang-perl.yml
@@ -49,25 +49,14 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          sudo apt-get -qqy install --no-install-recommends libjansson-dev \
-                                                            libcompress-raw-zlib-perl \
-                                                            libcpan-uploader-perl \
-                                                            libencode-perl \
-                                                            libio-string-perl \
-                                                            libjson-xs-perl \
-                                                            libmodule-install-perl \
-                                                            libmodule-install-readmefrompod-perl \
-                                                            libobject-tiny-perl \
-                                                            libperl-critic-perl \
-                                                            libsnappy-dev \
-                                                            libtest-exception-perl \
-                                                            libtest-pod-perl
           cpanm --mirror https://www.cpan.org/ install Compress::Zstd \
+                                                       Encode \
                                                        Error::Simple \
                                                        IO::String \
                                                        Module::Install::ReadmeFromPod \
                                                        Module::Install::Repository \
                                                        Object::Tiny \
+                                                       Perl::Critic \
                                                        Regexp::Common \
                                                        Test::Exception \
                                                        Try::Tiny \
@@ -95,23 +84,18 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          sudo apt-get -qqy install --no-install-recommends libcompress-raw-zlib-perl \
-                                                            libcpan-uploader-perl \
-                                                            libencode-perl \
-                                                            libio-string-perl \
-                                                            libjansson-dev \
-                                                            libjson-xs-perl \
-                                                            libmodule-install-perl \
-                                                            libmodule-install-readmefrompod-perl \
-                                                            libobject-tiny-perl \
-                                                            libsnappy-dev \
-                                                            libtest-exception-perl \
-                                                            libtest-pod-perl
-          cpanm --mirror https://www.cpan.org/ install Compress::Zstd \
+          sudo apt-get -qqy install --no-install-recommends libjansson-dev \
+                                                            libsnappy-dev
+          cpanm --mirror https://www.cpan.org/ install CPAN::Uploader \
+                                                       Compress::Zstd \
+                                                       Encode \
                                                        Error::Simple \
+                                                       IO::String \
+                                                       Module::Install::ReadmeFromPod \
                                                        Module::Install::Repository \
                                                        Object::Tiny \
                                                        Regexp::Common \
+                                                       Test::Exception \
                                                        Try::Tiny \
                                                        inc::Module::Install
 

--- a/.github/workflows/test-lang-perl.yml
+++ b/.github/workflows/test-lang-perl.yml
@@ -54,7 +54,6 @@ jobs:
                                                        Error::Simple \
                                                        IO::String \
                                                        Module::Install::ReadmeFromPod \
-                                                       Module::Install::Repository \
                                                        Object::Tiny \
                                                        Perl::Critic \
                                                        Regexp::Common \
@@ -92,7 +91,6 @@ jobs:
                                                        Error::Simple \
                                                        IO::String \
                                                        Module::Install::ReadmeFromPod \
-                                                       Module::Install::Repository \
                                                        Object::Tiny \
                                                        Regexp::Common \
                                                        Test::Exception \

--- a/.github/workflows/test-lang-perl.yml
+++ b/.github/workflows/test-lang-perl.yml
@@ -52,7 +52,6 @@ jobs:
           cpanm --mirror https://www.cpan.org/ install Compress::Zstd \
                                                        Encode \
                                                        Error::Simple \
-                                                       IO::String \
                                                        Module::Install::ReadmeFromPod \
                                                        Object::Tiny \
                                                        Perl::Critic \
@@ -89,7 +88,6 @@ jobs:
                                                        Compress::Zstd \
                                                        Encode \
                                                        Error::Simple \
-                                                       IO::String \
                                                        Module::Install::ReadmeFromPod \
                                                        Object::Tiny \
                                                        Regexp::Common \

--- a/BUILD.md
+++ b/BUILD.md
@@ -15,8 +15,8 @@ The following packages must be installed before Avro can be built:
  - Perl: Perl 5.24.1 or greater, gmake, Module::Install,
    Module::Install::ReadmeFromPod, Module::Install::Repository,
    Math::BigInt, JSON::MaybeXS, Try::Tiny, Regexp::Common, Encode,
-   IO::String, Object::Tiny, Compress::ZLib, Error::Simple,
-   Test::More, Test::Exception, Test::Pod
+   Object::Tiny, Compress::ZLib, Error::Simple, Test::More,
+   Test::Exception, Test::Pod
  - Rust: rustc and Cargo 1.65.0 or greater
  - Apache Ant 1.7
  - md5sum, sha1sum, used by top-level dist target

--- a/lang/perl/Changes
+++ b/lang/perl/Changes
@@ -2,6 +2,8 @@ Revision history for Perl extension Avro
 
         - Switch from JSON::XS to JSON::MaybeXS to support
           multiple JSON backends
+        - Drop dependency on IO::String, since we don't need
+          it now we depend on Perl 5.10.1 or greater
 
 1.00  Fri Jan 17 15:00:00 2014
         - Relicense under apache license 2.0

--- a/lang/perl/MANIFEST
+++ b/lang/perl/MANIFEST
@@ -25,7 +25,6 @@ inc/Module/Install/Makefile.pm
 inc/Module/Install/MakeMaker.pm
 inc/Module/Install/Metadata.pm
 inc/Module/Install/ReadmeFromPod.pm
-inc/Module/Install/Repository.pm
 lib/Avro.pm
 lib/Avro/BinaryDecoder.pm
 lib/Avro/BinaryEncoder.pm

--- a/lang/perl/Makefile.PL
+++ b/lang/perl/Makefile.PL
@@ -33,6 +33,8 @@ repository {
 bugtracker { web => 'http://issues.apache.org/jira/browse/AVRO/' };
 readme_from 'lib/Avro.pm';
 all_from 'lib/Avro.pm';
+configure_requires 'Module::Install';
+configure_requires 'Module::Install::ReadmeFromPod';
 test_requires 'Math::BigInt';
 test_requires 'Perl::Critic';
 test_requires 'Test::Exception';

--- a/lang/perl/Makefile.PL
+++ b/lang/perl/Makefile.PL
@@ -41,7 +41,6 @@ requires 'Compress::Zlib';
 requires 'Compress::Zstd';
 requires 'Encode';
 requires 'Error::Simple';
-requires 'IO::String';
 requires 'JSON::MaybeXS';
 requires 'Object::Tiny';
 requires 'Regexp::Common';

--- a/lang/perl/Makefile.PL
+++ b/lang/perl/Makefile.PL
@@ -33,10 +33,10 @@ repository {
 bugtracker { web => 'http://issues.apache.org/jira/browse/AVRO/' };
 readme_from 'lib/Avro.pm';
 all_from 'lib/Avro.pm';
-build_requires 'Test::More', 0.88;
 test_requires 'Math::BigInt';
 test_requires 'Perl::Critic';
 test_requires 'Test::Exception';
+test_requires 'Test::More', 0.88;
 test_requires 'Test::Pod';
 requires 'Compress::Zlib';
 requires 'Compress::Zstd';

--- a/lang/perl/Makefile.PL
+++ b/lang/perl/Makefile.PL
@@ -24,6 +24,13 @@ chomp $version;
 
 license 'apache';
 version $version;
+homepage 'http://avro.apache.org/';
+repository {
+    type => 'git',
+    url  => 'git://git.apache.org/avro.git',
+    web  => 'http://github.com/apache/avro',
+};
+bugtracker { web => 'http://issues.apache.org/jira/browse/AVRO/' };
 readme_from 'lib/Avro.pm';
 all_from 'lib/Avro.pm';
 build_requires 'Test::More', 0.88;
@@ -43,7 +50,6 @@ requires 'parent';
 unless ($Config{use64bitint}) {
     requires 'Math::BigInt';
 }
-auto_set_repository();
 
 my %packages = (
     'Avro'                    => 'lib/Avro.pm',

--- a/lang/perl/Makefile.PL
+++ b/lang/perl/Makefile.PL
@@ -37,6 +37,7 @@ build_requires 'Test::More', 0.88;
 test_requires 'Math::BigInt';
 test_requires 'Perl::Critic';
 test_requires 'Test::Exception';
+test_requires 'Test::Pod';
 requires 'Compress::Zlib';
 requires 'Compress::Zstd';
 requires 'Encode';

--- a/lang/perl/lib/Avro/BinaryDecoder.pm
+++ b/lang/perl/lib/Avro/BinaryDecoder.pm
@@ -49,9 +49,9 @@ The schema we want to use to decode the data.
 
 =item * reader
 
-An object implementing a straightforward interface. C<read($buf, $nbytes)> and
-C<seek($nbytes, $whence)> are expected. Typically a IO::String object or a
-IO::File object. It is expected that this calls will block the decoder, if not
+A file handle, or an object implementing a similar interface, like L<IO::File>.
+Specifically, it must support C<read($buf, $nbytes)> and
+C<seek($nbytes, $whence)>. These calls will block the decoder if not
 enough data is available for read.
 
 =back


### PR DESCRIPTION
## What is the purpose of the change

Many of the changes in this pull request were made back in 2014 by John Karp for https://issues.apache.org/jira/browse/AVRO-1514, motivated by the fact that we were no longer constrained by targetting 5.8 (since we are currently targetting 5.10).

The main motivation here was to remove some dependencies that were no longer needed (like IO::String), add some dependencies that were not properly reported (Module::Install and friends as configure dependencies, Test::Pod as a test dependency, etc), and generally clean up some of the dependencies particularly in the Github actions, which were installing many Perl dependencies twice (once with apt, once with cpanm).

## Verifying this change

This change only affects the way dependencies are reported and installed, and is already covered by existing tests, such as `.github/workflows/test-lang-perl.yml` and `.github/workflows/test-lang-perl-ARM.yml`.

No dependencies that _were_ reported are being removed, only new ones that were missing, so this should be a safe change.

## Documentation

- Does this pull request introduce a new feature? (yes / **no**)
- If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
