### PR TITLE
fix 'occured' -> 'occurred' typos in error messages across C# and Python IPC

### DIFF
--- a/lang/csharp/src/apache/ipc/HttpListenerServer.cs
+++ b/lang/csharp/src/apache/ipc/HttpListenerServer.cs
@@ -77,7 +77,7 @@ namespace Avro.ipc
                 //    ExceptionHandler(ex, result);
                 //else
                 //    Debug.Print("Exception occured while processing a request, no exception handler was provided - ignoring", ex);
-                Debug.Print("Exception occured while processing a web request, skipping this request: ", ex);
+                Debug.Print("Exception occurred while processing a web request, skipping this request: ", ex);
             }
         }
 

--- a/lang/py/avro/tether/tether_task.py
+++ b/lang/py/avro/tether/tether_task.py
@@ -422,7 +422,7 @@ class TetherTask(abc.ABC):
         """
         Call to fail the task.
         """
-        self.log.error("TetherTask.fail: failure occured message follows:\n%s", message)
+        self.log.error("TetherTask.fail: failure occurred message follows:\n%s", message)
         try:
             message = message.decode()
         except AttributeError:
@@ -431,7 +431,7 @@ class TetherTask(abc.ABC):
         try:
             self.outputClient.request("fail", {"message": message})
         except Exception:
-            self.log.exception("TetherTask.fail: an exception occured while trying to send the fail message to the output server.")
+            self.log.exception("TetherTask.fail: an exception occurred while trying to send the fail message to the output server.")
 
         self.close()
 

--- a/lang/py/avro/tether/tether_task_runner.py
+++ b/lang/py/avro/tether/tether_task_runner.py
@@ -67,7 +67,7 @@ class TaskRunnerResponder(avro.ipc.Responder):
                 try:
                     self.task.partitions = request["partitions"]
                 except Exception:
-                    self.log.error("Exception occured while processing the partitions message: Message:\n%s", traceback.format_exc())
+                    self.log.error("Exception occurred while processing the partitions message: Message:\n%s", traceback.format_exc())
                     raise
             elif message.name == "input":
                 self.log.info("TetherTaskRunner: Received input")
@@ -84,7 +84,7 @@ class TaskRunnerResponder(avro.ipc.Responder):
                 self.log.warning("TetherTaskRunner: Received unknown message %s", message.name)
 
         except Exception:
-            self.log.error("Error occured while processing message: %s", message.name)
+            self.log.error("Error occurred while processing message: %s", message.name)
             e = traceback.format_exc()
             self.task.fail(e)
 


### PR DESCRIPTION
Trivial spelling fix in three files — `occured` → `occurred`.

All occurrences are in user-visible log or debug messages:

- `lang/csharp/.../HttpListenerServer.cs` — `Debug.Print` when the HTTP request handler throws.
- `lang/py/.../tether/tether_task_runner.py` — two `log.error` messages from `TetherTaskRunner.process_message`.
- `lang/py/.../tether/tether_task.py` — two log messages from `TetherTask.fail`.

No functional changes.