### PR TITLE
Fix build when cpp_reserved_words_union_typedef.hh is not ready

### DIFF
--- a/lang/c++/CMakeLists.txt
+++ b/lang/c++/CMakeLists.txt
@@ -218,6 +218,8 @@ unittest (AvrogencppTestReservedWords)
 unittest (CommonsSchemasTests)
 
 add_dependencies (AvrogencppTestReservedWords cpp_reserved_words_hh)
+add_dependencies (AvrogencppTestReservedWords cpp_reserved_words_hh
+    cpp_reserved_words_union_typedef_hh)
 
 add_dependencies (AvrogencppTests bigrecord_hh bigrecord_r_hh bigrecord2_hh
     tweet_hh


### PR DESCRIPTION
Here is the build log on FreeBSD.
```
[ 95% 96/101] cd /wrkdirs/usr/ports/devel/avro-cpp/work/.build && /wrkdirs/usr/ports/devel/avro-cpp/work/.build/avrogencpp -p - -i /wrkdirs/usr/ports/devel/avro-cpp/work/avro-cpp-1.12.0/jsonschemas/cpp_reserved_words -o cpp_reserved_words.hh -n cppres
[ 96% 97/101] /usr/local/libexec/ccache/c++ -DAVRO_VERSION=\"1.12.0\" -DFMT_HEADER_ONLY=1 -I/wrkdirs/usr/ports/devel/avro-cpp/work/avro-cpp-1.12.0/include/avro -I/wrkdirs/usr/ports/devel/avro-cpp/work/.build -I/wrkdirs/usr/ports/devel/avro-cpp/work/avro-cpp-1.12.0/include -isystem /usr/local/include -O2 -pipe  -fstack-protector-strong -fno-strict-aliasing   -std=c++17 -O2 -pipe  -fstack-protector-strong -fno-strict-aliasing   -std=c++17  -DNDEBUG -std=gnu++17 -MD -MT CMakeFiles/AvrogencppTestReservedWords.dir/test/AvrogencppTestReservedWords.cc.o -MF CMakeFiles/AvrogencppTestReservedWords.dir/test/AvrogencppTestReservedWords.cc.o.d -o CMakeFiles/AvrogencppTestReservedWords.dir/test/AvrogencppTestReservedWords.cc.o -c /wrkdirs/usr/ports/devel/avro-cpp/work/avro-cpp-1.12.0/test/AvrogencppTestReservedWords.cc
FAILED: CMakeFiles/AvrogencppTestReservedWords.dir/test/AvrogencppTestReservedWords.cc.o
/usr/local/libexec/ccache/c++ -DAVRO_VERSION=\"1.12.0\" -DFMT_HEADER_ONLY=1 -I/wrkdirs/usr/ports/devel/avro-cpp/work/avro-cpp-1.12.0/include/avro -I/wrkdirs/usr/ports/devel/avro-cpp/work/.build -I/wrkdirs/usr/ports/devel/avro-cpp/work/avro-cpp-1.12.0/include -isystem /usr/local/include -O2 -pipe  -fstack-protector-strong -fno-strict-aliasing   -std=c++17 -O2 -pipe  -fstack-protector-strong -fno-strict-aliasing   -std=c++17  -DNDEBUG -std=gnu++17 -MD -MT CMakeFiles/AvrogencppTestReservedWords.dir/test/AvrogencppTestReservedWords.cc.o -MF CMakeFiles/AvrogencppTestReservedWords.dir/test/AvrogencppTestReservedWords.cc.o.d -o CMakeFiles/AvrogencppTestReservedWords.dir/test/AvrogencppTestReservedWords.cc.o -c /wrkdirs/usr/ports/devel/avro-cpp/work/avro-cpp-1.12.0/test/AvrogencppTestReservedWords.cc
/wrkdirs/usr/ports/devel/avro-cpp/work/avro-cpp-1.12.0/test/AvrogencppTestReservedWords.cc:19:10: fatal error: 'cpp_reserved_words_union_typedef.hh' file not found
   19 | #include "cpp_reserved_words_union_typedef.hh"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
ninja: build stopped: subcommand failed.
```

<!--

*Thank you very much for contributing to Apache Avro - we are happy that you want to help us improve Avro. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Avro a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/AVRO/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "AVRO-XXXX: [component] Title of the pull request", where *AVRO-XXXX* should be replaced by the actual issue number. 
    The *component* is optional, but can help identify the correct reviewers faster: either the language ("java", "python") or subsystem such as "build" or "doc" are good candidates.  

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests. You can [build the entire project](https://github.com/apache/avro/blob/main/BUILD.md) or just the [language-specific SDK](https://avro.apache.org/project/how-to-contribute/#unit-tests).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Every commit message references Jira issues in their subject lines. In addition, commits follow the guidelines from [How to write a good git commit message](https://chris.beams.io/posts/git-commit/)
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

-->

## What is the purpose of the change

*(For example: This pull request improves file read performance by buffering data, fixing AVRO-XXXX.)*


## Verifying this change

*(Please pick one of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
- *Extended interop tests to verify consistent valid schema names between SDKs*
- *Added test that validates that Java throws an AvroRuntimeException on invalid binary data*
- *Manually verified the change by building the website and checking the new redirect*


## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
