### PR TITLE
AVRO-4163: [java] add java 17 test module.

### DIFF
--- a/lang/java/java17-test/pom.xml
+++ b/lang/java/java17-test/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+       https://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<project
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+        xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+      <artifactId>avro-parent</artifactId>
+      <groupId>org.apache.avro</groupId>
+      <version>1.13.0-SNAPSHOT</version>
+      <relativePath>../</relativePath>
+  </parent>
+
+  <artifactId>java17-test</artifactId>
+  <name>Avro Java 17 Tests</name>
+  <description>Unit tests that require java 17 language support.</description>
+  <url>https://avro.apache.org/</url>
+
+  <properties>
+    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.release>17</maven.compiler.release>
+    <main.basedir>${project.parent.parent.basedir}</main.basedir>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>avro</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/lang/java/java17-test/src/test/java/org/apache/avro/reflect/TestJavaRecords.java
+++ b/lang/java/java17-test/src/test/java/org/apache/avro/reflect/TestJavaRecords.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.avro.reflect;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.io.EncoderFactory;
+import org.junit.jupiter.api.Test;
+
+public class TestJavaRecords {
+
+  EncoderFactory factory = new EncoderFactory();
+
+  @Test
+  void testRecordWithEncoder() throws IOException {
+
+    var wrapper = new Wrapper(new R1("test"));
+
+    var read = readWrite(wrapper);
+
+    assertEquals("test", wrapper.getR1().value());
+    assertEquals("test used this", read.getR1().value());
+  }
+
+  public static class Wrapper {
+
+    @AvroEncode(using = R1Encoding.class)
+    private R1 r1;
+
+    public Wrapper() {
+    }
+
+    public Wrapper(R1 r1) {
+      this.r1 = r1;
+    }
+
+    public R1 getR1() {
+      return r1;
+    }
+
+    public void setR1(R1 r1) {
+      this.r1 = r1;
+    }
+
+  }
+
+  public static record R1(String value) {
+  }
+
+  public static class R1Encoding extends CustomEncoding<R1> {
+
+    {
+
+      schema = Schema.createRecord("R1", null, null, false,
+          Arrays.asList(new Schema.Field("value", Schema.create(Schema.Type.STRING), null, null)));
+    }
+
+    @Override
+    protected void write(Object datum, Encoder out) throws IOException {
+      if (datum instanceof R1 r1) {
+        out.writeString(r1.value());
+
+      } else {
+        throw new AvroTypeException("Expected R1, got " + datum.getClass());
+      }
+
+    }
+
+    @Override
+    protected R1 read(Object reuse, Decoder in) throws IOException {
+      return new R1(in.readString() + " used this");
+    }
+  }
+
+  <T> T readWrite(T object) throws IOException {
+    var schema = ReflectData.get().getSchema(object.getClass());
+    ReflectDatumWriter<T> writer = new ReflectDatumWriter<>(schema);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    writer.write(object, factory.directBinaryEncoder(out, null));
+    ReflectDatumReader<T> reader = new ReflectDatumReader<>(schema);
+    return reader.read(null, DecoderFactory.get().binaryDecoder(out.toByteArray(), null));
+  }
+
+}

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -91,6 +91,7 @@
     <module>integration-test</module>
     <module>perf</module>
     <module>interop-data-test</module>
+    <module>java17-test</module>
   </modules>
 
   <build>
@@ -393,6 +394,7 @@
                       <pluginExecutionFilter>
                         <groupId>com.diffplug.spotless</groupId>
                         <artifactId>spotless-maven-plugin</artifactId>
+                        <versionRange>[0,)</versionRange>
                         <goals>
                           <goal>check</goal>
                         </goals>
@@ -405,6 +407,7 @@
                       <pluginExecutionFilter>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-plugin-plugin</artifactId>
+                        <versionRange>[0,)</versionRange>
                         <goals>
                           <goal>helpmojo</goal>
                           <goal>descriptor</goal>


### PR DESCRIPTION
This pull request adds Java 17 test support.
This will allow adding support for features like Java records without requiring an update to the Maven build.


This change added tests and can be verified as follows:

This adds a test that if a `@AvroEncode` is specified on a Java record, it works correctly.



