### PR TITLE
[AVRO-4248] Fix misaligned pointer use in BufferDetail.hh and BufferReader.hh

### DIFF
--- a/lang/c++/include/avro/buffer/BufferReader.hh
+++ b/lang/c++/include/avro/buffer/BufferReader.hh
@@ -20,6 +20,7 @@
 #define avro_BufferReader_hh__
 
 #include "Buffer.hh"
+#include <cstring>
 #include <type_traits>
 
 #ifdef min
@@ -233,7 +234,7 @@ private:
         }
 
         if (sizeof(T) <= chunkRemaining()) {
-            val = *(reinterpret_cast<const T *>(addr()));
+            memcpy(&val, addr(), sizeof(T));
             incrementChunk(sizeof(T));
         } else {
             read(reinterpret_cast<data_type *>(&val), sizeof(T));

--- a/lang/c++/include/avro/buffer/detail/BufferDetail.hh
+++ b/lang/c++/include/avro/buffer/detail/BufferDetail.hh
@@ -20,6 +20,7 @@
 #define avro_BufferDetail_hh__
 
 #include <cassert>
+#include <cstring>
 #include <deque>
 #include <exception>
 #include <functional>
@@ -320,7 +321,7 @@ public:
         if (freeSpace_ && (sizeof(T) <= writeChunks_.front().freeSize())) {
             // fast path, there's enough room in the writeable chunk to just
             // straight out copy it
-            *(reinterpret_cast<T *>(writeChunks_.front().tellWritePos())) = val;
+            memcpy(writeChunks_.front().tellWritePos(), &val, sizeof(T));
             postWrite(sizeof(T));
         } else {
             // need to fixup chunks first, so use the regular memcpy


### PR DESCRIPTION
## What is the purpose of the change

Fix a misaligned pointer use by replacing cast with memcpy.

## Verifying this change

Verified with same asan test that found the failure. See AVRO-4248

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable