### PR TITLE
AVRO-4211: Java Schema Gen for Unions w/ Default Value

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/util/internal/JacksonUtils.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/util/internal/JacksonUtils.java
@@ -114,14 +114,26 @@ public class JacksonUtils {
   }
 
   public static Object toObject(JsonNode jsonNode, Schema schema) {
-    if (schema != null && schema.getType().equals(Schema.Type.UNION)) {
-      return toObject(jsonNode, schema.getTypes().get(0));
-    }
     if (jsonNode == null) {
       return null;
     } else if (jsonNode.isNull()) {
       return JsonProperties.NULL_VALUE;
-    } else if (jsonNode.isBoolean()) {
+    }
+
+    if (schema != null && schema.getType().equals(Schema.Type.UNION)) {
+      for (Schema unionType : schema.getTypes()) {
+        if (unionType.getType().equals(Schema.Type.NULL)) {
+          continue;
+        }
+        Object unionObject = toObject(jsonNode, unionType);
+        if (unionObject != null) {
+          return unionObject;
+        }
+      }
+      return null;
+    }
+
+    if (jsonNode.isBoolean()) {
       return jsonNode.asBoolean();
     } else if (jsonNode.isInt()) {
       if (schema == null || schema.getType().equals(Schema.Type.INT)) {
@@ -187,7 +199,7 @@ public class JacksonUtils {
 
   /**
    * Convert an object into a map
-   * 
+   *
    * @param datum The object
    * @return Its Map representation
    */

--- a/lang/java/avro/src/test/java/org/apache/avro/util/internal/TestJacksonUtils.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/util/internal/TestJacksonUtils.java
@@ -100,6 +100,11 @@ public class TestJacksonUtils {
         toObject(NullNode.getInstance(), SchemaBuilder.unionOf().nullType().and().intType().endUnion()));
 
     assertEquals("a", toObject(TextNode.valueOf("a"), SchemaBuilder.unionOf().stringType().and().intType().endUnion()));
+
+    assertEquals(1, toObject(IntNode.valueOf(1), SchemaBuilder.unionOf().nullType().and().intType().endUnion()));
+    assertEquals(42.0,
+        toObject(DoubleNode.valueOf(42.0), SchemaBuilder.unionOf().intType().and().doubleType().endUnion()));
+    assertEquals("1", toObject(TextNode.valueOf("1"), SchemaBuilder.unionOf().intType().and().stringType().endUnion()));
   }
 
 }


### PR DESCRIPTION
## What is the purpose of the change
This PR addresses [AVRO-4211](https://issues.apache.org/jira/browse/AVRO-4211). In Java, the IDLUtils does not generate Schemas correctly for fields which are unions and have a default value if the default value is not the first element in the union.

For example:
```
@Union({ Void.class, Integer.class })
@AvroDefault("1")
int someIntField = 1
```
Will produce a Schema like
```
someIntField = null
```
because `Void.class` is the first element in the union.

This change aligns the Java library with the [current documentation](https://avro.apache.org/docs/1.12.0/specification/#unions):

>Note that when a default value is specified for a record field whose type is a union, the type of the default value must match with one element of the union.

## Verifying this change
This change modified tests and can be verified as follows:

Modified `TestJacksonUtils.java`, adding a union with default value matching the second element of the union to the `testToObject()` test.

## Documentation
- Does this pull request introduce a new feature?
  - No