### PR TITLE
AVRO-4061: Use Default Value of 1 For UTF8 Hash

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/io/BinaryData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/BinaryData.java
@@ -257,7 +257,7 @@ public class BinaryData {
     case FIXED:
       return hashBytes(1, data, schema.getFixedSize(), false);
     case STRING:
-      return hashBytes(0, data, decoder.readInt(), false);
+      return hashBytes(1, data, decoder.readInt(), false);
     case BYTES:
       return hashBytes(1, data, decoder.readInt(), true);
     case NULL:

--- a/lang/java/avro/src/main/java/org/apache/avro/util/Utf8.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/util/Utf8.java
@@ -41,7 +41,8 @@ public class Utf8 implements Comparable<Utf8>, CharSequence, Externalizable {
   private String string;
 
   public Utf8() {
-    bytes = EMPTY;
+    this.bytes = EMPTY;
+    this.hash = 1;
   }
 
   public Utf8(String string) {
@@ -174,6 +175,7 @@ public class Utf8 implements Comparable<Utf8>, CharSequence, Externalizable {
     if (h == 0) {
       byte[] bytes = this.bytes;
       int length = this.length;
+      h = 1;
       for (int i = 0; i < length; i++) {
         h = h * 31 + bytes[i];
       }

--- a/lang/java/avro/src/test/java/org/apache/avro/util/TestUtf8.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/util/TestUtf8.java
@@ -59,43 +59,44 @@ public class TestUtf8 {
 
   @Test
   void hashCodeReused() {
-    assertEquals(97, new Utf8("a").hashCode());
-    assertEquals(3904, new Utf8("zz").hashCode());
-    assertEquals(122, new Utf8("z").hashCode());
-    assertEquals(99162322, new Utf8("hello").hashCode());
-    assertEquals(3198781, new Utf8("hell").hashCode());
+    assertEquals(1, new Utf8().hashCode());
+    assertEquals(128, new Utf8("a").hashCode());
+    assertEquals(4865, new Utf8("zz").hashCode());
+    assertEquals(153, new Utf8("z").hashCode());
+    assertEquals(127791473, new Utf8("hello").hashCode());
+    assertEquals(4122302, new Utf8("hell").hashCode());
 
     Utf8 u = new Utf8("a");
-    assertEquals(97, u.hashCode());
-    assertEquals(97, u.hashCode());
+    assertEquals(128, u.hashCode());
+    assertEquals(128, u.hashCode());
 
     u.set("a");
-    assertEquals(97, u.hashCode());
+    assertEquals(128, u.hashCode());
 
     u.setByteLength(1);
-    assertEquals(97, u.hashCode());
+    assertEquals(128, u.hashCode());
     u.setByteLength(2);
-    assertNotEquals(97, u.hashCode());
+    assertNotEquals(128, u.hashCode());
 
     u.set("zz");
-    assertEquals(3904, u.hashCode());
+    assertEquals(4865, u.hashCode());
     u.setByteLength(1);
-    assertEquals(122, u.hashCode());
+    assertEquals(153, u.hashCode());
 
     u.set("hello");
-    assertEquals(99162322, u.hashCode());
+    assertEquals(127791473, u.hashCode());
     u.setByteLength(4);
-    assertEquals(3198781, u.hashCode());
+    assertEquals(4122302, u.hashCode());
 
     u.set(new Utf8("zz"));
-    assertEquals(3904, u.hashCode());
+    assertEquals(4865, u.hashCode());
     u.setByteLength(1);
-    assertEquals(122, u.hashCode());
+    assertEquals(153, u.hashCode());
 
     u.set(new Utf8("hello"));
-    assertEquals(99162322, u.hashCode());
+    assertEquals(127791473, u.hashCode());
     u.setByteLength(4);
-    assertEquals(3198781, u.hashCode());
+    assertEquals(4122302, u.hashCode());
   }
 
   @Test


### PR DESCRIPTION
## What is the purpose of the change

* This pull request improves file read performance by using a cacheable hashcode value for empty strings , fixing AVRO-4061


## Verifying this change

This change is a trivial rework / code cleanup with small additional test coverage.

## Documentation

- Does this pull request introduce a new feature? no
