### PR TITLE
AVRO-4045: Use JDK compare for byte arrays

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/generic/GenericData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/generic/GenericData.java
@@ -545,7 +545,7 @@ public class GenericData {
 
     @Override
     public int compareTo(Fixed that) {
-      return BinaryData.compareBytes(this.bytes, 0, this.bytes.length, that.bytes, 0, that.bytes.length);
+      return Arrays.compare(this.bytes, 0, this.bytes.length, that.bytes, 0, that.bytes.length);
     }
   }
 

--- a/lang/java/avro/src/main/java/org/apache/avro/io/BinaryData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/BinaryData.java
@@ -18,6 +18,7 @@
 package org.apache.avro.io;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field;
@@ -155,7 +156,8 @@ public class BinaryData {
     }
     case FIXED: {
       int size = schema.getFixedSize();
-      int c = compareBytes(d.d1.getBuf(), d.d1.getPos(), size, d.d2.getBuf(), d.d2.getPos(), size);
+      int c = Arrays.compare(d.d1.getBuf(), d.d1.getPos(), d.d1.getPos() + size, d.d2.getBuf(), d.d2.getPos(),
+          d.d2.getPos() + size);
       d.d1.skipFixed(size);
       d.d2.skipFixed(size);
       return c;
@@ -164,7 +166,8 @@ public class BinaryData {
     case BYTES: {
       int l1 = d1.readInt();
       int l2 = d2.readInt();
-      int c = compareBytes(d.d1.getBuf(), d.d1.getPos(), l1, d.d2.getBuf(), d.d2.getPos(), l2);
+      int c = Arrays.compare(d.d1.getBuf(), d.d1.getPos(), d.d1.getPos() + l1, d.d2.getBuf(), d.d2.getPos(),
+          d.d2.getPos() + l2);
       d.d1.skipFixed(l1);
       d.d2.skipFixed(l2);
       return c;
@@ -181,16 +184,7 @@ public class BinaryData {
    * return a positive value, if less than return a negative value.
    */
   public static int compareBytes(byte[] b1, int s1, int l1, byte[] b2, int s2, int l2) {
-    int end1 = s1 + l1;
-    int end2 = s2 + l2;
-    for (int i = s1, j = s2; i < end1 && j < end2; i++, j++) {
-      int a = (b1[i] & 0xff);
-      int b = (b2[j] & 0xff);
-      if (a != b) {
-        return a - b;
-      }
-    }
-    return l1 - l2;
+    return Arrays.compare(b1, s1, s1 + l1, b2, s2, s2 + l2);
   }
 
   private static class HashData {
@@ -298,7 +292,7 @@ public class BinaryData {
   /**
    * Encode a boolean to the byte array at the given position. Will throw
    * IndexOutOfBounds if the position is not valid.
-   * 
+   *
    * @return The number of bytes written to the buffer, 1.
    */
   public static int encodeBoolean(boolean b, byte[] buf, int pos) {
@@ -310,7 +304,7 @@ public class BinaryData {
    * Encode an integer to the byte array at the given position. Will throw
    * IndexOutOfBounds if it overflows. Users should ensure that there are at least
    * 5 bytes left in the buffer before calling this method.
-   * 
+   *
    * @return The number of bytes written to the buffer, between 1 and 5.
    */
   public static int encodeInt(int n, byte[] buf, int pos) {
@@ -341,7 +335,7 @@ public class BinaryData {
    * Encode a long to the byte array at the given position. Will throw
    * IndexOutOfBounds if it overflows. Users should ensure that there are at least
    * 10 bytes left in the buffer before calling this method.
-   * 
+   *
    * @return The number of bytes written to the buffer, between 1 and 10.
    */
   public static int encodeLong(long n, byte[] buf, int pos) {
@@ -392,7 +386,7 @@ public class BinaryData {
    * Encode a float to the byte array at the given position. Will throw
    * IndexOutOfBounds if it overflows. Users should ensure that there are at least
    * 4 bytes left in the buffer before calling this method.
-   * 
+   *
    * @return Returns the number of bytes written to the buffer, 4.
    */
   public static int encodeFloat(float f, byte[] buf, int pos) {
@@ -408,7 +402,7 @@ public class BinaryData {
    * Encode a double to the byte array at the given position. Will throw
    * IndexOutOfBounds if it overflows. Users should ensure that there are at least
    * 8 bytes left in the buffer before calling this method.
-   * 
+   *
    * @return Returns the number of bytes written to the buffer, 8.
    */
   public static int encodeDouble(double d, byte[] buf, int pos) {

--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectData.java
@@ -30,7 +30,6 @@ import org.apache.avro.generic.GenericContainer;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.generic.IndexedRecord;
-import org.apache.avro.io.BinaryData;
 import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.DatumWriter;
 import org.apache.avro.specific.FixedSize;
@@ -987,7 +986,7 @@ public class ReflectData extends SpecificData {
         break;
       byte[] b1 = (byte[]) o1;
       byte[] b2 = (byte[]) o2;
-      return BinaryData.compareBytes(b1, 0, b1.length, b2, 0, b2.length);
+      return Arrays.compare(b1, 0, b1.length, b2, 0, b2.length);
     }
     return super.compare(o1, o2, s, equals);
   }

--- a/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificFixed.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificFixed.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericFixed;
-import org.apache.avro.io.BinaryData;
 
 /** Base class for generated fixed-sized data classes. */
 public abstract class SpecificFixed implements GenericFixed, Comparable<SpecificFixed>, Externalizable {
@@ -70,7 +69,7 @@ public abstract class SpecificFixed implements GenericFixed, Comparable<Specific
 
   @Override
   public int compareTo(SpecificFixed that) {
-    return BinaryData.compareBytes(this.bytes, 0, this.bytes.length, that.bytes, 0, that.bytes.length);
+    return Arrays.compare(this.bytes, 0, this.bytes.length, that.bytes, 0, that.bytes.length);
   }
 
   @Override

--- a/lang/java/avro/src/main/java/org/apache/avro/util/Utf8.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/util/Utf8.java
@@ -25,7 +25,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import org.apache.avro.SystemLimitException;
-import org.apache.avro.io.BinaryData;
 
 /**
  * A Utf8 string. Unlike {@link String}, instances are mutable. This is more
@@ -181,7 +180,7 @@ public class Utf8 implements Comparable<Utf8>, CharSequence, Externalizable {
 
   @Override
   public int compareTo(Utf8 that) {
-    return BinaryData.compareBytes(this.bytes, 0, this.length, that.bytes, 0, that.length);
+    return Arrays.compare(this.bytes, 0, this.length, that.bytes, 0, that.length);
   }
 
   // CharSequence implementation


### PR DESCRIPTION
## What is the purpose of the change

* This pull request improves read performance by using JDK byte compare functionality, fixing AVRO-4045.

## Verifying this change

* This change is a trivial rework / code cleanup without any test coverage.

## Documentation

- Does this pull request introduce a new feature? no
