### PR TITLE
AVRO-4182: Avoid ANTLR parsing edge cases

### DIFF
--- a/lang/java/idl/src/main/java/org/apache/avro/idl/IdlReader.java
+++ b/lang/java/idl/src/main/java/org/apache/avro/idl/IdlReader.java
@@ -212,8 +212,9 @@ public class IdlReader {
     parser.setTrace(false);
 
     // Parse the input, then walk the parse tree using the listener.
-    // Although the parse can call the listener directly, there are edge cases where the enter and exit rules are not
-    // called in pairs. This a known issue and currently by design. See: https://github.com/antlr/antlr4/issues/18
+    // Although the parse can call the listener directly, there are edge cases where
+    // the enter and exit rules are not called in pairs. This a known issue and
+    // currently by design. See: https://github.com/antlr/antlr4/issues/18
     try {
       IdlFileContext idlFileContext = parser.idlFile();
       ParseTreeWalker.DEFAULT.walk(parseListener, idlFileContext);

--- a/lang/java/idl/src/main/java/org/apache/avro/idl/IdlReader.java
+++ b/lang/java/idl/src/main/java/org/apache/avro/idl/IdlReader.java
@@ -34,6 +34,7 @@ import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
 import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import org.apache.avro.JsonProperties;
 import org.apache.avro.JsonSchemaParser;
 import org.apache.avro.LogicalType;
@@ -207,20 +208,21 @@ public class IdlReader {
     IdlParser parser = new IdlParser(tokenStream);
     parser.removeErrorListeners();
     parser.addErrorListener(SIMPLE_AVRO_ERROR_LISTENER);
-    parser.addParseListener(parseListener);
+    // parser.addParseListener(parseListener);
     parser.setTrace(false);
-    parser.setBuildParseTree(false);
 
+    // Parse the input, then walk the parse tree using the listener.
+    // Although the parse can call the listener directly, there are edge cases where the enter and exit rules are not
+    // called in pairs. This a known issue and currently by design. See: https://github.com/antlr/antlr4/issues/18
     try {
-      // Trigger parsing.
-      parser.idlFile();
+      IdlFileContext idlFileContext = parser.idlFile();
+      ParseTreeWalker.DEFAULT.walk(parseListener, idlFileContext);
+      return parseListener.getIdlFile();
     } catch (SchemaParseException e) {
       throw e;
     } catch (RuntimeException e) {
       throw new SchemaParseException(e);
     }
-
-    return parseListener.getIdlFile();
   }
 
   /* Package private to facilitate testing */

--- a/lang/java/idl/src/main/java/org/apache/avro/idl/IdlReader.java
+++ b/lang/java/idl/src/main/java/org/apache/avro/idl/IdlReader.java
@@ -208,7 +208,6 @@ public class IdlReader {
     IdlParser parser = new IdlParser(tokenStream);
     parser.removeErrorListeners();
     parser.addErrorListener(SIMPLE_AVRO_ERROR_LISTENER);
-    // parser.addParseListener(parseListener);
     parser.setTrace(false);
 
     // Parse the input, then walk the parse tree using the listener.

--- a/lang/java/idl/src/test/idl/extra/duplicateNameErrorParsing.avdl
+++ b/lang/java/idl/src/test/idl/extra/duplicateNameErrorParsing.avdl
@@ -1,0 +1,14 @@
+namespace duplicateNameParseError;
+
+// Test that parsing fails when redefining an enum with different symbols.
+// Avro 1.12.0 fails to parse this, but the correct result is an explicit error that redefinition is not allowed.
+
+enum Foo {
+  UNKNOWN,
+  BAR
+} = UNKNOWN;
+
+enum Foo {
+  UNKNOWN,
+  BAZ
+} = UNKNOWN;

--- a/lang/java/idl/src/test/java/org/apache/avro/idl/TestIdlReader.java
+++ b/lang/java/idl/src/test/java/org/apache/avro/idl/TestIdlReader.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.avro.Protocol;
 import org.apache.avro.Schema;
+import org.apache.avro.SchemaParseException;
 import org.junit.Before;
 import org.junit.Test;
 import java.io.BufferedReader;
@@ -156,7 +157,16 @@ public class TestIdlReader {
         warnings);
   }
 
-  @SuppressWarnings("SameParameterValue")
+  @Test
+  public void testErrorDuplicateNamedType() throws IOException {
+    try {
+      parseExtraIdlFile("duplicateNameErrorParsing.avdl");
+      fail("Expected a failure: named schemas cannot be redefined.");
+    } catch (SchemaParseException e) {
+      assertEquals("Can't redefine: duplicateNameParseError.Foo", e.getMessage());
+    }
+  }
+
   private IdlFile parseExtraIdlFile(String fileName) throws IOException {
     return new IdlReader().parse(EXTRA_TEST_DIR.toPath().resolve(fileName));
   }


### PR DESCRIPTION
<!--

*Thank you very much for contributing to Apache Avro - we are happy that you want to help us improve Avro. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Avro a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/AVRO/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "AVRO-XXXX: [component] Title of the pull request", where *AVRO-XXXX* should be replaced by the actual issue number. 
    The *component* is optional, but can help identify the correct reviewers faster: either the language ("java", "python") or subsystem such as "build" or "doc" are good candidates.  

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests. You can [build the entire project](https://github.com/apache/avro/blob/main/BUILD.md) or just the [language-specific SDK](https://avro.apache.org/project/how-to-contribute/#unit-tests).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Every commit message references Jira issues in their subject lines. In addition, commits follow the guidelines from [How to write a good git commit message](https://chris.beams.io/posts/git-commit/)
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

-->

## What is the purpose of the change

In some cases, enter and exit rules are not called in pairs. Apparently, this is by design. This fix adds a test that the fix does indeed work (it tests an exception, as the error does not show up with a duplicated definition).

Note: this change keeps the entire parse tree in memory during parsing, and allows it to be collected directly afterwards.

This PR fixes the bug reported as AVRO-4182.


## Verifying this change

This change adds a test: `org.apache.avro.idl.TestIdlReader#testErrorDuplicateNamedType()`


## Documentation

- Does this pull request introduce a new feature? (~yes~ / **no**)
- If yes, how is the feature documented? (**not applicable** / ~docs / JavaDocs / not documented~)
