### PR TITLE
[C++] g++ (GCC) 14.2.1 20240910 fails to compile due to -Werror=conversion

### DIFF
--- a/lang/c++/impl/DataFile.cc
+++ b/lang/c++/impl/DataFile.cc
@@ -183,7 +183,7 @@ void DataFileWriterBase::sync() {
         crc.process_bytes(reinterpret_cast<const char *>(temp.data()),
                           temp.size());
         // For Snappy, add the CRC32 checksum
-        int32_t checksum = crc();
+        auto checksum = crc();
 
         // Now compress
         size_t compressed_size = snappy::Compress(
@@ -408,7 +408,7 @@ void DataFileReaderBase::readDataBlock() {
                 "Snappy Compression reported an error when decompressing");
         }
         crc.process_bytes(uncompressed.c_str(), uncompressed.size());
-        uint32_t c = crc();
+        auto c = crc();
         if (checksum != c) {
             throw Exception(
                 "Checksum did not match for Snappy compression: Expected: {}, computed: {}",

--- a/lang/c++/impl/Node.cc
+++ b/lang/c++/impl/Node.cc
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+#include <algorithm>
 #include <cmath>
 #include <unordered_set>
 

--- a/lang/c++/impl/parsing/Symbol.hh
+++ b/lang/c++/impl/parsing/Symbol.hh
@@ -19,6 +19,7 @@
 #ifndef avro_parsing_Symbol_hh__
 #define avro_parsing_Symbol_hh__
 
+#include <algorithm>
 #include <map>
 #include <set>
 #include <sstream>


### PR DESCRIPTION
Example of changed code to remove error.
`int32_t checksum = crc();`
to
`auto checksum = crc();`

`error: conversion from ‘boost::crc_optimal<32, 79764919, 4294967295, 4294967295, true, true>::value_type’ {aka ‘long unsigned int’} to ‘uint32_t’ {aka ‘unsigned int’} may change value [-Werror=conversion]`

Further errors not related to avro cmake but using a meson build port was missing <algorithm> header in some files such that std::find and std::find_if could not be found. Thought to include them in PR. 

These changes passed ./build.sh test

Thanks for the code!
Sorry for the informal request a bit busy but wanted to give back.

