### PR TITLE
AVRO-4031: [Rust]  builder header

### DIFF
--- a/lang/rust/avro/src/writer.rs
+++ b/lang/rust/avro/src/writer.rs
@@ -49,7 +49,7 @@ pub struct Writer<'a, W> {
     num_values: usize,
     #[builder(default = generate_sync_marker())]
     marker: [u8; 16],
-    #[builder(default = false, setter(skip))]
+    #[builder(default = false)]
     has_header: bool,
     #[builder(default)]
     user_metadata: HashMap<String, Value>,
@@ -114,8 +114,8 @@ impl<'a, W: Write> Writer<'a, W> {
             .writer(writer)
             .codec(codec)
             .marker(marker)
+            .has_header(true)
             .build();
-        w.has_header = true;
         w.resolved_schema = ResolvedSchema::try_from(schema).ok();
         w
     }
@@ -134,8 +134,8 @@ impl<'a, W: Write> Writer<'a, W> {
             .writer(writer)
             .codec(codec)
             .marker(marker)
+            .has_header(true)
             .build();
-        w.has_header = true;
         w.resolved_schema = ResolvedSchema::try_from(schemata).ok();
         w
     }

--- a/lang/rust/avro/tests/append_to_existing.rs
+++ b/lang/rust/avro/tests/append_to_existing.rs
@@ -22,19 +22,17 @@ use apache_avro::{
 };
 use apache_avro_test_helper::TestResult;
 
+const SCHEMA: &str = r#"{
+    "type": "record",
+    "name": "append_to_existing_file",
+    "fields": [
+        {"name": "a", "type": "int"}
+    ]
+}"#;
+
 #[test]
 fn avro_3630_append_to_an_existing_file() -> TestResult {
-    let schema_str = r#"
-            {
-                "type": "record",
-                "name": "append_to_existing_file",
-                "fields": [
-                    {"name": "a", "type": "int"}
-                ]
-            }
-        "#;
-
-    let schema = Schema::parse_str(schema_str).expect("Cannot parse the schema");
+    let schema = Schema::parse_str(SCHEMA).expect("Cannot parse the schema");
 
     let bytes = get_avro_bytes(&schema);
 
@@ -51,10 +49,34 @@ fn avro_3630_append_to_an_existing_file() -> TestResult {
     let reader = Reader::new(&*new_bytes).expect("Cannot read the new bytes");
     let mut i = 1;
     for value in reader {
-        check(value, i);
+        check(&value, i);
         i += 1
     }
 
+    Ok(())
+}
+
+#[test]
+fn append_to_file_using_multiple_writers() -> TestResult {
+    let schema = Schema::parse_str(SCHEMA).expect("Cannot parse the schema");
+
+    let mut first_writer = Writer::builder().schema(&schema).writer(Vec::new()).build();
+    first_writer.append(create_datum(&schema, -42))?;
+    let mut resulting_bytes = first_writer.into_inner()?;
+    let first_marker = read_marker(&resulting_bytes);
+
+    let mut second_writer = Writer::builder()
+        .schema(&schema)
+        .has_header(true)
+        .marker(first_marker)
+        .writer(Vec::new())
+        .build();
+    second_writer.append(create_datum(&schema, 42))?;
+    resulting_bytes.append(&mut second_writer.into_inner()?);
+
+    let values: Vec<_> = Reader::new(&resulting_bytes[..])?.collect();
+    check(&values[0], -42);
+    check(&values[1], 42);
     Ok(())
 }
 
@@ -75,7 +97,7 @@ fn create_datum(schema: &Schema, value: i32) -> Record {
 }
 
 /// Checks the read values
-fn check(value: AvroResult<Value>, expected: i32) {
+fn check(value: &AvroResult<Value>, expected: i32) {
     match value {
         Ok(value) => match value {
             Value::Record(fields) => match &fields[0] {

--- a/lang/rust/avro/tests/append_to_existing.rs
+++ b/lang/rust/avro/tests/append_to_existing.rs
@@ -57,7 +57,7 @@ fn avro_3630_append_to_an_existing_file() -> TestResult {
 }
 
 #[test]
-fn append_to_file_using_multiple_writers() -> TestResult {
+fn avro_4031_append_to_file_using_multiple_writers() -> TestResult {
     let schema = Schema::parse_str(SCHEMA).expect("Cannot parse the schema");
 
     let mut first_writer = Writer::builder().schema(&schema).writer(Vec::new()).build();


### PR DESCRIPTION
<!--

*Thank you very much for contributing to Apache Avro - we are happy that you want to help us improve Avro. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Avro a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/AVRO/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "AVRO-XXXX: [component] Title of the pull request", where *AVRO-XXXX* should be replaced by the actual issue number. 
    The *component* is optional, but can help identify the correct reviewers faster: either the language ("java", "python") or subsystem such as "build" or "doc" are good candidates.  

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests. You can [build the entire project](https://github.com/apache/avro/blob/main/BUILD.md) or just the [language-specific SDK](https://avro.apache.org/project/how-to-contribute/#unit-tests).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Every commit message references Jira issues in their subject lines. In addition, commits follow the guidelines from [How to write a good git commit message](https://chris.beams.io/posts/git-commit/)
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

-->

## What is the purpose of the change

This PR allows for more flexibility when creating new avro writers with the goal of appending to an existing file. Current functions are convenient wrappers but do not allow fully configuring the parameters for the new writer when it's meant for appending to an existing file.

Some more context pertaining to my particular use case: parameters such as block size become quite important when using compression so being able to append with a new writer using the same, larger-than-default block size the first writer used can make a significant difference for compression.

## Verifying this change

Added a new test.

## Documentation

- Does this pull request introduce a new feature?
Yes, now it is possible to create Writer for appending with any other parameter available when creating the initial writer.
- If yes, how is the feature documented? 
The newly exposed field (i.e. `has_header`) is documented automatically thanks to the `TypedBuilder` macro.