### PR TITLE
Remove the default serializable packages and deprecated the property to introduce org.apache.avro.SERIALIZABLE_CLASSES instead

### DIFF
--- a/lang/java/avro/pom.xml
+++ b/lang/java/avro/pom.xml
@@ -90,6 +90,9 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <parallel>none</parallel>
+          <systemProperties>
+            <org.apache.avro.SERIALIZABLE_CLASSES>java.math.BigDecimal,java.math.BigInteger,java.net.URI,java.net.URL,java.io.File,java.lang.Integer,org.apache.avro.reflect.TestReflect$R10</org.apache.avro.SERIALIZABLE_CLASSES>
+          </systemProperties>
         </configuration>
         <executions>
           <execution>

--- a/lang/java/avro/src/test/java/org/apache/avro/reflect/TestReflect.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/reflect/TestReflect.java
@@ -615,6 +615,7 @@ public class TestReflect {
   }
 
   void checkReadWrite(Object object, Schema s) throws Exception {
+
     ReflectDatumWriter<Object> writer = new ReflectDatumWriter<>(s);
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     writer.write(object, factory.directBinaryEncoder(out, null));

--- a/lang/java/ipc/pom.xml
+++ b/lang/java/ipc/pom.xml
@@ -62,6 +62,9 @@
           <forkCount>1</forkCount>
           <reuseForks>false</reuseForks>
            <parallel>none</parallel>
+          <systemProperties>
+            <org.apache.avro.SERIALIZABLE_CLASSES>java.math.BigDecimal,java.math.BigInteger</org.apache.avro.SERIALIZABLE_CLASSES>
+          </systemProperties>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
As discussed within the Parquet community, this PR is more "restrictive":
1. no serializable packages by default
2. deprecate `org.apache.avro.SERIALIZABLE_PACKAGES` property
3. instead of `SERIALIZABLE_PACKAGES`, users should use `org.apache.avro.SERIALIZABLE_CLASSES`

This is a much more "strict" security enforcement.