### PR TITLE
[AVRO-3710] [C++] Permit DataFile use without stream ownership

### DIFF
--- a/lang/c++/build.sh
+++ b/lang/c++/build.sh
@@ -79,7 +79,7 @@ case "$target" in
   lint)
     # some versions of cppcheck seem to require an explicit
     # "--error-exitcode" option to return non-zero code
-    cppcheck --error-exitcode=1 --inline-suppr -f -q -x c++ api examples impl test
+    cppcheck --error-exitcode=1 --inline-suppr -f -q -x c++ include examples impl test
     ;;
 
   test)
@@ -118,7 +118,7 @@ case "$target" in
     ;;
 
   format)
-    clang-format -i --style file `find api -type f` `find impl -type f` `find test -type f`
+    clang-format -i --style file `find include -type f` `find impl -type f` `find test -type f`
     ;;
 
   clean)

--- a/lang/c++/test/CodecTests.cc
+++ b/lang/c++/test/CodecTests.cc
@@ -1337,7 +1337,7 @@ static const TestData3 data3[] = {
      "U0N[c3sS1sS2sS3][]",
      1},
     {
-      R"({"name": "Project", "type": "record", "fields": [
+        R"({"name": "Project", "type": "record", "fields": [
         { "name": "_types", "type": [
             "null",
             { "name": "Record1", "type": "record", "fields": [{ "name": "Record1_field1", "type": "string" }]}
@@ -1345,7 +1345,7 @@ static const TestData3 data3[] = {
         { "name": "field1", "type": { "type": "array", "items": "Record1" } }
       ]})",
         "U0N[c3sS1sS2sS3]",
-      R"({"name": "Project", "type": "record", "fields": [
+        R"({"name": "Project", "type": "record", "fields": [
         { "name": "_types", "type": [
             "null",
             { "name": "Record1", "type": "record", "fields": [{ "name": "Record1_field1", "type": "string" }]},
@@ -1375,7 +1375,7 @@ static const TestData3 data3[] = {
         { "name": "field2", "type": { "type": "array", "items": "Record3" }, "default": [] }
       ]})",
         "U0N[c3sS1sS2sS3][]",
-      R"({"name": "Project", "type": "record", "fields": [
+        R"({"name": "Project", "type": "record", "fields": [
         { "name": "_types", "type": [
             "null",
             { "name": "Record1", "type": "record", "fields": [{ "name": "Record1_field1", "type": "string" }]}

--- a/lang/c++/test/DataFileTests.cc
+++ b/lang/c++/test/DataFileTests.cc
@@ -756,6 +756,32 @@ void testSkipString(avro::Codec codec) {
     }
 }
 
+void testSameStreamReadWriteDataFile() {
+    BOOST_TEST_CHECKPOINT(__func__);
+    auto schema = makeValidSchema(dsch);
+    auto stream = avro::memoryOutputStream();
+
+    {
+        ComplexDouble complex;
+        complex.re = 1.0;
+        complex.im = 2.0;
+
+        // Note: We dereference stream here so the writer does not take ownership
+        avro::DataFileWriter<ComplexDouble> writer(*stream, schema);
+        writer.write(complex);
+    }
+
+    // Again, the input stream does not take ownership of the memory stream
+    auto inputStream = avro::memoryInputStream(*stream);
+    // But the reader does take ownership of the input stream
+    avro::DataFileReader<ComplexDouble> reader(std::move(inputStream));
+    ComplexDouble output;
+
+    BOOST_CHECK(reader.read(output));
+    BOOST_CHECK(output.re == 1.0);
+    BOOST_CHECK(output.im == 2.0);
+}
+
 void testSkipStringNullCodec() {
     BOOST_TEST_CHECKPOINT(__func__);
     testSkipString(avro::NULL_CODEC);
@@ -1125,6 +1151,8 @@ init_unit_test_suite(int, char *[]) {
         ts->add(BOOST_CLASS_TEST_CASE(&DataFileTest::testCleanup, t));
         boost::unit_test::framework::master_test_suite().add(ts);
     }
+
+    boost::unit_test::framework::master_test_suite().add(BOOST_TEST_CASE(&testSameStreamReadWriteDataFile));
 
     boost::unit_test::framework::master_test_suite().add(BOOST_TEST_CASE(&testSkipStringNullCodec));
     boost::unit_test::framework::master_test_suite().add(BOOST_TEST_CASE(&testSkipStringDeflateCodec));


### PR DESCRIPTION
## What is the purpose of the change

As requested by AVRO-3710, this makes it possible to create DataFile reader and writer instances which do not take exclusive ownership of their underlying stream. This makes it more convenient to use data files without effectively being forced to write to a file.

This also fixes an issue with the build format and cppcheck steps which were broken with #3042

## Verifying this change

*(Please pick one of the following options)*

This change added a test demonstrating the use of DataFile reader/writer constructors which do not take exclusive ownership of the pointer.

## Documentation

- Does this pull request introduce a new feature? yes
- If yes, how is the feature documented? Included in doc comments for data file classes
