### PR TITLE
AVRO-4026: [C++] Allow non-string custom attributes

### DIFF
--- a/lang/c++/impl/Compiler.cc
+++ b/lang/c++/impl/Compiler.cc
@@ -291,7 +291,8 @@ static void getCustomAttributes(const Object &m, CustomAttributes &customAttribu
     const std::unordered_set<std::string> &kKnownFields = getKnownFields();
     for (const auto &entry : m) {
         if (kKnownFields.find(entry.first) == kKnownFields.end()) {
-            customAttributes.addAttribute(entry.first, entry.second.toLiteralString());
+            bool addQuotes = entry.second.type() == json::EntityType::String;
+            customAttributes.addAttribute(entry.first, entry.second.toLiteralString(), addQuotes);
         }
     }
 }

--- a/lang/c++/impl/CustomAttributes.cc
+++ b/lang/c++/impl/CustomAttributes.cc
@@ -35,19 +35,28 @@ std::optional<std::string> CustomAttributes::getAttribute(const std::string &nam
 }
 
 void CustomAttributes::addAttribute(const std::string &name,
-                                    const std::string &value) {
+                                    const std::string &value,
+                                    bool addQuotes) {
     auto iter_and_find =
         attributes_.insert(std::pair<std::string, std::string>(name, value));
     if (!iter_and_find.second) {
         throw Exception(name + " already exists and cannot be added");
     }
+    if (addQuotes) {
+        keysNeedQuotes_.insert(name);
+    }
 }
 
 void CustomAttributes::printJson(std::ostream &os,
                                  const std::string &name) const {
-    if (attributes().find(name) == attributes().end()) {
+    auto iter = attributes_.find(name);
+    if (iter == attributes_.cend()) {
         throw Exception(name + " doesn't exist");
     }
-    os << "\"" << name << "\": \"" << attributes().at(name) << "\"";
+    if (keysNeedQuotes_.find(name) != keysNeedQuotes_.cend()) {
+        os << "\"" << name << "\": \"" << iter->second << "\"";
+    } else {
+        os << "\"" << name << "\": " << iter->second;
+    }
 }
 } // namespace avro

--- a/lang/c++/include/avro/CustomAttributes.hh
+++ b/lang/c++/include/avro/CustomAttributes.hh
@@ -24,6 +24,7 @@
 #include <map>
 #include <optional>
 #include <string>
+#include <unordered_set>
 
 namespace avro {
 
@@ -37,7 +38,10 @@ public:
     std::optional<std::string> getAttribute(const std::string &name) const;
 
     // Adds a custom attribute. If the attribute already exists, throw an exception.
-    void addAttribute(const std::string &name, const std::string &value);
+    //
+    // If `addQuotes` is true, the `value` will be wrapped in double quotes in the
+    // json serialization; otherwise, the `value` will be serialized as is.
+    void addAttribute(const std::string &name, const std::string &value, bool addQuotes = true);
 
     // Provides a way to iterate over the custom attributes or check attribute size.
     const std::map<std::string, std::string> &attributes() const {
@@ -49,6 +53,7 @@ public:
 
 private:
     std::map<std::string, std::string> attributes_;
+    std::unordered_set<std::string> keysNeedQuotes_;
 };
 
 } // namespace avro


### PR DESCRIPTION
## What is the purpose of the change

This PR takes a different approach than https://github.com/apache/avro/pull/3308, https://github.com/apache/avro/pull/3069, https://github.com/apache/avro/pull/3064 and https://github.com/apache/avro/pull/3266 to fix the non-string custom attributes. It extends the `CustomAttributes::addAttribute(const std::string &name, const std::string &value)` with a third parameter `bool addQuotes` with default value set to `true` to support adding non-string values explicitly and keep backward compatibility.


## Verifying this change

- Make sure that all existing test cases are passed so backward compatibility is preserved.
- Added new test case to verify that both `json->schema->json` and `schema->json->schema` round trips have preserved non-string attributes correctly.


## Documentation

- Does this pull request introduce a new feature? yes
- If yes, how is the feature documented? added comment to explain the behavior
