### PR TITLE
Refactor `_skip_sync` for Improved Readability & Performance

### DIFF
--- a/lang/py/avro/datafile.py
+++ b/lang/py/avro/datafile.py
@@ -387,13 +387,13 @@ class DataFileReader(_DataFileMetadata):
 
     def _skip_sync(self) -> bool:
         """
-        Read the length of the sync marker; if it matches the sync marker,
-        return True. Otherwise, seek back to where we started and return False.
+        Check if the next bytes match the sync marker.
+        If not, rewind the read position.
         """
-        proposed_sync_marker = self.reader.read(SYNC_SIZE)
-        if proposed_sync_marker == self.sync_marker:
+        pos = self.reader.tell()
+        if self.reader.read(SYNC_SIZE) == self.sync_marker:
             return True
-        self.reader.seek(-SYNC_SIZE, 1)
+        self.reader.seek(pos)  # Reset position if sync doesn't match
         return False
 
     def __next__(self) -> object:


### PR DESCRIPTION
## What is the purpose of the change?

This pull request improves the `_skip_sync` method to enhance readability, maintainability, and correctness when checking for sync markers.  
Instead of using `seek(-SYNC_SIZE, 1)`, the method now stores the original file position using `tell()`, ensuring the read position can be reset explicitly when sync markers do not match.  

## Verifying this change

This change is a **trivial rework / code cleanup** without affecting the core logic of the reader.  

This change is already covered by existing tests, such as:  
- Existing unit tests that verify proper sync marker detection and file position resetting.  

Additionally, the change was manually verified by:  
- Running integration tests with AVRO files of various sizes.  
- Logging file positions before and after sync checks to confirm correct seek behavior.  

## Documentation

- Does this pull request introduce a new feature? **No**
- How is this change documented? **Not applicable (code comments included for clarity).**
