### PR TITLE
AVRO-1523 [Perl] Fix valid range for int and long

### DIFF
--- a/lang/perl/Changes
+++ b/lang/perl/Changes
@@ -7,6 +7,8 @@ Revision history for Perl extension Avro
         - Support object containers without an explicit
           codec. It will be assumed to be 'null' as mandated
           by the spec.
+        - Fixed an issue that meant the minimum accepted values
+          for int and long types were off by one
 
 1.00  Fri Jan 17 15:00:00 2014
         - Relicense under apache license 2.0


### PR DESCRIPTION
The check for valid int and long values was using the absolute value of the input, but in in two's complement arithmetic types the minimum and maximum values have different absolute values, which resulted in the minimum values for both types being rejected (because their absolute values are greater than those of the corresponding maxima).

This change fixes this and expands the binary encoder tests to check the ends of the accepted ranges.

The change in this PR is based on an original submission by John Karp submitted in 2014 to https://issues.apache.org/jira/browse/AVRO-1523.

## Verifying this change

This change extended `t/02_bin_encode.t` to add tests for these scenarios, for values just in and just out of the accepted ranges, on both the lower and upper bounds.

## Documentation

- Does this pull request introduce a new feature? (yes / **no**)
- If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
