### PR TITLE
Symbol.cc and FileStream.cc: Fix -Wconversion and -Wuseless-cast on 32-bit builds

### DIFF
--- a/lang/c++/impl/FileStream.cc
+++ b/lang/c++/impl/FileStream.cc
@@ -205,8 +205,15 @@ class BufferCopyInInputStream : public SeekableInputStream {
     void seek(int64_t position) final {
         // BufferCopyIn::seek is relative to byteCount_, whereas position is
         // absolute.
-        in_->seek(position - byteCount_ - available_);
-        byteCount_ = position;
+        int64_t offset = position - static_cast<int64_t>(byteCount_) - static_cast<int64_t>(available_);
+        if (offset < 0) {
+            throw Exception("Negative offset in seek");
+        }
+        in_->seek(static_cast<size_t>(offset));
+        if (position < 0) {
+            throw Exception("Negative position not allowed");
+        }
+        byteCount_ = static_cast<size_t>(position);
         available_ = 0;
     }
 

--- a/lang/c++/impl/parsing/Symbol.cc
+++ b/lang/c++/impl/parsing/Symbol.cc
@@ -88,7 +88,12 @@ Symbol Symbol::enumAdjustSymbol(const NodePtr &writer, const NodePtr &reader) {
             adj.push_back(static_cast<int>(-pos));
             err.push_back(s);
         } else {
-            adj.push_back(static_cast<int>(it - rs.begin()));
+            auto index = it - rs.begin();
+            if constexpr (std::is_same_v<decltype(index), int>) {
+                adj.push_back(index);  // 32-bit: already int
+            } else {
+                adj.push_back(static_cast<int>(index));  // 64-bit: long to int
+            }
         }
     }
     return Symbol(Kind::EnumAdjust, make_pair(adj, err));


### PR DESCRIPTION
Symbol.cc:

it - rs.begin() returns a value of type std::ptrdiff_t. On 32-bit systems, this is typically int, so casting it to int is redundant and triggers -Wuseless-cast.

FileStream.cc:

size_t is 32-bit on 32-bit systems, while position is int64_t. Casting int64_t to size_t can lead to truncation, causing -Wconversion errors. The fix ensures the offset and position are checked for negativity before conversion.

Fix:

lib32-avro-c++/1.12/sources/avro-c++-1.12/lang/c++/impl/parsing/Symbol.cc:91:27: error: useless cast to type 'int' [-Werror=useless-cast]
   91 |             adj.push_back(static_cast<int>(it - rs.begin()));
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors

lib32-avro-c++/1.12/sources/avro-c++-1.12/lang/c++/impl/FileStream.cc:208:41: error: conversion from 'int64_t' {aka 'long long int'} to 'size_t' {aka 'unsigned int'} may change value [-Werror=conversion]
  208 |         in_->seek(position - byteCount_ - available_);
      |                   ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
lib32-avro-c++/1.12/sources/avro-c++-1.12/lang/c++/impl/FileStream.cc:209:22:
error: conversion from 'int64_t' {aka 'long long int'} to 'size_t'
{aka 'unsigned int'} may change value [-Werror=conversion]
  209 |         byteCount_ = position;
      |                      ^~~~~~~~
cc1plus: all warnings being treated as errors

These changes fix build failures on 32-bit systems and ensure safe type conversions.