### PR TITLE
[NO_JIRA] [CI] Fix the version of libssl1 Ubuntu package

### DIFF
--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -96,7 +96,7 @@ RUN apt-get -qqy install --no-install-recommends libzstd-dev \
 
 # Required for Dotnet
 RUN export ARCH="$(dpkg --print-architecture)"; \
-  export LIBSSL_DEB="libssl1.1_1.1.1f-1ubuntu2.22_$ARCH.deb"; \
+  export LIBSSL_DEB="libssl1.1_1.1.1f-1ubuntu2.23_$ARCH.deb"; \
   wget -q "http://security.ubuntu.com/ubuntu/pool/main/o/openssl/$LIBSSL_DEB" || \
     wget -q "http://ports.ubuntu.com/ubuntu-ports/pool/main/o/openssl/$LIBSSL_DEB"; \
   dpkg -i "$LIBSSL_DEB"; \


### PR DESCRIPTION
## What is the purpose of the change

* This PR fixes the "Docker tests" CI workflow

https://github.com/apache/avro/actions/runs/10283162033/job/28456409653

```
 > [ 5/22] RUN export ARCH="$(dpkg --print-architecture)";   export LIBSSL_DEB="libssl1.1_1.1.1f-1ubuntu2.22_$ARCH.deb";   wget -q "http://security.ubuntu.com/ubuntu/pool/main/o/openssl/$LIBSSL_DEB" ||     wget -q "http://ports.ubuntu.com/ubuntu-ports/pool/main/o/openssl/$LIBSSL_DEB";   dpkg -i "$LIBSSL_DEB";   rm "$LIBSSL_DEB":
0.570 dpkg: error: cannot access archive 'libssl1.1_1.1.1f-1ubuntu2.22_amd64.deb': No such file or directory
0.571 rm: cannot remove 'libssl1.1_1.1.1f-1ubuntu2.22_amd64.deb': No such file or directory
```

It got bumped from 2.22 to 2.23 ...
TODO: We need to find a repo that keeps the old versions!

## Verifying this change

* https://github.com/apache/avro/actions/workflows/test-docker.yml must pass !

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable
