### PR TITLE
AVRO-4101: [C++] Remove boost::{blank,function,shared_ptr,static_assert,utility}

### DIFF
--- a/lang/c++/impl/json/JsonIO.hh
+++ b/lang/c++/impl/json/JsonIO.hh
@@ -21,7 +21,6 @@
 
 #include <boost/lexical_cast.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
-#include <boost/utility.hpp>
 #include <locale>
 #include <sstream>
 #include <stack>

--- a/lang/c++/include/avro/DataFile.hh
+++ b/lang/c++/include/avro/DataFile.hh
@@ -26,12 +26,11 @@
 #include "ValidSchema.hh"
 #include "buffer/Buffer.hh"
 
+#include <array>
 #include <map>
 #include <string>
 #include <vector>
 
-#include "array"
-#include "boost/utility.hpp"
 #include <boost/iostreams/filtering_stream.hpp>
 
 namespace avro {

--- a/lang/c++/include/avro/Generic.hh
+++ b/lang/c++/include/avro/Generic.hh
@@ -19,8 +19,6 @@
 #ifndef avro_Generic_hh__
 #define avro_Generic_hh__
 
-#include <boost/utility.hpp>
-
 #include "Config.hh"
 #include "Decoder.hh"
 #include "Encoder.hh"

--- a/lang/c++/include/avro/Specific.hh
+++ b/lang/c++/include/avro/Specific.hh
@@ -48,7 +48,8 @@
  */
 namespace avro {
 
-typedef boost::blank null;
+struct null {
+};
 
 template<typename T>
 void encode(Encoder &e, const T &t);

--- a/lang/c++/include/avro/Stream.hh
+++ b/lang/c++/include/avro/Stream.hh
@@ -24,8 +24,6 @@
 #include <memory>
 #include <vector>
 
-#include "boost/utility.hpp"
-
 #include "Config.hh"
 #include "Exception.hh"
 

--- a/lang/c++/include/avro/buffer/detail/BufferDetail.hh
+++ b/lang/c++/include/avro/buffer/detail/BufferDetail.hh
@@ -19,18 +19,14 @@
 #ifndef avro_BufferDetail_hh__
 #define avro_BufferDetail_hh__
 
-#include <boost/function.hpp>
 #include <boost/shared_array.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/static_assert.hpp>
-#include <boost/utility.hpp>
-#include <utility>
 #ifdef HAVE_BOOST_ASIO
 #include <boost/asio/buffer.hpp>
 #endif
 #include <cassert>
 #include <deque>
 #include <exception>
+#include <utility>
 
 /**
  * \file BufferDetail.hh
@@ -55,7 +51,7 @@ const size_type kMinBlockSize = 4096;
 const size_type kMaxBlockSize = 16384;
 const size_type kDefaultBlockSize = kMinBlockSize;
 
-typedef boost::function<void(void)> free_func;
+typedef std::function<void(void)> free_func;
 
 /**
  * Simple class to hold a functor that executes on delete
@@ -108,7 +104,7 @@ public:
 
 private:
     // reference counted object will call a functor when it's destroyed
-    boost::shared_ptr<CallOnDestroy> callOnDestroy_;
+    std::shared_ptr<CallOnDestroy> callOnDestroy_;
 
 public:
     /// Remove readable bytes from the front of the chunk by advancing the
@@ -274,8 +270,8 @@ class BufferImpl {
 
 public:
     typedef std::deque<Chunk> ChunkList;
-    typedef boost::shared_ptr<BufferImpl> SharedPtr;
-    typedef boost::shared_ptr<const BufferImpl> ConstSharedPtr;
+    typedef std::shared_ptr<BufferImpl> SharedPtr;
+    typedef std::shared_ptr<const BufferImpl> ConstSharedPtr;
 
     /// Default constructor, creates a buffer without any chunks
     BufferImpl() : freeSpace_(0),
@@ -343,7 +339,7 @@ public:
     /// and will compile-time assert.
     template<typename T>
     void writeTo(T /*val*/, const std::false_type &) {
-        BOOST_STATIC_ASSERT(sizeof(T) == 0);
+        static_assert(sizeof(T) == 0);
     }
 
     /// Write a block of data to the buffer, adding new chunks if necessary.


### PR DESCRIPTION
## What is the purpose of the change

Remove a set of boost includes.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Documentation

- Does this pull request introduce a new feature? no
