### PR TITLE
[C++] AVRO-4058: Allow custom attributes in arrays

### DIFF
--- a/lang/c++/impl/Compiler.cc
+++ b/lang/c++/impl/Compiler.cc
@@ -267,7 +267,7 @@ static const std::unordered_set<std::string> &getKnownFields() {
     // return known fields
     static const std::unordered_set<std::string> kKnownFields =
         {"name", "type", "aliases", "default", "doc", "size", "logicalType",
-         "values", "precision", "scale", "namespace"};
+         "values", "precision", "scale", "namespace", "items"};
     return kKnownFields;
 }
 
@@ -424,6 +424,9 @@ static NodePtr makeArrayNode(const Entity &e, const Object &m,
     if (containsField(m, "doc")) {
         node->setDoc(getDocField(e, m));
     }
+    CustomAttributes customAttributes;
+    getCustomAttributes(m, customAttributes);
+    node->addCustomAttributesForField(customAttributes);
     return node;
 }
 

--- a/lang/c++/impl/NodeImpl.cc
+++ b/lang/c++/impl/NodeImpl.cc
@@ -554,6 +554,9 @@ void NodeArray::printJson(std::ostream &os, size_t depth) const {
     os << indent(depth + 1) << "\"items\": ";
     leafAttributes_.get()->printJson(os, depth + 1);
     os << '\n';
+    for (size_t i = 0; i != customAttributes_.size(); i++){
+        printCustomAttributes(customAttributes_.get(i), depth + 1, os);
+    }
     os << indent(depth) << '}';
 }
 

--- a/lang/c++/include/avro/NodeImpl.hh
+++ b/lang/c++/include/avro/NodeImpl.hh
@@ -234,7 +234,7 @@ using NodeImplSymbolic = NodeImpl<HasName, NoLeaves, NoLeafNames, NoAttributes, 
 
 using NodeImplRecord = NodeImpl<HasName, MultiLeaves, LeafNames, MultiAttributes, NoSize>;
 using NodeImplEnum = NodeImpl<HasName, NoLeaves, LeafNames, NoAttributes, NoSize>;
-using NodeImplArray = NodeImpl<NoName, SingleLeaf, NoLeafNames, NoAttributes, NoSize>;
+using NodeImplArray = NodeImpl<NoName, SingleLeaf, NoLeafNames, MultiAttributes, NoSize>;
 using NodeImplMap = NodeImpl<NoName, MultiLeaves, NoLeafNames, NoAttributes, NoSize>;
 using NodeImplUnion = NodeImpl<NoName, MultiLeaves, NoLeafNames, NoAttributes, NoSize>;
 using NodeImplFixed = NodeImpl<HasName, NoLeaves, NoLeafNames, NoAttributes, HasSize>;
@@ -363,7 +363,7 @@ class AVRO_DECL NodeArray : public NodeImplArray {
 public:
     NodeArray() : NodeImplArray(AVRO_ARRAY) {}
 
-    explicit NodeArray(const SingleLeaf &items) : NodeImplArray(AVRO_ARRAY, NoName(), items, NoLeafNames(), NoAttributes(), NoSize()) {}
+    explicit NodeArray(const SingleLeaf &items) : NodeImplArray(AVRO_ARRAY, NoName(), items, NoLeafNames(), {}, NoSize()) {}
 
     SchemaResolution resolve(const Node &reader) const override;
 

--- a/lang/c++/test/SchemaTests.cc
+++ b/lang/c++/test/SchemaTests.cc
@@ -143,7 +143,7 @@ const char *basicSchemas[] = {
         "extra attribute": 1
     })",
     R"({"type": "enum", "name": "Test", "symbols": ["A", "B"],"extra attribute": 1})",
-    R"({"type": "array", "items": "long", "extra attribute": 1})",
+    R"({"type": "array", "items": "long", "extra attribute": "1"})",
     R"({"type": "map", "values": "long", "extra attribute": 1})",
     R"({"type": "fixed", "name": "Test", "size": 1, "extra attribute": 1})",
 

--- a/lang/c++/test/SchemaTests.cc
+++ b/lang/c++/test/SchemaTests.cc
@@ -92,7 +92,7 @@ const char *basicSchemas[] = {
     "[{\"name\": \"f\",\"type\": \"long\"}], \"extra attribute\": 1}",
     "{\"type\": \"enum\", \"name\": \"Test\", \"symbols\": [\"A\", \"B\"],"
     "\"extra attribute\": 1}",
-    R"({"type": "array", "items": "long", "extra attribute": 1})",
+    R"({"type": "array", "items": "long", "extra attribute": "1"})",
     R"({"type": "map", "values": "long", "extra attribute": 1})",
     R"({"type": "fixed", "name": "Test", "size": 1, "extra attribute": 1})",
 
@@ -236,6 +236,7 @@ const char *roundTripSchemas[] = {
     "[{\"name\":\"f1\",\"type\":\"long\",\"extra_field\":\"1\"},"
     "{\"name\":\"f2\",\"type\":\"int\","
     "\"extra_field1\":\"21\",\"extra_field2\":\"22\"}]}",
+    R"({"type":"array","items":"long","extra":"1"})"
 };
 
 const char *malformedLogicalTypes[] = {
@@ -315,11 +316,11 @@ static void testRoundTrip(const char *schema) {
     compiledSchema.toJson(os);
     std::string result = os.str();
     result.erase(std::remove_if(result.begin(), result.end(), ::isspace), result.end()); // Remove whitespace
-    BOOST_CHECK(result == std::string(schema));
+    BOOST_CHECK_EQUAL(result, std::string(schema));
     // Verify that the compact schema from toJson has the same content as the
     // schema.
     std::string result2 = compiledSchema.toJson(false);
-    BOOST_CHECK(result2 == std::string(schema));
+    BOOST_CHECK_EQUAL(result2, std::string(schema));
 }
 
 static void testCompactSchemas() {


### PR DESCRIPTION
[AVRO-4058](https://issues.apache.org/jira/browse/AVRO-4058)

## What is the purpose of the change
Other languages (i.e. Java) allow adding custom attributes in the schema of an array while the C++ implementation does not. The sparse spec states to allow all custom attributes ("Attributes not defined in this document are permitted as metadata, but must not affect the format of serialized data") and other projects using avro (i.e. Iceberg) depend on custom attributes in arrays.

This PR allows adding custom attributes to arrays.

## Verifying this change

This change added tests and can be verified as follows:

Run SchemaTests, I added a single additional test case in testRoundTrip 


## Documentation

- Does this pull request introduce a new feature?  no
- If yes, how is the feature documented? not applicable 
