### PR TITLE
AVRO-4135: [Java] JSON decoding unqualified union types

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/io/parsing/Symbol.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/parsing/Symbol.java
@@ -475,6 +475,16 @@ public abstract class Symbol {
             return i;
           }
         }
+        // AVRO-4135 We are a bit more flexible here since we have to deal with the C
+        // serializer being less strict, so
+        // we fall back to looking up unqualified names.
+        for (int i = 0; i < labels.length; i++) {
+          String candidate = labels[i];
+          if (candidate != null && candidate.length() > label.length()
+              && candidate.charAt(candidate.length() - label.length() - 1) == '.' && candidate.endsWith(label)) {
+            return i;
+          }
+        }
       }
       return -1;
     }


### PR DESCRIPTION
Support unqualified type references for unions when decoding them from json.
AVRO-2287 makes it unclear if type reference for a JSON encoded union needs to be qualified or not.
Today all encoders use the fully qualified types except the C JSON encoder which uses the unqualified type.

In this patch we make the java JSON Decoder more lenient and let it fallback to unqualified types names when no qualified type name matches.  Which matches the behavior currently implemented in the Javascript Json decoder.

This patch is an alternative for apache/avro#3373 where it is proposed to update the C library instead.

<!--

*Thank you very much for contributing to Apache Avro - we are happy that you want to help us improve Avro. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Avro a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/AVRO/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "AVRO-XXXX: [component] Title of the pull request", where *AVRO-XXXX* should be replaced by the actual issue number. 
    The *component* is optional, but can help identify the correct reviewers faster: either the language ("java", "python") or subsystem such as "build" or "doc" are good candidates.  

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests. You can [build the entire project](https://github.com/apache/avro/blob/main/BUILD.md) or just the [language-specific SDK](https://avro.apache.org/project/how-to-contribute/#unit-tests).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Every commit message references Jira issues in their subject lines. In addition, commits follow the guidelines from [How to write a good git commit message](https://chris.beams.io/posts/git-commit/)
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

-->



## Verifying this change

This change added tests and can be verified as follows: run newly added test: `org.apache.avro.io.TestJsonDecoder#testUnionTypeQualification`


## Documentation

- Does this pull request introduce a new feature? no
