### PR TITLE
AVRO-1425: [Java] prioritise thread context ClassLoader over context class ClassLoader

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificData.java
@@ -389,7 +389,7 @@ public class SpecificData extends GenericData {
         return null;
       Class<?> c = classCache.computeIfAbsent(name, n -> {
         try {
-          return ClassUtils.forName(getClassLoader(), getClassName(schema));
+          return ClassUtils.forName(getClassName(schema));
         } catch (ClassNotFoundException e) {
           // This might be a nested namespace. Try using the last tokens in the
           // namespace as an enclosing class by progressively replacing period
@@ -399,7 +399,7 @@ public class SpecificData extends GenericData {
           while (lastDot != -1) {
             nestedName.setCharAt(lastDot, '$');
             try {
-              return ClassUtils.forName(getClassLoader(), nestedName.toString());
+              return ClassUtils.forName(nestedName.toString());
             } catch (ClassNotFoundException ignored) {
             }
             lastDot = n.lastIndexOf('.', lastDot - 1);

--- a/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificDatumReader.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/specific/SpecificDatumReader.java
@@ -157,7 +157,7 @@ public class SpecificDatumReader<T> extends GenericDatumReader<T> {
       return null;
     try {
       checkSecurity(name);
-      Class clazz = ClassUtils.forName(getData().getClassLoader(), name);
+      Class clazz = ClassUtils.forName(name);
       return clazz;
     } catch (ClassNotFoundException e) {
       throw new AvroRuntimeException(e);

--- a/lang/java/avro/src/main/java/org/apache/avro/util/ClassUtils.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/util/ClassUtils.java
@@ -45,34 +45,11 @@ public class ClassUtils {
    */
   public static Class<?> forName(Class<?> contextClass, String className) throws ClassNotFoundException {
     Class<?> c = null;
-    if (contextClass.getClassLoader() != null) {
+    if (Thread.currentThread().getContextClassLoader() != null) {
+      c = forName(className, Thread.currentThread().getContextClassLoader());
+    }
+    if (c == null && contextClass.getClassLoader() != null) {
       c = forName(className, contextClass.getClassLoader());
-    }
-    if (c == null && Thread.currentThread().getContextClassLoader() != null) {
-      c = forName(className, Thread.currentThread().getContextClassLoader());
-    }
-    if (c == null) {
-      throw new ClassNotFoundException("Failed to load class" + className);
-    }
-    return c;
-  }
-
-  /**
-   * Loads a class using the class loader. 1. The class loader of the context
-   * class is being used. 2. The thread context class loader is being used. If
-   * both approaches fail, returns null.
-   *
-   * @param classLoader The classloader to use.
-   * @param className   The name of the class to load
-   * @return The class or null if no class loader could load the class.
-   */
-  public static Class<?> forName(ClassLoader classLoader, String className) throws ClassNotFoundException {
-    Class<?> c = null;
-    if (classLoader != null) {
-      c = forName(className, classLoader);
-    }
-    if (c == null && Thread.currentThread().getContextClassLoader() != null) {
-      c = forName(className, Thread.currentThread().getContextClassLoader());
     }
     if (c == null) {
       throw new ClassNotFoundException("Failed to load class" + className);
@@ -84,9 +61,9 @@ public class ClassUtils {
    * Loads a {@link Class} from the specified {@link ClassLoader} without throwing
    * {@link ClassNotFoundException}.
    *
-   * @param className
-   * @param classLoader
-   * @return
+   * @param className   The name of the class to load
+   * @param classLoader The classloader to use.
+   * @return The class or null if no class loader could load the class.
    */
   private static Class<?> forName(String className, ClassLoader classLoader) {
     Class<?> c = null;

--- a/lang/java/protobuf/src/main/java/org/apache/avro/protobuf/ProtobufData.java
+++ b/lang/java/protobuf/src/main/java/org/apache/avro/protobuf/ProtobufData.java
@@ -404,7 +404,7 @@ public class ProtobufData extends GenericData {
     String dot = namespace.endsWith("$") ? "" : "."; // back-compatibly handle $
 
     try {
-      Class clazz = ClassUtils.forName(getClassLoader(), namespace + dot + name);
+      Class clazz = ClassUtils.forName(namespace + dot + name);
       return getConversionByClass(clazz);
     } catch (ClassNotFoundException e) {
       return null;


### PR DESCRIPTION
## What is the purpose of the change

Resolves [AVRO-1425](https://issues.apache.org/jira/browse/AVRO-1425):

Changes the class loading strategy in ClassUtils to first try the current thread's context class loader before falling back to the context class's class loader. This improves class loading reliability in different runtime environments.

Removes the overloaded forName method that accepted a ClassLoader parameter and updates all callers to use the simplified method signature.

## Verifying this change

This change is already covered by existing tests, such as *TestSpecificData*.

I also tested with a local SpringBoot application using Avro/Kafka and SpringBoot DevTools. Without the change I get a ClassCastException, and with the change it works as expected.

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? already working as documented