### PR TITLE
AVRO-4127: Use the dist target to build website

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -163,7 +163,7 @@ jobs:
         run: |
           set -x
           cd lang/java
-          mvn javadoc::aggregate
+          ./build.sh dist
       - uses: actions/upload-artifact@v4
         with:
           name: api-java


### PR DESCRIPTION
## What is the purpose of the change

Ensure that the current jars are used to build the website.

## Verifying this change

Manually verified.

## Documentation

- Does this pull request introduce a new feature? *no*
- If yes, how is the feature documented? *not applicable*