### PR TITLE
Add sleep to make sure that the `getLastModifiedTime` is different

### DIFF
--- a/lang/java/maven-plugin/src/test/java/org/apache/avro/mojo/TestIDLProtocolMojo.java
+++ b/lang/java/maven-plugin/src/test/java/org/apache/avro/mojo/TestIDLProtocolMojo.java
@@ -111,6 +111,7 @@ public class TestIDLProtocolMojo extends AbstractAvroMojoTest {
     final Path idlUserFilePath = outputDirPath.resolve("IdlUser.java");
     final FileTime idlUserModificationTime = Files.getLastModifiedTime(idlUserFilePath);
 
+    Thread.sleep(1000);
     mojo.execute();
 
     // Asserting contents is done in previous tests so just assert existence.


### PR DESCRIPTION
The modification time is on a second granularity, with our crazy fast Macbooks this now runs within the second. I think it would be good to just add a sleep of 1 second in here to make sure that the release verification passes locally:

![image](https://github.com/apache/avro/assets/1134248/50188ea6-d00e-4ea0-afa1-895c7741abb2)
