### PR TITLE
AVRO-4228: [c++] Fix BinaryDecoder::arrayNext() to handle negative block counts

### DIFF
--- a/lang/c++/impl/BinaryDecoder.cc
+++ b/lang/c++/impl/BinaryDecoder.cc
@@ -164,7 +164,7 @@ size_t BinaryDecoder::doDecodeItemCount() {
     auto result = doDecodeLong();
     if (result < 0) {
         doDecodeLong();
-        return static_cast<size_t>(-result);
+        return static_cast<size_t>(-(result + 1)) + 1;
     }
     return static_cast<size_t>(result);
 }

--- a/lang/c++/impl/BinaryDecoder.cc
+++ b/lang/c++/impl/BinaryDecoder.cc
@@ -170,7 +170,7 @@ size_t BinaryDecoder::doDecodeItemCount() {
 }
 
 size_t BinaryDecoder::arrayNext() {
-    return static_cast<size_t>(doDecodeLong());
+    return doDecodeItemCount();
 }
 
 size_t BinaryDecoder::skipArray() {

--- a/lang/c++/test/CodecTests.cc
+++ b/lang/c++/test/CodecTests.cc
@@ -2100,6 +2100,42 @@ static void testJsonCodecReinit() {
     }
 }
 
+static void testArrayNegativeBlockCount() {
+    // Array of ints [10, 20, 30, 40, 50] encoded with a negative block count.
+    // Per the Avro spec, a negative count means: abs(count) items follow,
+    // preceded by a long byte-size of the block.
+    //
+    // Block 1: count=-3, bytesize=3, items: 10, 20, 30
+    // Block 2: count=2, items: 40, 50
+    // Terminal: count=0
+    const uint8_t data[] = {
+        0x05,                    // zigzag(-3) = 5
+        0x06,                    // zigzag(3) = 6  (byte-size of block)
+        0x14, 0x28, 0x3c,       // zigzag ints: 10, 20, 30
+        0x04,                    // zigzag(2) = 4
+        0x50, 0x64,             // zigzag ints: 40, 50
+        0x00                     // terminal
+    };
+
+    InputStreamPtr is = memoryInputStream(data, sizeof(data));
+    DecoderPtr d = binaryDecoder();
+    d->init(*is);
+
+    std::vector<int32_t> result;
+    for (size_t n = d->arrayStart(); n != 0; n = d->arrayNext()) {
+        for (size_t i = 0; i < n; ++i) {
+            result.push_back(d->decodeInt());
+        }
+    }
+
+    BOOST_CHECK_EQUAL(result.size(), 5u);
+    BOOST_CHECK_EQUAL(result[0], 10);
+    BOOST_CHECK_EQUAL(result[1], 20);
+    BOOST_CHECK_EQUAL(result[2], 30);
+    BOOST_CHECK_EQUAL(result[3], 40);
+    BOOST_CHECK_EQUAL(result[4], 50);
+}
+
 static void testByteCount() {
     OutputStreamPtr os1 = memoryOutputStream();
     EncoderPtr e1 = binaryEncoder();
@@ -2125,6 +2161,7 @@ init_unit_test_suite(int, char *[]) {
     ts->add(BOOST_PARAM_TEST_CASE(&avro::testJson, avro::jsonData,
                                   ENDOF(avro::jsonData)));
     ts->add(BOOST_TEST_CASE(avro::testJsonCodecReinit));
+    ts->add(BOOST_TEST_CASE(avro::testArrayNegativeBlockCount));
     ts->add(BOOST_TEST_CASE(avro::testByteCount));
 
     return ts;


### PR DESCRIPTION
What is the purpose of the change

BinaryDecoder::arrayNext() calls doDecodeLong() directly instead of doDecodeItemCount(), causing it to mishandle negative array block counts. Per the Avro spec, a negative block count means the absolute value is the item count followed by an additional long for the byte-size of the block. When arrayNext() reads a negative count, static_cast<size_t>(-100) produces a huge value and the byte-size long is left unconsumed, corrupting the stream position.

doDecodeItemCount() already handles this correctly and is used by arrayStart(), mapStart(), and mapNext(). Only arrayNext() bypassed it. The fix changes arrayNext() to call doDecodeItemCount() for consistency.

This affects any array large enough to be encoded in multiple blocks with negative counts. ClickHouse independently found the same bug (https://github.com/ClickHouse/ClickHouse/issues/60438, https://github.com/ClickHouse/avro/pull/23).

Verifying this change

- Added testArrayNegativeBlockCount in CodecTests.cc that decodes a hand-crafted array with negative block counts and verifies all items are read correctly
- The fix was also verified against production Avro messages containing arrays with 266+ items encoded in multiple blocks with negative counts, which previously failed ~20% of the time in our systems and now decode correctly.

Documentation
- Does this pull request introduce a new feature? no
