### PR TITLE
AVRO-4076: [java] Parse Fields before adding to the context.

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/Protocol.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Protocol.java
@@ -402,9 +402,12 @@ public class Protocol extends JsonProperties {
     if (!(o instanceof Protocol))
       return false;
     Protocol that = (Protocol) o;
+
+    List<Schema> resolvedSchemas = this.context.resolveAllSchemas();
+    List<Schema> thatResolvedSchemas = that.context.resolveAllSchemas();
     return Objects.equals(this.name, that.name) && Objects.equals(this.namespace, that.namespace)
-        && Objects.equals(this.context.resolveAllSchemas(), that.context.resolveAllSchemas())
-        && Objects.equals(this.messages, that.messages) && this.propsEqual(that);
+        && Objects.equals(this.messages, that.messages) && this.propsEqual(that)
+        && resolvedSchemas.size() == thatResolvedSchemas.size() && resolvedSchemas.containsAll(thatResolvedSchemas);
   }
 
   @Override

--- a/lang/java/avro/src/main/java/org/apache/avro/Schema.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Schema.java
@@ -1862,7 +1862,6 @@ public abstract class Schema extends JsonProperties implements Serializable {
     Name name = parseName(schema, currentNameSpace);
     String doc = parseDoc(schema);
     Schema result = new RecordSchema(name, doc, isTypeError);
-    context.put(result);
 
     JsonNode fieldsNode = schema.get("fields");
     if (fieldsNode == null || !fieldsNode.isArray())
@@ -1877,6 +1876,7 @@ public abstract class Schema extends JsonProperties implements Serializable {
             name, f.name(), getOptionalText(field, "logicalType"));
     }
     result.setFields(fields);
+    context.put(result);
     parsePropertiesAndLogicalType(schema, result, SCHEMA_RESERVED);
     parseAliases(schema, result);
     return result;

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchema.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchema.java
@@ -599,25 +599,30 @@ public class TestSchema {
     File f1 = new File(directory.getPath(), "ApplicationEvent.avsc");
     File f2 = new File(directory.getPath(), "DocumentInfo.avsc");
     File f3 = new File(directory.getPath(), "MyResponse.avsc");
+    File f4 = new File(directory.getPath(), "EmbeddedRecord.avsc");
     Assertions.assertTrue(f1.exists(), "File not exist for test " + f1.getPath());
     Assertions.assertTrue(f2.exists(), "File not exist for test " + f2.getPath());
     Assertions.assertTrue(f3.exists(), "File not exist for test " + f3.getPath());
+    Assertions.assertTrue(f4.exists(), "File not exist for test " + f4.getPath());
     SchemaParser parser = new SchemaParser();
     parser.parse(f1);
     parser.parse(f2);
     parser.parse(f3);
+    parser.parse(f4);
     final List<Schema> schemas = parser.getParsedNamedSchemas();
-    Assertions.assertEquals(3, schemas.size());
-    Schema schemaAppEvent = schemas.get(0);
-    Schema schemaDocInfo = schemas.get(1);
-    Schema schemaResponse = schemas.get(2);
+    Assertions.assertEquals(4, schemas.size());
+    Schema eventHeaderEvent = schemas.get(0);
+    Schema schemaAppEvent = schemas.get(1);
+    Schema schemaDocInfo = schemas.get(2);
+    Schema schemaResponse = schemas.get(3);
     Assertions.assertNotNull(schemaAppEvent);
-    Assertions.assertEquals(3, schemaAppEvent.getFields().size());
+    Assertions.assertEquals(4, schemaAppEvent.getFields().size());
     Field documents = schemaAppEvent.getField("documents");
     Schema docSchema = documents.schema().getTypes().get(1).getElementType();
     Assertions.assertEquals(docSchema, schemaDocInfo);
     Assertions.assertNotNull(schemaDocInfo);
     Assertions.assertNotNull(schemaResponse);
+    Assertions.assertNotNull(eventHeaderEvent);
   }
 
   @Test

--- a/lang/java/avro/src/test/resources/multipleFile/ApplicationEvent.avsc
+++ b/lang/java/avro/src/test/resources/multipleFile/ApplicationEvent.avsc
@@ -5,6 +5,20 @@
   "name": "ApplicationEvent",
   "fields": [
     {
+      "name": "embedded_record",
+      "type": {
+        "type": "record",
+        "name": "EmbeddedRecord",
+        "namespace": "model",
+        "fields": [
+          {
+            "name": "type",
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {
       "name": "applicationId",
       "type": "string",
       "doc": "Application ID"

--- a/lang/java/avro/src/test/resources/multipleFile/EmbeddedRecord.avsc
+++ b/lang/java/avro/src/test/resources/multipleFile/EmbeddedRecord.avsc
@@ -1,0 +1,11 @@
+{
+  "namespace": "model",
+  "type" : "record",
+  "name" : "EmbeddedRecord",
+  "fields" : [
+    {
+      "name" : "type",
+      "type" : "string"
+    }
+  ]
+}


### PR DESCRIPTION
<!--

*Thank you very much for contributing to Apache Avro - we are happy that you want to help us improve Avro. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Avro a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/AVRO/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "AVRO-XXXX: [component] Title of the pull request", where *AVRO-XXXX* should be replaced by the actual issue number. 
    The *component* is optional, but can help identify the correct reviewers faster: either the language ("java", "python") or subsystem such as "build" or "doc" are good candidates.  

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests. You can [build the entire project](https://github.com/apache/avro/blob/main/BUILD.md) or just the [language-specific SDK](https://avro.apache.org/project/how-to-contribute/#unit-tests).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Every commit message references Jira issues in their subject lines. In addition, commits follow the guidelines from [How to write a good git commit message](https://chris.beams.io/posts/git-commit/)
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

-->

## What is the purpose of the change

This pull request fixes the issue identified by [AVRO-4076](https://issues.apache.org/jira/browse/AVRO-4076).

This is potentially not the best way to do this but I think it at least demonstrates what I think the issue is. 
In Schema, we [put the result](https://github.com/apache/avro/blob/main/lang/java/avro/src/main/java/org/apache/avro/Schema.java#L1865) into the context, ([ultimately leading to the throw](https://github.com/apache/avro/blob/main/lang/java/avro/src/main/java/org/apache/avro/ParseContext.java#L218)). But we haven't [loaded the fields at that point](https://github.com/apache/avro/blob/main/lang/java/avro/src/main/java/org/apache/avro/Schema.java#L1871-L1879), causing the equality check to fail even if the schemas do match.

Unfortunately I had to change the equals in `Protocol.java` in order to get the tests to pass. The order of schemas returned by `ParseContext.resolveAllSchemas` has slightly changed. I'm not sure that the order matters, but if I change ParseContext.resolveAllSchemas to return an unordered collection I get failures in TestIdlReader.runTests.

## Verifying this change

This change added tests and can be verified as follows:

- `TestSchema::testParseMultipleFile` has been updated to include the redefined Schema scenario.


## Documentation

- Does this pull request introduce a new feature? - no
- If yes, how is the feature documented? not applicable
