### PR TITLE
AVRO-4132: [C++] Add ZSTD codec

### DIFF
--- a/.github/workflows/test-lang-c++-ARM.yml
+++ b/.github/workflows/test-lang-c++-ARM.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update -q
-          sudo apt-get install -q -y gcc g++ libboost-all-dev libfmt-dev zlib1g-dev cmake
+          sudo apt-get install -q -y gcc g++ libboost-all-dev libfmt-dev zlib1g-dev libzstd-dev cmake
 
       - name: Build
         run: |

--- a/.github/workflows/test-lang-c++.yml
+++ b/.github/workflows/test-lang-c++.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Dependencies
-        run: sudo apt update && sudo apt-get install -qqy cppcheck libboost-all-dev libsnappy-dev libfmt-dev zlib1g-dev cmake
+        run: sudo apt update && sudo apt-get install -qqy cppcheck libboost-all-dev libsnappy-dev libfmt-dev zlib1g-dev libzstd-dev cmake
 
       - name: Print Versions
         run: |

--- a/lang/c++/CMakeLists.txt
+++ b/lang/c++/CMakeLists.txt
@@ -98,6 +98,16 @@ else ()
     message("Disabled snappy codec.")
 endif ()
 
+find_package(zstd CONFIG)
+if(zstd_FOUND)
+    message("Enabled zstd codec, version: ${zstd_VERSION}")
+    set(ZSTD_TARGET $<IF:$<TARGET_EXISTS:zstd::libzstd_shared>,zstd::libzstd_shared,zstd::libzstd_static>)
+    add_definitions(-DZSTD_CODEC_AVAILABLE)
+else()
+    message("Disabled zstd codec.")
+    set(ZSTD_TARGET "")
+endif()
+
 # FindZLIB guarantees that ZLIB::ZLIB target exists if found
 # See https://cmake.org/cmake/help/latest/module/FindZLIB.html#imported-targets
 find_package(ZLIB REQUIRED)
@@ -135,18 +145,22 @@ target_link_libraries(avrocpp PUBLIC
   $<BUILD_INTERFACE:fmt::fmt-header-only>
   $<BUILD_INTERFACE:ZLIB::ZLIB>
   $<BUILD_INTERFACE:$<TARGET_NAME_IF_EXISTS:Snappy::snappy>>
+  $<$<BOOL:${zstd_FOUND}>:$<BUILD_INTERFACE:$<TARGET_NAME_IF_EXISTS:${ZSTD_TARGET}>>>
   $<BUILD_INTERFACE:$<TARGET_NAME_IF_EXISTS:Boost::system>>
   $<INSTALL_INTERFACE:ZLIB::ZLIB>
   $<INSTALL_INTERFACE:$<TARGET_NAME_IF_EXISTS:Snappy::snappy>>
+  $<$<BOOL:${zstd_FOUND}>:$<INSTALL_INTERFACE:$<TARGET_NAME_IF_EXISTS:${ZSTD_TARGET}>>>
   $<INSTALL_INTERFACE:$<TARGET_NAME_IF_EXISTS:Boost::system>>
 )
 target_link_libraries(avrocpp_s PUBLIC
   $<BUILD_INTERFACE:fmt::fmt-header-only>
   $<BUILD_INTERFACE:ZLIB::ZLIB>
   $<BUILD_INTERFACE:$<TARGET_NAME_IF_EXISTS:Snappy::snappy>>
+  $<$<BOOL:${zstd_FOUND}>:$<BUILD_INTERFACE:$<TARGET_NAME_IF_EXISTS:${ZSTD_TARGET}>>>
   $<BUILD_INTERFACE:$<TARGET_NAME_IF_EXISTS:Boost::system>>
   $<INSTALL_INTERFACE:ZLIB::ZLIB>
   $<INSTALL_INTERFACE:$<TARGET_NAME_IF_EXISTS:Snappy::snappy>>
+  $<$<BOOL:${zstd_FOUND}>:$<INSTALL_INTERFACE:$<TARGET_NAME_IF_EXISTS:${ZSTD_TARGET}>>>
   $<INSTALL_INTERFACE:$<TARGET_NAME_IF_EXISTS:Boost::system>>
 )
 
@@ -205,7 +219,7 @@ if (AVRO_BUILD_TESTS)
 
     macro (unittest name)
         add_executable (${name} test/${name}.cc)
-        target_link_libraries (${name} avrocpp_s Boost::system ZLIB::ZLIB $<TARGET_NAME_IF_EXISTS:Snappy::snappy>)
+        target_link_libraries (${name} avrocpp_s Boost::system ZLIB::ZLIB $<TARGET_NAME_IF_EXISTS:Snappy::snappy> $<$<BOOL:${zstd_FOUND}>:$<TARGET_NAME_IF_EXISTS:${ZSTD_TARGET}>>)
         add_test (NAME ${name} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
             COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${name})
     endmacro (unittest)

--- a/lang/c++/include/avro/DataFile.hh
+++ b/lang/c++/include/avro/DataFile.hh
@@ -35,15 +35,15 @@ namespace avro {
 
 /** Specify type of compression to use when writing data files. */
 enum Codec {
-    NULL_CODEC,
-    DEFLATE_CODEC,
+    NULL_CODEC = 0,
+    DEFLATE_CODEC = 1,
 
 #ifdef SNAPPY_CODEC_AVAILABLE
-    SNAPPY_CODEC,
+    SNAPPY_CODEC = 2,
 #endif
 
 #ifdef ZSTD_CODEC_AVAILABLE
-    ZSTD_CODEC
+    ZSTD_CODEC = 3,
 #endif
 
 };

--- a/lang/c++/include/avro/DataFile.hh
+++ b/lang/c++/include/avro/DataFile.hh
@@ -39,7 +39,11 @@ enum Codec {
     DEFLATE_CODEC,
 
 #ifdef SNAPPY_CODEC_AVAILABLE
-    SNAPPY_CODEC
+    SNAPPY_CODEC,
+#endif
+
+#ifdef ZSTD_CODEC_AVAILABLE
+    ZSTD_CODEC
 #endif
 
 };


### PR DESCRIPTION
## What is the purpose of the change

Add ZSTD codec to the C++ implementation


## Verifying this change

This change added tests and can be verified as follows:

- *Added test that validates the codec works perfectly*


## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable
