### PR TITLE
AVRO-4062: Allow leading underscores for names in idl

### DIFF
--- a/lang/java/idl/src/test/idl/input/leading_underscore.avdl
+++ b/lang/java/idl/src/test/idl/input/leading_underscore.avdl
@@ -1,0 +1,26 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+Testing leading underscore for identifiers
+*/
+protocol _LeadingUnderscore {
+  record _TestRecord {
+    string _testField;
+  }
+}

--- a/lang/java/idl/src/test/idl/output/leading_underscore.avpr
+++ b/lang/java/idl/src/test/idl/output/leading_underscore.avpr
@@ -1,0 +1,17 @@
+{
+  "protocol" : "_LeadingUnderscore",
+  "doc":"Testing leading underscore for identifiers",
+  "types" : [
+    {
+      "type" : "record",
+      "name" : "_TestRecord",
+      "fields" : [
+        {
+          "name" : "_testField",
+          "type" : "string"
+        }
+      ]
+    }
+  ],
+  "messages" : {}
+}

--- a/lang/java/idl/src/test/idl/output/simple.avpr
+++ b/lang/java/idl/src/test/idl/output/simple.avpr
@@ -80,11 +80,11 @@
       "default": null
     }, {
       "name": "numbers",
-      "type": {"type: array", "items": "int"},
+      "type": {"type": "array", "items": "int"},
       "default": []
     }, {
       "name": "dictionary",
-      "type": {"type: map", "items": "string"},
+      "type": {"type": "map", "values": "string"},
       "default": {}
     }],
     "my-property" : {

--- a/lang/java/idl/src/test/java/org/apache/avro/idl/TestIdlReader.java
+++ b/lang/java/idl/src/test/java/org/apache/avro/idl/TestIdlReader.java
@@ -23,7 +23,6 @@ import org.apache.avro.Protocol;
 import org.apache.avro.Schema;
 import org.junit.Before;
 import org.junit.Test;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -55,7 +54,7 @@ import static org.junit.Assert.fail;
  * To make it simpler to write these tests, you can run ant -Dtestcase=TestIdl
  * -Dtest.idl.mode=write, which will *replace* all expected output.
  */
-public class IdlReaderTest {
+public class TestIdlReader {
   private static final File TEST_DIR = new File(System.getProperty("test.idl.dir", "src/test/idl"));
 
   private static final File TEST_INPUT_DIR = new File(TEST_DIR, "input").getAbsoluteFile();

--- a/share/idl_grammar/org/apache/avro/idl/Idl.g4
+++ b/share/idl_grammar/org/apache/avro/idl/Idl.g4
@@ -252,6 +252,6 @@ fragment HexadecimalExponent: [pP] [+\-]? Digit+;
  * Also note that this token should *only* be used in the identifier grammar rule above.
  */
 IdentifierToken: ( '`' IdentifierPart '`' | IdentifierPart)([.-] ( '`' IdentifierPart '`' | IdentifierPart) )*;
-fragment IdentifierPart: [\p{XID_Start}] [\p{XID_Continue}]*;
+fragment IdentifierPart: [\p{XID_Start}_] [\p{XID_Continue}]*;
 // See discussion in AVRO-1022, AVRO-2659, AVRO-3115
-// fragment IdentifierPart: [A-Za-z] [A-Za-z0-9_]*
+// fragment IdentifierPart: [A-Za-z_] [A-Za-z0-9_]*


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds support for names with leading underscore in idl. Fixing AVRO-4062
The specification is pretty clear that leading underscore is allowed.

## Verifying this change

This change added tests and can be verified as follows:
- *Added java test that parses an example avdl file with leading underscores*

## Documentation

- Does this pull request introduce a new feature? no
