### PR TITLE
AVRO-4096: [C++] Replace boost::optional with std::optional

### DIFF
--- a/lang/c++/impl/CustomAttributes.cc
+++ b/lang/c++/impl/CustomAttributes.cc
@@ -23,8 +23,8 @@
 
 namespace avro {
 
-boost::optional<std::string> CustomAttributes::getAttribute(const std::string &name) const {
-    boost::optional<std::string> result;
+std::optional<std::string> CustomAttributes::getAttribute(const std::string &name) const {
+    std::optional<std::string> result;
     std::map<std::string, std::string>::const_iterator iter =
         attributes_.find(name);
     if (iter == attributes_.end()) {

--- a/lang/c++/include/avro/CustomAttributes.hh
+++ b/lang/c++/include/avro/CustomAttributes.hh
@@ -20,9 +20,9 @@
 #define avro_CustomAttributes_hh__
 
 #include "Config.hh"
-#include <boost/optional.hpp>
 #include <iostream>
 #include <map>
+#include <optional>
 #include <string>
 
 namespace avro {
@@ -34,7 +34,7 @@ class AVRO_DECL CustomAttributes {
 public:
     // Retrieves the custom attribute json entity for that attributeName, returns an
     // null if the attribute doesn't exist.
-    boost::optional<std::string> getAttribute(const std::string &name) const;
+    std::optional<std::string> getAttribute(const std::string &name) const;
 
     // Adds a custom attribute. If the attribute already exists, throw an exception.
     void addAttribute(const std::string &name, const std::string &value);

--- a/lang/c++/test/unittest.cc
+++ b/lang/c++/test/unittest.cc
@@ -494,7 +494,7 @@ struct TestSchema {
         cf.addAttribute("field1", std::string("1"));
 
         BOOST_CHECK_EQUAL(std::string("1"), *cf.getAttribute("field1"));
-        BOOST_CHECK_EQUAL(false, cf.getAttribute("not_existing").is_initialized());
+        BOOST_CHECK_EQUAL(false, cf.getAttribute("not_existing").has_value());
     }
 
     void test() {


### PR DESCRIPTION
## What is the purpose of the change

This is part of an effort to remove boost dependency as much as possible and replace it with standard library.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable
