### PR TITLE
java-[key-]class allowed packages must be packages

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificDatumReader.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificDatumReader.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * {@link org.apache.avro.io.DatumReader DatumReader} for generated Java
@@ -38,7 +39,7 @@ import java.util.Set;
 public class SpecificDatumReader<T> extends GenericDatumReader<T> {
 
   /**
-   * @deprecated prefer to use SERIALIZABLE_CLASSES instead.
+   * @deprecated prefer to use {@link #SERIALIZABLE_CLASSES} instead.
    */
   @Deprecated
   public static final String[] SERIALIZABLE_PACKAGES;
@@ -47,12 +48,29 @@ public class SpecificDatumReader<T> extends GenericDatumReader<T> {
 
   static {
     // no serializable classes by default
-    String serializableClassesProp = System.getProperty("org.apache.avro.SERIALIZABLE_CLASSES");
-    SERIALIZABLE_CLASSES = (serializableClassesProp == null) ? new String[0] : serializableClassesProp.split(",");
+    SERIALIZABLE_CLASSES = streamPropertyEntries(System.getProperty("org.apache.avro.SERIALIZABLE_CLASSES"))
+        .toArray(String[]::new);
 
     // no serializable packages by default
-    String serializablePackagesProp = System.getProperty("org.apache.avro.SERIALIZABLE_PACKAGES");
-    SERIALIZABLE_PACKAGES = (serializablePackagesProp == null) ? new String[0] : serializablePackagesProp.split(",");
+    SERIALIZABLE_PACKAGES = streamPropertyEntries(System.getProperty("org.apache.avro.SERIALIZABLE_PACKAGES"))
+        // Add a '.' suffix to ensure we'll be matching package names instead of
+        // arbitrary prefixes, except for the wildcard "*", which allows all
+        // packages (this is only safe in fully controlled environments!).
+        .map(entry -> "*".equals(entry) ? entry : entry + ".").toArray(String[]::new);
+  }
+
+  /**
+   * Parse a comma separated list into non-empty entries. Leading and trailing
+   * whitespace is stripped.
+   *
+   * @param commaSeparatedEntries the comma separated list of entries
+   * @return a stream of the entries
+   */
+  private static Stream<String> streamPropertyEntries(String commaSeparatedEntries) {
+    if (commaSeparatedEntries == null) {
+      return Stream.empty();
+    }
+    return Stream.of(commaSeparatedEntries.split(",")).map(String::strip).filter(s -> !s.isEmpty());
   }
 
   // The primitive "class names" based on Class.isPrimitive()
@@ -167,8 +185,10 @@ public class SpecificDatumReader<T> extends GenericDatumReader<T> {
       }
     }
 
-    throw new SecurityException("Forbidden " + className
-        + "! This class is not trusted to be included in Avro schema using java-class. Please set org.apache.avro.SERIALIZABLE_CLASSES system property with the class you trust or org.apache.avro.SERIALIZABLE_PACKAGES system property with the packages you trust.");
+    throw new SecurityException("Forbidden " + className + "! This class is not trusted to be included in Avro "
+        + "schemas using java-class. Please set the system property org.apache.avro.SERIALIZABLE_CLASSES to the comma "
+        + "separated list of classes you trust. You can also set the system property "
+        + "org.apache.avro.SERIALIZABLE_PACKAGES to the comma separated list of the packages you trust.");
   }
 
   /**


### PR DESCRIPTION
## What is the purpose of the change

`SpecificDatumReader.SERIALIZABLE_PACKAGES` was used as a list of class name prefixes instead of the package names it is designed as. This change forces the provided package names to be package names.

## Verifying this change

This change is a near-trivial refactoring without any test coverage.

Tests should be added, but this is a larger undertaking than a quick fix.


## Documentation

- Does this pull request introduce a new feature? (~yes~ / **no**)
- If yes, how is the feature documented? (**not applicable** / ~docs / JavaDocs / not documented~)
