### PR TITLE
[AVRO-4137, C#]: SpecificWriter Enum Name Matching

### DIFF
--- a/lang/csharp/src/apache/main/Specific/SpecificDatumWriter.cs
+++ b/lang/csharp/src/apache/main/Specific/SpecificDatumWriter.cs
@@ -139,7 +139,7 @@ namespace Avro.Specific
                     return obj is ISpecificRecord &&
                            ((obj as ISpecificRecord).Schema as RecordSchema).SchemaName.Equals((sc as RecordSchema).SchemaName);
                 case Schema.Type.Enumeration:
-                    return obj.GetType().IsEnum && (sc as EnumSchema).Symbols.Contains(obj.ToString());
+                    return obj.GetType().IsEnum && (sc as EnumSchema).Symbols.Contains(obj.ToString()) && sc.Name.Equals(obj.GetType().Name);
                 case Schema.Type.Array:
                     return obj is System.Collections.IList;
                 case Schema.Type.Map:

--- a/lang/csharp/src/apache/main/Specific/SpecificWriter.cs
+++ b/lang/csharp/src/apache/main/Specific/SpecificWriter.cs
@@ -209,7 +209,7 @@ namespace Avro.Specific
                     return obj is ISpecificRecord &&
                            ((obj as ISpecificRecord).Schema as RecordSchema).SchemaName.Equals((sc as RecordSchema).SchemaName);
                 case Schema.Type.Enumeration:
-                    return obj.GetType().IsEnum && (sc as EnumSchema).Symbols.Contains(obj.ToString());
+                    return obj.GetType().IsEnum && (sc as EnumSchema).Symbols.Contains(obj.ToString()) && sc.Name.Equals(obj.GetType().Name);
                 case Schema.Type.Array:
                     return obj is System.Collections.IList;
                 case Schema.Type.Map:


### PR DESCRIPTION
## Description

Quote from AVRO-4137:

At the moment, the C# library Avro matches Union types with Enum in the following way:

```csharp
// SpecificDefaultWriter.cs - LN159 - protected override bool Matches(Schema sc, object obj)

case Schema.Type.Enumeration:
   return obj.GetType().IsEnum && (sc as EnumSchema).Symbols.Contains(obj.ToString());
```

This leads to the scenario where several Enums declared within one Union schema cannot have the same value names, because upon serialization, the Enum that is declared earlier will be chosen, not the one that was originally passed.

It is further suggested to conduct a check on the type name and the schema itself:

```csharp
case Schema.Type.Enumeration:
  return obj.GetType().IsEnum && (sc as EnumSchema).Symbols.Contains(obj.ToString()) && sc.Name == obj.GetType().Name;
```

If you believe that this could lead to unforeseen problems (such as breaking backward compatibility), it is proposed to make the check optional, by default turned off. There may be other, more reliable methods to solve this issue, but the demonstrated one seemed the most optimal in my mind 😃 

Thank you!

## What is the purpose of the change

This pull request introduces SpecificWriter's Enum matching by name, fixing AVRO-4137

## Verifying this change

This change is already covered by existing tests.

## Documentation

- Does this pull request introduce a new feature? no
