### PR TITLE
AVRO-4097: Replace boost::any with std::any; boost::tuple with std::tuple

### DIFF
--- a/lang/c++/impl/json/JsonDom.cc
+++ b/lang/c++/impl/json/JsonDom.cc
@@ -145,12 +145,12 @@ void Entity::ensureType(EntityType type) const {
 
 String Entity::stringValue() const {
     ensureType(EntityType::String);
-    return JsonParser::toStringValue(**boost::any_cast<std::shared_ptr<String>>(&value_));
+    return JsonParser::toStringValue(**std::any_cast<std::shared_ptr<String>>(&value_));
 }
 
 String Entity::bytesValue() const {
     ensureType(EntityType::String);
-    return JsonParser::toBytesValue(**boost::any_cast<std::shared_ptr<String>>(&value_));
+    return JsonParser::toBytesValue(**std::any_cast<std::shared_ptr<String>>(&value_));
 }
 
 std::string Entity::toString() const {

--- a/lang/c++/impl/json/JsonDom.hh
+++ b/lang/c++/impl/json/JsonDom.hh
@@ -19,6 +19,7 @@
 #ifndef avro_json_JsonDom_hh__
 #define avro_json_JsonDom_hh__
 
+#include <any>
 #include <cstdint>
 #include <iostream>
 #include <map>
@@ -27,7 +28,6 @@
 #include <vector>
 
 #include "Config.hh"
-#include "boost/any.hpp"
 
 namespace avro {
 
@@ -67,7 +67,7 @@ inline std::ostream &operator<<(std::ostream &os, EntityType et) {
 
 class AVRO_DECL Entity {
     EntityType type_;
-    boost::any value_;
+    std::any value_;
     size_t line_; // can't be const else noncopyable...
 
     void ensureType(EntityType) const;
@@ -99,17 +99,17 @@ public:
 
     Bool boolValue() const {
         ensureType(EntityType::Bool);
-        return boost::any_cast<Bool>(value_);
+        return std::any_cast<Bool>(value_);
     }
 
     Long longValue() const {
         ensureType(EntityType::Long);
-        return boost::any_cast<Long>(value_);
+        return std::any_cast<Long>(value_);
     }
 
     Double doubleValue() const {
         ensureType(EntityType::Double);
-        return boost::any_cast<Double>(value_);
+        return std::any_cast<Double>(value_);
     }
 
     String stringValue() const;
@@ -118,12 +118,12 @@ public:
 
     const Array &arrayValue() const {
         ensureType(EntityType::Arr);
-        return **boost::any_cast<std::shared_ptr<Array>>(&value_);
+        return **std::any_cast<std::shared_ptr<Array>>(&value_);
     }
 
     const Object &objectValue() const {
         ensureType(EntityType::Obj);
-        return **boost::any_cast<std::shared_ptr<Object>>(&value_);
+        return **std::any_cast<std::shared_ptr<Object>>(&value_);
     }
 
     std::string toString() const;

--- a/lang/c++/impl/parsing/Symbol.hh
+++ b/lang/c++/impl/parsing/Symbol.hh
@@ -25,10 +25,9 @@
 #include <set>
 #include <sstream>
 #include <stack>
+#include <tuple>
 #include <utility>
 #include <vector>
-
-#include <boost/tuple/tuple.hpp>
 
 #include "Decoder.hh"
 #include "Exception.hh"
@@ -39,10 +38,10 @@ namespace parsing {
 
 class Symbol;
 
-typedef std::vector<Symbol> Production;
-typedef std::shared_ptr<Production> ProductionPtr;
-typedef boost::tuple<std::stack<ssize_t>, bool, ProductionPtr, ProductionPtr> RepeaterInfo;
-typedef boost::tuple<ProductionPtr, ProductionPtr> RootInfo;
+using Production = std::vector<Symbol>;
+using ProductionPtr = std::shared_ptr<Production>;
+using RepeaterInfo = std::tuple<std::stack<ssize_t>, bool, ProductionPtr, ProductionPtr>;
+using RootInfo = std::tuple<ProductionPtr, ProductionPtr>;
 
 class Symbol {
 public:
@@ -340,8 +339,8 @@ void fixup(Symbol &s, const std::map<T, ProductionPtr> &m,
         } break;
         case Symbol::Kind::Repeater: {
             const RepeaterInfo &ri = *s.extrap<RepeaterInfo>();
-            fixup_internal(boost::tuples::get<2>(ri), m, seen);
-            fixup_internal(boost::tuples::get<3>(ri), m, seen);
+            fixup_internal(std::get<2>(ri), m, seen);
+            fixup_internal(std::get<3>(ri), m, seen);
         } break;
         case Symbol::Kind::Placeholder: {
             typename std::map<T, std::shared_ptr<Production>>::const_iterator it =
@@ -419,7 +418,7 @@ public:
             } else {
                 switch (s.kind()) {
                     case Symbol::Kind::Root:
-                        append(boost::tuples::get<0>(*s.extrap<RootInfo>()));
+                        append(std::get<0>(*s.extrap<RootInfo>()));
                         continue;
                     case Symbol::Kind::Indirect: {
                         ProductionPtr pp =
@@ -437,7 +436,7 @@ public:
                         continue;
                     case Symbol::Kind::Repeater: {
                         auto *p = s.extrap<RepeaterInfo>();
-                        std::stack<ssize_t> &ns = boost::tuples::get<0>(*p);
+                        std::stack<ssize_t> &ns = std::get<0>(*p);
                         if (ns.empty()) {
                             throw Exception(
                                 "Empty item count stack in repeater advance");
@@ -447,7 +446,7 @@ public:
                                 "Zero item count in repeater advance");
                         }
                         --ns.top();
-                        append(boost::tuples::get<2>(*p));
+                        append(std::get<2>(*p));
                     }
                         continue;
                     case Symbol::Kind::Error:
@@ -527,7 +526,7 @@ public:
                     }
                     Symbol &t2 = parsingStack.top();
                     auto *p = t2.extrap<RepeaterInfo>();
-                    boost::tuples::get<0>(*p).push(n);
+                    std::get<0>(*p).push(n);
                     continue;
                 }
                 case Symbol::Kind::ArrayEnd:
@@ -542,7 +541,7 @@ public:
                     }
                     Symbol &t2 = parsingStack.top();
                     auto *p2 = t2.extrap<RepeaterInfo>();
-                    boost::tuples::get<0>(*p2).push(n);
+                    std::get<0>(*p2).push(n);
                     continue;
                 }
                 case Symbol::Kind::MapEnd:
@@ -564,19 +563,19 @@ public:
                 }
                 case Symbol::Kind::Repeater: {
                     auto *p = t.extrap<RepeaterInfo>();
-                    std::stack<ssize_t> &ns = boost::tuples::get<0>(*p);
+                    std::stack<ssize_t> &ns = std::get<0>(*p);
                     if (ns.empty()) {
                         throw Exception(
                             "Empty item count stack in repeater skip");
                     }
                     ssize_t &n = ns.top();
                     if (n == 0) {
-                        n = boost::tuples::get<1>(*p) ? d.arrayNext()
-                                                      : d.mapNext();
+                        n = std::get<1>(*p) ? d.arrayNext()
+                                            : d.mapNext();
                     }
                     if (n != 0) {
                         --n;
-                        append(boost::tuples::get<3>(*p));
+                        append(std::get<3>(*p));
                         continue;
                     } else {
                         ns.pop();
@@ -680,7 +679,7 @@ public:
         Symbol &s = parsingStack.top();
         assertMatch(Symbol::Kind::Repeater, s.kind());
         auto *p = s.extrap<RepeaterInfo>();
-        std::stack<ssize_t> &nn = boost::tuples::get<0>(*p);
+        std::stack<ssize_t> &nn = std::get<0>(*p);
         nn.push(n);
     }
 
@@ -689,7 +688,7 @@ public:
         Symbol &s = parsingStack.top();
         assertMatch(Symbol::Kind::Repeater, s.kind());
         auto *p = s.extrap<RepeaterInfo>();
-        std::stack<ssize_t> &nn = boost::tuples::get<0>(*p);
+        std::stack<ssize_t> &nn = std::get<0>(*p);
         if (nn.empty() || nn.top() != 0) {
             throw Exception("Wrong number of items");
         }
@@ -701,7 +700,7 @@ public:
         Symbol &s = parsingStack.top();
         assertMatch(Symbol::Kind::Repeater, s.kind());
         auto *p = s.extrap<RepeaterInfo>();
-        std::stack<ssize_t> &ns = boost::tuples::get<0>(*p);
+        std::stack<ssize_t> &ns = std::get<0>(*p);
         if (ns.empty()) {
             throw Exception("Incorrect number of items (empty)");
         }
@@ -770,7 +769,7 @@ public:
             parsingStack.pop();
         }
         Symbol &s = parsingStack.top();
-        append(boost::tuples::get<0>(*s.extrap<RootInfo>()));
+        append(std::get<0>(*s.extrap<RootInfo>()));
     }
 };
 
@@ -790,8 +789,8 @@ inline std::ostream &operator<<(std::ostream &os, const Symbol &s) {
         case Symbol::Kind::Repeater: {
             const RepeaterInfo &ri = *s.extrap<RepeaterInfo>();
             os << '(' << Symbol::toString(s.kind())
-               << ' ' << *boost::tuples::get<2>(ri)
-               << ' ' << *boost::tuples::get<3>(ri)
+               << ' ' << *std::get<2>(ri)
+               << ' ' << *std::get<3>(ri)
                << ')';
         } break;
         case Symbol::Kind::Indirect: {

--- a/lang/c++/impl/parsing/Symbol.hh
+++ b/lang/c++/impl/parsing/Symbol.hh
@@ -20,6 +20,7 @@
 #define avro_parsing_Symbol_hh__
 
 #include <algorithm>
+#include <any>
 #include <map>
 #include <set>
 #include <sstream>
@@ -27,7 +28,6 @@
 #include <utility>
 #include <vector>
 
-#include <boost/any.hpp>
 #include <boost/tuple/tuple.hpp>
 
 #include "Decoder.hh"
@@ -92,7 +92,7 @@ public:
 
 private:
     Kind kind_;
-    boost::any extra_;
+    std::any extra_;
 
     explicit Symbol(Kind k) : kind_(k) {}
     template<typename T>
@@ -105,17 +105,17 @@ public:
 
     template<typename T>
     T extra() const {
-        return boost::any_cast<T>(extra_);
+        return std::any_cast<T>(extra_);
     }
 
     template<typename T>
     T *extrap() {
-        return boost::any_cast<T>(&extra_);
+        return std::any_cast<T>(&extra_);
     }
 
     template<typename T>
     const T *extrap() const {
-        return boost::any_cast<T>(&extra_);
+        return std::any_cast<T>(&extra_);
     }
 
     template<typename T>


### PR DESCRIPTION
## What is the purpose of the change

This pull request reduces the usage of boost by replacing `boost::any` and `boost::tuple` with `std::any` and `std::tuple` respectively, fixing AVRO-4097

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Documentation

- Does this pull request introduce a new feature? **no**
- If yes, how is the feature documented? **not applicable**
