### PR TITLE
AVRO-4046: [PHP] Handling of default values

### DIFF
--- a/lang/php/lib/Datum/AvroIODatumReader.php
+++ b/lang/php/lib/Datum/AvroIODatumReader.php
@@ -358,6 +358,7 @@ class AvroIODatumReader
             }
         }
         // Fill in default values
+        $writers_fields = $writers_schema->fieldsHash();
         foreach ($readers_fields as $field_name => $field) {
             if (isset($writers_fields[$field_name])) {
                 continue;


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes the behavior that values are accidentially overwritten by default values from the reader's schema.
Detailed description: AVRO-4046


## Verifying this change

This change added tests and can be verified as follows:
- Added test that serializes some data and ensures that the data survives deserialization.


## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable


Issues: AVRO-4046