### PR TITLE
AVRO-4039 [java] fix GenericData.newArray to only return an appropriate array implementation

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/generic/GenericData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/generic/GenericData.java
@@ -1565,7 +1565,6 @@ public class GenericData {
    *         May be null if the type is not optimised
    */
   public static Schema.Type optimalValueType(Schema schema, LogicalType logicalType, Class<?> convertedElementType) {
-    final Schema.Type convertedType;
     if (logicalType == null)
       // if there are no logical types- use the schema type
       return schema.getElementType().getType();

--- a/lang/java/avro/src/main/java/org/apache/avro/generic/PrimitivesArrays.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/generic/PrimitivesArrays.java
@@ -52,6 +52,8 @@ public class PrimitivesArrays {
         return new PrimitivesArrays.FloatArray(size, schema);
       case DOUBLE:
         return new PrimitivesArrays.DoubleArray(size, schema);
+      default:
+        break;
       }
     return new GenericData.Array<>(size, schema);
   }

--- a/lang/java/avro/src/test/java/org/apache/avro/generic/GenericDataTest.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/generic/GenericDataTest.java
@@ -173,6 +173,7 @@ class GenericDataTest {
   private static <T> List<Conversion<?>> singleConversion(Schema.Type targetKey) {
     return Collections.singletonList(new Conversion<T>() {
 
+      @Override
       public Class<T> getConvertedType() {
         switch (targetKey) {
         case INT:
@@ -191,6 +192,7 @@ class GenericDataTest {
 
       }
 
+      @Override
       public String getLogicalTypeName() {
         return "Mike";
       }


### PR DESCRIPTION
## What is the purpose of the change
- Fix the class cast exceptions noted in the ticket (when using logical types) 
- Fix other paths that can return `PrimitiveArray` when it would not be appropriate
- Tightness the constraints for the return value, so if a `GenericContainer` is returned the schema must match the supplied schema

appropriate means that 
- If the suppled value could act as a container for the values that will be added, then clear its values, and reuse
- If it is a `GenericContainer` and thus has a schema, then the schema is the same
If we can't reuse the supplied value, then generate an appropriate collection, using the optimised values where we can

Updated the documentation, and added tests

## Verifying this change

This change added tests and can be verified as follows:

- Added unit tests to ensure that appropriate values are returned (as described above)

## Documentation

- Does this pull request introduce a new feature? (no)
