### PR TITLE
AVRO-4161: [C#] Fix System.Decimal to Avro decimal conversion

### DIFF
--- a/lang/csharp/src/apache/main/AvroDecimal.cs
+++ b/lang/csharp/src/apache/main/AvroDecimal.cs
@@ -53,8 +53,11 @@ namespace Avro
         {
             var bytes = GetBytesFromDecimal(value);
 
-            var unscaledValueBytes = new byte[12];
-            Array.Copy(bytes, unscaledValueBytes, unscaledValueBytes.Length);
+            // Copy the first 12 bytes of the decimal into an array of size 13
+            // so that the last byte is 0, which is required by the
+            // BigInteger constructor to ensure the unscaled value is positive.
+            var unscaledValueBytes = new byte[13];
+            Array.Copy(bytes, unscaledValueBytes, 12);
 
             var unscaledValue = new BigInteger(unscaledValueBytes);
             var scale = bytes[14];

--- a/lang/csharp/src/apache/test/AvroDecimalTest.cs
+++ b/lang/csharp/src/apache/test/AvroDecimalTest.cs
@@ -34,10 +34,20 @@ namespace Avro.test
         [TestCase(-10.10)]
         [TestCase(-0.1)]
         [TestCase(-0.01)]
-        [TestCase(4.1748330066797328106875724512m)]
-        [TestCase(-4.1748330066797328106875724512m)]
         public void TestAvroDecimalToString(decimal value)
         {
+            var valueString = value.ToString();
+
+            var avroDecimal = new AvroDecimal(value);
+            var avroDecimalString = avroDecimal.ToString();
+
+            Assert.AreEqual(valueString, avroDecimalString);
+        }
+
+        [Test]
+        public void TestHighPrecisionAvroDecimalToString()
+        {
+            var value = 4.1748330066797328106875724512m; // High precision decimal value
             var valueString = value.ToString();
 
             var avroDecimal = new AvroDecimal(value);

--- a/lang/csharp/src/apache/test/AvroDecimalTest.cs
+++ b/lang/csharp/src/apache/test/AvroDecimalTest.cs
@@ -34,11 +34,13 @@ namespace Avro.test
         [TestCase(-10.10)]
         [TestCase(-0.1)]
         [TestCase(-0.01)]
+        [TestCase(4.1748330066797328106875724512m)]
+        [TestCase(-4.1748330066797328106875724512m)]
         public void TestAvroDecimalToString(decimal value)
         {
             var valueString = value.ToString();
 
-            var avroDecimal = new AvroDecimal(value);            
+            var avroDecimal = new AvroDecimal(value);
             var avroDecimalString = avroDecimal.ToString();
 
             Assert.AreEqual(valueString, avroDecimalString);

--- a/lang/csharp/src/apache/test/AvroDecimalTest.cs
+++ b/lang/csharp/src/apache/test/AvroDecimalTest.cs
@@ -54,6 +54,14 @@ namespace Avro.test
             var avroDecimalString = avroDecimal.ToString();
 
             Assert.AreEqual(valueString, avroDecimalString);
+
+            value = -4.1748330066797328106875724512m; // High precision decimal value
+            valueString = value.ToString();
+
+            avroDecimal = new AvroDecimal(value);
+            avroDecimalString = avroDecimal.ToString();
+
+            Assert.AreEqual(valueString, avroDecimalString);
         }
     }
 }


### PR DESCRIPTION
<!--

*Thank you very much for contributing to Apache Avro - we are happy that you want to help us improve Avro. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Avro a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/AVRO/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "AVRO-XXXX: [component] Title of the pull request", where *AVRO-XXXX* should be replaced by the actual issue number. 
    The *component* is optional, but can help identify the correct reviewers faster: either the language ("java", "python") or subsystem such as "build" or "doc" are good candidates.  

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests. You can [build the entire project](https://github.com/apache/avro/blob/main/BUILD.md) or just the [language-specific SDK](https://avro.apache.org/project/how-to-contribute/#unit-tests).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Every commit message references Jira issues in their subject lines. In addition, commits follow the guidelines from [How to write a good git commit message](https://chris.beams.io/posts/git-commit/)
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

-->

## What is the purpose of the change

The conversion from the C# System.Decimal to an Avro logical type decimal is not correct. The first 12 bytes of the System.Decimal represent a positive unscaled value. This value is passed into a BigInteger constructor. However, the documentation of the [BigInteger constructor](https://learn.microsoft.com/en-us/dotnet/api/system.numerics.biginteger.-ctor?view=net-9.0#system-numerics-biginteger-ctor(system-byte())) states that the most significant bit of the last byte represents the sign of the BigInteger. The docs also explain that a 0 byte can be appended to the byte array passed to the BigInteger constructor to ensure the value is treated as positive.

## Verifying this change

Added a test that fails without the fix.

## Documentation

- Does this pull request introduce a new feature? (no)

