### PR TITLE
AVRO-1463 [Perl] Quietly validate undefined values

### DIFF
--- a/lang/perl/Changes
+++ b/lang/perl/Changes
@@ -9,6 +9,8 @@ Revision history for Perl extension Avro
           by the spec.
         - Fixed an issue that meant the minimum accepted values
           for int and long types were off by one
+        - Silenced a spurious warning that was raised when
+          validating an undefined value for some data types
 
 1.00  Fri Jan 17 15:00:00 2014
         - Relicense under apache license 2.0

--- a/lang/perl/lib/Avro/Schema.pm
+++ b/lang/perl/lib/Avro/Schema.pm
@@ -276,6 +276,14 @@ sub is_data_valid {
     my $schema = shift;
     my $data = shift;
     my $type = $schema->{type};
+
+    if ($type eq 'null') {
+        return ! defined $data;
+    }
+
+    # undef isn't valid for any other types
+    return 0 unless defined $data;
+
     if ($type eq 'int') {
         no warnings;
         my $packed_int = pack "l", $data;
@@ -306,10 +314,7 @@ sub is_data_valid {
         $data =~ /^$RE{num}{real}$/ ? return 1 : 0;
     }
     if ($type eq "bytes" or $type eq "string") {
-        return 1 unless !defined $data or ref $data;
-    }
-    if ($type eq 'null') {
-        return defined $data ? 0 : 1;
+        return 1 unless ref $data;
     }
     if ($type eq 'boolean') {
         return 0 if ref $data; # sometimes risky

--- a/lang/perl/t/01_schema.t
+++ b/lang/perl/t/01_schema.t
@@ -19,7 +19,7 @@ use strict;
 use warnings;
 
 use Test::More;
-plan tests => 130;
+plan tests => 137;
 use Test::Exception;
 use_ok 'Avro::Schema';
 
@@ -455,6 +455,12 @@ EOJ
     isa_ok $s, 'Avro::Schema::Record';
     is $s->fields->[0]{name}, 'a', 'a';
     isa_ok $s->fields->[0]{type}, 'Avro::Schema::Union';
+}
+
+## is_data_valid for primitives
+for my $type ( qw( int long float double string bytes boolean ) ) {
+    my $schema = Avro::Schema->parse(qq[{ "type": "$type" }]);
+    is $schema->is_data_valid(undef), 0, "$type is_data_valid undef";
 }
 
 sub match_ok {


### PR DESCRIPTION
## What is the purpose of the change

The code to validate data against a schema made some assumptions about the state of the data before validating, which resulted in some spurious warnings being raised when validating undefined values for some data types. This change, based on one submitted by John Karp back in 2014 for https://issues.apache.org/jira/browse/AVRO-1463, resolves this issue and expands the test suite to test the validation of undefined values for all primitive data types.

## Verifying this change

This change extends `t/01_schema.t` to include a test for validating undefined values for all primitive types.

Note that these tests do not _fail_ when warnings are raised, but simply exercise the code that used to issue warnings we want to avoid. Making the code fail on warnings, particularly as a global condition, risks making the test suite brittle, since we don't control what may raise warnings in the future. This makes it more likely we'll spot them.

## Documentation

- Does this pull request introduce a new feature? (yes / **no**)
- If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
