### PR TITLE
AVRO-4079: Remove C# netcoreapp3.1 and 5.0 support

### DIFF
--- a/.github/workflows/codeql-csharp-analysis.yml
+++ b/.github/workflows/codeql-csharp-analysis.yml
@@ -64,8 +64,6 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
-          3.1.x
-          5.0.x
           6.0.x
           7.0.x
           8.0.x

--- a/.github/workflows/test-lang-csharp-ARM.yml
+++ b/.github/workflows/test-lang-csharp-ARM.yml
@@ -34,7 +34,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -64,7 +64,7 @@ jobs:
         run: ./build.sh test
 
   interop:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test-lang-csharp-ARM.yml
+++ b/.github/workflows/test-lang-csharp-ARM.yml
@@ -46,8 +46,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            3.1.x
-            5.0.x
             6.0.x
             7.0.x
             8.0.x
@@ -78,8 +76,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            3.1.x
-            5.0.x
             6.0.x
             7.0.x
             8.0.x
@@ -146,8 +142,6 @@ jobs:
           sudo apt-get update -q
           sudo apt-get install -q -y wget libzstd-dev
           wget https://dot.net/v1/dotnet-install.sh
-          bash ./dotnet-install.sh --channel "3.1" --install-dir "$HOME/.dotnet" # 3.1
-          bash ./dotnet-install.sh --channel "5.0" --install-dir "$HOME/.dotnet" # 5.0
           bash ./dotnet-install.sh --channel "6.0" --install-dir "$HOME/.dotnet" # 6.0
           bash ./dotnet-install.sh --channel "7.0" --install-dir "$HOME/.dotnet" # 7.0
           bash ./dotnet-install.sh --channel "8.0" --install-dir "$HOME/.dotnet" # 8.0

--- a/.github/workflows/test-lang-csharp.yml
+++ b/.github/workflows/test-lang-csharp.yml
@@ -46,8 +46,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            3.1.x
-            5.0.x
             6.0.x
             7.0.x
             8.0.x
@@ -78,8 +76,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            3.1.x
-            5.0.x
             6.0.x
             7.0.x
             8.0.x

--- a/.github/workflows/test-lang-csharp.yml
+++ b/.github/workflows/test-lang-csharp.yml
@@ -34,7 +34,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -64,7 +64,7 @@ jobs:
         run: ./build.sh test
 
   interop:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test-lang-java.yml
+++ b/.github/workflows/test-lang-java.yml
@@ -129,8 +129,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            3.1.x
-            5.0.x
             6.0.x
             7.0.x
             8.0.x

--- a/lang/csharp/README.md
+++ b/lang/csharp/README.md
@@ -17,20 +17,20 @@ Install-Package Apache.Avro
 
 ## Project Target Frameworks
 
-| Project             | Published to nuget.org     | Type       | .NET Standard 2.0  | .NET Standard 2.1 | .NET Core 3.1 | .NET 5.0  | .NET 6.0  | .NET 7.0  | .NET 8.0  |
-|:-------------------:|:--------------------------:|:----------:|:------------------:|:-----------------:|:-------------:|:---------:|:---------:|:---------:|:---------:|
-| Avro.main           | Apache.Avro                | Library    | ✔️                 | ✔️               |               |           |           |           |           |
-| Avro.File.Snappy    | Apache.Avro.File.Snappy    | Library    | ✔️                 | ✔️               |               |           |           |           |           |
-| Avro.File.BZip2     | Apache.Avro.File.BZip2     | Library    | ✔️                 | ✔️               |               |           |           |           |           |
-| Avro.File.XZ        | Apache.Avro.File.XZ        | Library    | ✔️                 | ✔️               |               |           |           |           |           |
-| Avro.File.Zstandard | Apache.Avro.File.Zstandard | Library    | ✔️                 | ✔️               |               |           |           |           |           |
-| Avro.codegen        | Apache.Avro.Tools          |  Exe        |                    |                   | ✔️            |✔️        |✔️        |✔️        |✔️        |
-| Avro.ipc            |                            | Library    | ✔️                 | ✔️               |               |           |           |           |           |
-| Avro.ipc.test       |                            | Unit Tests |                    |                   | ✔️            |✔️        |✔️        |✔️        |✔️        |
-| Avro.msbuild        |                            | Library    | ✔️                 | ✔️               |               |           |           |           |           |
-| Avro.perf           |                            | Exe        |                    |                   | ✔️            |✔️        |✔️        |✔️        |✔️        |
-| Avro.test           |                            | Unit Tests |                    |                   | ✔️            |✔️        |✔️        |✔️        |✔️        |
-| Avro.benchmark      |                            | Exe        |                    |                   | ✔️            |✔️        |✔️        |✔️        |✔️        |
+| Project             | Published to nuget.org     | Type       | .NET Standard 2.0  | .NET Standard 2.1 | .NET 6.0  | .NET 7.0  | .NET 8.0  |
+|:-------------------:|:--------------------------:|:----------:|:------------------:|:-----------------:|:---------:|:---------:|:---------:|
+| Avro.main           | Apache.Avro                | Library    | ✔️                 | ✔️               |           |           |           |
+| Avro.File.Snappy    | Apache.Avro.File.Snappy    | Library    | ✔️                 | ✔️               |           |           |           |
+| Avro.File.BZip2     | Apache.Avro.File.BZip2     | Library    | ✔️                 | ✔️               |           |           |           |
+| Avro.File.XZ        | Apache.Avro.File.XZ        | Library    | ✔️                 | ✔️               |           |           |           |
+| Avro.File.Zstandard | Apache.Avro.File.Zstandard | Library    | ✔️                 | ✔️               |           |           |           |
+| Avro.codegen        | Apache.Avro.Tools          |  Exe        |                    |                   |✔️        |✔️        |✔️        |
+| Avro.ipc            |                            | Library    | ✔️                 | ✔️               |           |           |           |
+| Avro.ipc.test       |                            | Unit Tests |                    |                   |✔️        |✔️        |✔️        |
+| Avro.msbuild        |                            | Library    | ✔️                 | ✔️               |           |           |           |
+| Avro.perf           |                            | Exe        |                    |                   |✔️        |✔️        |✔️        |
+| Avro.test           |                            | Unit Tests |                    |                   |✔️        |✔️        |✔️        |
+| Avro.benchmark      |                            | Exe        |                    |                   |✔️        |✔️        |✔️        |
 
 ## Dependency package version strategy
 

--- a/lang/csharp/common.props
+++ b/lang/csharp/common.props
@@ -37,7 +37,7 @@
 
   <PropertyGroup Label="Target Frameworks">
     <!-- Exe -->
-    <DefaultExeTargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</DefaultExeTargetFrameworks>
+    <DefaultExeTargetFrameworks>net6.0;net7.0;net8.0</DefaultExeTargetFrameworks>
     <!-- Library -->
     <DefaultLibraryTargetFrameworks>netstandard2.0;netstandard2.1</DefaultLibraryTargetFrameworks>
     <!-- Unit Tests -->

--- a/lang/csharp/src/apache/benchmark/Program.cs
+++ b/lang/csharp/src/apache/benchmark/Program.cs
@@ -22,7 +22,7 @@ namespace Avro.Benchmark
     public class Program
     {
         // dotnet run -c Release -f net8.0
-        // dotnet run -c Release -f net8.0 --runtimes netcoreapp3.1 net5.0 net6.0 net7.0 net8.0
+        // dotnet run -c Release -f net8.0 --runtimes net6.0 net7.0 net8.0
         public static void Main(string[] args)
         {
             BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -227,8 +227,6 @@ ENV PATH $PATH:/root/.cargo/bin/
 # Install .NET SDK
 RUN cd /opt ; \
     wget https://dot.net/v1/dotnet-install.sh ; \
-    bash ./dotnet-install.sh --channel "3.1" --install-dir "/opt/dotnet" ; \
-    bash ./dotnet-install.sh --channel "5.0" --install-dir "/opt/dotnet" ; \
     bash ./dotnet-install.sh --channel "6.0" --install-dir "/opt/dotnet" ; \
     bash ./dotnet-install.sh --channel "7.0" --install-dir "/opt/dotnet" ; \
     bash ./dotnet-install.sh --channel "8.0" --install-dir "/opt/dotnet" ;


### PR DESCRIPTION
## What is the purpose of the change

*AVRO-4079*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)
