### PR TITLE
[ruby] Keep all union record errors and tag them accordingly

### DIFF
--- a/lang/ruby/lib/avro/schema_validator.rb
+++ b/lang/ruby/lib/avro/schema_validator.rb
@@ -24,6 +24,7 @@ module Avro
     COMPLEX_TYPES = [:array, :error, :map, :record, :request].freeze
     BOOLEAN_VALUES = [true, false].freeze
     DEFAULT_VALIDATION_OPTIONS = { recursive: true, encoded: false, fail_on_extra_fields: false }.freeze
+    NAMED_SCHEMAS = [Avro::Schema::RecordSchema, Avro::Schema::EnumSchema, Avro::Schema::FixedSchema].freeze
     RECURSIVE_SIMPLE_VALIDATION_OPTIONS = { encoded: true }.freeze
     RUBY_CLASS_TO_AVRO_TYPE = {
       NilClass => 'null',
@@ -198,18 +199,22 @@ module Avro
         compatible_type = first_compatible_type(datum, expected_schema, path, failures, options)
         return unless compatible_type.nil?
 
-        complex_type_failed = failures.select { |r| COMPLEX_TYPES.include?(r[:type]) }
-        if complex_type_failed.any?
-          complex_type_failed.each do |type_failures|
-            type_failures[:result].errors.each do |error|
-              error_msg = type_failures[:schema] ? "#{type_failures[:schema]} #{error}" : error
-              result << error_msg
-            end
-          end
-        else
-          types = expected_schema.schemas.map { |s| "'#{s.type_sym}'" }.join(', ')
-          result.add_error(path, "expected union of [#{types}], got #{actual_value_message(datum)}")
+
+        failed_complex_types = failures.select { |r| COMPLEX_TYPES.include?(r[:type]) }
+        complex_type_errors =  []
+        failed_complex_types.each do |failed_complex_type|
+          error_msg = failed_complex_type[:result].errors.map do |error|
+            error
+          end.join("; ")
+          schema_name_prefix = "#{failed_complex_type[:schema_name]}: " if failed_complex_type[:schema_name] 
+          complex_type_errors << "#{schema_name_prefix}#{error_msg}"
         end
+
+        types = expected_schema.schemas.map do |s|
+          s.respond_to?(:name) ? "#{s.name} ('#{s.type}')" : "'#{s.type}'"
+        end.join(', ')
+        type_mismatches = %Q{\nUnion type specific errors:\n#{complex_type_errors.join("\n")}} if complex_type_errors.any?
+        result.add_error(path, "expected union of [#{types}], got #{actual_value_message(datum)}#{type_mismatches}")
       end
 
       def first_compatible_type(datum, expected_schema, path, failures, options = {})
@@ -223,7 +228,7 @@ module Avro
           validate_recursive(schema, datum, path, result, options)
           if result.failure?
             failure = { type: schema.type_sym, result: result }
-            failure[:schema] = schema.name if schema.is_a?(Avro::Schema::RecordSchema)
+            failure[:schema_name] = schema.name if schema.respond_to?(:name)
             failures << failure
           end
           !result.failure?

--- a/lang/ruby/lib/avro/schema_validator.rb
+++ b/lang/ruby/lib/avro/schema_validator.rb
@@ -221,10 +221,11 @@ module Avro
 
           result = Result.new
           validate_recursive(schema, datum, path, result, options)
-
-          failure = { type: schema.type_sym, result: result }
-          failure[:schema] = schema.name if schema.is_a?(Avro::Schema::RecordSchema)
-          failures << failure if result.failure?
+          if result.failure?
+            failure = { type: schema.type_sym, result: result }
+            failure[:schema] = schema.name if schema.is_a?(Avro::Schema::RecordSchema)
+            failures << failure
+          end
           !result.failure?
         end
       end

--- a/lang/ruby/test/test_schema_validator.rb
+++ b/lang/ruby/test/test_schema_validator.rb
@@ -331,7 +331,12 @@ class TestSchemaValidator < Test::Unit::TestCase
     assert_nothing_raised { validate_simple!(schema, 'person' => { houses: [] }) }
     assert_nothing_raised { validate_simple!(schema, 'person' => { 'houses' => [{ 'number_of_rooms' => 1 }] }) }
 
-    message = 'at .person.houses[1].number_of_rooms expected type long, got string with value "not valid at all"'
+    message = <<~EXPECTED_ERROR.chomp
+      at .person.houses expected union of ['null', 'array'], got Array with value [{"number_of_rooms"=>2}, {"number_of_rooms"=>"not valid at all"}]
+      Union type specific errors:
+      at .person.houses[1].number_of_rooms expected type long, got string with value "not valid at all"
+    EXPECTED_ERROR
+
     datum = {
       'person' => {
         'houses' => [
@@ -556,8 +561,50 @@ class TestSchemaValidator < Test::Unit::TestCase
       validate!(schema, { 'name' => 'apple', 'color' => 'green' }, fail_on_extra_fields: true)
     end
     assert_equal(1, exception.result.errors.size)
-    assert_equal("fruit at . extra field 'color' - not in schema", exception.to_s)
+    expected_error = <<~EXPECTED_ERROR.chomp
+      at . expected union of ['null', fruit ('record')], got record with value {"name"=>"apple", "color"=>"green"}
+      Union type specific errors:
+      fruit: at . extra field 'color' - not in schema
+    EXPECTED_ERROR
+    assert_equal(expected_error, exception.to_s)
   end
+
+  def test_validate_union_complex_and_simple_types
+    schema = hash_to_schema([
+                              'null',
+                              {
+                                type: 'record',
+                                name: 'fruit',
+                                fields: [{ name: 'name', type: 'string' }]
+                              },
+                              {
+                                type: 'record',
+                                name: 'animal',
+                                fields: [
+                                  { name: 'name', type: 'string' },
+                                  { name: 'species', type: 'string' }
+                                ]
+                              },
+                              {
+                                type: 'enum',
+                                name: 'person',
+                                symbols: %w(one two three)
+                              }
+                            ])
+    exception = assert_raise(Avro::SchemaValidator::ValidationError) do
+      validate!(schema, { 'namo' => 'apple', 'color' => 'green' }, fail_on_extra_fields: true)
+    end
+
+    assert_equal(1, exception.result.errors.size)
+    expected_error = <<~EXPECTED_ERROR.chomp
+      at . expected union of ['null', fruit ('record'), animal ('record'), person ('enum')], got record with value {"namo"=>"apple", "color"=>"green"}
+      Union type specific errors:
+      fruit: at .name expected type string, got null; at . extra field 'namo' - not in schema; at . extra field 'color' - not in schema
+      animal: at .name expected type string, got null; at .species expected type string, got null; at . extra field 'namo' - not in schema; at . extra field 'color' - not in schema
+    EXPECTED_ERROR
+    assert_equal(expected_error, exception.to_s)
+  end
+
 
   def test_validate_bytes_decimal
     schema = hash_to_schema(type: 'bytes', logicalType: 'decimal', precision: 4, scale: 2)

--- a/lang/ruby/test/test_schema_validator.rb
+++ b/lang/ruby/test/test_schema_validator.rb
@@ -556,7 +556,7 @@ class TestSchemaValidator < Test::Unit::TestCase
       validate!(schema, { 'name' => 'apple', 'color' => 'green' }, fail_on_extra_fields: true)
     end
     assert_equal(1, exception.result.errors.size)
-    assert_equal("at . extra field 'color' - not in schema", exception.to_s)
+    assert_equal("fruit at . extra field 'color' - not in schema", exception.to_s)
   end
 
   def test_validate_bytes_decimal


### PR DESCRIPTION
I wasn't able to create an issue in JIRA, since I don't seem to be able to request a user. I am a first time contributor, apologies  in case something is not precise enough

## What is the purpose of the change

This is a second take on https://github.com/apache/avro/pull/2062 (hopefully better)
Improving validation errors for unions of records
When no valid union is found, this line selects the **first** error that it finds. If there would be 3 different possible schemas, there are 3 `failures`, however only the first one will be considered.

https://github.com/apache/avro/blob/fc2a4e0e5d88755c776b97fa1872e70ffbe0d4bb/lang/ruby/lib/avro/schema_validator.rb#L199

The returned error also does not give any context of the error, only about the invalid fields.

As an example, consider we have 3 types of adresses `PersonalAddress`, `WorkAddress`, `SecondAddress` and we made a typo: We used the field `compan` instead of `company`, which belongs to `WorkAddress`. No type will work for the union.
`{ "compan" => "acme inc.", "some_other_field" => "something else" }`

Since `PersonalAddress` is the first type that fails, the errors of `PersonalAddress` are the ones that will be returned. Since `PersonalAddress` has different structure, all fields that aren't the same as in `WorkAddress` will be shown as errors. The error will be something like

```
at .address extra field 'compan' - not in schema
at .address extra field 'some_other_field' - not in schema
```

This gets very confusing because 1) The issue is that no union matched 2) It is not clear because only one of the error is displayed.

I'd be happy if this is fix in some other fashion, this is just an example. With we replace `detect` with `select` and we add the schema name to the error. Then the error will be like:

```
PersonalAddress at .address extra field 'compan' - not in schema
PersonalAddress at .address extra field 'some_other_field' - not in schema
WorkAddress at .address extra field 'compan' - not in schema
SecondAddress at .address extra field 'compan' - not in schema
SecondAddress at .address extra field 'some_other_field' - not in schema
```

I don't know the internals very well, but the existing behaviour also seems flawed because if any of the types is complex, only the complex type errors are listed. 

I've changed this to list all errors. The error format isn't perfect and I'm happy to accept changes or improve it myself, but I would very much like this to get eventually merged, since the existing validation behaviour for unions is not correct.

## Verifying this change

This change added tests and can be verified as follows:

- Modified existing test, existing tests pass


## Documentation

- Does this pull request introduce a new feature?  no
