### PR TITLE
[NO-JIRA]: [Rust] Revert a temporary workaround for a problem in Darling dependency

### DIFF
--- a/lang/rust/avro_derive/src/lib.rs
+++ b/lang/rust/avro_derive/src/lib.rs
@@ -15,10 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// for Rust versions older than 1.79.0
-#![allow(unknown_lints)]
-// Allow until https://github.com/TedDriggs/darling/pull/292 is resolved
-#![allow(clippy::manual_unwrap_or_default)]
 use darling::FromAttributes;
 use proc_macro2::{Span, TokenStream};
 use quote::quote;


### PR DESCRIPTION
Introduced-with: https://github.com/apache/avro/commit/2c484c638cbad34fd1a683a7812564972af751f4
Fixed upstream with: https://github.com/TedDriggs/darling/pull/296

## What is the purpose of the change

* Revert a temporary workaround that allows a clippy check to pass

## Verifying this change

* The build should pass without any Clippy errors

## Documentation

- Does this pull request introduce a new feature? no