### PR TITLE
AVRO-3520: [java] expose read schema in custom encoding

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/CustomEncoding.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/CustomEncoding.java
@@ -48,4 +48,16 @@ public abstract class CustomEncoding<T> {
     return schema;
   }
 
+  /**
+   * Receives the schema, giving the concrete encoder implementation an
+   * opportunity to detect schema changes and behave accordingly. Useful for
+   * maintaining backwards compatibility.
+   *
+   * @param schema the schema detected during read.
+   * @return custom encoding to be used.
+   */
+  public CustomEncoding<T> withSchema(Schema schema) {
+    return this;
+  }
+
 }

--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/FieldAccess.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/FieldAccess.java
@@ -19,6 +19,8 @@ package org.apache.avro.reflect;
 
 import java.lang.reflect.Field;
 
+import org.apache.avro.Schema;
+
 abstract class FieldAccess {
 
   protected static final int INT_DEFAULT_VALUE = 0;
@@ -37,6 +39,6 @@ abstract class FieldAccess {
 
   protected static final double DOUBLE_DEFAULT_VALUE = 0.0d;
 
-  protected abstract FieldAccessor getAccessor(Field field);
+  protected abstract FieldAccessor getAccessor(Field field, Schema schema);
 
 }

--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/FieldAccessReflect.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/FieldAccessReflect.java
@@ -18,6 +18,7 @@
 package org.apache.avro.reflect;
 
 import org.apache.avro.AvroRuntimeException;
+import org.apache.avro.Schema;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.Encoder;
 
@@ -27,11 +28,12 @@ import java.lang.reflect.Field;
 class FieldAccessReflect extends FieldAccess {
 
   @Override
-  protected FieldAccessor getAccessor(Field field) {
+  protected FieldAccessor getAccessor(Field field, Schema schema) {
     AvroEncode enc = ReflectionUtil.getAvroEncode(field);
     if (enc != null)
       try {
-        return new ReflectionBasesAccessorCustomEncoded(field, enc.using().getDeclaredConstructor().newInstance());
+        var customEncoding = enc.using().getDeclaredConstructor().newInstance();
+        return new ReflectionBasesAccessorCustomEncoded(field, customEncoding.withSchema(schema));
       } catch (Exception e) {
         throw new AvroRuntimeException("Could not instantiate custom Encoding");
       }

--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectData.java
@@ -364,20 +364,12 @@ public class ReflectData extends SpecificData {
 
   static class ClassAccessorData {
     private final Class<?> clazz;
-    private final Map<String, FieldAccessor> byName = new HashMap<>();
-    // getAccessorsFor replaces this map with each modification
+    private final Map<String, FieldAccessor> byName;
     volatile Map<Schema, FieldAccessor[]> bySchema = new WeakHashMap<>();
 
     private ClassAccessorData(Class<?> c) {
       clazz = c;
-      for (Field f : getFields(c, false)) {
-        if (f.isAnnotationPresent(AvroIgnore.class)) {
-          continue;
-        }
-        FieldAccessor accessor = ReflectionUtil.getFieldAccess().getAccessor(f);
-        AvroName avroname = f.getAnnotation(AvroName.class);
-        byName.put((avroname != null ? avroname.value() : f.getName()), accessor);
-      }
+      byName = buildByName(c, null);
     }
 
     /**
@@ -397,10 +389,12 @@ public class ReflectData extends SpecificData {
     }
 
     private FieldAccessor[] createAccessorsFor(Schema schema) {
+
+      var byNameSchema = buildByName(clazz, schema);
       List<Schema.Field> avroFields = schema.getFields();
       FieldAccessor[] result = new FieldAccessor[avroFields.size()];
       for (Schema.Field avroField : schema.getFields()) {
-        result[avroField.pos()] = byName.get(avroField.name());
+        result[avroField.pos()] = byNameSchema.get(avroField.name());
       }
       return result;
     }
@@ -411,6 +405,25 @@ public class ReflectData extends SpecificData {
         throw new AvroRuntimeException("No field named " + fieldName + " in: " + clazz);
       }
       return result;
+    }
+
+    private static Map<String, FieldAccessor> buildByName(Class<?> c, Schema schema) {
+      Map<String, FieldAccessor> byName = new HashMap<>();
+      for (Field f : getFields(c, false)) {
+        if (f.isAnnotationPresent(AvroIgnore.class)) {
+          continue;
+        }
+        AvroName avroname = f.getAnnotation(AvroName.class);
+        var name = (avroname != null ? avroname.value() : f.getName());
+        Schema fieldSchema = null;
+        if (schema != null) {
+          var field = schema.getField(name);
+          fieldSchema = field != null ? field.schema() : null;
+        }
+        FieldAccessor accessor = ReflectionUtil.getFieldAccess().getAccessor(f, fieldSchema);
+        byName.put(name, accessor);
+      }
+      return byName;
     }
   }
 
@@ -1055,7 +1068,8 @@ public class ReflectData extends SpecificData {
     var enc = ReflectionUtil.getAvroEncode(getClass(schema));
     if (enc != null) {
       try {
-        return new CustomEncodingWrapper(enc.using().getDeclaredConstructor().newInstance());
+        var customEncodingClass = enc.using().getDeclaredConstructor().newInstance();
+        return new CustomEncodingWrapper(customEncodingClass.withSchema(schema));
       } catch (Exception e) {
         throw new AvroRuntimeException("Could not instantiate custom Encoding");
       }

--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectionUtil.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectionUtil.java
@@ -18,6 +18,7 @@
 package org.apache.avro.reflect;
 
 import org.apache.avro.AvroRuntimeException;
+import org.apache.avro.Schema;
 
 import java.lang.invoke.CallSite;
 import java.lang.invoke.LambdaMetafactory;
@@ -93,29 +94,30 @@ public class ReflectionUtil {
 
     private boolean validate(FieldAccess access) throws Exception {
       boolean valid = true;
-      valid &= validField(access, "b", b, false);
-      valid &= validField(access, "by", by, (byte) 0xaf);
-      valid &= validField(access, "c", c, 'C');
-      valid &= validField(access, "s", s, (short) 321);
-      valid &= validField(access, "i", i, 111);
-      valid &= validField(access, "l", l, 54321L);
-      valid &= validField(access, "f", f, 0.2f);
-      valid &= validField(access, "d", d, 0.4d);
-      valid &= validField(access, "o", o, new Object());
-      valid &= validField(access, "i2", i2, -555);
+      valid &= validField(access, "b", null, b, false);
+      valid &= validField(access, "by", null, by, (byte) 0xaf);
+      valid &= validField(access, "c", null, c, 'C');
+      valid &= validField(access, "s", null, s, (short) 321);
+      valid &= validField(access, "i", null, i, 111);
+      valid &= validField(access, "l", null, l, 54321L);
+      valid &= validField(access, "f", null, f, 0.2f);
+      valid &= validField(access, "d", null, d, 0.4d);
+      valid &= validField(access, "o", null, o, new Object());
+      valid &= validField(access, "i2", null, i2, -555);
       return valid;
     }
 
-    private boolean validField(FieldAccess access, String name, Object original, Object toSet) throws Exception {
-      FieldAccessor a = accessor(access, name);
+    private boolean validField(FieldAccess access, String name, Schema schema, Object original, Object toSet)
+        throws Exception {
+      FieldAccessor a = accessor(access, name, schema);
       boolean valid = original.equals(a.get(this));
       a.set(this, toSet);
       valid &= !original.equals(a.get(this));
       return valid;
     }
 
-    private FieldAccessor accessor(FieldAccess access, String name) throws Exception {
-      return access.getAccessor(this.getClass().getDeclaredField(name));
+    private FieldAccessor accessor(FieldAccess access, String name, Schema schema) throws Exception {
+      return access.getAccessor(this.getClass().getDeclaredField(name), schema);
     }
   }
 

--- a/lang/java/avro/src/test/java/org/apache/avro/reflect/TestCustomEncoderSchemaChanges.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/reflect/TestCustomEncoderSchemaChanges.java
@@ -1,0 +1,300 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.avro.reflect;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.io.EncoderFactory;
+import org.junit.jupiter.api.Test;
+
+public class TestCustomEncoderSchemaChanges {
+
+  private static final Schema SCHEMA1 = Schema.createRecord("R1", null, "org.apache.avro.reflect.TestCustomEncoderSchemaChanges",
+      false, Arrays.asList(new Schema.Field("v1", Schema.create(Schema.Type.STRING), null, null)));
+
+  private static final Schema SCHEMA2 = Schema.createRecord("R1", null, "org.apache.avro.reflect.TestCustomEncoderSchemaChanges",
+      false, Arrays.asList(new Schema.Field("v1", Schema.create(Schema.Type.STRING), null, null),
+          new Schema.Field("v2", Schema.create(Schema.Type.STRING), null, null)));
+
+  private static final Schema SCHEMA3 = Schema.createRecord("R1", null, "org.apache.avro.reflect.TestCustomEncoderSchemaChanges",
+      false,
+      Arrays.asList(new Schema.Field("v1", Schema.create(Schema.Type.STRING), null, null),
+          new Schema.Field("v2", Schema.create(Schema.Type.STRING), null, null),
+          new Schema.Field("v3", Schema.create(Schema.Type.STRING), null, null)));
+
+  private static final Schema SCHEMA_INT1 = Schema.createRecord("R1", null, "org.apache.avro.reflect.TestCustomEncoderSchemaChanges",
+      false, Arrays.asList(new Schema.Field("v1", Schema.create(Schema.Type.INT), null, null)));
+
+  private static final Schema SCHEMA_INT2 = Schema.createRecord("R1", null, "org.apache.avro.reflect.TestCustomEncoderSchemaChanges",
+      false, Arrays.asList(new Schema.Field("v1", Schema.create(Schema.Type.INT), null, null),
+          new Schema.Field("v2", Schema.create(Schema.Type.INT), null, null)));
+
+  private static final Schema SCHEMA_INT3 = Schema.createRecord("R1", null, "org.apache.avro.reflect.TestCustomEncoderSchemaChanges",
+      false,
+      Arrays.asList(new Schema.Field("v1", Schema.create(Schema.Type.INT), null, null),
+          new Schema.Field("v2", Schema.create(Schema.Type.INT), null, null),
+          new Schema.Field("v3", Schema.create(Schema.Type.INT), null, null)));
+
+  EncoderFactory factory = new EncoderFactory();
+
+  @Test
+  void testReadTopLevelSchema1() throws IOException {
+    // manually write with schema 1
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    var encoder = factory.directBinaryEncoder(out, null);
+    encoder.writeString("test");
+    ReflectDatumReader<R1> reader = new ReflectDatumReader<>(SCHEMA1);
+    var v1 = reader.read(null, DecoderFactory.get().binaryDecoder(out.toByteArray(), null));
+    assertEquals("test", v1.getValue());
+    assertEquals(null, v1.getName());
+    assertEquals(null, v1.getName2());
+  }
+
+  @Test
+  void testReadTopLevelSchema2() throws IOException {
+    // manually write with schema 2
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    var encoder = factory.directBinaryEncoder(out, null);
+    encoder.writeString("test");
+    encoder.writeString("name");
+
+    ReflectDatumReader<R1> reader = new ReflectDatumReader<>(SCHEMA2);
+    var v1 = reader.read(null, DecoderFactory.get().binaryDecoder(out.toByteArray(), null));
+    assertEquals("test", v1.getValue());
+    assertEquals("name", v1.getName());
+    assertEquals(null, v1.getName2());
+  }
+
+  @Test
+  void testWriteTopLevelSchema() throws IOException {
+    // test write uses correct schema if not specified
+
+    var schema = new ReflectData().getSchema(R1.class);
+    ReflectDatumWriter<R1> writer = new ReflectDatumWriter<>(schema);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    writer.write(new R1("1", "2", "3"), factory.directBinaryEncoder(out, null));
+    ReflectDatumReader<R1> reader = new ReflectDatumReader<>(schema);
+    var returned = reader.read(null, DecoderFactory.get().binaryDecoder(out.toByteArray(), null));
+
+    assertEquals("1", returned.getValue());
+    assertEquals("2", returned.getName());
+    assertEquals("3", returned.getName2());
+  }
+
+  @Test
+  void testReadInnerSchema1() throws IOException {
+    // manually write with schema 1
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    var encoder = factory.directBinaryEncoder(out, null);
+    encoder.writeInt(1);
+    ReflectDatumReader<R1Wrapper> reader = new ReflectDatumReader<>(wrapSchema(SCHEMA_INT1));
+    var v1 = reader.read(null, DecoderFactory.get().binaryDecoder(out.toByteArray(), null));
+    assertEquals("1", v1.r1.getValue());
+    assertEquals(null, v1.r1.getName());
+    assertEquals(null, v1.r1.getName2());
+  }
+
+  @Test
+  void testReadInnerSchema2() throws IOException {
+    // manually write with schema 2
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    var encoder = factory.directBinaryEncoder(out, null);
+    encoder.writeInt(1);
+    encoder.writeInt(2);
+    ReflectDatumReader<R1Wrapper> reader = new ReflectDatumReader<>(wrapSchema(SCHEMA_INT2));
+    var v1 = reader.read(null, DecoderFactory.get().binaryDecoder(out.toByteArray(), null));
+    assertEquals("1", v1.r1.getValue());
+    assertEquals("2", v1.r1.getName());
+    assertEquals(null, v1.r1.getName2());
+  }
+
+  @Test
+  void testWriteInnerSchema() throws IOException {
+    // test write uses correct schema if not specified
+
+    var schema = new ReflectData().getSchema(R1Wrapper.class);
+    ReflectDatumWriter<R1Wrapper> writer = new ReflectDatumWriter<>(schema);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    var wrapper = new R1Wrapper();
+    wrapper.r1 = new R1("1", "2", "3");
+
+    writer.write(wrapper, factory.directBinaryEncoder(out, null));
+    ReflectDatumReader<R1Wrapper> reader = new ReflectDatumReader<>(schema);
+    var returned = reader.read(null, DecoderFactory.get().binaryDecoder(out.toByteArray(), null));
+
+    assertEquals("1", returned.r1.getValue());
+    assertEquals("2", returned.r1.getName());
+    assertEquals("3", returned.r1.getName2());
+  }
+
+  public static Schema wrapSchema(Schema schema) {
+    return Schema.createRecord("R1Wrapper", null, "org.apache.avro.reflect.TestCustomEncoderSchemaChanges", false,
+        Arrays.asList(new Schema.Field("r1", schema, null, null)));
+  }
+
+  public static class R1Wrapper {
+    @AvroEncode(using = R1EncoderDouble.class)
+    private R1 r1;
+
+  }
+
+  @AvroEncode(using = R1Encoder.class)
+  public static class R1 {
+
+    private final String value;
+    private final String name;
+    private final String name2;
+
+    public R1(String value, String name, String name2) {
+      this.value = value;
+      this.name = name;
+      this.name2 = name2;
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public String getName2() {
+      return name2;
+    }
+
+  }
+
+  static class R1Encoder extends CustomEncoding<R1> {
+
+    {
+      schema = SCHEMA3;
+    }
+
+    @Override
+    protected void write(Object datum, Encoder out) throws IOException {
+      if (!(datum instanceof R1)) {
+        throw new AvroTypeException("Expected R1, but got: " + datum.getClass());
+      }
+      R1 r1 = (R1) datum;
+      switch (schema.getFields().size()) {
+      case 1:
+        out.writeString(r1.getValue());
+        break;
+      case 2:
+        out.writeString(r1.getValue());
+        out.writeString(r1.getName());
+        break;
+      case 3:
+        out.writeString(r1.getValue());
+        out.writeString(r1.getName());
+        out.writeString(r1.getName2());
+        break;
+      default:
+        throw new RuntimeException("Unexpected number of fields: " + schema.getFields().size());
+      }
+
+    }
+
+    @Override
+    protected R1 read(Object reuse, Decoder in) throws IOException {
+      switch (schema.getFields().size()) {
+      case 1:
+        return new R1(in.readString(), null, null);
+      case 2:
+        return new R1(in.readString(), in.readString(), null);
+      case 3:
+        return new R1(in.readString(), in.readString(), in.readString());
+
+      }
+      throw new RuntimeException("Unexpected number of fields: " + schema.getFields().size());
+    }
+
+    @Override
+    public CustomEncoding<R1> withSchema(Schema schema) {
+      var encoder = new R1Encoder();
+      encoder.schema = schema;
+      return encoder;
+    }
+
+  }
+
+  static class R1EncoderDouble extends CustomEncoding<R1> {
+
+    {
+      schema = SCHEMA_INT3;
+    }
+
+    @Override
+    protected void write(Object datum, Encoder out) throws IOException {
+      if (!(datum instanceof R1)) {
+        throw new AvroTypeException("Expected R1, but got: " + datum.getClass());
+      }
+      R1 r1 = (R1) datum;
+      switch (schema.getFields().size()) {
+      case 1:
+        out.writeInt(Integer.parseInt(r1.getValue()));
+        break;
+      case 2:
+        out.writeInt(Integer.parseInt(r1.getValue()));
+        out.writeInt(Integer.parseInt(r1.getName()));
+        break;
+      case 3:
+        out.writeInt(Integer.parseInt(r1.getValue()));
+        out.writeInt(Integer.parseInt(r1.getName()));
+        out.writeInt(Integer.parseInt(r1.getName2()));
+        break;
+      default:
+        throw new RuntimeException("Unexpected number of fields: " + schema.getFields().size());
+      }
+
+    }
+
+    @Override
+    protected R1 read(Object reuse, Decoder in) throws IOException {
+      switch (schema.getFields().size()) {
+      case 1:
+        return new R1(Integer.toString(in.readInt()), null, null);
+      case 2:
+        return new R1(Integer.toString(in.readInt()), Integer.toString(in.readInt()), null);
+      case 3:
+        return new R1(Integer.toString(in.readInt()), Integer.toString(in.readInt()), Integer.toString(in.readInt()));
+
+      }
+      throw new RuntimeException("Unexpected number of fields: " + schema.getFields().size());
+    }
+
+    @Override
+    public CustomEncoding<R1> withSchema(Schema schema) {
+      var encoder = new R1EncoderDouble();
+      encoder.schema = schema;
+      return encoder;
+    }
+
+  }
+
+}


### PR DESCRIPTION
## What is the purpose of the change

Allows custom encodings to support file changes.

Used https://github.com/apache/avro/pull/1692 as inspiration

## Verifying this change

*(Please pick one of the following options)*

This change added tests and can be verified as follows:
Test custom encodings with several different versions, confirming that the encoder is linked to the schema



## Documentation

- Does this pull request introduce a new feature? (yes)
- If yes, how is the feature documented? JavaDocs
