### PR TITLE
AVRO-4069: Remove Reader String Cache from Generic Datum Reader

### DIFF
--- a/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericDatumReader.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericDatumReader.java
@@ -23,8 +23,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import org.apache.avro.Schema;
 import org.junit.jupiter.api.Test;
@@ -34,47 +32,14 @@ public class TestGenericDatumReader {
   private static final Random r = new Random(System.currentTimeMillis());
 
   @Test
-  void readerCache() {
-    final GenericDatumReader.ReaderCache cache = new GenericDatumReader.ReaderCache(this::findStringClass);
-    List<Thread> threads = IntStream.rangeClosed(1, 200).mapToObj((int index) -> {
-      final Schema schema = TestGenericDatumReader.this.build(index);
-      final WithSchema s = new WithSchema(schema, cache);
-      return (Runnable) () -> s.test();
-    }).map(Thread::new).collect(Collectors.toList());
-    threads.forEach(Thread::start);
-    threads.forEach((Thread t) -> {
-      try {
-        t.join();
-      } catch (InterruptedException e) {
-        throw new RuntimeException(e);
-      }
-    });
-  }
-
-  @Test
   void newInstanceFromString() {
-    final GenericDatumReader.ReaderCache cache = new GenericDatumReader.ReaderCache(this::findStringClass);
+    final GenericDatumReader.ReaderCache cache = new GenericDatumReader.ReaderCache();
 
     Object object = cache.newInstanceFromString(StringBuilder.class, "Hello");
     assertEquals(StringBuilder.class, object.getClass());
     StringBuilder builder = (StringBuilder) object;
     assertEquals("Hello", builder.toString());
 
-  }
-
-  static class WithSchema {
-    private final Schema schema;
-
-    private final GenericDatumReader.ReaderCache cache;
-
-    public WithSchema(Schema schema, GenericDatumReader.ReaderCache cache) {
-      this.schema = schema;
-      this.cache = cache;
-    }
-
-    public void test() {
-      this.cache.getStringClass(schema);
-    }
   }
 
   private List<Schema> list = new ArrayList<>();


### PR DESCRIPTION
## What is the purpose of the change

* This pull request improves file read performance by removing an unnecessary caching level, fixing AVRO-4069.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
