### PR TITLE
AVRO-3985: Apply trusted packages check on SpecificDatumReader(data) constructor

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificDatumReader.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificDatumReader.java
@@ -74,6 +74,7 @@ public class SpecificDatumReader<T> extends GenericDatumReader<T> {
   /** Construct given a {@link SpecificData}. */
   public SpecificDatumReader(SpecificData data) {
     super(data);
+    trustedPackages.addAll(Arrays.asList(SERIALIZABLE_PACKAGES));
   }
 
   /** Return the contained {@link SpecificData}. */


### PR DESCRIPTION
## What is the purpose of the change

The initial fix for AVRO-3985 applied only to one constructor in `SpecificDatumReader`. This change extend the trusted packages check in all constructors.

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

## Documentation

- Does this pull request introduce a new feature? no
