### PR TITLE
AVRO-4171: [c++] find system installed fmt first

### DIFF
--- a/lang/c++/CMakeLists.txt
+++ b/lang/c++/CMakeLists.txt
@@ -79,15 +79,18 @@ if (AVRO_BUILD_TESTS OR AVRO_USE_BOOST)
     find_package (Boost 1.70 REQUIRED CONFIG COMPONENTS system)
 endif ()
 
-include(FetchContent)
-FetchContent_Declare(
-        fmt
-        GIT_REPOSITORY  https://github.com/fmtlib/fmt.git
-        GIT_TAG         10.2.1
-        GIT_PROGRESS    TRUE
-        USES_TERMINAL_DOWNLOAD TRUE
-)
-FetchContent_MakeAvailable(fmt)
+find_package(fmt)
+if (NOT fmt_FOUND)
+    include(FetchContent)
+    FetchContent_Declare(
+            fmt
+            GIT_REPOSITORY  https://github.com/fmtlib/fmt.git
+            GIT_TAG         10.2.1
+            GIT_PROGRESS    TRUE
+            USES_TERMINAL_DOWNLOAD TRUE
+    )
+    FetchContent_MakeAvailable(fmt)
+endif ()
 
 find_package(Snappy CONFIG)
 if (Snappy_FOUND)


### PR DESCRIPTION
## What is the purpose of the change

This pull request find system installed `fmt` package first and then try the original `fetch_content` to download it from upstream. Other packages are looking for it from the system but `fmt` is not yet.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Documentation

- Does this pull request introduce a new feature? (no)
