### PR TITLE
AVRO-4225: FastReaderBuilder throws ClassCastException for schemas with java-class attribute

### DIFF
--- a/lang/java/avro/src/test/java/org/apache/avro/io/FastReaderBuilderJavaClassTest.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/io/FastReaderBuilderJavaClassTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.avro.io;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for FastReaderBuilder behavior with schemas containing "java-class"
+ * attributes.
+ */
+public class FastReaderBuilderJavaClassTest {
+
+  /**
+   * Tests that GenericDatumReader can deserialize records with string fields that
+   * have a "java-class" attribute (e.g., BigDecimal).
+   *
+   * This test reproduces a bug where
+   * FastReaderBuilder.getTransformingStringReader() casts the result of
+   * stringReader.read() directly to String, but in GenericData mode the reader
+   * returns Utf8, causing a ClassCastException.
+   */
+  @Test
+  void genericDatumReaderWithJavaClassAttribute() throws IOException {
+    // Schema with a string field that has "java-class": "java.math.BigDecimal"
+    // This is a common pattern for representing decimal values as strings
+    String schemaJson = "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"TestRecord\",\n" + "  \"fields\": [\n"
+        + "    {\"name\": \"id\", \"type\": \"string\"},\n" + "    {\"name\": \"price\", \"type\": [\"null\", {\n"
+        + "      \"type\": \"string\",\n" + "      \"java-class\": \"java.math.BigDecimal\"\n" + "    }]}\n" + "  ]\n"
+        + "}";
+
+    Schema schema = new Schema.Parser().parse(schemaJson);
+
+    GenericRecord record = new GenericData.Record(schema);
+    record.put("id", "123");
+    record.put("price", "-0.0002");
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    GenericDatumWriter<GenericRecord> writer = new GenericDatumWriter<>(schema);
+    BinaryEncoder encoder = EncoderFactory.get().binaryEncoder(out, null);
+    writer.write(record, encoder);
+    encoder.flush();
+
+    byte[] serialized = out.toByteArray();
+
+    // Deserialize using GenericDatumReader (which uses FastReaderBuilder by
+    // default)
+    GenericDatumReader<GenericRecord> reader = new GenericDatumReader<>(schema);
+    BinaryDecoder decoder = DecoderFactory.get().binaryDecoder(serialized, null);
+
+    // AVRO-4225 this should not throw ClassCastException: Utf8 cannot be cast
+    // to String
+    GenericRecord result = reader.read(null, decoder);
+
+    assertNotNull(result);
+    assertEquals("123", result.get("id").toString());
+    assertEquals("-0.0002", result.get("price").toString());
+  }
+
+  /**
+   * Tests that GenericDatumReader can deserialize records with a direct string
+   * field (not in a union) that has a "java-class" attribute.
+   */
+  @Test
+  void genericDatumReaderWithDirectJavaClassString() throws IOException {
+    String schemaJson = "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"TestRecord\",\n" + "  \"fields\": [\n"
+        + "    {\"name\": \"amount\", \"type\": {\n" + "      \"type\": \"string\",\n"
+        + "      \"java-class\": \"java.math.BigDecimal\"\n" + "    }}\n" + "  ]\n" + "}";
+
+    Schema schema = new Schema.Parser().parse(schemaJson);
+
+    GenericRecord record = new GenericData.Record(schema);
+    record.put("amount", "123.45");
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    GenericDatumWriter<GenericRecord> writer = new GenericDatumWriter<>(schema);
+    BinaryEncoder encoder = EncoderFactory.get().binaryEncoder(out, null);
+    writer.write(record, encoder);
+    encoder.flush();
+
+    byte[] serialized = out.toByteArray();
+
+    GenericDatumReader<GenericRecord> reader = new GenericDatumReader<>(schema);
+    BinaryDecoder decoder = DecoderFactory.get().binaryDecoder(serialized, null);
+
+    GenericRecord result = reader.read(null, decoder);
+
+    assertNotNull(result);
+    assertEquals("123.45", result.get("amount").toString());
+  }
+}


### PR DESCRIPTION

<!--

*Thank you very much for contributing to Apache Avro - we are happy that you want to help us improve Avro. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Avro a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/AVRO/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "AVRO-XXXX: [component] Title of the pull request", where *AVRO-XXXX* should be replaced by the actual issue number. 
    The *component* is optional, but can help identify the correct reviewers faster: either the language ("java", "python") or subsystem such as "build" or "doc" are good candidates.  

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests. You can [build the entire project](https://github.com/apache/avro/blob/main/BUILD.md) or just the [language-specific SDK](https://avro.apache.org/project/how-to-contribute/#unit-tests).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Every commit message references Jira issues in their subject lines. In addition, commits follow the guidelines from [How to write a good git commit message](https://chris.beams.io/posts/git-commit/)
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

-->

## What is the purpose of the change

When using GenericDatumReader with schemas containing "java-class" attributes on string fields (e.g., java.math.BigDecimal), FastReaderBuilder throws:

    ClassCastException: Utf8 cannot be cast to String

The bug is in getTransformingStringReader() which casts the result of stringReader.read() directly to String, but GenericData returns Utf8.

This commit adds a failing test to reproduce the issue.

## Verifying this change

Run the test suite. 


## Documentation

- Does this pull request introduce a new feature? No
