### PR TITLE
AVRO-4122: [C++] Allow custom logical type

### DIFF
--- a/lang/c++/impl/Compiler.cc
+++ b/lang/c++/impl/Compiler.cc
@@ -399,6 +399,12 @@ static LogicalType makeLogicalType(const Entity &e, const Object &m) {
         t = LogicalType::DURATION;
     else if (typeField == "uuid")
         t = LogicalType::UUID;
+    else {
+        auto custom = CustomLogicalTypeRegistry::instance().create(typeField, e.toString());
+        if (custom != nullptr) {
+            return LogicalType(std::move(custom));
+        }
+    }
     return LogicalType(t);
 }
 

--- a/lang/c++/impl/Node.cc
+++ b/lang/c++/impl/Node.cc
@@ -233,6 +233,11 @@ void Node::setLogicalType(LogicalType logicalType) {
                                 "STRING type");
             }
             break;
+        case LogicalType::CUSTOM:
+            if (logicalType.customLogicalType() == nullptr) {
+                throw Exception("CUSTOM logical type is not set");
+            }
+            break;
     }
 
     logicalType_ = logicalType;

--- a/lang/c++/impl/NodeImpl.cc
+++ b/lang/c++/impl/NodeImpl.cc
@@ -252,9 +252,18 @@ static void printName(std::ostream &os, const Name &n, size_t depth) {
     os << indent(depth) << R"("name": ")" << n.simpleName() << "\",\n";
 }
 
+static void printLogicalType(std::ostream &os, const LogicalType &logicalType, size_t depth) {
+    if (logicalType.type() != LogicalType::NONE) {
+        os << indent(depth);
+        logicalType.printJson(os);
+        os << ",\n";
+    }
+}
+
 void NodeRecord::printJson(std::ostream &os, size_t depth) const {
     os << "{\n";
     os << indent(++depth) << "\"type\": \"record\",\n";
+    printLogicalType(os, logicalType(), depth);
     const Name &name = nameAttribute_.get();
     printName(os, name, depth);
 
@@ -524,6 +533,7 @@ void NodeMap::printDefaultToJson(const GenericDatum &g, std::ostream &os,
 void NodeEnum::printJson(std::ostream &os, size_t depth) const {
     os << "{\n";
     os << indent(++depth) << "\"type\": \"enum\",\n";
+    printLogicalType(os, logicalType(), depth);
     if (!getDoc().empty()) {
         os << indent(depth) << R"("doc": ")"
            << escape(getDoc()) << "\",\n";
@@ -550,6 +560,7 @@ void NodeEnum::printJson(std::ostream &os, size_t depth) const {
 void NodeArray::printJson(std::ostream &os, size_t depth) const {
     os << "{\n";
     os << indent(depth + 1) << "\"type\": \"array\",\n";
+    printLogicalType(os, logicalType(), depth + 1);
     if (!getDoc().empty()) {
         os << indent(depth + 1) << R"("doc": ")"
            << escape(getDoc()) << "\",\n";
@@ -566,6 +577,7 @@ void NodeArray::printJson(std::ostream &os, size_t depth) const {
 void NodeMap::printJson(std::ostream &os, size_t depth) const {
     os << "{\n";
     os << indent(depth + 1) << "\"type\": \"map\",\n";
+    printLogicalType(os, logicalType(), depth + 1);
     if (!getDoc().empty()) {
         os << indent(depth + 1) << R"("doc": ")"
            << escape(getDoc()) << "\",\n";


### PR DESCRIPTION
## What is the purpose of the change

- The Java library supports registering custom logical types: https://github.com/apache/avro/pull/885
- Apache Iceberg requires custom `map` logical type: https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/avro/LogicalMap.java

## Verifying this change

This change added tests and can be verified as follows:

- Added a test case to verify that custom `map` logical type can be respected correctly.

## Documentation

- Does this pull request introduce a new feature? yes
- If yes, how is the feature documented? added comment around the new class
