### PR TITLE
Fixes a memory leak issue in the Avro C library under abnormal data scenarios.

### DIFF
--- a/lang/c/src/avro/io.h
+++ b/lang/c/src/avro/io.h
@@ -52,6 +52,7 @@ avro_reader_memory_set_source(avro_reader_t reader, const char *buf, int64_t len
 void
 avro_writer_memory_set_dest(avro_writer_t writer, const char *buf, int64_t len);
 
+int64_t avro_max_read(avro_reader_t reader);
 int avro_read(avro_reader_t reader, void *buf, int64_t len);
 int avro_skip(avro_reader_t reader, int64_t len);
 int avro_write(avro_writer_t writer, void *buf, int64_t len);

--- a/lang/c/src/avro/io.h
+++ b/lang/c/src/avro/io.h
@@ -52,7 +52,15 @@ avro_reader_memory_set_source(avro_reader_t reader, const char *buf, int64_t len
 void
 avro_writer_memory_set_dest(avro_writer_t writer, const char *buf, int64_t len);
 
+
+/*
+ * Returns the number of bytes available to read from the reader.
+ * For memory readers, returns remaining bytes (len - read).
+ * For file readers, returns buffered bytes available.
+ * Returns -1 for unknown reader types.
+ */
 int64_t avro_max_read(avro_reader_t reader);
+
 int avro_read(avro_reader_t reader, void *buf, int64_t len);
 int avro_skip(avro_reader_t reader, int64_t len);
 int avro_write(avro_writer_t writer, void *buf, int64_t len);

--- a/lang/c/src/encoding.h
+++ b/lang/c/src/encoding.h
@@ -99,7 +99,7 @@ typedef struct avro_encoding_t avro_encoding_t;
 #define AVRO_SKIP(reader, len) \
 { int rval = avro_skip( reader, len); if (rval) return rval; }
 
-#define AVRO_SAFE_READ(reader, buf, len, mem_size)  \
+#define AVRO_READ_OR_FREE(reader, buf, len, mem_size)  \
 { int rval = avro_read( reader, buf, len ); if(rval) { if(buf) avro_free(buf, mem_size); buf = NULL;  return rval; } }
 
 extern const avro_encoding_t avro_binary_encoding;	/* in

--- a/lang/c/src/encoding.h
+++ b/lang/c/src/encoding.h
@@ -99,6 +99,9 @@ typedef struct avro_encoding_t avro_encoding_t;
 #define AVRO_SKIP(reader, len) \
 { int rval = avro_skip( reader, len); if (rval) return rval; }
 
+#define AVRO_SAFE_READ(reader, buf, len, mem_size)  \
+{ int rval = avro_read( reader, buf, len ); if(rval) { if(buf) avro_free(buf, mem_size); buf = NULL;  return rval; } }
+
 extern const avro_encoding_t avro_binary_encoding;	/* in
 							 * encoding_binary 
 							 */

--- a/lang/c/src/encoding_binary.c
+++ b/lang/c/src/encoding_binary.c
@@ -148,7 +148,7 @@ static int read_bytes(avro_reader_t reader, char **bytes, int64_t * len)
 	}
 	
 	(*bytes)[*len] = '\0';
-	AVRO_SAFE_READ(reader, *bytes, *len, *len+1);
+	AVRO_READ_OR_FREE(reader, *bytes, *len, *len+1);
 
 	return 0;
 }

--- a/lang/c/src/encoding_binary.c
+++ b/lang/c/src/encoding_binary.c
@@ -134,9 +134,9 @@ static int read_bytes(avro_reader_t reader, char **bytes, int64_t * len)
 	}
 
 	max_available = avro_max_read(reader);
-	if (max_available >= 0 && str_len > max_available) {
+	if (max_available >= 0 && *len > max_available) {
 	    avro_set_error("String length %" PRId64 " is greater than available buffer size %" PRId64,
-				str_len, max_available);
+				*len, max_available);
 		return ERANGE;
 	}
 

--- a/lang/c/src/io.c
+++ b/lang/c/src/io.c
@@ -274,6 +274,20 @@ int avro_read(avro_reader_t reader, void *buf, int64_t len)
 	return EINVAL;
 }
 
+
+int64_t avro_max_read(avro_reader_t reader)
+{
+	if (is_memory_io(reader)) {
+		struct _avro_reader_memory_t *mem_reader = avro_reader_to_memory(reader);
+		return mem_reader->len - mem_reader->read;
+	} else if (is_file_io(reader)) {
+		struct _avro_reader_file_t *file_reader = avro_reader_to_file(reader);
+		return bytes_available(file_reader);
+	}
+	return -1;
+}
+
+
 static int avro_skip_memory(struct _avro_reader_memory_t *reader, int64_t len)
 {
 	if (len > 0) {

--- a/lang/c/src/io.c
+++ b/lang/c/src/io.c
@@ -281,11 +281,26 @@ int64_t avro_max_read(avro_reader_t reader)
 		struct _avro_reader_memory_t *mem_reader = avro_reader_to_memory(reader);
 		return mem_reader->len - mem_reader->read;
 	} else if (is_file_io(reader)) {
-		struct _avro_reader_file_t *file_reader = avro_reader_to_file(reader);
-		return bytes_available(file_reader);
-	}
+		struct _avro_reader_file_t *file_reader = avro_reader_to_file(reader); 
+		
+		// For file I/O - needs to get file size and current position  
+		int64_t current_pos, file_size;  
+      
+	    // Get current position (accounting for buffered data)  
+	    current_pos = ftell(file_reader->fp) - bytes_available(file_reader);  
+	      
+	    // Get file size  
+	    fseek(file_reader->fp, 0, SEEK_END);  
+	    file_size = ftell(file_reader->fp);  
+	    fseek(file_reader->fp, current_pos, SEEK_SET);  
+	      
+	    return file_size - current_pos;  
+	}  
 	return -1;
 }
+
+
+
 
 
 static int avro_skip_memory(struct _avro_reader_memory_t *reader, int64_t len)


### PR DESCRIPTION
<!--

*Thank you very much for contributing to Apache Avro - we are happy that you want to help us improve Avro. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Avro a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/AVRO/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "AVRO-XXXX: [component] Title of the pull request", where *AVRO-XXXX* should be replaced by the actual issue number. 
    The *component* is optional, but can help identify the correct reviewers faster: either the language ("java", "python") or subsystem such as "build" or "doc" are good candidates.  

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests. You can [build the entire project](https://github.com/apache/avro/blob/main/BUILD.md) or just the [language-specific SDK](https://avro.apache.org/project/how-to-contribute/#unit-tests).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Every commit message references Jira issues in their subject lines. In addition, commits follow the guidelines from [How to write a good git commit message](https://chris.beams.io/posts/git-commit/)
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

-->

## What is the purpose of the change

- Does not properly validate that the string length does not exceed available buffer space, potentially leading to buffer overflow
- Add a macro definition `AVRO_SAFE_READ` to release memory upon exception return.


## Verifying this change

- Construct a schema and data that do not match, and call the `read_string` function to read them.
- Observe memory usage.
- Stop reading，Observe if memory usage decreases.

Alternatively, you can use `valgrind` to check for memory leaks.


## Documentation

