### PR TITLE
chore: docs: Add more aliases for `++version++` to `current`

### DIFF
--- a/doc/content/en/docs/++version++/Getting started (Java)/_index.md
+++ b/doc/content/en/docs/++version++/Getting started (Java)/_index.md
@@ -4,6 +4,8 @@ tags: ["java"]
 title: "Getting Started (Java)"
 linkTitle: "Getting Started (Java)"
 weight: 2
+aliases:
+- /docs/current/getting-started-java/
 ---
 
 <!--

--- a/doc/content/en/docs/++version++/Getting started (Python)/_index.md
+++ b/doc/content/en/docs/++version++/Getting started (Python)/_index.md
@@ -4,6 +4,8 @@ tags: ["python"]
 title: "Getting Started (Python)"
 linkTitle: "Getting Started (Python)"
 weight: 3
+aliases:
+- /docs/current/getting-started-python/
 ---
 
 <!--

--- a/doc/content/en/docs/++version++/IDL Language/_index.md
+++ b/doc/content/en/docs/++version++/IDL Language/_index.md
@@ -2,6 +2,8 @@
 title: "IDL Language"
 linkTitle: "IDL Language"
 weight: 201
+aliases:
+- /docs/current/idl-language/
 ---
 
 <!--

--- a/doc/content/en/docs/++version++/MapReduce guide/_index.md
+++ b/doc/content/en/docs/++version++/MapReduce guide/_index.md
@@ -2,6 +2,8 @@
 title: "MapReduce guide"
 linkTitle: "MapReduce guide"
 weight: 200
+aliases:
+- /docs/current/mapreduce-guide/
 ---
 
 <!--

--- a/doc/content/en/docs/++version++/SASL profile/_index.md
+++ b/doc/content/en/docs/++version++/SASL profile/_index.md
@@ -2,6 +2,8 @@
 title: "SASL profile"
 linkTitle: "SASL profile"
 weight: 202
+aliases:
+- /docs/current/sasl-profile/
 ---
 
 <!--

--- a/doc/content/en/docs/++version++/Specification/_index.md
+++ b/doc/content/en/docs/++version++/Specification/_index.md
@@ -5,6 +5,7 @@ weight: 4
 date: 2021-10-25
 aliases:
 - spec.html
+- /docs/current/specification/
 ---
 
 <!--


### PR DESCRIPTION
Reported at https://github.com/apache/avro-rs/issues/22 
Discussed at https://github.com/apache/avro-rs/pull/20#issuecomment-2409096820

## What is the purpose of the change

* Add more aliases from `++version++` to `current` in the Hugo based docs

## Verifying this change

* `cd .../avro/doc`
* Start the website locally: `hugo server --buildDrafts --buildFuture --bind 0.0.0.0`
* in a browser navigate to http://localhost:1313/docs/current/specification/#schema-resolution

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable