### PR TITLE
AVRO-4168: [C++] Make static and shared libs optional

### DIFF
--- a/lang/c++/CMakeLists.txt
+++ b/lang/c++/CMakeLists.txt
@@ -56,8 +56,25 @@ set(AVRO_VERSION "${AVRO_VERSION_MAJOR}.${AVRO_VERSION_MINOR}.${AVRO_VERSION_PAT
 project (Avro-cpp)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR})
 
+# Try to respect BUILD_SHARED_LIBS if set. If not set, then fall back to the original default of
+# both static and shared.
+if (DEFINED BUILD_SHARED_LIBS)
+    if (BUILD_SHARED_LIBS)
+        set(AVRO_DEFAULT_BUILD_SHARED ON)
+        set(AVRO_DEFAULT_BUILD_STATIC OFF)
+    else ()
+        set(AVRO_DEFAULT_BUILD_SHARED OFF)
+        set(AVRO_DEFAULT_BUILD_STATIC ON)
+    endif ()
+else ()
+    set(AVRO_DEFAULT_BUILD_SHARED ON)
+    set(AVRO_DEFAULT_BUILD_STATIC ON)
+endif ()
+
 option(AVRO_BUILD_EXECUTABLES "Build executables" ON)
 option(AVRO_BUILD_TESTS "Build tests" ON)
+option(AVRO_BUILD_SHARED "Build shared library" ${AVRO_DEFAULT_BUILD_SHARED})
+option(AVRO_BUILD_STATIC "Build static library" ${AVRO_DEFAULT_BUILD_STATIC})
 option(AVRO_USE_BOOST "Use Boost" OFF)
 
 if (WIN32 AND NOT CYGWIN AND NOT MSYS)
@@ -77,6 +94,10 @@ if (AVRO_BUILD_TESTS OR AVRO_USE_BOOST)
     # It guarantees that Boost::system target exists if found.
     # See https://cmake.org/cmake/help/latest/policy/CMP0167.html
     find_package (Boost 1.70 REQUIRED CONFIG COMPONENTS system)
+endif ()
+
+if (NOT AVRO_BUILD_STATIC AND NOT AVRO_BUILD_SHARED)
+    message(FATAL_ERROR "At least one of AVRO_BUILD_STATIC or AVRO_BUILD_SHARED must be ON.")
 endif ()
 
 include(FetchContent)
@@ -132,54 +153,64 @@ set (AVRO_SOURCE_FILES
         impl/CustomAttributes.cc
         )
 
-add_library (avrocpp SHARED ${AVRO_SOURCE_FILES})
-add_library (avrocpp_s STATIC ${AVRO_SOURCE_FILES})
+set (AVRO_INSTALL_LIBS)
 
-target_compile_definitions(avrocpp PRIVATE AVRO_SOURCE AVRO_DYN_LINK)
-target_compile_definitions(avrocpp_s PRIVATE AVRO_SOURCE)
+if (AVRO_BUILD_SHARED)
+    add_library (avrocpp SHARED ${AVRO_SOURCE_FILES})
+    target_compile_definitions(avrocpp PRIVATE AVRO_SOURCE PUBLIC AVRO_DYN_LINK)
+    set_target_properties (avrocpp PROPERTIES VERSION ${AVRO_VERSION})
+    target_link_libraries(avrocpp PUBLIC
+      $<BUILD_INTERFACE:fmt::fmt-header-only>
+      $<BUILD_INTERFACE:ZLIB::ZLIB>
+      $<BUILD_INTERFACE:$<TARGET_NAME_IF_EXISTS:Snappy::snappy>>
+      $<$<BOOL:${zstd_FOUND}>:$<BUILD_INTERFACE:$<TARGET_NAME_IF_EXISTS:${ZSTD_TARGET}>>>
+      $<BUILD_INTERFACE:$<TARGET_NAME_IF_EXISTS:Boost::system>>
+      $<INSTALL_INTERFACE:ZLIB::ZLIB>
+      $<INSTALL_INTERFACE:$<TARGET_NAME_IF_EXISTS:Snappy::snappy>>
+      $<$<BOOL:${zstd_FOUND}>:$<INSTALL_INTERFACE:$<TARGET_NAME_IF_EXISTS:${ZSTD_TARGET}>>>
+      $<INSTALL_INTERFACE:$<TARGET_NAME_IF_EXISTS:Boost::system>>
+    )
+    target_include_directories(avrocpp PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+      $<INSTALL_INTERFACE:include>
+    )
 
-set_target_properties (avrocpp PROPERTIES VERSION ${AVRO_VERSION})
-set_target_properties (avrocpp_s PROPERTIES VERSION ${AVRO_VERSION})
+    list (APPEND AVRO_INSTALL_LIBS avrocpp)
+    set (AVRO_LINK_LIB avrocpp)
+endif ()
 
-target_link_libraries(avrocpp PUBLIC 
-  $<BUILD_INTERFACE:fmt::fmt-header-only>
-  $<BUILD_INTERFACE:ZLIB::ZLIB>
-  $<BUILD_INTERFACE:$<TARGET_NAME_IF_EXISTS:Snappy::snappy>>
-  $<$<BOOL:${zstd_FOUND}>:$<BUILD_INTERFACE:$<TARGET_NAME_IF_EXISTS:${ZSTD_TARGET}>>>
-  $<BUILD_INTERFACE:$<TARGET_NAME_IF_EXISTS:Boost::system>>
-  $<INSTALL_INTERFACE:ZLIB::ZLIB>
-  $<INSTALL_INTERFACE:$<TARGET_NAME_IF_EXISTS:Snappy::snappy>>
-  $<$<BOOL:${zstd_FOUND}>:$<INSTALL_INTERFACE:$<TARGET_NAME_IF_EXISTS:${ZSTD_TARGET}>>>
-  $<INSTALL_INTERFACE:$<TARGET_NAME_IF_EXISTS:Boost::system>>
-)
-target_link_libraries(avrocpp_s PUBLIC
-  $<BUILD_INTERFACE:fmt::fmt-header-only>
-  $<BUILD_INTERFACE:ZLIB::ZLIB>
-  $<BUILD_INTERFACE:$<TARGET_NAME_IF_EXISTS:Snappy::snappy>>
-  $<$<BOOL:${zstd_FOUND}>:$<BUILD_INTERFACE:$<TARGET_NAME_IF_EXISTS:${ZSTD_TARGET}>>>
-  $<BUILD_INTERFACE:$<TARGET_NAME_IF_EXISTS:Boost::system>>
-  $<INSTALL_INTERFACE:ZLIB::ZLIB>
-  $<INSTALL_INTERFACE:$<TARGET_NAME_IF_EXISTS:Snappy::snappy>>
-  $<$<BOOL:${zstd_FOUND}>:$<INSTALL_INTERFACE:$<TARGET_NAME_IF_EXISTS:${ZSTD_TARGET}>>>
-  $<INSTALL_INTERFACE:$<TARGET_NAME_IF_EXISTS:Boost::system>>
-)
+if (AVRO_BUILD_STATIC)
+    add_library (avrocpp_s STATIC ${AVRO_SOURCE_FILES})
+    target_compile_definitions(avrocpp_s PRIVATE AVRO_SOURCE)
+    set_target_properties (avrocpp_s PROPERTIES VERSION ${AVRO_VERSION})
+    target_link_libraries(avrocpp_s PUBLIC
+      $<BUILD_INTERFACE:fmt::fmt-header-only>
+      $<BUILD_INTERFACE:ZLIB::ZLIB>
+      $<BUILD_INTERFACE:$<TARGET_NAME_IF_EXISTS:Snappy::snappy>>
+      $<$<BOOL:${zstd_FOUND}>:$<BUILD_INTERFACE:$<TARGET_NAME_IF_EXISTS:${ZSTD_TARGET}>>>
+      $<BUILD_INTERFACE:$<TARGET_NAME_IF_EXISTS:Boost::system>>
+      $<INSTALL_INTERFACE:ZLIB::ZLIB>
+      $<INSTALL_INTERFACE:$<TARGET_NAME_IF_EXISTS:Snappy::snappy>>
+      $<$<BOOL:${zstd_FOUND}>:$<INSTALL_INTERFACE:$<TARGET_NAME_IF_EXISTS:${ZSTD_TARGET}>>>
+      $<INSTALL_INTERFACE:$<TARGET_NAME_IF_EXISTS:Boost::system>>
+    )
+    target_include_directories(avrocpp_s PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+      $<INSTALL_INTERFACE:include>
+    )
 
-target_include_directories(avrocpp PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>
-)
-target_include_directories(avrocpp_s PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>
-)
+    list (APPEND AVRO_INSTALL_LIBS avrocpp_s)
+    # Static takes precedence for linking if both are set.
+    set (AVRO_LINK_LIB avrocpp_s)
+endif ()
 
 if (AVRO_BUILD_EXECUTABLES)
     add_executable (precompile test/precompile.cc)
 
-    target_link_libraries (precompile avrocpp_s)
+    target_link_libraries (precompile ${AVRO_LINK_LIB})
 
     add_executable (avrogencpp impl/avrogencpp.cc)
-    target_link_libraries (avrogencpp avrocpp_s)
+    target_link_libraries (avrogencpp ${AVRO_LINK_LIB})
     target_compile_definitions(avrogencpp PRIVATE AVRO_VERSION="${AVRO_VERSION}")
 endif ()
 
@@ -219,7 +250,7 @@ if (AVRO_BUILD_TESTS)
 
     macro (unittest name)
         add_executable (${name} test/${name}.cc)
-        target_link_libraries (${name} avrocpp_s Boost::system ZLIB::ZLIB $<TARGET_NAME_IF_EXISTS:Snappy::snappy> $<$<BOOL:${zstd_FOUND}>:$<TARGET_NAME_IF_EXISTS:${ZSTD_TARGET}>>)
+        target_link_libraries (${name} ${AVRO_LINK_LIB} Boost::system ZLIB::ZLIB $<TARGET_NAME_IF_EXISTS:Snappy::snappy> $<$<BOOL:${zstd_FOUND}>:$<TARGET_NAME_IF_EXISTS:${ZSTD_TARGET}>>)
         add_test (NAME ${name} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
             COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${name})
     endmacro (unittest)
@@ -256,7 +287,7 @@ set (CPACK_PACKAGE_FILE_NAME "avrocpp-${AVRO_VERSION_MAJOR}")
 
 include (CPack)
 
-install (TARGETS avrocpp avrocpp_s
+install (TARGETS ${AVRO_INSTALL_LIBS}
     EXPORT avrocpp_targets
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib


### PR DESCRIPTION
<!--

*Thank you very much for contributing to Apache Avro - we are happy that you want to help us improve Avro. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Avro a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/AVRO/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "AVRO-XXXX: [component] Title of the pull request", where *AVRO-XXXX* should be replaced by the actual issue number. 
    The *component* is optional, but can help identify the correct reviewers faster: either the language ("java", "python") or subsystem such as "build" or "doc" are good candidates.  

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests. You can [build the entire project](https://github.com/apache/avro/blob/main/BUILD.md) or just the [language-specific SDK](https://avro.apache.org/project/how-to-contribute/#unit-tests).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Every commit message references Jira issues in their subject lines. In addition, commits follow the guidelines from [How to write a good git commit message](https://chris.beams.io/posts/git-commit/)
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

-->

## What is the purpose of the change

This allows for only the static or shared library to be built if only one of them is needed, avoiding the duplicate compilations and avoiding installing unwanted libraries. The standard CMake variable `BUILD_SHARED_LIBS` is also respected when explicitly set, enabling only the corresponding shared/static library, allowing the build to interface cleaner with standard build scripts built on CMake.

The `AVRO_BUILD_SHARED` CMake variable may now be set to `OFF` to disable building of the shared library, and `AVRO_BUILD_STATIC` may be set to `OFF` to disable building of the static library. The default values of these variables respect the value of `BUILD_SHARED_LIBS`:
* If `BUILD_SHARED_LIBS` is unset, shared and static are both enabled with the same behavior as before.
* If `BUILD_SHARED_LIBS` is `ON`, only the shared library is enabled.
* If `BUILD_SHARED_LIBS` is `OFF`, only the static library is enabled.

The tests and executables will link against the shared library if the static library is disabled.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage. I manually checked all three permutations of the default static and shared, static only, and shared only.


## Documentation

CMake build options do not appear to be documented, so no documentation has been added.
