### PR TITLE
AVRO-3731 [java/gradle-plugin] retry on any schema parse failure

### DIFF
--- a/lang/java/gradle-plugin/src/main/java/com/github/davidmc24/gradle/plugin/avro/SchemaResolver.java
+++ b/lang/java/gradle-plugin/src/main/java/com/github/davidmc24/gradle/plugin/avro/SchemaResolver.java
@@ -6,14 +6,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.Schema;
-import org.apache.avro.SchemaParseException;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.logging.Logger;
 
 class SchemaResolver {
-    private static Pattern ERROR_UNKNOWN_TYPE = Pattern.compile("(?i).*(undefined name|not a defined name|type not supported).*");
     private static Pattern ERROR_DUPLICATE_TYPE = Pattern.compile("Can't redefine: (.*)");
 
     private final ProjectLayout projectLayout;
@@ -58,15 +57,10 @@ class SchemaResolver {
             } else {
                 logger.info("Processed {}", path);
             }
-        } catch (SchemaParseException ex) {
+        } catch (AvroRuntimeException ex) {
             String errorMessage = ex.getMessage();
-            Matcher unknownTypeMatcher = ERROR_UNKNOWN_TYPE.matcher(errorMessage);
             Matcher duplicateTypeMatcher = ERROR_DUPLICATE_TYPE.matcher(errorMessage);
-            if (unknownTypeMatcher.matches()) {
-                fileState.setError(ex);
-                processingState.queueForDelayedProcessing(fileState);
-                logger.debug("Found undefined name in {} ({}); will try again", path, errorMessage);
-            } else if (duplicateTypeMatcher.matches()) {
+            if (duplicateTypeMatcher.matches()) {
                 String typeName = duplicateTypeMatcher.group(1);
                 if (fileState.containsDuplicateTypeName(typeName)) {
                     throw new GradleException(
@@ -79,7 +73,9 @@ class SchemaResolver {
                     logger.debug("Identified duplicate type {} in {}; will re-process excluding it", typeName, path);
                 }
             } else {
-                throw new GradleException(String.format("Failed to resolve schema definition file %s", path), ex);
+                fileState.setError(ex);
+                processingState.queueForDelayedProcessing(fileState);
+                logger.debug("Found error in {} ({}); will try again", path, errorMessage);
             }
         } catch (IOException ex) {
             throw new GradleException(String.format("Failed to resolve schema definition file %s", path), ex);


### PR DESCRIPTION
With the introduction of the new SchemaParser in 1.12 the variety of errors which can be thrown when an unresolved type is found increased significantly.
In the past unresolved type errors were tracked with a brittle regexp. In the newly proposed logic we propose to retry failed parse steps on any AvroRuntimeException.  So this works for all past and future avro library versions.

@frevib this is a small proposal for an update on #3305 so the gradle plugin support 1.12 and others.
Let me know what you think, and if I can help you improving it somehow.

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change can be verified as follows:
- run `SchemaResolverSpec.groovy`
- And manually verified on internal corpus.

## Documentation

- Does this pull request introduce a new feature? (no)
