### PR TITLE
AVRO-4106: [C++] Remove boost::random

### DIFF
--- a/lang/c++/impl/DataFile.cc
+++ b/lang/c++/impl/DataFile.cc
@@ -20,13 +20,13 @@
 #include "Compiler.hh"
 #include "Exception.hh"
 
+#include <random>
 #include <sstream>
 
 #include <boost/crc.hpp> // for boost::crc_32_type
 #include <boost/iostreams/device/file.hpp>
 #include <boost/iostreams/filter/gzip.hpp>
 #include <boost/iostreams/filter/zlib.hpp>
-#include <boost/random/mersenne_twister.hpp>
 
 #ifdef SNAPPY_CODEC_AVAILABLE
 #include <snappy.h>
@@ -236,7 +236,7 @@ void DataFileWriterBase::flush() {
 }
 
 DataFileSync DataFileWriterBase::makeSync() {
-    boost::mt19937 random(static_cast<uint32_t>(time(nullptr)));
+    std::mt19937 random(static_cast<uint32_t>(time(nullptr)));
     DataFileSync sync;
     std::generate(sync.begin(), sync.end(), random);
     return sync;

--- a/lang/c++/impl/avrogencpp.cc
+++ b/lang/c++/impl/avrogencpp.cc
@@ -24,13 +24,12 @@
 #include <iostream>
 #include <map>
 #include <optional>
+#include <random>
 #include <set>
+#include <utility>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/program_options.hpp>
-
-#include <boost/random/mersenne_twister.hpp>
-#include <utility>
 
 #include "Compiler.hh"
 #include "NodeImpl.hh"
@@ -89,7 +88,7 @@ class CodeGen {
     const std::string includePrefix_;
     const bool noUnion_;
     const std::string guardString_;
-    boost::mt19937 random_;
+    std::mt19937 random_;
 
     vector<PendingSetterGetter> pendingGettersAndSetters;
     vector<PendingConstructor> pendingConstructors;

--- a/lang/c++/include/avro/Specific.hh
+++ b/lang/c++/include/avro/Specific.hh
@@ -25,8 +25,6 @@
 #include <string>
 #include <vector>
 
-#include "boost/blank.hpp"
-
 #include "AvroTraits.hh"
 #include "Config.hh"
 #include "Decoder.hh"


### PR DESCRIPTION
## What is the purpose of the change

Remove boost::random

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Documentation

- Does this pull request introduce a new feature? no
