### PR TITLE
AVRO-4185: [C++] Use a temp file in StreamTests

### DIFF
--- a/lang/c++/test/StreamTests.cc
+++ b/lang/c++/test/StreamTests.cc
@@ -138,7 +138,7 @@ void testNonEmpty2(const TestData &td) {
 struct FileGuard {
     const std::filesystem::path path{ std::tmpnam(nullptr) };
     ~FileGuard() { std::filesystem::remove(path); }
-    const char* filename() const { return path.c_str(); };
+    const char* filename() const { return path.c_str(); }
 };
 
 template<typename V>


### PR DESCRIPTION
## What is the purpose of the change

StreamTests uses the test_str.bin file. This is problematic in our setup because we build and test 32-bit and 64-bit versions in parallel. When the 32-bit and 64-bit StreamTest happen to run concurrently, one ends up deleting the file that the other is trying to read.

My solution here is to use a temporary file instead of the hard-coded test_str.bin.

This fixes AVRO-4185.

## Verifying this change

This change is already covered by existing tests, such as StreamTests.

## Documentation

- Does this pull request introduce a new feature? (no)
