### PR TITLE
Fix compilation under linux for int32_t 

### DIFF
--- a/lang/c++/include/avro/LogicalType.hh
+++ b/lang/c++/include/avro/LogicalType.hh
@@ -22,6 +22,7 @@
 #include <iostream>
 
 #include "Config.hh"
+#include <cstdint>
 
 namespace avro {
 


### PR DESCRIPTION
Fix compilation under linux && gcc

/mnt/d/vcpkg/vcpkg/buildtrees/avro-cpp/src/ase-1.12.0-9c954b550d.clean/lang/c++/include/avro/LogicalType.hh:51:5: error: 'int32_t' does not name a type
   51 |     int32_t precision() const { return precision_; }
      |     ^~~~~~~
/mnt/d/vcpkg/vcpkg/buildtrees/avro-cpp/src/ase-1.12.0-9c954b550d.clean/lang/c++/include/avro/LogicalType.hh:25:1: note: 'int32_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
   24 | #include "Config.hh"
  +++ |+#include <cstdint>
   25 | 
/mnt/d/vcpkg/vcpkg/buildtrees/avro-cpp/src/ase-1.12.0-9c954b550d.clean/lang/c++/include/avro/LogicalType.hh:52:19: error: 'int32_t' has not been declared
   52 |     void setScale(int32_t scale);
