### PR TITLE
AVRO 4091: [C#] Allow previously parsed schemas to be referenced when parsing a schema

### DIFF
--- a/lang/csharp/src/apache/main/Schema/Schema.cs
+++ b/lang/csharp/src/apache/main/Schema/Schema.cs
@@ -228,7 +228,7 @@ namespace Avro
         public static Schema Parse(string json)
         {
             if (string.IsNullOrEmpty(json)) throw new ArgumentNullException(nameof(json), "json cannot be null.");
-            return Parse(json.Trim(), new SchemaNames(), null); // standalone schema, so no enclosing namespace
+            return ParseInternal(json.Trim(), new SchemaNames(), null); // standalone schema, so no enclosing namespace
         }
 
         /// <summary>
@@ -239,6 +239,19 @@ namespace Avro
         /// <param name="encspace">enclosing namespace of the schema</param>
         /// <returns>new Schema object</returns>
         public static Schema Parse(string json, SchemaNames names, string encspace = null)
+        {
+            if (string.IsNullOrEmpty(json)) throw new ArgumentNullException(nameof(json), "json cannot be null.");
+            return ParseInternal(json.Trim(), names, encspace); // standalone schema, so no enclosing namespace
+        }
+
+        /// <summary>
+        /// Parses a JSON string to create a new schema object
+        /// </summary>
+        /// <param name="json">JSON string</param>
+        /// <param name="names">list of named schemas already read</param>
+        /// <param name="encspace">enclosing namespace of the schema</param>
+        /// <returns>new Schema object</returns>
+        internal static Schema ParseInternal(string json, SchemaNames names, string encspace)
         {
             Schema sc = PrimitiveSchema.NewInstance(json);
             if (null != sc) return sc;

--- a/lang/csharp/src/apache/main/Schema/Schema.cs
+++ b/lang/csharp/src/apache/main/Schema/Schema.cs
@@ -238,7 +238,7 @@ namespace Avro
         /// <param name="names">list of named schemas already read</param>
         /// <param name="encspace">enclosing namespace of the schema</param>
         /// <returns>new Schema object</returns>
-        internal static Schema Parse(string json, SchemaNames names, string encspace)
+        public static Schema Parse(string json, SchemaNames names, string encspace = null)
         {
             Schema sc = PrimitiveSchema.NewInstance(json);
             if (null != sc) return sc;

--- a/lang/csharp/src/apache/test/Schema/SchemaTests.cs
+++ b/lang/csharp/src/apache/test/Schema/SchemaTests.cs
@@ -413,7 +413,7 @@ namespace Avro.Test
         {
             string nestedSchema = "{\"name\":\"NestedRecord\",\"type\":\"record\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\"}]}";
             // The root schema references the nested schema above by name only.
-            // This mimics tools that
+            // This mimics tools that allow schemas to have references to other schemas.
             string rootSchema = "{\"name\":\"RootRecord\",\"type\":\"record\",\"fields\":[{\"name\": \"nestedField\",\"type\":\"NestedRecord\"}]}";
 
             NamedSchema nestedRecord = (NamedSchema) Schema.Parse(nestedSchema);

--- a/lang/csharp/src/apache/test/Schema/SchemaTests.cs
+++ b/lang/csharp/src/apache/test/Schema/SchemaTests.cs
@@ -408,6 +408,25 @@ namespace Avro.Test
             Assert.AreEqual(schema, recordSchema.ToString());
         }
 
+        [TestCase]
+        public void TestRecordWithNamedReference()
+        {
+            string nestedSchema = "{\"name\":\"NestedRecord\",\"type\":\"record\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\"}]}";
+            // The root schema references the nested schema above by name only.
+            // This mimics tools that
+            string rootSchema = "{\"name\":\"RootRecord\",\"type\":\"record\",\"fields\":[{\"name\": \"nestedField\",\"type\":\"NestedRecord\"}]}";
+
+            NamedSchema nestedRecord = (NamedSchema) Schema.Parse(nestedSchema);
+
+            SchemaNames names = new SchemaNames();
+            names.Add(nestedRecord.SchemaName, nestedRecord);
+
+            // Pass the schema names when parsing the root schema and its reference.
+            RecordSchema rootRecord = (RecordSchema) Schema.Parse(rootSchema, names);
+            Assert.AreEqual("RootRecord", rootRecord.Name);
+            Assert.AreEqual("NestedRecord", rootRecord.Fields[0].Schema.Name);
+        }
+
         [TestCase("{\"type\":\"enum\",\"name\":\"Test\",\"symbols\":[\"A\",\"B\"]}",
                 new string[] { "A", "B" })]
 


### PR DESCRIPTION
<!--

*Thank you very much for contributing to Apache Avro - we are happy that you want to help us improve Avro. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Avro a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/AVRO/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "AVRO-XXXX: [component] Title of the pull request", where *AVRO-XXXX* should be replaced by the actual issue number. 
    The *component* is optional, but can help identify the correct reviewers faster: either the language ("java", "python") or subsystem such as "build" or "doc" are good candidates.  

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests. You can [build the entire project](https://github.com/apache/avro/blob/main/BUILD.md) or just the [language-specific SDK](https://avro.apache.org/project/how-to-contribute/#unit-tests).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Every commit message references Jira issues in their subject lines. In addition, commits follow the guidelines from [How to write a good git commit message](https://chris.beams.io/posts/git-commit/)
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

-->

## What is the purpose of the change

Currently the C# Avro library does not have a way to parse a new schema that refers to named schemas that have been previously parsed.

The equivalent in the Java Avro library is to construct an instance of `Schema.Parser` and to use the same parser instance to parse the referenced schemas before the referring schema.

The change that is needed is to simply modify the following method in `Schema.cs` from internal to public:
```
internal static Schema Parse(string json, SchemaNames names, string encspace)
```

Without this change, tools that allow Avro schemas to reference one another, such as the [Confluent Schema Registry](https://github.com/confluentinc/schema-registry), cannot interoperate well with C# applications.


## Verifying this change



This change is a trivial rework / code cleanup without any test coverage.



## Documentation

- Does this pull request introduce a new feature? (no)

