### PR TITLE
AVRO-4121: [C++] Add Node::getCustomAttributes

### DIFF
--- a/lang/c++/include/avro/Node.hh
+++ b/lang/c++/include/avro/Node.hh
@@ -170,6 +170,8 @@ public:
         doAddCustomAttribute(customAttributes);
     }
 
+    virtual CustomAttributes getCustomAttributes() const = 0;
+
     virtual bool isValid() const = 0;
 
     virtual SchemaResolution resolve(const Node &reader) const = 0;

--- a/lang/c++/include/avro/NodeImpl.hh
+++ b/lang/c++/include/avro/NodeImpl.hh
@@ -164,6 +164,17 @@ protected:
         customAttributes_.add(customAttributes);
     }
 
+    CustomAttributes getCustomAttributes() const override {
+        CustomAttributes mergedCustomAttributes;
+        for (size_t i = 0; i < customAttributes_.size(); i++) {
+            const auto &customAttribute = customAttributes_.get(i);
+            for (const auto &[key, value] : customAttribute.attributes()) {
+                mergedCustomAttributes.addAttribute(key, value);
+            }
+        }
+        return mergedCustomAttributes;
+    }
+
     SchemaResolution furtherResolution(const Node &reader) const {
         SchemaResolution match = RESOLVE_NO_MATCH;
 

--- a/lang/c++/test/unittest.cc
+++ b/lang/c++/test/unittest.cc
@@ -1066,6 +1066,16 @@ void testNestedMapSchema() {
     BOOST_CHECK_EQUAL(expected, actual.str());
 }
 
+void testCustomAttributes() {
+    std::string schema = R"({"type":"array","items":"long","extra":"1","extra2":"2"})";
+    avro::ValidSchema compiledSchema =
+        compileJsonSchemaFromString(schema);
+    auto customAttributes = compiledSchema.root()->getCustomAttributes();
+    BOOST_CHECK_EQUAL(customAttributes.attributes().size(), 2);
+    BOOST_CHECK_EQUAL(customAttributes.getAttribute("extra").value(), "1");
+    BOOST_CHECK_EQUAL(customAttributes.getAttribute("extra2").value(), "2");
+}
+
 boost::unit_test::test_suite *
 init_unit_test_suite(int /*argc*/, char * /*argv*/[]) {
     using namespace boost::unit_test;
@@ -1086,6 +1096,7 @@ init_unit_test_suite(int /*argc*/, char * /*argv*/[]) {
                                     boost::make_shared<TestResolution>()));
     test->add(BOOST_TEST_CASE(&testNestedArraySchema));
     test->add(BOOST_TEST_CASE(&testNestedMapSchema));
+    test->add(BOOST_TEST_CASE(&testCustomAttributes));
 
     return test;
 }


### PR DESCRIPTION
## What is the purpose of the change

Currently we cannot get custom attribute from any Node type. This commit aims to add a public API to Node to get all attributes from a single CustomAttributes object.

## Verifying this change

This change added tests and can be verified as follows:

- Added a test case to verify that CustomAttributes are properly populated.

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable
