### PR TITLE
AVRO-4035 [C++] Add doc strings to generated classes

### DIFF
--- a/lang/c++/impl/avrogencpp.cc
+++ b/lang/c++/impl/avrogencpp.cc
@@ -747,7 +747,19 @@ void CodeGen::generateDocComment(const NodePtr &n, const char *indent) {
         std::vector<std::string> lines;
         boost::algorithm::split(lines, n->getDoc(), boost::algorithm::is_any_of("\n"));
         for (auto &line : lines) {
-            os_ << indent << "// " << line << "\n";
+            boost::algorithm::replace_all(line, "\r", "");
+
+            if (line.empty()) {
+                os_ << indent << "//\n";
+            } else {
+                // If a comment line ends with a backslash, avoid generating code which will generate
+                // multi-line comment warnings on GCC. We can't just append whitespace here as escaped
+                // newlines ignore trailing whitespace.
+                if (line.back() == '\\') {
+                    line.append("(backslash)");
+                }
+                os_ << indent << "// " << line << "\n";
+            }
         }
     }
 }

--- a/lang/c++/impl/avrogencpp.cc
+++ b/lang/c++/impl/avrogencpp.cc
@@ -752,10 +752,14 @@ void CodeGen::generateDocComment(const NodePtr &n, const char *indent) {
             if (line.empty()) {
                 os_ << indent << "//\n";
             } else {
-                // If a comment line ends with a backslash, avoid generating code which will generate
-                // multi-line comment warnings on GCC. We can't just append whitespace here as escaped
-                // newlines ignore trailing whitespace.
-                if (line.back() == '\\') {
+                // If a comment line ends with a backslash or backslash and whitespace,
+                // avoid generating code which will generate multi-line comment warnings
+                // on GCC. We can't just append whitespace here as escaped newlines ignore
+                // trailing whitespace.
+                auto lastBackslash = std::find(line.rbegin(), line.rend(), '\\');
+                auto lastNonWs = std::find_if(line.rbegin(), line.rend(), [](char c) { return !std::isspace(static_cast<int>(c)); });
+                // Note: lastBackslash <= lastNonWs because the iterators are reversed, "less" is later in the string.
+                if (lastBackslash != line.rend() && lastBackslash <= lastNonWs) {
                     line.append("(backslash)");
                 }
                 os_ << indent << "// " << line << "\n";

--- a/lang/c++/impl/avrogencpp.cc
+++ b/lang/c++/impl/avrogencpp.cc
@@ -113,6 +113,7 @@ class CodeGen {
     void generateTraits(const NodePtr &n);
     void generateRecordTraits(const NodePtr &n);
     void generateUnionTraits(const NodePtr &n);
+    void generateDocComment(const NodePtr &n, const char *indent = "");
     void emitCopyright();
     void emitGeneratedWarning();
 
@@ -253,6 +254,7 @@ string CodeGen::generateRecordType(const NodePtr &n) {
         return it->second;
     }
 
+    generateDocComment(n);
     os_ << "struct " << decoratedName << " {\n";
     if (!noUnion_) {
         for (size_t i = 0; i < c; ++i) {
@@ -271,6 +273,7 @@ string CodeGen::generateRecordType(const NodePtr &n) {
         // the nameAt(i) does not take c++ reserved words into account
         // so we need to call decorate on it
         std::string decoratedNameAt = decorate(n->nameAt(i));
+        generateDocComment(n->leafAt(i), "    ");
         os_ << "    " << types[i];
         os_ << ' ' << decoratedNameAt << ";\n";
     }
@@ -409,7 +412,7 @@ string CodeGen::generateUnionType(const NodePtr &n) {
     for (size_t i = 0; i < c; ++i) {
         // escape reserved literals for c++
         auto branch_name = decorate(names[i]);
-        // avoid rare collisions, e.g. somone might name their struct int_
+        // avoid rare collisions, e.g. someone might name their struct int_
         if (used_branch_names.find(branch_name) != used_branch_names.end()) {
             size_t postfix = 2;
             std::string escaped_name = branch_name + "_" + std::to_string(postfix);
@@ -736,6 +739,16 @@ void CodeGen::generateTraits(const NodePtr &n) {
         case avro::AVRO_FIXED:
         default:
             break;
+    }
+}
+
+void CodeGen::generateDocComment(const NodePtr &n, const char *indent) {
+    if (!n->getDoc().empty()) {
+        std::vector<std::string> lines;
+        boost::algorithm::split(lines, n->getDoc(), boost::algorithm::is_any_of("\n"));
+        for (auto &line : lines) {
+            os_ << indent << "// " << line << "\n";
+        }
     }
 }
 

--- a/lang/c++/jsonschemas/bigrecord
+++ b/lang/c++/jsonschemas/bigrecord
@@ -10,7 +10,7 @@
         },
         {
             "name": "nestedrecord",
-            "doc": "Doc edge cases\r\nwith trailing backslash\\",
+            "doc": "Doc edge cases\r\nwith trailing backslash\\\t \n\\\n\\ \n\\x",
             "type": {
                 "type": "record",
                 "name": "Nested",

--- a/lang/c++/jsonschemas/bigrecord
+++ b/lang/c++/jsonschemas/bigrecord
@@ -10,6 +10,7 @@
         },
         {
             "name": "nestedrecord",
+            "doc": "Doc edge cases\r\nwith trailing backslash\\",
             "type": {
                 "type": "record",
                 "name": "Nested",

--- a/lang/c++/jsonschemas/bigrecord
+++ b/lang/c++/jsonschemas/bigrecord
@@ -1,6 +1,6 @@
 {
     "type": "record",
-    "doc": "Top level Doc.",
+    "doc": "Top level Doc.\nWith multiple lines",
     "name": "RootRecord",
     "fields": [
         {


### PR DESCRIPTION
## What is the purpose of the change

As requested by AVRO-4035, this uses the `doc` field from the avro schema when generating code.

That is, this schema:

```json
{
    "type": "record",
    "doc": "Top level Doc.\nWith multiple lines",
    "name": "RootRecord",
    "fields": [
        {
            "name": "mylong",
            "doc": "mylong field doc.",
            "type": "long"
        },
```

Generates the following when run through `avrogencpp`

```c++
// Top level Doc.
// With multiple lines
struct RootRecord {
    typedef _bigrecord_Union__0__ myunion_t;
    typedef _bigrecord_Union__1__ anotherunion_t;
    // mylong field doc.
    int64_t mylong;
```

Note: I decided to use line comments (`//`) rather than block comments (`/*` or `/**`) as they make the logic for handling escapes simpler, and make it easy to properly indent the entire comment when generating comments for record fields.

## Verifying this change

This change is already covered by existing tests - avrogencpp is used to compile several schemas which include `doc` fields. The generated code is still valid, and one schema was adjusted to test the edge case with new lines.

## Documentation

- Does this pull request introduce a new feature? yes
- If yes, how is the feature documented? I have updated the Jira issue to contain the release note:

    > avrogencpp will now include the `doc` fields in schemas in the generated code for records 
