### PR TITLE
AVRO-2032: [Java] Add support for NaN, Infinity and -Infinity in JsonDecoder

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/io/JsonDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/JsonDecoder.java
@@ -199,6 +199,19 @@ public class JsonDecoder extends ParsingDecoder implements Parser.ActionHandler 
       float result = in.getFloatValue();
       in.nextToken();
       return result;
+    } else if (in.getCurrentToken() == JsonToken.VALUE_STRING) {
+      String stringValue = in.getText();
+      in.nextToken();
+      if (isNaNString(stringValue)) {
+        return Float.NaN;
+      }
+      if (isNegativeInfinityString(stringValue)) {
+        return Float.NEGATIVE_INFINITY;
+      }
+      if (isPositiveInfinityString(stringValue)) {
+        return Float.POSITIVE_INFINITY;
+      }
+      throw error("float");
     } else {
       throw error("float");
     }
@@ -211,9 +224,40 @@ public class JsonDecoder extends ParsingDecoder implements Parser.ActionHandler 
       double result = in.getDoubleValue();
       in.nextToken();
       return result;
+    } else if (in.getCurrentToken() == JsonToken.VALUE_STRING) {
+      String stringValue = in.getText();
+      in.nextToken();
+      if (isNaNString(stringValue)) {
+        return Double.NaN;
+      }
+      if (isNegativeInfinityString(stringValue)) {
+        return Double.NEGATIVE_INFINITY;
+      }
+      if (isPositiveInfinityString(stringValue)) {
+        return Double.POSITIVE_INFINITY;
+      }
+      throw error("double");
     } else {
       throw error("double");
     }
+  }
+
+  // check whether the given string represents an IEEE 754 'NaN' string value as
+  // serialized by Jackson
+  private static boolean isNaNString(String value) {
+    return "NaN".equals(value);
+  }
+
+  // check whether the given string represents an IEEE 754 'Infinity' string value
+  // as serialized by Jackson
+  private static boolean isPositiveInfinityString(String value) {
+    return "Infinity".equals(value) || "INF".equals(value);
+  }
+
+  // check whether the given string represents an IEEE 754 '-Infinity' string
+  // value as serialized by Jackson
+  private static boolean isNegativeInfinityString(String value) {
+    return "-Infinity".equals(value) || "-INF".equals(value);
   }
 
   @Override

--- a/lang/java/avro/src/test/java/org/apache/avro/io/TestJsonDecoder.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/io/TestJsonDecoder.java
@@ -118,4 +118,26 @@ public class TestJsonDecoder {
     JsonDecoder decoder = DecoderFactory.get().jsonDecoder(schema, record);
     Assertions.assertThrows(AvroTypeException.class, () -> reader.read(null, decoder));
   }
+
+  @Test
+  void testIeee754SpecialCases() throws IOException {
+    String def = "{\"type\":\"record\",\"name\":\"X\",\"fields\": [" + "{\"type\":\"float\",\"name\":\"nanFloat\"},"
+        + "{\"type\":\"float\",\"name\":\"infinityFloat\"},"
+        + "{\"type\":\"float\",\"name\":\"negativeInfinityFloat\"}," + "{\"type\":\"double\",\"name\":\"nanDouble\"},"
+        + "{\"type\":\"double\",\"name\":\"infinityDouble\"},"
+        + "{\"type\":\"double\",\"name\":\"negativeInfinityDouble\"}" + "]}";
+    Schema schema = new Schema.Parser().parse(def);
+    DatumReader<GenericRecord> reader = new GenericDatumReader<>(schema);
+
+    String record = "{\"nanFloat\":\"NaN\", \"infinityFloat\":\"Infinity\", \"negativeInfinityFloat\":\"-Infinity\", "
+        + "\"nanDouble\":\"NaN\", \"infinityDouble\":\"Infinity\", \"negativeInfinityDouble\":\"-Infinity\"}";
+    Decoder decoder = DecoderFactory.get().jsonDecoder(schema, record);
+    GenericRecord r = reader.read(null, decoder);
+    assertEquals(Float.NaN, r.get("nanFloat"));
+    assertEquals(Float.POSITIVE_INFINITY, r.get("infinityFloat"));
+    assertEquals(Float.NEGATIVE_INFINITY, r.get("negativeInfinityFloat"));
+    assertEquals(Double.NaN, r.get("nanDouble"));
+    assertEquals(Double.POSITIVE_INFINITY, r.get("infinityDouble"));
+    assertEquals(Double.NEGATIVE_INFINITY, r.get("negativeInfinityDouble"));
+  }
 }


### PR DESCRIPTION
<!--

*Thank you very much for contributing to Apache Avro - we are happy that you want to help us improve Avro. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Avro a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/AVRO/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "AVRO-XXXX: [component] Title of the pull request", where *AVRO-XXXX* should be replaced by the actual issue number. 
    The *component* is optional, but can help identify the correct reviewers faster: either the language ("java", "python") or subsystem such as "build" or "doc" are good candidates.  

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests. You can [build the entire project](https://github.com/apache/avro/blob/main/BUILD.md) or just the [language-specific SDK](https://avro.apache.org/project/how-to-contribute/#unit-tests).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Every commit message references Jira issues in their subject lines. In addition, commits follow the guidelines from [How to write a good git commit message](https://chris.beams.io/posts/git-commit/)
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

-->

## What is the purpose of the change

JsonEncoder uses special string values to represent NaN, Infinity and -Infinity values for float and double values, but JsonDecoder does not accept these string values. This change adds support for these special values to JsonDecoder.

## Verifying this change

This change added tests and can be verified as follows:
* The change adds an unit tests which verifies all 6 special cases:
  * `NaN` for float fields
  * `NaN` for double fields
  * `Infinity` for float fields
  * `Infinity` for double fields
  * `-Infinity` for float fields
  * `-Infinity` for double fields
* These values are defined in Jackson.  
  [StdDeserializer](https://github.com/FasterXML/jackson-databind/blob/92181dfae2d857ed728df4a8c5ab904f9eb323c1/src/main/java/com/fasterxml/jackson/databind/deser/std/StdDeserializer.java#L1487)

## Documentation

- This PR doesn't introduce a new feature but implements a behavior which is not documented at all.
- The Avro spec doesn't mention how these special cases are handled in JSON ([RFC 8259](https://datatracker.ietf.org/doc/html/rfc8259) does not define numeric literals for `NaN`, `Infinity` and `-Infinity`)
- `JsonEncoder`/`JsonDecoder` resemble the behavior of Jackson
