### PR TITLE
[Java] Reduce buffer size for ASCII string optimization to 63 bytes

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/io/BinaryEncoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/BinaryEncoder.java
@@ -37,8 +37,12 @@ import org.apache.avro.util.Utf8;
  */
 public abstract class BinaryEncoder extends Encoder {
 
-  // Buffer used for writing ASCII strings
-  private final byte[] stringBuffer = new byte[128];
+  /*
+   * Buffer used for writing ASCII strings. A string is encoded as a long followed
+   * by that many bytes of character data. A string of length 63 is the upper
+   * limit for a 1 byte variable-length long value.
+   */
+  private final byte[] stringBuffer = new byte[63];
 
   @Override
   public void writeNull() throws IOException {


### PR DESCRIPTION
As part of my earlier work for AVRO-4074, I introduced a buffer to store strings during serialization. I chose a buffer size of 128 bytes somewhat arbitrarily: it is a power of 2. However, upon further reflection, a value of 63 is a better partition. A string is decomposed into two fields:

> a string is encoded as a long followed by that many bytes of UTF-8 encoded character data.

For the binary format of Avro:

> int and long values are written using [variable-length](https://lucene.apache.org/java/3_5_0/fileformats.html#VInt) [zig-zag](https://code.google.com/apis/protocolbuffers/docs/encoding.html#types) coding.

63 bytes is the largest ASCII string that can be written using only a single byte for the variable-length size. This makes a more sane boundary for the upper limit of this string buffer. With a string size of 128, two bytes are required for the variable length value.