### PR TITLE
AVRO-4004: [Rust] Ignore logicalType fields when creating the canonical form

### DIFF
--- a/lang/rust/avro/src/schema.rs
+++ b/lang/rust/avro/src/schema.rs
@@ -2156,7 +2156,12 @@ fn pcf_map(schema: &Map<String, Value>) -> String {
         }
 
         // Strip out unused fields ([STRIP] rule)
-        if field_ordering_position(k).is_none() || k == "default" || k == "doc" || k == "aliases" {
+        if field_ordering_position(k).is_none()
+            || k == "default"
+            || k == "doc"
+            || k == "aliases"
+            || k == "logicalType"
+        {
             continue;
         }
 
@@ -2432,6 +2437,7 @@ pub mod derive {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::rabin::Rabin;
     use apache_avro_test_helper::{
         logger::{assert_logged, assert_not_logged},
         TestResult,
@@ -3404,16 +3410,16 @@ mod tests {
 
         let schema = Schema::parse_str(raw_schema)?;
         assert_eq!(
-            "abf662f831715ff78f88545a05a9262af75d6406b54e1a8a174ff1d2b75affc4",
+            "7eb3b28d73dfc99bdd9af1848298b40804a2f8ad5d2642be2ecc2ad34842b987",
             format!("{}", schema.fingerprint::<Sha256>())
         );
 
         assert_eq!(
-            "6e21c350f71b1a34e9efe90970f1bc69",
+            "cb11615e412ee5d872620d8df78ff6ae",
             format!("{}", schema.fingerprint::<Md5>())
         );
         assert_eq!(
-            "28cf0a67d9937bb3",
+            "92f2ccef718c6754",
             format!("{}", schema.fingerprint::<Rabin>())
         );
 
@@ -6751,6 +6757,31 @@ mod tests {
             }
         }
 
+        Ok(())
+    }
+
+    #[test]
+    fn avro_4004_canonical_form_strip_logical_types() -> TestResult {
+        let schema_str = r#"
+      {
+        "type": "record",
+        "name": "test",
+        "fields": [
+            {"name": "a", "type": "long", "default": 42, "doc": "The field a"},
+            {"name": "b", "type": "string", "namespace": "test.a"},
+            {"name": "c", "type": "long", "logicalType": "timestamp-micros"}
+        ]
+    }"#;
+
+        let schema = Schema::parse_str(schema_str)?;
+
+        let canonical_form = schema.canonical_form();
+        let fp_rabin = schema.fingerprint::<Rabin>();
+        assert_eq!(
+            r#"{"name":"test","type":"record","fields":[{"name":"a","type":"long"},{"name":"test.a.b","type":"string"},{"name":"c","type":{"type":"long"}}]}"#,
+            canonical_form
+        );
+        assert_eq!("f4e6a3c026f4fd2a", fp_rabin.to_string());
         Ok(())
     }
 }


### PR DESCRIPTION
AVRO-4004

## What is the purpose of the change

* Strip the `logicalType` field when creating the canonical form of a Schema
According to the [specification](https://avro.apache.org/docs/1.11.1/specification/#transforming-into-parsing-canonical-form) :
```
[STRIP] Keep only attributes that are relevant to parsing data, which are: type, name, fields, symbols, items, values, size. Strip all others (e.g., doc and aliases).
``` 

## Verifying this change

* Add new tests, update the old ones

## Documentation

- Does this pull request introduce a new feature? no