### PR TITLE
AVRO-4014: [Rust] Add value and schema to ValidationWithReason error class

### DIFF
--- a/lang/rust/avro/src/error.rs
+++ b/lang/rust/avro/src/error.rs
@@ -16,8 +16,8 @@
 // under the License.
 
 use crate::{
-    schema::{Name, SchemaKind},
-    types::ValueKind,
+    schema::{Name, Schema, SchemaKind},
+    types::{Value, ValueKind},
 };
 use std::{error::Error as _, fmt};
 
@@ -55,8 +55,12 @@ pub enum Error {
     Validation,
 
     /// Describes errors happened while validating Avro data.
-    #[error("Value does not match schema: Reason: {0}")]
-    ValidationWithReason(String),
+    #[error("Value {value} does not match schema {schema}: Reason: {reason}")]
+    ValidationWithReason {
+        value: Value,
+        schema: Schema,
+        reason: String,
+    },
 
     #[error("Unable to allocate {desired} bytes (maximum allowed: {maximum})")]
     MemoryAllocation { desired: usize, maximum: usize },

--- a/lang/rust/avro/src/error.rs
+++ b/lang/rust/avro/src/error.rs
@@ -55,7 +55,7 @@ pub enum Error {
     Validation,
 
     /// Describes errors happened while validating Avro data.
-    #[error("Value {value} does not match schema {schema}: Reason: {reason}")]
+    #[error("Value {value:?} does not match schema {schema:?}: Reason: {reason}")]
     ValidationWithReason {
         value: Value,
         schema: Schema,

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -31,7 +31,7 @@ use serde_json::{Number, Value as JsonValue};
 use std::{
     borrow::Borrow,
     collections::{BTreeMap, HashMap},
-    fmt::{Debug, Display, Formatter},
+    fmt::Debug,
     hash::BuildHasher,
     str::FromStr,
 };
@@ -123,12 +123,6 @@ pub enum Value {
     Duration(Duration),
     /// Universally unique identifier.
     Uuid(Uuid),
-}
-
-impl Display for Value {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        write!(f, "{:?}", self)
-    }
 }
 
 /// Any structure implementing the [ToAvro](trait.ToAvro.html) trait will be usable
@@ -619,7 +613,10 @@ impl Value {
                     }
                 })
             }
-            (_v, _s) => Some("Unsupported value-schema combination".to_string()),
+            (v, s) => Some(format!(
+                "Unsupported value-schema combination! Value: {:?}, schema: {:?}",
+                v, s
+            )),
         }
     }
 
@@ -1228,7 +1225,7 @@ mod tests {
                 Value::Int(42),
                 Schema::Boolean,
                 false,
-                "Invalid value: Int(42) for schema: Boolean. Reason: Unsupported value-schema combination",
+                "Invalid value: Int(42) for schema: Boolean. Reason: Unsupported value-schema combination! Value: Int(42), schema: Boolean",
             ),
             (
                 Value::Union(0, Box::new(Value::Null)),
@@ -1246,7 +1243,7 @@ mod tests {
                 Value::Union(0, Box::new(Value::Null)),
                 Schema::Union(UnionSchema::new(vec![Schema::Double, Schema::Int])?),
                 false,
-                "Invalid value: Union(0, Null) for schema: Union(UnionSchema { schemas: [Double, Int], variant_index: {Int: 1, Double: 0} }). Reason: Unsupported value-schema combination",
+                "Invalid value: Union(0, Null) for schema: Union(UnionSchema { schemas: [Double, Int], variant_index: {Int: 1, Double: 0} }). Reason: Unsupported value-schema combination! Value: Null, schema: Double",
             ),
             (
                 Value::Union(3, Box::new(Value::Int(42))),
@@ -1286,9 +1283,9 @@ mod tests {
                 Value::Array(vec![Value::Boolean(true)]),
                 Schema::array(Schema::Long),
                 false,
-                "Invalid value: Array([Boolean(true)]) for schema: Array(ArraySchema { items: Long, attributes: {} }). Reason: Unsupported value-schema combination",
+                "Invalid value: Array([Boolean(true)]) for schema: Array(ArraySchema { items: Long, attributes: {} }). Reason: Unsupported value-schema combination! Value: Boolean(true), schema: Long",
             ),
-            (Value::Record(vec![]), Schema::Null, false, "Invalid value: Record([]) for schema: Null. Reason: Unsupported value-schema combination"),
+            (Value::Record(vec![]), Schema::Null, false, "Invalid value: Record([]) for schema: Null. Reason: Unsupported value-schema combination! Value: Record([]), schema: Null"),
             (
                 Value::Fixed(12, vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
                 Schema::Duration,
@@ -1558,7 +1555,7 @@ mod tests {
         ]);
         assert!(!value.validate(&schema));
         assert_logged(
-            r#"Invalid value: Record([("a", Boolean(false)), ("b", String("foo"))]) for schema: Record(RecordSchema { name: Name { name: "some_record", namespace: None }, aliases: None, doc: None, fields: [RecordField { name: "a", doc: None, aliases: None, default: None, schema: Long, order: Ascending, position: 0, custom_attributes: {} }, RecordField { name: "b", doc: None, aliases: None, default: None, schema: String, order: Ascending, position: 1, custom_attributes: {} }, RecordField { name: "c", doc: None, aliases: None, default: Some(Null), schema: Union(UnionSchema { schemas: [Null, Int], variant_index: {Null: 0, Int: 1} }), order: Ascending, position: 2, custom_attributes: {} }], lookup: {"a": 0, "b": 1, "c": 2}, attributes: {} }). Reason: Unsupported value-schema combination"#,
+            r#"Invalid value: Record([("a", Boolean(false)), ("b", String("foo"))]) for schema: Record(RecordSchema { name: Name { name: "some_record", namespace: None }, aliases: None, doc: None, fields: [RecordField { name: "a", doc: None, aliases: None, default: None, schema: Long, order: Ascending, position: 0, custom_attributes: {} }, RecordField { name: "b", doc: None, aliases: None, default: None, schema: String, order: Ascending, position: 1, custom_attributes: {} }, RecordField { name: "c", doc: None, aliases: None, default: Some(Null), schema: Union(UnionSchema { schemas: [Null, Int], variant_index: {Null: 0, Int: 1} }), order: Ascending, position: 2, custom_attributes: {} }], lookup: {"a": 0, "b": 1, "c": 2}, attributes: {} }). Reason: Unsupported value-schema combination! Value: Boolean(false), schema: Long"#,
         );
 
         let value = Value::Record(vec![

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -31,7 +31,7 @@ use serde_json::{Number, Value as JsonValue};
 use std::{
     borrow::Borrow,
     collections::{BTreeMap, HashMap},
-    fmt::Debug,
+    fmt::{Debug, Display, Formatter},
     hash::BuildHasher,
     str::FromStr,
 };
@@ -124,6 +124,13 @@ pub enum Value {
     /// Universally unique identifier.
     Uuid(Uuid),
 }
+
+impl Display for Value {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
 /// Any structure implementing the [ToAvro](trait.ToAvro.html) trait will be usable
 /// from a [Writer](../writer/struct.Writer.html).
 #[deprecated(

--- a/lang/rust/avro/src/types.rs
+++ b/lang/rust/avro/src/types.rs
@@ -127,7 +127,7 @@ pub enum Value {
 
 impl Display for Value {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "{:?}", self)
     }
 }
 

--- a/lang/rust/avro/src/writer.rs
+++ b/lang/rust/avro/src/writer.rs
@@ -542,10 +542,10 @@ fn write_value_ref_resolved(
     buffer: &mut Vec<u8>,
 ) -> AvroResult<()> {
     match value.validate_internal(schema, resolved_schema.get_names(), &schema.namespace()) {
-        Some(err) => Err(Error::ValidationWithReason {
+        Some(reason) => Err(Error::ValidationWithReason {
             value: value.clone(),
             schema: schema.clone(),
-            reason: err,
+            reason,
         }),
         None => encode_internal(
             value,
@@ -563,7 +563,7 @@ fn write_value_ref_owned_resolved(
     buffer: &mut Vec<u8>,
 ) -> AvroResult<()> {
     let root_schema = resolved_schema.get_root_schema();
-    if let Some(err) = value.validate_internal(
+    if let Some(reason) = value.validate_internal(
         root_schema,
         resolved_schema.get_names(),
         &root_schema.namespace(),
@@ -571,7 +571,7 @@ fn write_value_ref_owned_resolved(
         return Err(Error::ValidationWithReason {
             value: value.clone(),
             schema: root_schema.clone(),
-            reason: err,
+            reason,
         });
     }
     encode_internal(
@@ -1380,6 +1380,44 @@ mod tests {
 
         assert_eq!(198, bytes);
 
+        Ok(())
+    }
+
+    #[test]
+    fn avro_4014_validation_returns_a_detailed_error() -> TestResult {
+        const SCHEMA: &str = r#"
+  {
+      "type": "record",
+      "name": "Conference",
+      "fields": [
+          {"type": "string", "name": "name"},
+          {"type": ["null", "long"], "name": "date", "aliases" : [ "time2", "time" ]}
+      ]
+  }"#;
+
+        #[derive(Debug, PartialEq, Clone, Serialize)]
+        pub struct Conference {
+            pub name: String,
+            pub time: Option<f64>, // wrong type: f64 instead of i64
+        }
+
+        let conf = Conference {
+            name: "RustConf".to_string(),
+            time: Some(12345678.90),
+        };
+
+        let schema = Schema::parse_str(SCHEMA)?;
+        let mut writer = Writer::new(&schema, Vec::new());
+
+        match writer.append_ser(conf) {
+            Ok(bytes) => panic!("Expected an error, but got {} bytes written", bytes),
+            Err(e) => {
+                assert_eq!(
+                    e.to_string(),
+                    r#"Value Record([("name", String("RustConf")), ("time", Union(1, Double(12345678.9)))]) does not match schema Record(RecordSchema { name: Name { name: "Conference", namespace: None }, aliases: None, doc: None, fields: [RecordField { name: "name", doc: None, aliases: None, default: None, schema: String, order: Ascending, position: 0, custom_attributes: {} }, RecordField { name: "date", doc: None, aliases: Some(["time2", "time"]), default: None, schema: Union(UnionSchema { schemas: [Null, Long], variant_index: {Null: 0, Long: 1} }), order: Ascending, position: 1, custom_attributes: {} }], lookup: {"date": 1, "name": 0, "time": 1, "time2": 1}, attributes: {} }): Reason: Unsupported value-schema combination! Value: Double(12345678.9), schema: Long"#
+                );
+            }
+        }
         Ok(())
     }
 }

--- a/lang/rust/avro/src/writer.rs
+++ b/lang/rust/avro/src/writer.rs
@@ -542,7 +542,11 @@ fn write_value_ref_resolved(
     buffer: &mut Vec<u8>,
 ) -> AvroResult<()> {
     match value.validate_internal(schema, resolved_schema.get_names(), &schema.namespace()) {
-        Some(err) => Err(Error::ValidationWithReason(err)),
+        Some(err) => Err(Error::ValidationWithReason {
+            value: value.clone(),
+            schema: schema.clone(),
+            reason: err,
+        }),
         None => encode_internal(
             value,
             schema,
@@ -564,7 +568,11 @@ fn write_value_ref_owned_resolved(
         resolved_schema.get_names(),
         &root_schema.namespace(),
     ) {
-        return Err(Error::ValidationWithReason(err));
+        return Err(Error::ValidationWithReason {
+            value: value.clone(),
+            schema: root_schema.clone(),
+            reason: err,
+        });
     }
     encode_internal(
         value,


### PR DESCRIPTION
## What is the purpose of the change

This pull request is intended to improve the logging of value-schema mismatch errors when appending data to a `Writer`, so that it specifies which value and schema failed validation. This changes the current error: `Value does not match schema: Reason: Unsupported value-schema combination` to specify `Value {value} does not match schema {schema}`, bringing it in line with other error reporting in some of the other structs in the Rust implementation of Avro.

This aims to make it easier to debug the issue underlying AVRO-4014 and determine what is causing it.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
