### PR TITLE
AVRO-4105: [C++] Remove boost::lexical_cast and boost::math

### DIFF
--- a/lang/c++/impl/avrogencpp.cc
+++ b/lang/c++/impl/avrogencpp.cc
@@ -27,7 +27,6 @@
 #include <set>
 
 #include <boost/algorithm/string.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/program_options.hpp>
 
 #include <boost/random/mersenne_twister.hpp>
@@ -46,8 +45,6 @@ using std::ostream;
 using std::set;
 using std::string;
 using std::vector;
-
-using boost::lexical_cast;
 
 using avro::compileJsonSchema;
 using avro::ValidSchema;
@@ -195,7 +192,7 @@ string CodeGen::cppTypeOf(const NodePtr &n) {
         case avro::AVRO_MAP:
             return "std::map<std::string, " + cppTypeOf(n->leafAt(1)) + " >";
         case avro::AVRO_FIXED:
-            return "std::array<uint8_t, " + lexical_cast<string>(n->fixedSize()) + ">";
+            return "std::array<uint8_t, " + std::to_string(n->fixedSize()) + ">";
         case avro::AVRO_SYMBOLIC:
             return cppTypeOf(resolveSymbol(n));
         case avro::AVRO_UNION:
@@ -770,7 +767,7 @@ void CodeGen::emitGeneratedWarning() {
 string CodeGen::guard() {
     string h = headerFile_;
     makeCanonical(h, true);
-    return h + "_" + lexical_cast<string>(random_()) + "_H";
+    return h + "_" + std::to_string(random_()) + "_H";
 }
 
 void CodeGen::generate(const ValidSchema &schema) {
@@ -943,7 +940,7 @@ std::string UnionCodeTracker::generateNewUnionName(const std::vector<std::string
     }
     makeCanonical(s, false);
 
-    std::string result = s + "_Union__" + boost::lexical_cast<string>(unionNumber_++) + "__";
+    std::string result = s + "_Union__" + std::to_string(unionNumber_++) + "__";
     unionBranchNameMapping_.emplace(unionBranches, result);
     return result;
 }

--- a/lang/c++/impl/json/JsonIO.hh
+++ b/lang/c++/impl/json/JsonIO.hh
@@ -414,7 +414,7 @@ public:
         sep();
         std::ostringstream oss;
         if (std::isfinite(t)) {
-            oss << std::setprecision(10) << t;
+            oss << std::setprecision(9) << t;
         } else if (std::isnan(t)) {
             oss << "NaN";
         } else if (t == std::numeric_limits<float>::infinity()) {
@@ -431,7 +431,7 @@ public:
         sep();
         std::ostringstream oss;
         if (std::isfinite(t)) {
-            oss << std::setprecision(18) << t;
+            oss << std::setprecision(17) << t;
         } else if (std::isnan(t)) {
             oss << "NaN";
         } else if (t == std::numeric_limits<double>::infinity()) {

--- a/lang/c++/impl/json/JsonIO.hh
+++ b/lang/c++/impl/json/JsonIO.hh
@@ -414,6 +414,7 @@ public:
         sep();
         std::ostringstream oss;
         if (std::isfinite(t)) {
+            oss.imbue(std::locale::classic());
             oss << std::setprecision(9) << t;
         } else if (std::isnan(t)) {
             oss << "NaN";
@@ -431,6 +432,7 @@ public:
         sep();
         std::ostringstream oss;
         if (std::isfinite(t)) {
+            oss.imbue(std::locale::classic());
             oss << std::setprecision(17) << t;
         } else if (std::isnan(t)) {
             oss << "NaN";

--- a/lang/c++/impl/json/JsonIO.hh
+++ b/lang/c++/impl/json/JsonIO.hh
@@ -20,6 +20,7 @@
 #define avro_json_JsonIO_hh__
 
 #include <cmath>
+#include <iomanip>
 #include <locale>
 #include <sstream>
 #include <stack>

--- a/lang/c++/impl/json/JsonIO.hh
+++ b/lang/c++/impl/json/JsonIO.hh
@@ -409,11 +409,28 @@ public:
         sep2();
     }
 
+    void encodeNumber(float t) {
+        sep();
+        std::ostringstream oss;
+        if (std::isfinite(t)) {
+            oss << std::setprecision(10) << t;
+        } else if (std::isnan(t)) {
+            oss << "NaN";
+        } else if (t == std::numeric_limits<float>::infinity()) {
+            oss << "Infinity";
+        } else {
+            oss << "-Infinity";
+        }
+        const std::string s = oss.str();
+        out_.writeBytes(reinterpret_cast<const uint8_t *>(s.data()), s.size());
+        sep2();
+    }
+
     void encodeNumber(double t) {
         sep();
         std::ostringstream oss;
         if (std::isfinite(t)) {
-            oss << t;
+            oss << std::setprecision(18) << t;
         } else if (std::isnan(t)) {
             oss << "NaN";
         } else if (t == std::numeric_limits<double>::infinity()) {

--- a/lang/c++/impl/json/JsonIO.hh
+++ b/lang/c++/impl/json/JsonIO.hh
@@ -19,8 +19,7 @@
 #ifndef avro_json_JsonIO_hh__
 #define avro_json_JsonIO_hh__
 
-#include <boost/lexical_cast.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <cmath>
 #include <locale>
 #include <sstream>
 #include <stack>
@@ -405,9 +404,7 @@ public:
     template<typename T>
     void encodeNumber(T t) {
         sep();
-        std::ostringstream oss;
-        oss << boost::lexical_cast<std::string>(t);
-        const std::string s = oss.str();
+        const std::string s = std::to_string(t);
         out_.writeBytes(reinterpret_cast<const uint8_t *>(s.data()), s.size());
         sep2();
     }
@@ -415,9 +412,9 @@ public:
     void encodeNumber(double t) {
         sep();
         std::ostringstream oss;
-        if (boost::math::isfinite(t)) {
-            oss << boost::lexical_cast<std::string>(t);
-        } else if (boost::math::isnan(t)) {
+        if (std::isfinite(t)) {
+            oss << t;
+        } else if (std::isnan(t)) {
             oss << "NaN";
         } else if (t == std::numeric_limits<double>::infinity()) {
             oss << "Infinity";

--- a/lang/c++/impl/parsing/JsonCodec.cc
+++ b/lang/c++/impl/parsing/JsonCodec.cc
@@ -17,7 +17,6 @@
  */
 
 #include <algorithm>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <map>
 #include <memory>
 #include <string>
@@ -539,7 +538,7 @@ void JsonEncoder<P, F>::encodeFloat(float f) {
         out_.encodeString("Infinity");
     } else if (-f == std::numeric_limits<float>::infinity()) {
         out_.encodeString("-Infinity");
-    } else if (boost::math::isnan(f)) {
+    } else if (std::isnan(f)) {
         out_.encodeString("NaN");
     } else {
         out_.encodeNumber(f);
@@ -553,7 +552,7 @@ void JsonEncoder<P, F>::encodeDouble(double d) {
         out_.encodeString("Infinity");
     } else if (-d == std::numeric_limits<double>::infinity()) {
         out_.encodeString("-Infinity");
-    } else if (boost::math::isnan(d)) {
+    } else if (std::isnan(d)) {
         out_.encodeString("NaN");
     } else {
         out_.encodeNumber(d);


### PR DESCRIPTION
## What is the purpose of the change

Remove boost::lexical_cast and boost::math

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Documentation

- Does this pull request introduce a new feature? no
