### PR TITLE
Don't use specific git hash (SHA1) for GitHub Actions

### DIFF
--- a/.github/workflows/codeql-java-analysis.yml
+++ b/.github/workflows/codeql-java-analysis.yml
@@ -71,7 +71,7 @@ jobs:
         queries: +security-and-quality
 
     - name: 'Setup Temurin JDK 8, 11, 17 & 21'
-      uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
+      uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: |

--- a/.github/workflows/java-publish-snapshot.yml
+++ b/.github/workflows/java-publish-snapshot.yml
@@ -44,7 +44,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: 'Setup Temurin JDK 8, 11, 17 & 21'
-        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: |

--- a/.github/workflows/maven4.yml
+++ b/.github/workflows/maven4.yml
@@ -51,7 +51,7 @@ jobs:
             ${{ runner.os }}-maven-build-cache
 
       - name: 'Setup Temurin JDK 8, 11, 17 & 21'
-        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: |

--- a/.github/workflows/rat.yml
+++ b/.github/workflows/rat.yml
@@ -40,7 +40,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: 'Setup Temurin JDK 8, 11, 17 & 21'
-        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: |

--- a/.github/workflows/spotless.yml
+++ b/.github/workflows/spotless.yml
@@ -43,7 +43,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: 'Setup Temurin JDK 8, 11, 17 & 21'
-        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: |

--- a/.github/workflows/test-lang-c.yml
+++ b/.github/workflows/test-lang-c.yml
@@ -64,7 +64,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: 'Setup Temurin JDK 8, 11, 17 & 21'
-        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: |
@@ -118,7 +118,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: 'Setup Temurin JDK 8, 11, 17 & 21'
-        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: |

--- a/.github/workflows/test-lang-csharp-ARM.yml
+++ b/.github/workflows/test-lang-csharp-ARM.yml
@@ -89,7 +89,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: 'Setup Temurin JDK 8, 11, 17 & 21'
-        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: |

--- a/.github/workflows/test-lang-csharp.yml
+++ b/.github/workflows/test-lang-csharp.yml
@@ -89,7 +89,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: 'Setup Temurin JDK 8, 11, 17 & 21'
-        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: |

--- a/.github/workflows/test-lang-java-ARM.yml
+++ b/.github/workflows/test-lang-java-ARM.yml
@@ -40,10 +40,10 @@ jobs:
 
     steps:
       - name: 'Checkout sourcecode'
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@v4
 
       - name: 'Setup Temurin JDK 8, 11, 17 & 21'
-        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: |
@@ -53,7 +53,7 @@ jobs:
             21
 
       - name: 'Cache Local Maven Repository'
-        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/test-lang-java.yml
+++ b/.github/workflows/test-lang-java.yml
@@ -39,10 +39,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout sourcecode'
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@v4
 
       - name: 'Cache Local Maven Repository'
-        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -50,7 +50,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: 'Setup Temurin JDK 11, 17 & 21'
-        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: |
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@v4
 
       - name: 'Cache Local Maven Repository'
         uses: actions/cache@v4
@@ -97,7 +97,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: 'Setup Temurin JDK 11, 17 & 21'
-        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: |

--- a/.github/workflows/test-lang-perl-ARM.yml
+++ b/.github/workflows/test-lang-perl-ARM.yml
@@ -111,7 +111,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: 'Setup Temurin JDK 8, 11, 17 & 21'
-        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: |

--- a/.github/workflows/test-lang-perl.yml
+++ b/.github/workflows/test-lang-perl.yml
@@ -110,7 +110,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: 'Setup Temurin JDK 8, 11, 17 & 21'
-        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: |

--- a/.github/workflows/test-lang-php.yml
+++ b/.github/workflows/test-lang-php.yml
@@ -97,7 +97,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: 'Setup Temurin JDK 8, 11, 17 & 21'
-        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: |

--- a/.github/workflows/test-lang-py.yml
+++ b/.github/workflows/test-lang-py.yml
@@ -123,7 +123,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: 'Setup Temurin JDK 8, 11, 17 & 21'
-        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: |

--- a/.github/workflows/test-lang-ruby.yml
+++ b/.github/workflows/test-lang-ruby.yml
@@ -114,7 +114,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: 'Setup Temurin JDK 8, 11, 17 & 21'
-        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: |


### PR DESCRIPTION
The use of specific Git hash (SHA1) for GitHub Actions versions is only required for external actions.
We use all actions internal to the `apache/*`, `github/*` and `actions/*` namespaces without restrictions (see https://infra.apache.org/github-actions-policy.html).

This change use version alias for GitHub Actions.