### PR TITLE
AVRO-4024: [Rust] support nan/inf/-inf as float/double default

### DIFF
--- a/lang/rust/avro/tests/io.rs
+++ b/lang/rust/avro/tests/io.rs
@@ -107,6 +107,14 @@ fn default_value_examples() -> &'static Vec<(&'static str, &'static str, Value)>
             (r#""long""#, "5", Value::Long(5)),
             (r#""float""#, "1.1", Value::Float(1.1)),
             (r#""double""#, "1.1", Value::Double(1.1)),
+            (r#""float""#, r#""  +inf ""#, Value::Float(f32::INFINITY)),
+            (
+                r#""double""#,
+                r#""-Infinity""#,
+                Value::Double(f64::NEG_INFINITY),
+            ),
+            (r#""float""#, r#""-NAN""#, Value::Float(f32::NAN)),
+            (r#""double""#, r#""-NAN""#, Value::Double(f64::NAN)),
             (
                 r#"{"type": "fixed", "name": "F", "size": 2}"#,
                 r#""a""#,
@@ -312,11 +320,41 @@ fn test_default_value() -> TestResult {
             &mut Cursor::new(encoded),
             Some(&reader_schema),
         )?;
-        assert_eq!(
-            datum_read, datum_to_read,
-            "{} -> {}",
-            *field_type, *default_json
-        );
+
+        match default_datum {
+            // For float/double, NaN != NaN, so we check specially here.
+            Value::Double(f) if f.is_nan() => {
+                let Value::Record(fields) = datum_read else {
+                    unreachable!("the test always constructs top level as record")
+                };
+                let Value::Double(f) = fields[0].1 else {
+                    panic!("double expected")
+                };
+                assert!(
+                    f.is_nan(),
+                    "{field_type} -> {default_json} is parsed as {f} rather than NaN"
+                );
+            }
+            Value::Float(f) if f.is_nan() => {
+                let Value::Record(fields) = datum_read else {
+                    unreachable!("the test always constructs top level as record")
+                };
+                let Value::Float(f) = fields[0].1 else {
+                    panic!("double expected")
+                };
+                assert!(
+                    f.is_nan(),
+                    "{field_type} -> {default_json} is parsed as {f} rather than NaN"
+                );
+            }
+            _ => {
+                assert_eq!(
+                    datum_read, datum_to_read,
+                    "{} -> {}",
+                    *field_type, *default_json
+                );
+            }
+        }
     }
 
     Ok(())


### PR DESCRIPTION
<!--

*Thank you very much for contributing to Apache Avro - we are happy that you want to help us improve Avro. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Avro a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Every commit message references Jira issues in their subject lines. In addition, commits follow the guidelines from [How to write a good git commit message](https://chris.beams.io/posts/git-commit/)
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

-->

## What is the purpose of the change

As title

[[AVRO-4024] [Rust]: Fix default value support for double and float as "NaN", "Infinity" and "-Infinity" - ASF JIRA](https://issues.apache.org/jira/browse/AVRO-4024)

## Verifying this change
CI must pass

## Documentation

- Does this pull request introduce a new feature? no
