### PR TITLE
AVRO-4071: put the recorde schema to the context after adding the fields

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/Schema.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Schema.java
@@ -1862,7 +1862,6 @@ public abstract class Schema extends JsonProperties implements Serializable {
     Name name = parseName(schema, currentNameSpace);
     String doc = parseDoc(schema);
     Schema result = new RecordSchema(name, doc, isTypeError);
-    context.put(result);
 
     JsonNode fieldsNode = schema.get("fields");
     if (fieldsNode == null || !fieldsNode.isArray())
@@ -1877,6 +1876,7 @@ public abstract class Schema extends JsonProperties implements Serializable {
             name, f.name(), getOptionalText(field, "logicalType"));
     }
     result.setFields(fields);
+    context.put(result);
     parsePropertiesAndLogicalType(schema, result, SCHEMA_RESERVED);
     parseAliases(schema, result);
     return result;


### PR DESCRIPTION
## What is the purpose of the change

*(For example: This pull request improves file read performance by buffering data, fixing AVRO-XXXX.)*
This pull request fixes the behavior when adding two records with the same name and namespace.
As described in the Jira-Issue, the existing schema and the current one weren't compared correctly so it was never possible to add two identical records.

## Verifying this change

Haven't added tests yet but can provide some to verify the change.

## Documentation

No documentation needed