### PR TITLE
AVRO-4027: Fix bug in JSON object syntax

### DIFF
--- a/lang/java/idl/src/test/idl/input/simple.avdl
+++ b/lang/java/idl/src/test/idl/input/simple.avdl
@@ -65,6 +65,9 @@ protocol Simple {
     @foo.bar.bar("foo.bar2") array<string> a = [];
     // An optional type with a null default value (results in a union with null first).
     @foo.foo.bar(42) @foo.foo.foo("3foo") string? prop = null;
+    // Arrays and maps can have empty defaults
+    array<int> numbers = [];
+    map<string> dictionary = {};
   }
 
   /** An MD5 hash. */

--- a/lang/java/idl/src/test/idl/output/simple.avpr
+++ b/lang/java/idl/src/test/idl/output/simple.avpr
@@ -78,6 +78,14 @@
       "name": "prop",
       "type": [ "null" , {"type":"string", "foo.foo.bar": 42, "foo.foo.foo": "3foo"} ],
       "default": null
+    }, {
+      "name": "numbers",
+      "type": {"type: array", "items": "int"},
+      "default": []
+    }, {
+      "name": "dictionary",
+      "type": {"type: map", "items": "string"},
+      "default": {}
     }],
     "my-property" : {
       "key" : 3

--- a/share/idl_grammar/org/apache/avro/idl/Idl.g4
+++ b/share/idl_grammar/org/apache/avro/idl/Idl.g4
@@ -138,7 +138,7 @@ unionType: Union LBrace types+=fullType (Comma types+=fullType)* RBrace;
 
 jsonValue: jsonObject | jsonArray | jsonLiteral;
 jsonLiteral: literal=(StringLiteral | IntegerLiteral | FloatingPointLiteral | BTrue | BFalse | Null);
-jsonObject: LBrace jsonPairs+=jsonPair (Comma jsonPairs+=jsonPair)* RBrace;
+jsonObject: LBrace (jsonPairs+=jsonPair (Comma jsonPairs+=jsonPair)*)? RBrace;
 jsonPair: name=StringLiteral Colon value=jsonValue;
 jsonArray: LBracket (jsonValues+=jsonValue (Comma jsonValues+=jsonValue)*)? RBracket;
 


### PR DESCRIPTION
The IDL grammar mistakenly did not accept empty JSON objects.