### PR TITLE
AVRO-3989: [java] add conversion classes to default instance of SpecificData

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectData.java
@@ -20,12 +20,14 @@ package org.apache.avro.reflect;
 import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Conversion;
+import org.apache.avro.Conversions;
 import org.apache.avro.JsonProperties;
 import org.apache.avro.LogicalType;
 import org.apache.avro.Protocol;
 import org.apache.avro.Protocol.Message;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaNormalization;
+import org.apache.avro.data.TimeConversions;
 import org.apache.avro.generic.GenericContainer;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericFixed;
@@ -103,6 +105,23 @@ public class ReflectData extends SpecificData {
   }
 
   private static final ReflectData INSTANCE = new ReflectData();
+  static {
+    INSTANCE.addLogicalTypeConversion(new Conversions.UUIDConversion());
+    // Disable DecimalConversion since it's gated behind
+    // `compiler.setEnableDecimalLogicalType`
+    // INSTANCE.addLogicalTypeConversion(new Conversions.DecimalConversion());
+    INSTANCE.addLogicalTypeConversion(new Conversions.BigDecimalConversion());
+    INSTANCE.addLogicalTypeConversion(new Conversions.DurationConversion());
+    INSTANCE.addLogicalTypeConversion(new TimeConversions.DateConversion());
+    INSTANCE.addLogicalTypeConversion(new TimeConversions.LocalTimestampMicrosConversion());
+    INSTANCE.addLogicalTypeConversion(new TimeConversions.LocalTimestampMillisConversion());
+    INSTANCE.addLogicalTypeConversion(new TimeConversions.LocalTimestampNanosConversion());
+    INSTANCE.addLogicalTypeConversion(new TimeConversions.TimeMicrosConversion());
+    INSTANCE.addLogicalTypeConversion(new TimeConversions.TimeMillisConversion());
+    INSTANCE.addLogicalTypeConversion(new TimeConversions.TimestampMicrosConversion());
+    INSTANCE.addLogicalTypeConversion(new TimeConversions.TimestampMillisConversion());
+    INSTANCE.addLogicalTypeConversion(new TimeConversions.TimestampNanosConversion());
+  }
 
   /** For subclasses. Applications normally use {@link ReflectData#get()}. */
   public ReflectData() {

--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectData.java
@@ -20,14 +20,12 @@ package org.apache.avro.reflect;
 import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Conversion;
-import org.apache.avro.Conversions;
 import org.apache.avro.JsonProperties;
 import org.apache.avro.LogicalType;
 import org.apache.avro.Protocol;
 import org.apache.avro.Protocol.Message;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaNormalization;
-import org.apache.avro.data.TimeConversions;
 import org.apache.avro.generic.GenericContainer;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericFixed;
@@ -105,22 +103,9 @@ public class ReflectData extends SpecificData {
   }
 
   private static final ReflectData INSTANCE = new ReflectData();
+
   static {
-    INSTANCE.addLogicalTypeConversion(new Conversions.UUIDConversion());
-    // Disable DecimalConversion since it's gated behind
-    // `compiler.setEnableDecimalLogicalType`
-    // INSTANCE.addLogicalTypeConversion(new Conversions.DecimalConversion());
-    INSTANCE.addLogicalTypeConversion(new Conversions.BigDecimalConversion());
-    INSTANCE.addLogicalTypeConversion(new Conversions.DurationConversion());
-    INSTANCE.addLogicalTypeConversion(new TimeConversions.DateConversion());
-    INSTANCE.addLogicalTypeConversion(new TimeConversions.LocalTimestampMicrosConversion());
-    INSTANCE.addLogicalTypeConversion(new TimeConversions.LocalTimestampMillisConversion());
-    INSTANCE.addLogicalTypeConversion(new TimeConversions.LocalTimestampNanosConversion());
-    INSTANCE.addLogicalTypeConversion(new TimeConversions.TimeMicrosConversion());
-    INSTANCE.addLogicalTypeConversion(new TimeConversions.TimeMillisConversion());
-    INSTANCE.addLogicalTypeConversion(new TimeConversions.TimestampMicrosConversion());
-    INSTANCE.addLogicalTypeConversion(new TimeConversions.TimestampMillisConversion());
-    INSTANCE.addLogicalTypeConversion(new TimeConversions.TimestampNanosConversion());
+    addLogicalTypeConversions(INSTANCE);
   }
 
   /** For subclasses. Applications normally use {@link ReflectData#get()}. */

--- a/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificData.java
@@ -61,21 +61,25 @@ public class SpecificData extends GenericData {
   private static final SpecificData INSTANCE = new SpecificData();
 
   static {
-    INSTANCE.addLogicalTypeConversion(new Conversions.UUIDConversion());
+    addLogicalTypeConversions(INSTANCE);
+  }
+
+  protected static void addLogicalTypeConversions(SpecificData instance) {
+    instance.addLogicalTypeConversion(new Conversions.UUIDConversion());
     // Disable DecimalConversion since it's gated behind
     // `compiler.setEnableDecimalLogicalType`
     // INSTANCE.addLogicalTypeConversion(new Conversions.DecimalConversion());
-    INSTANCE.addLogicalTypeConversion(new Conversions.BigDecimalConversion());
-    INSTANCE.addLogicalTypeConversion(new Conversions.DurationConversion());
-    INSTANCE.addLogicalTypeConversion(new TimeConversions.DateConversion());
-    INSTANCE.addLogicalTypeConversion(new TimeConversions.LocalTimestampMicrosConversion());
-    INSTANCE.addLogicalTypeConversion(new TimeConversions.LocalTimestampMillisConversion());
-    INSTANCE.addLogicalTypeConversion(new TimeConversions.LocalTimestampNanosConversion());
-    INSTANCE.addLogicalTypeConversion(new TimeConversions.TimeMicrosConversion());
-    INSTANCE.addLogicalTypeConversion(new TimeConversions.TimeMillisConversion());
-    INSTANCE.addLogicalTypeConversion(new TimeConversions.TimestampMicrosConversion());
-    INSTANCE.addLogicalTypeConversion(new TimeConversions.TimestampMillisConversion());
-    INSTANCE.addLogicalTypeConversion(new TimeConversions.TimestampNanosConversion());
+    instance.addLogicalTypeConversion(new Conversions.BigDecimalConversion());
+    instance.addLogicalTypeConversion(new Conversions.DurationConversion());
+    instance.addLogicalTypeConversion(new TimeConversions.DateConversion());
+    instance.addLogicalTypeConversion(new TimeConversions.LocalTimestampMicrosConversion());
+    instance.addLogicalTypeConversion(new TimeConversions.LocalTimestampMillisConversion());
+    instance.addLogicalTypeConversion(new TimeConversions.LocalTimestampNanosConversion());
+    instance.addLogicalTypeConversion(new TimeConversions.TimeMicrosConversion());
+    instance.addLogicalTypeConversion(new TimeConversions.TimeMillisConversion());
+    instance.addLogicalTypeConversion(new TimeConversions.TimestampMicrosConversion());
+    instance.addLogicalTypeConversion(new TimeConversions.TimestampMillisConversion());
+    instance.addLogicalTypeConversion(new TimeConversions.TimestampNanosConversion());
   }
 
   private static final Class<?>[] NO_ARG = new Class[] {};

--- a/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificData.java
@@ -62,7 +62,9 @@ public class SpecificData extends GenericData {
 
   static {
     INSTANCE.addLogicalTypeConversion(new Conversions.UUIDConversion());
-    INSTANCE.addLogicalTypeConversion(new Conversions.DecimalConversion());
+    // Disable DecimalConversion since it's gated behind
+    // `compiler.setEnableDecimalLogicalType`
+    // INSTANCE.addLogicalTypeConversion(new Conversions.DecimalConversion());
     INSTANCE.addLogicalTypeConversion(new Conversions.BigDecimalConversion());
     INSTANCE.addLogicalTypeConversion(new Conversions.DurationConversion());
     INSTANCE.addLogicalTypeConversion(new TimeConversions.DateConversion());

--- a/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificData.java
@@ -19,9 +19,11 @@ package org.apache.avro.specific;
 
 import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.AvroTypeException;
+import org.apache.avro.Conversions;
 import org.apache.avro.Protocol;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Type;
+import org.apache.avro.data.TimeConversions;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.BinaryEncoder;
@@ -57,6 +59,22 @@ import java.util.function.Function;
 public class SpecificData extends GenericData {
 
   private static final SpecificData INSTANCE = new SpecificData();
+
+  static {
+    INSTANCE.addLogicalTypeConversion(new Conversions.UUIDConversion());
+    INSTANCE.addLogicalTypeConversion(new Conversions.DecimalConversion());
+    INSTANCE.addLogicalTypeConversion(new Conversions.BigDecimalConversion());
+    INSTANCE.addLogicalTypeConversion(new Conversions.DurationConversion());
+    INSTANCE.addLogicalTypeConversion(new TimeConversions.DateConversion());
+    INSTANCE.addLogicalTypeConversion(new TimeConversions.LocalTimestampMicrosConversion());
+    INSTANCE.addLogicalTypeConversion(new TimeConversions.LocalTimestampMillisConversion());
+    INSTANCE.addLogicalTypeConversion(new TimeConversions.LocalTimestampNanosConversion());
+    INSTANCE.addLogicalTypeConversion(new TimeConversions.TimeMicrosConversion());
+    INSTANCE.addLogicalTypeConversion(new TimeConversions.TimeMillisConversion());
+    INSTANCE.addLogicalTypeConversion(new TimeConversions.TimestampMicrosConversion());
+    INSTANCE.addLogicalTypeConversion(new TimeConversions.TimestampMillisConversion());
+    INSTANCE.addLogicalTypeConversion(new TimeConversions.TimestampNanosConversion());
+  }
 
   private static final Class<?>[] NO_ARG = new Class[] {};
   private static final Class<?>[] SCHEMA_ARG = new Class[] { Schema.class };

--- a/lang/java/ipc/src/test/java/org/apache/avro/TestDataFileReflect.java
+++ b/lang/java/ipc/src/test/java/org/apache/avro/TestDataFileReflect.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.avro;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.Instant;
+
+import example.avro.Bar;
+import org.apache.avro.file.DataFileReader;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.reflect.ReflectDatumReader;
+import org.apache.avro.reflect.ReflectDatumWriter;
+import org.apache.avro.specific.SpecificDatumReader;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class TestDataFileReflect {
+
+  @TempDir
+  public File DIR;
+
+  @Test
+  public void reflectDatumReaderUnionWithLogicalType() throws IOException {
+    File file = new File(DIR.getPath(), "testReflectDatumReaderUnionWithLogicalType");
+    Schema schema = Bar.SCHEMA$;
+    // Create test data
+    Instant value = Instant.now();
+    try (DataFileWriter<GenericData.Record> writer = new DataFileWriter<>(
+        new GenericDatumWriter<GenericData.Record>(schema)).create(schema, file)) {
+      for (int i = 0; i < 10; i++) {
+        GenericData.Record r = new GenericData.Record(schema);
+        r.put("title", "title" + i);
+        r.put("created_at", value.toEpochMilli() + i * 1000);
+        writer.append(r);
+      }
+    }
+
+    // read using a 'new ReflectDatumReader<T>()' to force inference of
+    // reader's schema from runtime
+    try (DataFileReader<Bar> reader = new DataFileReader<>(file, new ReflectDatumReader<>())) {
+      int i = 0;
+      for (Bar instance : reader) {
+        assertEquals("title" + i, instance.getTitle());
+        assertEquals(Instant.ofEpochMilli(value.plusSeconds(i).toEpochMilli()), instance.getCreatedAt());
+        i++;
+      }
+      assertEquals(10, i);
+    }
+  }
+
+  @Test
+  public void reflectDatumWriterUnionWithLogicalType() throws IOException {
+    File file = new File(DIR.getPath(), "testReflectDatumWriterUnionWithLogicalType");
+
+    // Create test data
+    Instant value = Instant.now();
+    try (DataFileWriter<Bar> writer = new DataFileWriter<>(new ReflectDatumWriter<Bar>()).create(Bar.SCHEMA$, file)) {
+      for (int i = 0; i < 10; i++) {
+        Bar r = Bar.newBuilder().setTitle("title" + i).setCreatedAt(value.plusSeconds(i)).build();
+        writer.append(r);
+      }
+    }
+
+    // read using a 'new SpecificDatumReader<T>()' to force inference of
+    // reader's schema from runtime
+    try (DataFileReader<Bar> reader = new DataFileReader<>(file, new SpecificDatumReader<>())) {
+      int i = 0;
+      for (Bar instance : reader) {
+        assertEquals("title" + i, instance.getTitle());
+        assertEquals(Instant.ofEpochMilli(value.plusSeconds(i).toEpochMilli()), instance.getCreatedAt());
+        i++;
+      }
+      assertEquals(10, i);
+    }
+  }
+}

--- a/share/test/schemas/fooBar.avsc
+++ b/share/test/schemas/fooBar.avsc
@@ -1,0 +1,21 @@
+{
+   "fields" : [
+      {
+         "name" : "title",
+         "type" : "string"
+      },
+      {
+         "name" : "created_at",
+         "type" : [
+            "null",
+            {
+               "logicalType" : "timestamp-millis",
+               "type" : "long"
+            }
+         ]
+      }
+   ],
+   "name" : "Bar",
+   "namespace" : "foo",
+   "type" : "record"
+}

--- a/share/test/schemas/fooBar.avsc
+++ b/share/test/schemas/fooBar.avsc
@@ -16,6 +16,6 @@
       }
    ],
    "name" : "Bar",
-   "namespace" : "foo",
+   "namespace" : "example.avro",
    "type" : "record"
 }


### PR DESCRIPTION
## What is the purpose of the change

This pull request improves deserialization of data when using default `SpecificData` instance.

Why?
Often times, `SpecificDatumReader` and `ReflectDatumReader` are configured using the default `SpecificData` instance. This leads to deserialization error when reading fields with union type and inner logical type (see test-case).

Deserialization works correctly when using the custom `SpecificData` instance stored in the `MODEL$` field of the schema class that `extends SpecificRecord`. The custom `SpecificData` has the necessary conversions stored to handle fields with union and logical types. The issue has been reported multiple times, notably in [AVRO-3989](linked JIRA).

## Verifying this change

This change added tests and can be verified as follows:
- *The added test passes when the code is present but fails when the code is removed*


## Documentation

- Does this pull request introduce a new feature? (no)