### PR TITLE
[NO-JIRA] [Rust] Bump the version to 0.18.0

### DIFF
--- a/lang/rust/Cargo.lock
+++ b/lang/rust/Cargo.lock
@@ -70,7 +70,7 @@ checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "apache-avro"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "apache-avro-derive",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "apache-avro-derive"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "apache-avro",
  "darling",
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "apache-avro-test-helper"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "better-panic",

--- a/lang/rust/Cargo.toml
+++ b/lang/rust/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Apache Avro team <dev@avro.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/avro"

--- a/lang/rust/avro/Cargo.toml
+++ b/lang/rust/avro/Cargo.toml
@@ -54,7 +54,7 @@ harness = false
 name = "single"
 
 [dependencies]
-apache-avro-derive = { default-features = false, version = "0.17.0", path = "../avro_derive", optional = true }
+apache-avro-derive = { default-features = false, version = "0.18.0", path = "../avro_derive", optional = true }
 bigdecimal = { default-features = false, version = "0.4.5", features = ["std", "serde"] }
 bzip2 = { default-features = false, version = "0.4.4", optional = true }
 crc32fast = { default-features = false, version = "1.4.2", optional = true }
@@ -84,7 +84,7 @@ rand = { default-features = false, version = "0.8.5", features = ["default"] }
 
 [dev-dependencies]
 anyhow = { default-features = false, version = "1.0.86", features = ["std"] }
-apache-avro-test-helper = { default-features = false, version = "0.17.0", path = "../avro_test_helper" }
+apache-avro-test-helper = { default-features = false, version = "0.18.0", path = "../avro_test_helper" }
 criterion = { default-features = false, version = "0.5.1" }
 hex-literal = { default-features = false, version = "0.4.1" }
 md-5 = { default-features = false, version = "0.10.6" }


### PR DESCRIPTION
Rust SDK 0.17.0 has been released with Avro 1.12.0

## What is the purpose of the change

* Change the crate version from 0.17.0 to 0.18.0

## Verifying this change

* The CI checks must pass

## Documentation

- Does this pull request introduce a new feature? no