### PR TITLE
AVRO-4112: [C++][CMake] Do not find Boost when test is not built

### DIFF
--- a/lang/c++/CMakeLists.txt
+++ b/lang/c++/CMakeLists.txt
@@ -57,16 +57,13 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR})
 
 option(AVRO_BUILD_EXECUTABLES "Build executables" ON)
 option(AVRO_BUILD_TESTS "Build tests" ON)
+option(AVRO_USE_BOOST "Use Boost" OFF)
 
 if (WIN32 AND NOT CYGWIN AND NOT MSYS)
     add_definitions (/EHa)
     add_definitions (
         -DNOMINMAX
-        -DBOOST_REGEX_DYN_LINK
-        -DBOOST_FILESYSTEM_DYN_LINK
         -DBOOST_SYSTEM_DYN_LINK
-        -DBOOST_IOSTREAMS_DYN_LINK
-        -DBOOST_PROGRAM_OPTIONS_DYN_LINK
         -DBOOST_ALL_NO_LIB)
 endif()
 
@@ -81,11 +78,8 @@ if (AVRO_ADD_PROTECTOR_FLAGS)
 endif ()
 endif ()
 
-if (AVRO_BUILD_TESTS OR AVRO_BUILD_EXECUTABLES)
-    find_package (Boost 1.38 REQUIRED
-        COMPONENTS filesystem iostreams program_options system)
-else ()
-    find_package (Boost 1.38 REQUIRED COMPONENTS iostreams)
+if (AVRO_BUILD_TESTS OR AVRO_USE_BOOST)
+    find_package (Boost 1.38 REQUIRED COMPONENTS system)
 endif ()
 
 include(FetchContent)

--- a/lang/c++/test/DataFileTests.cc
+++ b/lang/c++/test/DataFileTests.cc
@@ -16,7 +16,6 @@
  * limitations under the License.
  */
 
-#include <boost/filesystem.hpp>
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/uniform_int_distribution.hpp>
 #include <boost/shared_ptr.hpp>
@@ -24,6 +23,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <chrono>
+#include <filesystem>
 #include <thread>
 
 #include <sstream>
@@ -199,7 +199,7 @@ public:
     using Pair = pair<ValidSchema, GenericDatum>;
 
     void testCleanup() {
-        BOOST_CHECK(boost::filesystem::remove(filename));
+        BOOST_CHECK(std::filesystem::remove(filename));
     }
 
     void testWrite() {
@@ -278,12 +278,12 @@ public:
 
     void testTruncate() {
         testWriteDouble();
-        uintmax_t size = boost::filesystem::file_size(filename);
+        uintmax_t size = std::filesystem::file_size(filename);
         {
             avro::DataFileWriter<Pair> df(filename, writerSchema, 100);
             df.close();
         }
-        uintmax_t new_size = boost::filesystem::file_size(filename);
+        uintmax_t new_size = std::filesystem::file_size(filename);
         BOOST_CHECK(size > new_size);
     }
 
@@ -471,7 +471,7 @@ public:
     void testReaderSplits() {
         boost::mt19937 random(static_cast<uint32_t>(time(nullptr)));
         avro::DataFileReader<ComplexInteger> df(filename, writerSchema);
-        int length = static_cast<int>(boost::filesystem::file_size(filename));
+        int length = static_cast<int>(std::filesystem::file_size(filename));
         int splits = 10;
         int end = length;     // end of split
         int remaining = end;  // bytes remaining

--- a/lang/c++/test/StreamTests.cc
+++ b/lang/c++/test/StreamTests.cc
@@ -18,9 +18,10 @@
 
 #include "Exception.hh"
 #include "Stream.hh"
-#include "boost/filesystem.hpp"
 #include <boost/test/included/unit_test.hpp>
 #include <boost/test/parameterized_test.hpp>
+
+#include <filesystem>
 
 namespace avro {
 namespace stream {
@@ -136,9 +137,9 @@ void testNonEmpty2(const TestData &td) {
 static const char filename[] = "test_str.bin";
 
 struct FileRemover {
-    const boost::filesystem::path file;
+    const std::filesystem::path file;
     explicit FileRemover(const char *fn) : file(fn) {}
-    ~FileRemover() { boost::filesystem::remove(file); }
+    ~FileRemover() { std::filesystem::remove(file); }
 };
 
 template<typename V>


### PR DESCRIPTION
## What is the purpose of the change

- Added a CMake option `AVRO_USE_BOOST` to indicate whether boost is required for non-test targets.
- Do not find Boost library when test is not required to build.

## Verifying this change

- Manually verified that Boost is not found.
- Pass CIs.

## Documentation

- Does this pull request introduce a new feature? no
