### PR TITLE
AVRO-4026: [c++] Allow non-string custom attributes in schemas.

### DIFF
--- a/lang/c++/impl/Compiler.cc
+++ b/lang/c++/impl/Compiler.cc
@@ -277,7 +277,11 @@ static void getCustomAttributes(const Object &m, CustomAttributes &customAttribu
     const std::unordered_set<std::string> &kKnownFields = getKnownFields();
     for (const auto &entry : m) {
         if (kKnownFields.find(entry.first) == kKnownFields.end()) {
-            customAttributes.addAttribute(entry.first, entry.second.stringValue());
+            if (entry.second.type() == json::EntityType::String) {
+                customAttributes.addAttribute(entry.first, entry.second.stringValue());
+            } else {
+                customAttributes.addAttribute(entry.first, entry.second.toString());
+            }
         }
     }
 }

--- a/lang/c++/test/SchemaTests.cc
+++ b/lang/c++/test/SchemaTests.cc
@@ -111,7 +111,10 @@ const char *basicSchemas[] = {
     "[{\"name\": \"f1\",\"type\": \"long\",\"extra field\": \"1\"}]}",
     "{\"type\": \"record\",\"name\": \"Test\",\"fields\": "
     "[{\"name\": \"f1\",\"type\": \"long\","
-    "\"extra field1\": \"1\",\"extra field2\": \"2\"}]}"};
+    "\"extra field1\": \"1\",\"extra field2\": \"2\"}]}"
+    ,R"({"type": "record","name": "Test","fields":
+    [{"name": "f1","type": "string", "extra": {"custom1": "value","custom2": true }}]})"
+};
 
 const char *basicSchemaErrors[] = {
     // Record


### PR DESCRIPTION
## What is the purpose of the change

Fix schema compilation errors when non-string custom attributes are present.

## Verifying this change

This change added tests and can be verified as follows:

- Added test case that contains non-string custom attributes

## Documentation

- Does this pull request introduce a new feature? no
