### PR TITLE
AVRO-4050: Deprecate MapUtil computeIfAbsent

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectData.java
@@ -36,7 +36,6 @@ import org.apache.avro.io.DatumWriter;
 import org.apache.avro.specific.FixedSize;
 import org.apache.avro.specific.SpecificData;
 import org.apache.avro.util.ClassUtils;
-import org.apache.avro.util.MapUtil;
 
 import java.io.IOException;
 import java.lang.annotation.Annotation;
@@ -839,7 +838,7 @@ public class ReflectData extends SpecificData {
 
   // Return of this class and its superclasses to serialize.
   private static Field[] getCachedFields(Class<?> recordClass) {
-    return MapUtil.computeIfAbsent(FIELDS_CACHE, recordClass, rc -> getFields(rc, true));
+    return FIELDS_CACHE.computeIfAbsent(recordClass, rc -> getFields(rc, true));
   }
 
   private static Field[] getFields(Class<?> recordClass, boolean excludeJava) {

--- a/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificData.java
@@ -30,7 +30,6 @@ import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.util.ClassUtils;
-import org.apache.avro.util.MapUtil;
 import org.apache.avro.util.SchemaUtil;
 import org.apache.avro.util.internal.ClassValueCache;
 
@@ -379,7 +378,7 @@ public class SpecificData extends GenericData {
       String name = schema.getFullName();
       if (name == null)
         return null;
-      Class<?> c = MapUtil.computeIfAbsent(classCache, name, n -> {
+      Class<?> c = classCache.computeIfAbsent(name, n -> {
         try {
           return ClassUtils.forName(getClassLoader(), getClassName(schema));
         } catch (ClassNotFoundException e) {

--- a/lang/java/avro/src/main/java/org/apache/avro/util/MapUtil.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/util/MapUtil.java
@@ -27,13 +27,13 @@ public class MapUtil {
   }
 
   /**
-   * A temporary workaround for Java 8 specific performance issue JDK-8161372
-   * .<br>
-   * This class should be removed once we drop Java 8 support.
+   * A temporary workaround for Java 8 specific performance issue JDK-8161372.
    *
    * @see <a href=
    *      "https://bugs.openjdk.java.net/browse/JDK-8161372">JDK-8161372</a>
+   * @deprecated As of JDK 1.9 this issue has been resolved.
    */
+  @Deprecated
   public static <K, V> V computeIfAbsent(ConcurrentMap<K, V> map, K key, Function<K, V> mappingFunction) {
     V value = map.get(key);
     if (value != null) {

--- a/lang/java/avro/src/main/java/org/apache/avro/util/MapUtil.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/util/MapUtil.java
@@ -33,6 +33,7 @@ public class MapUtil {
    *      "https://bugs.openjdk.java.net/browse/JDK-8161372">JDK-8161372</a>
    * @deprecated As of JDK 1.9 this issue has been resolved.
    */
+  // TODO: Remove for 1.13.0 or later
   @Deprecated
   public static <K, V> V computeIfAbsent(ConcurrentMap<K, V> map, K key, Function<K, V> mappingFunction) {
     V value = map.get(key);


### PR DESCRIPTION
## What is the purpose of the change

* Make overall Avro package smaller and faster

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Documentation

- Does this pull request introduce a new feature? no
