### PR TITLE
AVRO-4158: [c++] Update for fmtlib 10+

### DIFF
--- a/lang/c++/include/avro/Node.hh
+++ b/lang/c++/include/avro/Node.hh
@@ -225,7 +225,7 @@ inline std::ostream &operator<<(std::ostream &os, const avro::Node &n) {
 template<>
 struct fmt::formatter<avro::Name> : fmt::formatter<std::string> {
     template<typename FormatContext>
-    auto format(const avro::Name &n, FormatContext &ctx) {
+    constexpr auto format(const avro::Name &n, FormatContext &ctx) const {
         return fmt::formatter<std::string>::format(n.fullname(), ctx);
     }
 };

--- a/lang/c++/include/avro/Types.hh
+++ b/lang/c++/include/avro/Types.hh
@@ -113,7 +113,7 @@ std::ostream &operator<<(std::ostream &os, const Null &null);
 template<>
 struct fmt::formatter<avro::Type> : fmt::formatter<std::string> {
     template<typename FormatContext>
-    auto format(avro::Type t, FormatContext &ctx) {
+    constexpr auto format(avro::Type t, FormatContext &ctx) const {
         return fmt::formatter<std::string>::format(avro::toString(t), ctx);
     }
 };


### PR DESCRIPTION
This PR introduces compatibility with fmtlib 10+, fixing AVRO-4158.
This change is for build-time compatibility only and therefore does not introduce any new tests.

I ran the automated test suite on Arch and everything passed. I can confirm that it still compiles against fmtlib 8.1 as well, but I didn't go back any further.