### PR TITLE
AVRO-2818: [ruby] Support ISO 8601 string input in IntDate logical type encode

### DIFF
--- a/lang/ruby/lib/avro/logical_types.rb
+++ b/lang/ruby/lib/avro/logical_types.rb
@@ -205,6 +205,7 @@ module Avro
       def self.encode(date)
         return date.to_i if date.is_a?(Numeric)
 
+        date = Date.parse(date) if date.is_a?(String)
         (date - EPOCH_START).to_i
       end
 

--- a/lang/ruby/test/test_logical_types.rb
+++ b/lang/ruby/test/test_logical_types.rb
@@ -38,6 +38,9 @@ class TestLogicalTypes < Test::Unit::TestCase
     assert_equal 0, type.encode(Date.new(1970, 1, 1))
     assert_equal(-5, type.encode(Date.new(1969, 12, 27)))
 
+    assert_equal 5, type.encode('1970-01-06')
+    assert_equal 0, type.encode('1970-01-01')
+
     assert_equal Date.new(1970, 1, 6), type.decode(5)
     assert_equal Date.new(1970, 1, 1), type.decode(0)
     assert_equal Date.new(1969, 12, 27), type.decode(-5)

--- a/lang/ruby/test/test_logical_types.rb
+++ b/lang/ruby/test/test_logical_types.rb
@@ -40,6 +40,7 @@ class TestLogicalTypes < Test::Unit::TestCase
 
     assert_equal 5, type.encode('1970-01-06')
     assert_equal 0, type.encode('1970-01-01')
+    assert_equal(-5, type.encode('1969-12-27'))
 
     assert_equal Date.new(1970, 1, 6), type.decode(5)
     assert_equal Date.new(1970, 1, 1), type.decode(0)


### PR DESCRIPTION
## What is the purpose of the change

  This pull request partially addresses [AVRO-2818](https://issues.apache.org/jira/browse/AVRO-2818) by adding support for encoding ISO 8601 date strings (`YYYY-MM-DD`) in the Ruby SDK's `IntDate` logical type.

  Previously, `IntDate.encode` only accepted `Numeric` or `Date`/`Time` objects. Passing a string such as `'1970-01-06'` would raise a `NoMethodError` because `String#to_date` is not part of Ruby's standard library. This change adds a `Date.parse` call when the input is a `String`, allowing callers to pass ISO 8601 date strings directly without pre-converting them to `Date` objects.

  ## Verifying this change

  This change added tests and can be verified as follows:

  - Extended `test_int_date_conversion` in `test/test_logical_types.rb` to assert that ISO 8601 date strings are correctly encoded to their integer day offset from the Unix epoch
    - `'1970-01-06'` encodes to `5`
    - `'1970-01-01'` encodes to `0`

  ## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not documented