### PR TITLE
fix broken test after merging #3376

### DIFF
--- a/lang/java/avro/src/it/pom.xml
+++ b/lang/java/avro/src/it/pom.xml
@@ -94,6 +94,9 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>@maven-surefire-plugin.version@</version>
         <configuration>
+          <systemProperties>
+            <org.apache.avro.SERIALIZABLE_CLASSES>java.math.BigDecimal,java.math.BigInteger,java.net.URI,java.net.URL,java.io.File,java.lang.Integer,org.apache.avro.reflect.TestReflect$R10</org.apache.avro.SERIALIZABLE_CLASSES>
+          </systemProperties>
           <useModulePath>false</useModulePath>
           <failIfNoTests>true</failIfNoTests>
         </configuration>


### PR DESCRIPTION
Tests got broken after merging #3376, because in `avro/src/it/pom.xml` we forgot to set `org.apache.avro.SERIALIZABLE_CLASSES`.