### PR TITLE
AVRO-4049: Use JDK Arrays equal to test if two UTF8 strings are equal

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/util/Utf8.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/util/Utf8.java
@@ -158,6 +158,10 @@ public class Utf8 implements Comparable<Utf8>, CharSequence, Externalizable {
     Utf8 that = (Utf8) o;
     if (!(this.length == that.length))
       return false;
+    // For longer strings, leverage vectorization (JDK 9+) to determine equality
+    // For shorter strings, the overhead of this method defeats the value
+    if (this.length > 7)
+      return Arrays.equals(this.bytes, 0, this.length, that.bytes, 0, that.length);
     byte[] thatBytes = that.bytes;
     for (int i = 0; i < this.length; i++)
       if (bytes[i] != thatBytes[i])


### PR DESCRIPTION


## What is the purpose of the change

* Improves performance of testing Strings for equality


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.