### PR TITLE
[website]Fix incorrect privacy link

### DIFF
--- a/doc/content/en/project/Privacy policy/_index.md
+++ b/doc/content/en/project/Privacy policy/_index.md
@@ -2,7 +2,7 @@
 title: "Privacy policy"
 linkTitle: "Privacy policy"
 weight: 9
-manualLink: https://hadoop.apache.org/privacy_policy.html
+manualLink: https://privacy.apache.org/policies/privacy-policy-public.html
 ---
 
 <!--
@@ -26,4 +26,4 @@ manualLink: https://hadoop.apache.org/privacy_policy.html
 
 -->
 
-Apache Avro project shares the same privacy policy as the [Apache Software Foundation](https://hadoop.apache.org/privacy_policy.html)
+Apache Avro project shares the same privacy policy as the [Apache Software Foundation](https://privacy.apache.org/policies/privacy-policy-public.html)


### PR DESCRIPTION

## What is the purpose of the change

We have not used Google Analytics or other services related to privacy policy issues, so linking to Hadoop is not appropriate. Additionally, ASF also recommends against using Google Analytics. 

By the way, we should add links to LICENSE, Privacy, and Security on our homepage(now at https://avro.apache.org/project/), but I'm not sure which method everyone prefers. Maybe we could add an ASF menu to the navigation bar, or simply use text links at the bottom?
