### PR TITLE
AVRO-3984 [C++] Improve code generated for unions

### DIFF
--- a/lang/c++/CMakeLists.txt
+++ b/lang/c++/CMakeLists.txt
@@ -181,6 +181,7 @@ gen (crossref cr)
 gen (primitivetypes pt)
 gen (cpp_reserved_words cppres)
 gen (cpp_reserved_words_union_typedef cppres_union)
+gen (big_union big_union)
 
 add_executable (avrogencpp impl/avrogencpp.cc)
 target_link_libraries (avrogencpp avrocpp_s)
@@ -224,7 +225,7 @@ add_dependencies (AvrogencppTests bigrecord_hh bigrecord_r_hh bigrecord2_hh
     union_array_union_hh union_map_union_hh union_conflict_hh
     recursive_hh reuse_hh circulardep_hh tree1_hh tree2_hh crossref_hh
     primitivetypes_hh empty_record_hh cpp_reserved_words_union_typedef_hh
-    union_empty_record_hh)
+    union_empty_record_hh big_union_hh)
 
 include (InstallRequiredSystemLibraries)
 

--- a/lang/c++/impl/avrogencpp.cc
+++ b/lang/c++/impl/avrogencpp.cc
@@ -418,6 +418,7 @@ string CodeGen::generateUnionType(const NodePtr &n) {
     os_ << "    };\n";
 
     os_ << "    size_t idx() const { return idx_; }\n";
+    os_ << "    Branch branch() const { return static_cast<Branch>(idx_); }\n";
 
     for (size_t i = 0; i < c; ++i) {
         const NodePtr &nn = n->leafAt(i);

--- a/lang/c++/impl/avrogencpp.cc
+++ b/lang/c++/impl/avrogencpp.cc
@@ -336,6 +336,13 @@ static void generateGetterAndSetter(ostream &os,
        << "    idx_ = " << idx << ";\n"
        << "    value_ = v;\n"
        << "}\n\n";
+
+    os << "inline\n"
+       << "void" << sn << "set_" << name
+       << "(" << type << "&& v) {\n"
+       << "    idx_ = " << idx << ";\n"
+       << "    value_ = std::move(v);\n"
+       << "}\n\n";
 }
 
 static void generateConstructor(ostream &os,
@@ -404,7 +411,8 @@ string CodeGen::generateUnionType(const NodePtr &n) {
             os_ << "    "
                 << "const " << type << "& get_" << name << "() const;\n"
                 << "    " << type << "& get_" << name << "();\n"
-                << "    void set_" << name << "(const " << type << "& v);\n";
+                << "    void set_" << name << "(const " << type << "& v);\n"
+                << "    void set_" << name << "(" << type << "&& v);\n";
             pendingGettersAndSetters.emplace_back(result, type, name, i);
         }
     }
@@ -740,6 +748,7 @@ void CodeGen::generate(const ValidSchema &schema) {
 
     os_ << "#include <sstream>\n"
         << "#include <any>\n"
+        << "#include <utility>\n"
         << "#include \"" << includePrefix_ << "Specific.hh\"\n"
         << "#include \"" << includePrefix_ << "Encoder.hh\"\n"
         << "#include \"" << includePrefix_ << "Decoder.hh\"\n"

--- a/lang/c++/impl/avrogencpp.cc
+++ b/lang/c++/impl/avrogencpp.cc
@@ -322,6 +322,15 @@ static void generateGetterAndSetter(ostream &os,
        << "}\n\n";
 
     os << "inline\n"
+       << type << "&" << sn << "get_" << name << "() {\n"
+       << "    if (idx_ != " << idx << ") {\n"
+       << "        throw avro::Exception(\"Invalid type for "
+       << "union " << structName << "\");\n"
+       << "    }\n"
+       << "    return *std::any_cast<" << type << " >(&value_);\n"
+       << "}\n\n";
+
+    os << "inline\n"
        << "void" << sn << "set_" << name
        << "(const " << type << "& v) {\n"
        << "    idx_ = " << idx << ";\n"
@@ -392,9 +401,10 @@ string CodeGen::generateUnionType(const NodePtr &n) {
         } else {
             const string &type = types[i];
             const string &name = names[i];
-            os_ << "    " << "const " << type << "& get_" << name << "() const;\n"
-                                                        "    void set_"
-                << name << "(const " << type << "& v);\n";
+            os_ << "    "
+                << "const " << type << "& get_" << name << "() const;\n"
+                << "    " << type << "& get_" << name << "();\n"
+                << "    void set_" << name << "(const " << type << "& v);\n";
             pendingGettersAndSetters.emplace_back(result, type, name, i);
         }
     }

--- a/lang/c++/impl/avrogencpp.cc
+++ b/lang/c++/impl/avrogencpp.cc
@@ -663,7 +663,7 @@ void CodeGen::generateUnionTraits(const NodePtr &n) {
             os_ << "            {\n"
                 << "                " << cppTypeOf(nn) << " vv;\n"
                 << "                avro::decode(d, vv);\n"
-                << "                v.set_" << cppNameOf(nn) << "(vv);\n"
+                << "                v.set_" << cppNameOf(nn) << "(std::move(vv));\n"
                 << "            }\n";
         }
         os_ << "            break;\n";

--- a/lang/c++/impl/avrogencpp.cc
+++ b/lang/c++/impl/avrogencpp.cc
@@ -313,12 +313,12 @@ static void generateGetterAndSetter(ostream &os,
 
     os << "inline\n";
 
-    os << type << sn << "get_" << name << "() const {\n"
+    os << "const " << type << "&" << sn << "get_" << name << "() const {\n"
        << "    if (idx_ != " << idx << ") {\n"
        << "        throw avro::Exception(\"Invalid type for "
        << "union " << structName << "\");\n"
        << "    }\n"
-       << "    return std::any_cast<" << type << " >(value_);\n"
+       << "    return *std::any_cast<" << type << " >(&value_);\n"
        << "}\n\n";
 
     os << "inline\n"
@@ -392,7 +392,7 @@ string CodeGen::generateUnionType(const NodePtr &n) {
         } else {
             const string &type = types[i];
             const string &name = names[i];
-            os_ << "    " << type << " get_" << name << "() const;\n"
+            os_ << "    " << "const " << type << "& get_" << name << "() const;\n"
                                                         "    void set_"
                 << name << "(const " << type << "& v);\n";
             pendingGettersAndSetters.emplace_back(result, type, name, i);

--- a/lang/c++/jsonschemas/big_union
+++ b/lang/c++/jsonschemas/big_union
@@ -1,0 +1,101 @@
+{
+    "type": "record",
+    "doc": "Top level Doc.",
+    "name": "RootRecord",
+    "fields": [
+        {
+            "name": "big_union",
+            "doc": "A large union containing the primitive types, a array, a map and records.",
+            "type": [
+                "null",
+                "boolean",
+                "int",
+                "long",
+                "float",
+                "double",
+                {
+                    "type": "fixed",
+                    "size": 16,
+                    "name": "MD5"
+                },
+                "string",
+                {
+                    "type": "record",
+                    "name": "Vec2",
+                    "fields": [
+                        {
+                            "name": "x",
+                            "type": "long"
+                        },
+                        {
+                            "name": "y",
+                            "type": "long"
+                        }
+                    ]
+                },
+                {
+                    "type": "record",
+                    "name": "Vec3",
+                    "fields": [
+                        {
+                            "name": "x",
+                            "type": "long"
+                        },
+                        {
+                            "name": "y",
+                            "type": "long"
+                        },
+                        {
+                            "name": "z",
+                            "type": "long"
+                        }
+                    ]
+                },
+                {
+                    "type": "enum",
+                    "name": "Suit",
+                    "symbols": [
+                        "SPADES",
+                        "HEARTS",
+                        "DIAMONDS",
+                        "CLUBS"
+                    ]
+                },
+                {
+                    "type": "array",
+                    "items": "string",
+                    "default": []
+                },
+                {
+                    "type": "map",
+                    "values": "long",
+                    "default": {}
+                },
+                {
+                    "type": "record",
+                    "name": "int_",
+                    "doc": "try to force a collision with int",
+                    "fields": []
+                },
+                {
+                    "type": "record",
+                    "name": "int__",
+                    "doc": "try to force a collision with int",
+                    "fields": []
+                },
+                {
+                    "type": "record",
+                    "name": "Int",
+                    "doc": "name similar to primitive name",
+                    "fields": []
+                },
+                {
+                    "type": "record",
+                    "name": "_Int",
+                    "doc": "name with underscore as prefix",
+                    "fields": []
+                }
+            ]
+        }
+    ]
+}

--- a/lang/c++/test/AvrogencppTests.cc
+++ b/lang/c++/test/AvrogencppTests.cc
@@ -133,6 +133,14 @@ void checkDefaultValues(const testgen_r::RootRecord &r) {
     BOOST_CHECK_EQUAL(r.byteswithDefaultValue.get_bytes()[1], 0xaa);
 }
 
+// enable use of BOOST_CHECK_EQUAL
+template<>
+struct boost::test_tools::tt_detail::print_log_value<big_union::RootRecord::big_union_t::Branch> {
+    void operator()(std::ostream &stream, const big_union::RootRecord::big_union_t::Branch &branch) const {
+        stream << "big_union_t::Branch{" << static_cast<size_t>(branch) << "}";
+    }
+};
+
 void testEncoding() {
     ValidSchema s;
     ifstream ifs("jsonschemas/bigrecord");
@@ -330,15 +338,13 @@ void testUnionMethods() {
     avro::decode(*decoder, decoded_record);
 
     // check that a reference can be obtained from a union
-    const auto myunion_branch = static_cast<testgen::RootRecord::myunion_t::Branch>(decoded_record.myunion.idx());
-    BOOST_CHECK(myunion_branch == testgen::RootRecord::myunion_t::Branch::map);
+    BOOST_CHECK(decoded_record.myunion.branch() == testgen::RootRecord::myunion_t::Branch::map);
     const std::map<std::string, int32_t> &read_map = decoded_record.myunion.get_map();
     BOOST_CHECK_EQUAL(read_map.size(), 2);
     BOOST_CHECK_EQUAL(read_map.at("zero"), 0);
     BOOST_CHECK_EQUAL(read_map.at("one"), 1);
 
-    const auto anotherunion_branch = static_cast<testgen::RootRecord::anotherunion_t::Branch>(decoded_record.anotherunion.idx());
-    BOOST_CHECK(anotherunion_branch == testgen::RootRecord::anotherunion_t::Branch::bytes);
+    BOOST_CHECK(decoded_record.anotherunion.branch() == testgen::RootRecord::anotherunion_t::Branch::bytes);
     const std::vector<uint8_t> read_bytes = decoded_record.anotherunion.get_bytes();
     const std::vector<uint8_t> expected_bytes{1, 2, 3, 4};
     BOOST_CHECK_EQUAL_COLLECTIONS(read_bytes.begin(), read_bytes.end(), expected_bytes.begin(), expected_bytes.end());
@@ -349,57 +355,57 @@ void testUnionBranchEnum() {
 
     using Branch = big_union::RootRecord::big_union_t::Branch;
 
-    BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::null));
+    BOOST_CHECK_EQUAL(record.big_union.branch(), Branch::null);
     record.big_union.set_null();
-    BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::null));
+    BOOST_CHECK_EQUAL(record.big_union.branch(), Branch::null);
 
     record.big_union.set_bool(false);
-    BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::bool_));
+    BOOST_CHECK_EQUAL(record.big_union.branch(), Branch::bool_);
 
     record.big_union.set_int(123);
-    BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::int_));
+    BOOST_CHECK_EQUAL(record.big_union.branch(), Branch::int_);
 
     record.big_union.set_long(456);
-    BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::long_));
+    BOOST_CHECK_EQUAL(record.big_union.branch(), Branch::long_);
 
     record.big_union.set_float(555.555f);
-    BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::float_));
+    BOOST_CHECK_EQUAL(record.big_union.branch(), Branch::float_);
 
     record.big_union.set_double(777.777);
-    BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::double_));
+    BOOST_CHECK_EQUAL(record.big_union.branch(), Branch::double_);
 
     record.big_union.set_MD5({});
-    BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::MD5));
+    BOOST_CHECK_EQUAL(record.big_union.branch(), Branch::MD5);
 
     record.big_union.set_string("test");
-    BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::string));
+    BOOST_CHECK_EQUAL(record.big_union.branch(), Branch::string);
 
     record.big_union.set_Vec2({});
-    BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::Vec2));
+    BOOST_CHECK_EQUAL(record.big_union.branch(), Branch::Vec2);
 
     record.big_union.set_Vec3({});
-    BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::Vec3));
+    BOOST_CHECK_EQUAL(record.big_union.branch(), Branch::Vec3);
 
     record.big_union.set_Suit(big_union::Suit::CLUBS);
-    BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::Suit));
+    BOOST_CHECK_EQUAL(record.big_union.branch(), Branch::Suit);
 
     record.big_union.set_array({});
-    BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::array));
+    BOOST_CHECK_EQUAL(record.big_union.branch(), Branch::array);
 
     record.big_union.set_map({});
-    BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::map));
+    BOOST_CHECK_EQUAL(record.big_union.branch(), Branch::map);
 
     record.big_union.set_int_({});
-    BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::int__2));
+    BOOST_CHECK_EQUAL(record.big_union.branch(), Branch::int__2);
 
     record.big_union.set_int__({});
-    BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::int__));
+    BOOST_CHECK_EQUAL(record.big_union.branch(), Branch::int__);
 
     record.big_union.set_Int({});
-    BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::Int));
+    BOOST_CHECK_EQUAL(record.big_union.branch(), Branch::Int);
 
     record.big_union.set__Int({});
-    BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::_Int));
+    BOOST_CHECK_EQUAL(record.big_union.branch(), Branch::_Int);
 }
 
 boost::unit_test::test_suite *init_unit_test_suite(int /*argc*/, char * /*argv*/[]) {

--- a/lang/c++/test/AvrogencppTests.cc
+++ b/lang/c++/test/AvrogencppTests.cc
@@ -17,6 +17,7 @@
  */
 
 #include "Compiler.hh"
+#include "big_union.hh"
 #include "bigrecord.hh"
 #include "bigrecord_r.hh"
 #include "tweet.hh"
@@ -339,6 +340,65 @@ void testUnionMethods() {
     BOOST_CHECK_EQUAL_COLLECTIONS(read_bytes.begin(), read_bytes.end(), expected_bytes.begin(), expected_bytes.end());
 }
 
+void testUnionBranchEnum() {
+    big_union::RootRecord record;
+
+    using Branch = big_union::RootRecord::big_union_t::Branch;
+    ;
+
+    BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::null));
+    record.big_union.set_null();
+    BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::null));
+
+    record.big_union.set_bool(false);
+    BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::bool_));
+
+    record.big_union.set_int(123);
+    BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::int_));
+
+    record.big_union.set_long(456);
+    BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::long_));
+
+    record.big_union.set_float(555.555f);
+    BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::float_));
+
+    record.big_union.set_double(777.777);
+    BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::double_));
+
+    record.big_union.set_MD5({});
+    BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::MD5));
+
+    record.big_union.set_string("test");
+    BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::string));
+
+    record.big_union.set_Vec2({});
+    BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::Vec2));
+
+    record.big_union.set_Vec3({});
+    BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::Vec3));
+
+    record.big_union.set_Suit(big_union::Suit::CLUBS);
+    BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::Suit));
+
+    record.big_union.set_array({});
+    BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::array));
+
+    record.big_union.set_map({});
+    BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::map));
+
+    record.big_union.set_int_({});
+    BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::int__2));
+
+    record.big_union.set_int__({});
+    BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::int__));
+
+    record.big_union.set_Int({});
+    BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::Int));
+
+    record.big_union.set__Int({});
+    BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::_Int));
+}
+
 boost::unit_test::test_suite *init_unit_test_suite(int /*argc*/, char * /*argv*/[]) {
     auto *ts = BOOST_TEST_SUITE("Code generator tests");
     ts->add(BOOST_TEST_CASE(testEncoding));
@@ -348,5 +408,6 @@ boost::unit_test::test_suite *init_unit_test_suite(int /*argc*/, char * /*argv*/
     ts->add(BOOST_TEST_CASE(testNamespace));
     ts->add(BOOST_TEST_CASE(testEmptyRecord));
     ts->add(BOOST_TEST_CASE(testUnionMethods));
+    ts->add(BOOST_TEST_CASE(testUnionBranchEnum));
     return ts;
 }

--- a/lang/c++/test/AvrogencppTests.cc
+++ b/lang/c++/test/AvrogencppTests.cc
@@ -330,11 +330,15 @@ void testUnionMethods() {
     avro::decode(*decoder, decoded_record);
 
     // check that a reference can be obtained from a union
+    const auto myunion_branch = static_cast<testgen::RootRecord::myunion_t::Branch>(decoded_record.myunion.idx());
+    BOOST_CHECK(myunion_branch == testgen::RootRecord::myunion_t::Branch::map);
     const std::map<std::string, int32_t> &read_map = decoded_record.myunion.get_map();
     BOOST_CHECK_EQUAL(read_map.size(), 2);
     BOOST_CHECK_EQUAL(read_map.at("zero"), 0);
     BOOST_CHECK_EQUAL(read_map.at("one"), 1);
 
+    const auto anotherunion_branch = static_cast<testgen::RootRecord::anotherunion_t::Branch>(decoded_record.anotherunion.idx());
+    BOOST_CHECK(anotherunion_branch == testgen::RootRecord::anotherunion_t::Branch::bytes);
     const std::vector<uint8_t> read_bytes = decoded_record.anotherunion.get_bytes();
     const std::vector<uint8_t> expected_bytes{1, 2, 3, 4};
     BOOST_CHECK_EQUAL_COLLECTIONS(read_bytes.begin(), read_bytes.end(), expected_bytes.begin(), expected_bytes.end());
@@ -344,7 +348,6 @@ void testUnionBranchEnum() {
     big_union::RootRecord record;
 
     using Branch = big_union::RootRecord::big_union_t::Branch;
-    ;
 
     BOOST_CHECK_EQUAL(record.big_union.idx(), static_cast<size_t>(Branch::null));
     record.big_union.set_null();


### PR DESCRIPTION
# What is the purpose of the change

[AVRO-3984](https://issues.apache.org/jira/browse/AVRO-3984)

This pull request should improve the code generated by avrogencpp for union types. The improvements are:

## Getter return a reference

Previously the getters for a union branch returned a value:

    std::map<std::string, float > get_map() const;


This lead to a complete copy of the map, which may be really expensive depending on the use case.

In this pull request the getter return a reference instead, which allows the user to choose if a copy should be done.

    const std::map<std::string, float >& get_map() const;

Additionally a getter is created, that returns a mutable reference. This can be useful if a value needs to be added to a map or array.
    
    std::map<std::string, int32_t >& get_map();

## Setters can take a r-value reference

Currently the setter of a union takes a reference to the value that should be set. This forces the user to copy the value here.

    void set_map(const std::map<std::string, int32_t >& v);

With this pull request a alternative overload is provided that takes a r-value reference. Now copies can be avoided, since the cheaper move assignment is called.

    void set_map(std::map<std::string, int32_t >&& v);

## Additional Branch enum for each union type

Currently the `idx()` method is available to check which branch of a union is set. 

    size_t idx() const { return idx_; }

The issue is that the user needs to know which size_t value matches to which branch. This might lead to issues if values are inserted in the middle of a union and the indices change.

To avoid such issues a enum is generated that maps the branch types to the index. For a union of null, map and float this will look like this:

    enum class Branch: size_t {
        null = 0,
        map = 1,
        float_ = 2,
    };

The user can then cast the value return by idx() to this enum and write a switch case statement


    const auto myunion_branch = static_cast<testgen::RootRecord::myunion_t::Branch>(decoded_record.myunion.idx());
    switch (myunion_branch) {
        case testgen::RootRecord::myunion_t::Branch::null:
            std::cout << "null" << std::endl;
            break;
        case testgen::RootRecord::myunion_t::Branch::map:
            std::cout << "map" << std::endl;
            break;
        case testgen::RootRecord::myunion_t::Branch::float_:
            std::cout << "float: " << decoded_record.myunion.get_float() << std::endl;
            break;
    }

## Verifying this change

I added unit tests for the new generated functions and enum class. Also existing test still pass.

## Documentation

* Does this pull request introduce a new feature? no
  * the setters and getters are changed in a way that should be backwards compatible, so no new feature i think
  * i would not consider the new enum a real feature 
* If yes, how is the feature documented? - 