### PR TITLE
AVRO-4140: [C++] Support uuid to annotate fixed[16]

### DIFF
--- a/lang/c++/impl/Node.cc
+++ b/lang/c++/impl/Node.cc
@@ -228,9 +228,9 @@ void Node::setLogicalType(LogicalType logicalType) {
             }
             break;
         case LogicalType::UUID:
-            if (type_ != AVRO_STRING) {
+            if (type_ != AVRO_STRING && (type_ != AVRO_FIXED || fixedSize() != 16)) {
                 throw Exception("UUID logical type can only annotate "
-                                "STRING type");
+                                "STRING type or FIXED type of length 16");
             }
             break;
         case LogicalType::CUSTOM:


### PR DESCRIPTION
## What is the purpose of the change

Support uuid logical type to annotate fixed type of length 16. This is required by uuid type of Apache Iceberg.

## Verifying this change

Added test cases for uuid type based on fixed[16] and verify it throws correctly for other size.

## Documentation

- Does this pull request introduce a new feature? technically no
- If yes, how is the feature documented? not applicable
