### PR TITLE
Close the Jackson Generator to save buffer leaks

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/Schema.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Schema.java
@@ -444,12 +444,13 @@ public abstract class Schema extends JsonProperties implements Serializable {
   String toString(Set<String> knownNames, boolean pretty) {
     try {
       StringWriter writer = new StringWriter();
-      JsonGenerator gen = FACTORY.createGenerator(writer);
-      if (pretty)
-        gen.useDefaultPrettyPrinter();
-      toJson(knownNames, null, gen);
-      gen.flush();
-      return writer.toString();
+      try (JsonGenerator gen = FACTORY.createGenerator(writer)) {
+        if (pretty)
+          gen.useDefaultPrettyPrinter();
+        toJson(knownNames, null, gen);
+        gen.flush();
+        return writer.toString();
+      }
     } catch (IOException e) {
       throw new AvroRuntimeException(e);
     }


### PR DESCRIPTION
Since https://github.com/FasterXML/jackson-core/issues/919 jackson now requires to close its `JsonGenerator` to save buffer leaks - and eventually cause further big allocations due to not be able to reuse the existing one.
This can be saved by correctly closing the used `JsonGenerator`.
