### PR TITLE
AVRO-4170: [Java] Improve sync marker error message in DataFileStream

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/file/DataFileStream.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/file/DataFileStream.java
@@ -330,7 +330,10 @@ public class DataFileStream<D> implements Iterator<D>, Iterable<D>, Closeable {
     vin.readFixed(syncBuffer);
     availableBlock = false;
     if (!Arrays.equals(syncBuffer, header.sync))
-      throw new IOException("Invalid sync!");
+      throw new IOException("Invalid sync marker! The sync marker in the data block doesn't match the "
+          + "file header's sync marker. This likely indicates data corruption, truncated file, "
+          + "or incorrectly concatenated Avro files. Verify file integrity and ensure proper "
+          + "file transmission or creation.");
     return reuse;
   }
 

--- a/lang/java/avro/src/test/java/org/apache/avro/TestDataFileCorruption.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestDataFileCorruption.java
@@ -87,7 +87,10 @@ public class TestDataFileCorruption {
       assertEquals("fig", r.next().toString());
       assertFalse(r.hasNext());
     } catch (AvroRuntimeException e) {
-      assertEquals("Invalid sync!", e.getCause().getMessage());
+      assertEquals("Invalid sync marker! The sync marker in the data block doesn't match the "
+          + "file header's sync marker. This likely indicates data corruption, truncated file, "
+          + "or incorrectly concatenated Avro files. Verify file integrity and ensure proper "
+          + "file transmission or creation.", e.getCause().getMessage());
     }
 
   }


### PR DESCRIPTION
## What is the purpose of the change

Enhanced the error message when an invalid sync marker is encountered in `DataFileStream`. The new message provides more context about what a sync marker is, why it might be invalid, and suggests possible solutions to fix the problem.

The previous error message was too brief ("Invalid sync!") and didn't provide users with enough information to understand or troubleshoot the issue. The improved message makes debugging easier by explaining:
- What exactly failed (sync marker mismatch)
- Likely causes (data corruption, truncation, incorrect concatenation)
- Steps to resolve the issue