### PR TITLE
AVRO-4100: [C++] Remove boost::noncopyable and boost::any

### DIFF
--- a/lang/c++/examples/imaginary.hh
+++ b/lang/c++/examples/imaginary.hh
@@ -22,7 +22,6 @@
 #include "avro/Decoder.hh"
 #include "avro/Encoder.hh"
 #include "avro/Specific.hh"
-#include "boost/any.hpp"
 
 namespace i {
 struct cpx {

--- a/lang/c++/impl/Resolver.cc
+++ b/lang/c++/impl/Resolver.cc
@@ -445,7 +445,7 @@ protected:
     size_t offset_;
 };
 
-class ResolverFactory : private boost::noncopyable {
+class ResolverFactory {
 
     template<typename T>
     unique_ptr<Resolver>
@@ -512,6 +512,10 @@ class ResolverFactory : private boost::noncopyable {
     }
 
 public:
+    ResolverFactory() = default;
+    ResolverFactory(const ResolverFactory &) = delete;
+    ResolverFactory &operator=(const ResolverFactory &) = delete;
+
     unique_ptr<Resolver>
     construct(const NodePtr &writer, const NodePtr &reader, const Layout &offset) {
 

--- a/lang/c++/impl/json/JsonIO.hh
+++ b/lang/c++/impl/json/JsonIO.hh
@@ -37,7 +37,7 @@ inline char toHex(unsigned int n) {
     return static_cast<char>((n < 10) ? (n + '0') : (n + 'a' - 10));
 }
 
-class AVRO_DECL JsonParser : boost::noncopyable {
+class AVRO_DECL JsonParser {
 public:
     enum class Token {
         Null,
@@ -88,6 +88,9 @@ private:
 public:
     JsonParser() : curState(stValue), hasNext(false), nextChar(0), peeked(false),
                    curToken(Token::Null), bv(false), lv(0), dv(0), line_(1) {}
+
+    JsonParser(const JsonParser &) = delete;
+    JsonParser &operator=(const JsonParser &) = delete;
 
     void init(InputStream &is) {
         // Clear by swapping with an empty stack

--- a/lang/c++/impl/parsing/ValidatingCodec.cc
+++ b/lang/c++/impl/parsing/ValidatingCodec.cc
@@ -19,7 +19,6 @@
 #include "ValidatingCodec.hh"
 
 #include <algorithm>
-#include <boost/any.hpp>
 #include <map>
 #include <memory>
 #include <utility>

--- a/lang/c++/include/avro/DataFile.hh
+++ b/lang/c++/include/avro/DataFile.hh
@@ -58,7 +58,7 @@ typedef std::array<uint8_t, SyncSize> DataFileSync;
  *  At any given point in time, at most one file can be written using
  *  this object.
  */
-class AVRO_DECL DataFileWriterBase : boost::noncopyable {
+class AVRO_DECL DataFileWriterBase {
     const std::string filename_;
     const ValidSchema schema_;
     const EncoderPtr encoderPtr_;
@@ -122,6 +122,9 @@ public:
     DataFileWriterBase(std::unique_ptr<OutputStream> outputStream,
                        const ValidSchema &schema, size_t syncInterval, Codec codec);
 
+    DataFileWriterBase(const DataFileWriterBase &) = delete;
+    DataFileWriterBase &operator=(const DataFileWriterBase &) = delete;
+
     ~DataFileWriterBase();
     /**
      * Closes the current file. Once closed this datafile object cannot be
@@ -144,7 +147,7 @@ public:
  *  An Avro datafile that can store objects of type T.
  */
 template<typename T>
-class DataFileWriter : boost::noncopyable {
+class DataFileWriter {
     std::unique_ptr<DataFileWriterBase> base_;
 
 public:
@@ -156,6 +159,9 @@ public:
 
     DataFileWriter(std::unique_ptr<OutputStream> outputStream, const ValidSchema &schema,
                    size_t syncInterval = 16 * 1024, Codec codec = NULL_CODEC) : base_(new DataFileWriterBase(std::move(outputStream), schema, syncInterval, codec)) {}
+
+    DataFileWriter(const DataFileWriter &) = delete;
+    DataFileWriter &operator=(const DataFileWriter &) = delete;
 
     /**
      * Writes the given piece of data into the file.
@@ -191,7 +197,7 @@ public:
 /**
  * The type independent portion of reader.
  */
-class AVRO_DECL DataFileReaderBase : boost::noncopyable {
+class AVRO_DECL DataFileReaderBase {
     const std::string filename_;
     const std::unique_ptr<InputStream> stream_;
     const DecoderPtr decoder_;
@@ -244,6 +250,9 @@ public:
     explicit DataFileReaderBase(const char *filename);
 
     explicit DataFileReaderBase(std::unique_ptr<InputStream> inputStream);
+
+    DataFileReaderBase(const DataFileReaderBase &) = delete;
+    DataFileReaderBase &operator=(const DataFileReaderBase &) = delete;
 
     /**
      * Initializes the reader so that the reader and writer schemas
@@ -303,7 +312,7 @@ public:
  * Reads the contents of data file one after another.
  */
 template<typename T>
-class DataFileReader : boost::noncopyable {
+class DataFileReader {
     std::unique_ptr<DataFileReaderBase> base_;
 
 public:
@@ -357,6 +366,9 @@ public:
                    const ValidSchema &readerSchema) : base_(std::move(base)) {
         base_->init(readerSchema);
     }
+
+    DataFileReader(const DataFileReader &) = delete;
+    DataFileReader &operator=(const DataFileReader &) = delete;
 
     /**
      * Reads the next entry from the data file.

--- a/lang/c++/include/avro/Generic.hh
+++ b/lang/c++/include/avro/Generic.hh
@@ -31,7 +31,7 @@ namespace avro {
 /**
  * A utility class to read generic datum from decoders.
  */
-class AVRO_DECL GenericReader : boost::noncopyable {
+class AVRO_DECL GenericReader {
     const ValidSchema schema_;
     const bool isResolving_;
     const DecoderPtr decoder_;
@@ -51,6 +51,9 @@ public:
      */
     GenericReader(const ValidSchema &writerSchema,
                   const ValidSchema &readerSchema, const DecoderPtr &decoder);
+
+    GenericReader(const GenericReader &) = delete;
+    GenericReader &operator=(const GenericReader &) = delete;
 
     /**
      * Reads a value off the decoder.
@@ -79,7 +82,7 @@ public:
 /**
  * A utility class to write generic datum to encoders.
  */
-class AVRO_DECL GenericWriter : boost::noncopyable {
+class AVRO_DECL GenericWriter {
     const ValidSchema schema_;
     const EncoderPtr encoder_;
 
@@ -90,6 +93,9 @@ public:
      * Constructs a writer for the given schema using the given encoder.
      */
     GenericWriter(ValidSchema s, EncoderPtr encoder);
+
+    GenericWriter(const GenericWriter &) = delete;
+    GenericWriter &operator=(const GenericWriter &) = delete;
 
     /**
      * Writes a value onto the encoder.

--- a/lang/c++/include/avro/Layout.hh
+++ b/lang/c++/include/avro/Layout.hh
@@ -20,16 +20,20 @@
 #define avro_Layout_hh__
 
 #include "Config.hh"
-#include <boost/noncopyable.hpp>
+
+#include <cstddef>
 
 /// \file Layout.hh
 ///
 
 namespace avro {
 
-class AVRO_DECL Layout : private boost::noncopyable {
+class AVRO_DECL Layout {
 protected:
     explicit Layout(size_t offset = 0) : offset_(offset) {}
+
+    Layout(const Layout &) = delete;
+    Layout &operator=(const Layout &) = delete;
 
 public:
     size_t offset() const {

--- a/lang/c++/include/avro/Layout.hh
+++ b/lang/c++/include/avro/Layout.hh
@@ -21,7 +21,7 @@
 
 #include "Config.hh"
 
-#include <cstddef>
+#include <stddef.h>
 
 /// \file Layout.hh
 ///

--- a/lang/c++/include/avro/Node.hh
+++ b/lang/c++/include/avro/Node.hh
@@ -21,7 +21,6 @@
 
 #include "Config.hh"
 
-#include <boost/noncopyable.hpp>
 #include <cassert>
 #include <memory>
 #include <utility>
@@ -97,11 +96,14 @@ inline std::ostream &operator<<(std::ostream &os, const Name &n) {
 /// different node types.
 ///
 
-class AVRO_DECL Node : private boost::noncopyable {
+class AVRO_DECL Node {
 public:
     explicit Node(Type type) : type_(type),
                                logicalType_(LogicalType::NONE),
                                locked_(false) {}
+
+    Node(const Node &) = delete;
+    Node &operator=(const Node &) = delete;
 
     virtual ~Node();
 

--- a/lang/c++/include/avro/Parser.hh
+++ b/lang/c++/include/avro/Parser.hh
@@ -32,7 +32,7 @@ namespace avro {
 ///
 
 template<class Reader>
-class Parser : private boost::noncopyable {
+class Parser {
 
 public:
     // Constructor only works with Writer
@@ -40,6 +40,9 @@ public:
 
     /// Constructor only works with ValidatingWriter
     Parser(const ValidSchema &schema, const InputBuffer &in) : reader_(schema, in) {}
+
+    Parser(const Parser &) = delete;
+    Parser &operator=(const Parser &) = delete;
 
     void readNull() {
         Null null;

--- a/lang/c++/include/avro/Reader.hh
+++ b/lang/c++/include/avro/Reader.hh
@@ -20,7 +20,6 @@
 #define avro_Reader_hh__
 
 #include <array>
-#include <boost/noncopyable.hpp>
 #include <cstdint>
 #include <vector>
 
@@ -38,13 +37,16 @@ namespace avro {
 ///
 
 template<class ValidatorType>
-class ReaderImpl : private boost::noncopyable {
+class ReaderImpl {
 
 public:
     explicit ReaderImpl(const InputBuffer &buffer) : reader_(buffer) {}
 
     ReaderImpl(const ValidSchema &schema, const InputBuffer &buffer) : validator_(schema),
                                                                        reader_(buffer) {}
+
+    ReaderImpl(const ReaderImpl &) = delete;
+    ReaderImpl &operator=(const ReaderImpl &) = delete;
 
     void readValue(Null &) {
         validator_.checkTypeExpected(AVRO_NULL);

--- a/lang/c++/include/avro/Resolver.hh
+++ b/lang/c++/include/avro/Resolver.hh
@@ -19,7 +19,6 @@
 #ifndef avro_Resolver_hh__
 #define avro_Resolver_hh__
 
-#include <boost/noncopyable.hpp>
 #include <cstdint>
 #include <memory>
 
@@ -34,8 +33,12 @@ namespace avro {
 class ValidSchema;
 class Layout;
 
-class AVRO_DECL Resolver : private boost::noncopyable {
+class AVRO_DECL Resolver {
 public:
+    Resolver() = default;
+    Resolver(const Resolver &) = delete;
+    Resolver &operator=(const Resolver &) = delete;
+
     virtual void parse(Reader &reader, uint8_t *address) const = 0;
     virtual ~Resolver() = default;
 };

--- a/lang/c++/include/avro/ResolverSchema.hh
+++ b/lang/c++/include/avro/ResolverSchema.hh
@@ -19,7 +19,6 @@
 #ifndef avro_ResolverSchema_hh__
 #define avro_ResolverSchema_hh__
 
-#include <boost/noncopyable.hpp>
 #include <cstdint>
 #include <memory>
 

--- a/lang/c++/include/avro/ResolvingReader.hh
+++ b/lang/c++/include/avro/ResolvingReader.hh
@@ -19,7 +19,6 @@
 #ifndef avro_ResolvingReader_hh__
 #define avro_ResolvingReader_hh__
 
-#include <boost/noncopyable.hpp>
 #include <stdint.h>
 
 #include "Config.hh"
@@ -28,11 +27,13 @@
 
 namespace avro {
 
-class AVRO_DECL ResolvingReader : private boost::noncopyable {
+class AVRO_DECL ResolvingReader {
 
 public:
     ResolvingReader(const ResolverSchema &schema, const InputBuffer &in) : reader_(in),
                                                                            schema_(schema) {}
+    ResolvingReader(const ResolvingReader &) = delete;
+    ResolvingReader &operator=(const ResolvingReader &) = delete;
 
     template<typename T>
     void parse(T &object) {

--- a/lang/c++/include/avro/Serializer.hh
+++ b/lang/c++/include/avro/Serializer.hh
@@ -20,7 +20,6 @@
 #define avro_Serializer_hh__
 
 #include <array>
-#include <boost/noncopyable.hpp>
 
 #include "Config.hh"
 #include "Writer.hh"
@@ -31,7 +30,7 @@ namespace avro {
 /// explicit write* names instead of writeValue
 
 template<class Writer>
-class Serializer : private boost::noncopyable {
+class Serializer {
 
 public:
     /// Constructor only works with Writer
@@ -39,6 +38,9 @@ public:
 
     /// Constructor only works with ValidatingWriter
     explicit Serializer(const ValidSchema &schema) : writer_(schema) {}
+
+    Serializer(const Serializer &) = delete;
+    Serializer &operator=(const Serializer &) = delete;
 
     void writeNull() {
         writer_.writeValue(Null());

--- a/lang/c++/include/avro/Stream.hh
+++ b/lang/c++/include/avro/Stream.hh
@@ -34,12 +34,15 @@ namespace avro {
 /**
  * A no-copy input stream.
  */
-class AVRO_DECL InputStream : boost::noncopyable {
+class AVRO_DECL InputStream {
 protected:
     /**
      * An empty constructor.
      */
     InputStream() = default;
+
+    InputStream(const InputStream &) = delete;
+    InputStream &operator=(const InputStream &) = delete;
 
 public:
     /**
@@ -106,12 +109,15 @@ typedef std::unique_ptr<SeekableInputStream> SeekableInputStreamPtr;
 /**
  * A no-copy output stream.
  */
-class AVRO_DECL OutputStream : boost::noncopyable {
+class AVRO_DECL OutputStream {
 protected:
     /**
      * An empty constructor.
      */
     OutputStream() = default;
+
+    OutputStream(const OutputStream &) = delete;
+    OutputStream &operator=(const OutputStream &) = delete;
 
 public:
     /**

--- a/lang/c++/include/avro/Validator.hh
+++ b/lang/c++/include/avro/Validator.hh
@@ -19,7 +19,6 @@
 #ifndef avro_Validating_hh__
 #define avro_Validating_hh__
 
-#include <boost/noncopyable.hpp>
 #include <cstdint>
 #include <utility>
 #include <vector>
@@ -30,10 +29,13 @@
 
 namespace avro {
 
-class AVRO_DECL NullValidator : private boost::noncopyable {
+class AVRO_DECL NullValidator {
 public:
     explicit NullValidator(const ValidSchema &) {}
     NullValidator() = default;
+
+    NullValidator(const NullValidator &) = delete;
+    NullValidator &operator=(const NullValidator &) = delete;
 
     void setCount(size_t) {}
 
@@ -67,9 +69,12 @@ public:
 /// through all leaf nodes but a union only skips to one), and reports which
 /// type is next.
 
-class AVRO_DECL Validator : private boost::noncopyable {
+class AVRO_DECL Validator {
 public:
     explicit Validator(ValidSchema schema);
+
+    Validator(const Validator &) = delete;
+    Validator &operator=(const Validator &) = delete;
 
     void setCount(size_t val);
 

--- a/lang/c++/include/avro/Writer.hh
+++ b/lang/c++/include/avro/Writer.hh
@@ -20,7 +20,6 @@
 #define avro_Writer_hh__
 
 #include <array>
-#include <boost/noncopyable.hpp>
 
 #include "Config.hh"
 #include "Types.hh"
@@ -33,12 +32,15 @@ namespace avro {
 /// Class for writing avro data to a stream.
 
 template<class ValidatorType>
-class WriterImpl : private boost::noncopyable {
+class WriterImpl {
 
 public:
     WriterImpl() = default;
 
     explicit WriterImpl(const ValidSchema &schema) : validator_(schema) {}
+
+    WriterImpl(const WriterImpl &) = delete;
+    WriterImpl &operator=(const WriterImpl &) = delete;
 
     void writeValue(const Null &) {
         validator_.checkTypeExpected(AVRO_NULL);

--- a/lang/c++/include/avro/buffer/BufferReader.hh
+++ b/lang/c++/include/avro/buffer/BufferReader.hh
@@ -40,7 +40,7 @@ namespace avro {
  * chunk boundaries.  May read from an InputBuffer or OutputBuffer.
  *
  **/
-class AVRO_DECL BufferReader : private boost::noncopyable {
+class AVRO_DECL BufferReader {
 
 public:
     typedef detail::data_type data_type;
@@ -82,6 +82,9 @@ public:
                                                      bytes_(bufferImpl_->size()),
                                                      bytesRemaining_(bytes_),
                                                      chunkPos_(0) {}
+
+    BufferReader(const BufferReader &) = delete;
+    BufferReader &operator=(const BufferReader &) = delete;
 
     /**
      * How many bytes are still not read from this buffer.

--- a/lang/c++/include/avro/buffer/detail/BufferDetail.hh
+++ b/lang/c++/include/avro/buffer/detail/BufferDetail.hh
@@ -191,7 +191,7 @@ inline bool operator!=(const Chunk &lhs, const Chunk &rhs) {
  *
  */
 
-class BufferImpl : boost::noncopyable {
+class BufferImpl {
 
     /// Add a new chunk to the list of chunks for this buffer, growing the
     /// buffer by the default block size.


### PR DESCRIPTION
## What is the purpose of the change

Remove boost::noncopyable and boost::any

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Documentation

- Does this pull request introduce a new feature? no
