### PR TITLE
AVRO-4078: [Java] Add the test classes as test case

### DIFF
--- a/lang/java/avro/src/test/java/org/apache/avro/FullName.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/FullName.java
@@ -1,0 +1,64 @@
+package org.apache.avro;
+
+import org.apache.avro.AvroRuntimeException;
+import org.apache.avro.Schema;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.specific.AvroGenerated;
+import org.apache.avro.specific.SpecificDatumReader;
+import org.apache.avro.specific.SpecificDatumWriter;
+import org.apache.avro.specific.SpecificRecord;
+import org.apache.avro.specific.SpecificRecordBase;
+
+@AvroGenerated
+public class FullName extends SpecificRecordBase implements SpecificRecord {
+  private static final long serialVersionUID = 4560514203639509981L;
+  public static final Schema SCHEMA$ = (new Schema.Parser()).parse(
+      "{\"type\":\"record\",\"name\":\"FullName\",\"namespace\":\"com.example\",\"fields\":[{\"name\":\"first\",\"type\":{\"type\":\"string\",\"avro.java.string\":\"String\"}},{\"name\":\"last\",\"type\":{\"type\":\"string\",\"avro.java.string\":\"String\"}}]}");
+  private String first;
+  private String last;
+  private static final DatumWriter WRITER$;
+  private static final DatumReader READER$;
+
+  public FullName() {
+  }
+
+  public FullName(String first, String last) {
+    this.first = first;
+    this.last = last;
+  }
+
+  public Schema getSchema() {
+    return SCHEMA$;
+  }
+
+  public Object get(int field$) {
+    switch (field$) {
+    case 0:
+      return this.first;
+    case 1:
+      return this.last;
+    default:
+      throw new AvroRuntimeException("Bad index");
+    }
+  }
+
+  public void put(int field$, Object value$) {
+    switch (field$) {
+    case 0:
+      this.first = (String) value$;
+      break;
+    case 1:
+      this.last = (String) value$;
+      break;
+    default:
+      throw new AvroRuntimeException("Bad index");
+    }
+
+  }
+
+  static {
+    WRITER$ = new SpecificDatumWriter(SCHEMA$);
+    READER$ = new SpecificDatumReader(SCHEMA$);
+  }
+}

--- a/lang/java/avro/src/test/java/org/apache/avro/TestAvro4078.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestAvro4078.java
@@ -1,0 +1,21 @@
+package org.apache.avro;
+
+import org.apache.avro.specific.SpecificData;
+import org.junit.Test;
+
+/**
+ * Unit test for demonstrating specific data potential issue.
+ */
+public class TestAvro4078 {
+
+  public static final Schema FULLNAME_SCHEMA = (new Schema.Parser()).parse("{\n" + "     \"type\": \"record\",\n"
+      + "     \"namespace\": \"org.apache.avro\",\n" + "     \"name\": \"FullName\",\n" + "     \"fields\": [\n"
+      + "       { \"name\": \"first\", \"type\": \"string\" },\n"
+      + "       { \"name\": \"last\", \"type\": \"string\" }\n" + "     ]\n" + "}");
+
+  @Test
+  public void testClassLoad() {
+    System.err.println(FULLNAME_SCHEMA);
+    System.err.println(SpecificData.get().getClass(FULLNAME_SCHEMA));
+  }
+}


### PR DESCRIPTION
**DO NOT MERGE**


## What is the purpose of the change

* Add the test classes from the reproducer at https://github.com/pacificmist0900/avro

The reproducer fails against Avro 1.11.4 but passes against 1.12.0.

The test case passes against 1.11.5-SNAPSHOT and 1.13.0-SNAPSHOT.

## Verifying this change

*(Please pick one of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
- *Extended interop tests to verify consistent valid schema names between SDKs*
- *Added test that validates that Java throws an AvroRuntimeException on invalid binary data*
- *Manually verified the change by building the website and checking the new redirect*


## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
