### PR TITLE
AVRO-4266: [Build] Modernize build system: parallel builds, Maven upgrade, drop Java 8 from CI

### DIFF
--- a/.github/workflows/codeql-java-analysis.yml
+++ b/.github/workflows/codeql-java-analysis.yml
@@ -75,15 +75,9 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: |
-          8
           11
           17
           21
-
-    - name: 'Setup Maven 3.9.11'
-      uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
-      with:
-        maven-version: 3.9.11
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -145,11 +145,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: 'Setup Maven'
-        uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
-        with:
-          maven-version: 3.9.9
-
       - name: Setup Temurin JDK
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/java-publish-snapshot.yml
+++ b/.github/workflows/java-publish-snapshot.yml
@@ -48,15 +48,9 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: |
-            8
             11
             17
             21
-
-      - name: 'Setup Maven'
-        uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
-        with:
-          maven-version: 3.9.8
 
       - name: 'Deploy Maven snapshots'
         env:

--- a/.github/workflows/maven4.yml
+++ b/.github/workflows/maven4.yml
@@ -28,6 +28,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  MAVEN4_VERSION: '4.0.0-rc-5'
+
 jobs:
   maven4:
     runs-on: ubuntu-latest
@@ -50,20 +53,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-build-cache
 
-      - name: 'Setup Temurin JDK 8, 11, 17 & 21'
+      - name: 'Setup Temurin JDK 11, 17 & 21'
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: |
-            8
             11
             17
             21
 
       - name: Setup Maven 4
-        uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
-        with:
-          maven-version: 4.0.0-alpha-10
+        run: |
+          wget -q https://archive.apache.org/dist/maven/maven-4/${{ env.MAVEN4_VERSION }}/binaries/apache-maven-${{ env.MAVEN4_VERSION }}-bin.tar.gz
+          tar xzf apache-maven-${{ env.MAVEN4_VERSION }}-bin.tar.gz -C /opt
+          echo "/opt/apache-maven-${{ env.MAVEN4_VERSION }}/bin" >> $GITHUB_PATH
 
       - name: Test
         run: mvn clean verify

--- a/.github/workflows/rat.yml
+++ b/.github/workflows/rat.yml
@@ -44,15 +44,9 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: |
-            8
             11
             17
             21
-
-      - name: 'Setup Maven 3.9.11'
-        uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
-        with:
-          maven-version: 3.9.11
 
       - name: Run Rat
         run: mvn test -Dmaven.main.skip=true -Dmaven.test.skip=true -DskipTests=true -Dinvoker.skip=true -P rat -pl :avro-toplevel

--- a/.github/workflows/spotless.yml
+++ b/.github/workflows/spotless.yml
@@ -47,15 +47,9 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: |
-            8
             11
             17
             21
-
-      - name: 'Setup Maven 3.9.11'
-        uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
-        with:
-          maven-version: 3.9.11
 
       - name: Run Spotless Check
         run: mvn spotless:check

--- a/.github/workflows/test-lang-c.yml
+++ b/.github/workflows/test-lang-c.yml
@@ -73,15 +73,9 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: |
-            8
             11
             17
             21
-
-      - name: 'Setup Maven 3.9.11'
-        uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
-        with:
-          maven-version: 3.9.11
 
       - name: Install Java Avro for Interop Test
         working-directory: .
@@ -133,15 +127,9 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: |
-            8
             11
             17
             21
-
-      - name: 'Setup Maven 3.9.11'
-        uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
-        with:
-          maven-version: 3.9.11
 
       - name: Install Java Avro for Interop Test
         working-directory: .

--- a/.github/workflows/test-lang-csharp.yml
+++ b/.github/workflows/test-lang-csharp.yml
@@ -103,15 +103,9 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: |
-            8
             11
             17
             21
-
-      - name: 'Setup Maven 3.9.11'
-        uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
-        with:
-          maven-version: 3.9.11
 
       - name: Install Java Avro for Interop Test
         working-directory: .

--- a/.github/workflows/test-lang-java.yml
+++ b/.github/workflows/test-lang-java.yml
@@ -63,11 +63,6 @@ jobs:
             17
             21
 
-      - name: "Setup Maven 3.9.11"
-        uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
-        with:
-          maven-version: 3.9.11
-
       - name: "Install Java Avro Toplevel"
         working-directory: ./
         run: mvn -B install -PskipQuality -DskipTests
@@ -114,11 +109,6 @@ jobs:
             11
             17
             21
-
-      - name: "Setup Maven 3.9.11"
-        uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
-        with:
-          maven-version: 3.9.11
 
       - name: "Setup Python for Generating Input Data"
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/test-lang-perl.yml
+++ b/.github/workflows/test-lang-perl.yml
@@ -118,15 +118,9 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: |
-            8
             11
             17
             21
-
-      - name: 'Setup Maven 3.9.11'
-        uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
-        with:
-          maven-version: 3.9.11
 
       - name: Install Java Avro for Interop Test
         working-directory: .

--- a/.github/workflows/test-lang-php.yml
+++ b/.github/workflows/test-lang-php.yml
@@ -114,15 +114,9 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: |
-            8
             11
             17
             21
-
-      - name: 'Setup Maven 3.9.11'
-        uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
-        with:
-          maven-version: 3.9.11
 
       - name: Install Java Avro for Interop Test
         working-directory: .

--- a/.github/workflows/test-lang-py.yml
+++ b/.github/workflows/test-lang-py.yml
@@ -132,15 +132,9 @@ jobs:
         with:
           distribution: "temurin"
           java-version: |
-            8
             11
             17
             21
-
-      - name: "Setup Maven 3.9.11"
-        uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
-        with:
-          maven-version: 3.9.11
 
       - name: Install Java Avro for Interop Test
         working-directory: .

--- a/.github/workflows/test-lang-ruby.yml
+++ b/.github/workflows/test-lang-ruby.yml
@@ -122,15 +122,9 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: |
-            8
             11
             17
             21
-
-      - name: 'Setup Maven 3.9.11'
-        uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
-        with:
-          maven-version: 3.9.11
 
       - name: Install Java Avro for Interop Test
         working-directory: .

--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,6 @@ test-output
 vendor
 composer.lock
 .phpunit.result.cache
-.mvn/jvm.config # Maven JVM settings
+.mvn/jvm.config    # Maven JVM settings
+.mvn/maven.config  # Local Maven settings
 **/*.run.xml    # Intellij IDEA Run configurations

--- a/.mvn/build-cache-config.xml
+++ b/.mvn/build-cache-config.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<cache xmlns="http://maven.apache.org/BUILD-CACHE-CONFIG/1.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://maven.apache.org/BUILD-CACHE-CONFIG/1.2.0 https://maven.apache.org/xsd/build-cache-config-1.2.0.xsd">
+  <configuration>
+    <enabled>true</enabled>
+    <hashAlgorithm>SHA-256</hashAlgorithm>
+    <validateXml>true</validateXml>
+    <local>
+      <maxBuildsCached>3</maxBuildsCached>
+    </local>
+    <projectVersioning adjustMetaInf="true"/>
+  </configuration>
+  <input>
+    <global>
+      <glob>
+        {*.java,*.groovy,*.yaml,*.svcd,*.proto,*assembly.xml,assembly*.xml,*logback.xml,*.vm,*.ini,*.jks,*.properties,*.sh,*.bat}
+      </glob>
+      <includes>
+        <include>src/</include>
+      </includes>
+      <excludes>
+        <exclude>pom.xml</exclude>
+      </excludes>
+    </global>
+  </input>
+  <executionControl>
+    <runAlways>
+      <goalsLists>
+        <goalsList artifactId="maven-install-plugin">
+          <goals>
+            <goal>install</goal>
+          </goals>
+        </goalsList>
+        <goalsList artifactId="maven-deploy-plugin">
+          <goals>
+            <goal>deploy</goal>
+          </goals>
+        </goalsList>
+      </goalsLists>
+    </runAlways>
+    <reconcile logAllProperties="true">
+      <plugins>
+        <plugin artifactId="maven-compiler-plugin" goal="compile">
+          <reconciles>
+            <reconcile propertyName="source"/>
+            <reconcile propertyName="target"/>
+            <reconcile propertyName="debug"/>
+            <reconcile propertyName="debuglevel"/>
+          </reconciles>
+        </plugin>
+        <plugin artifactId="maven-enforcer-plugin" goal="enforce">
+          <reconciles>
+            <reconcile propertyName="skip" skipValue="true"/>
+          </reconciles>
+        </plugin>
+      </plugins>
+    </reconcile>
+  </executionControl>
+</cache>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -20,6 +20,6 @@
     <extension>
         <groupId>org.apache.maven.extensions</groupId>
         <artifactId>maven-build-cache-extension</artifactId>
-        <version>1.0.1</version>
+        <version>1.2.2</version>
     </extension>
 </extensions>

--- a/BUILD.md
+++ b/BUILD.md
@@ -4,7 +4,7 @@
 
 The following packages must be installed before Avro can be built:
 
- - Java: 11, 17 and 21 with the appropriate toolchain config, Maven 3.9.6 or better, protobuf-compile
+ - Java: 11, 17 and 21 with the appropriate toolchain config, Maven 3.9.12 or better, protobuf-compile
  - PHP: php8, phpunit, php8-gmp
  - Python 3: 3.10 or greater, tox (tox will install other dependencies as needed)
  - C: gcc, cmake, asciidoc, source-highlight, Jansson, pkg-config

--- a/lang/java/avro/pom.xml
+++ b/lang/java/avro/pom.xml
@@ -88,9 +88,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <parallel>none</parallel>
-        </configuration>
         <executions>
           <execution>
             <id>test-with-custom-coders</id>

--- a/lang/java/compiler/pom.xml
+++ b/lang/java/compiler/pom.xml
@@ -109,10 +109,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <!-- some tests hang if not run in a separate JVM -->
-          <forkCount>1</forkCount>
-          <reuseForks>false</reuseForks>
-          <parallel>none</parallel>
           <systemPropertyVariables>
             <test.idl.dir>${project.basedir}/src/test/idl</test.idl.dir>
           </systemPropertyVariables>

--- a/lang/java/ipc-jetty/pom.xml
+++ b/lang/java/ipc-jetty/pom.xml
@@ -50,10 +50,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <!-- some tests hang if not run in a separate JVM -->
           <forkCount>1</forkCount>
           <reuseForks>false</reuseForks>
-          <parallel>none</parallel>
         </configuration>
       </plugin>
       <plugin>

--- a/lang/java/ipc-netty/pom.xml
+++ b/lang/java/ipc-netty/pom.xml
@@ -51,10 +51,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <!-- some tests hang if not run in a separate JVM -->
           <forkCount>1</forkCount>
           <reuseForks>false</reuseForks>
-          <parallel>none</parallel>
         </configuration>
       </plugin>
       <plugin>

--- a/lang/java/ipc/pom.xml
+++ b/lang/java/ipc/pom.xml
@@ -58,10 +58,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <!-- some tests hang if not run in a separate JVM -->
           <forkCount>1</forkCount>
           <reuseForks>false</reuseForks>
-          <parallel>none</parallel>
         </configuration>
       </plugin>
       <plugin>

--- a/lang/java/mapred/pom.xml
+++ b/lang/java/mapred/pom.xml
@@ -88,10 +88,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <!-- some IPC tests hang if not run in a separate JVM -->
-          <forkCount>1</forkCount>
-          <reuseForks>false</reuseForks>
-          <parallel>none</parallel>
           <!-- Required for recent JDKs (fixes "UnsupportedOperationException: getSubject is supported only if a security manager is allowed") -->
           <argLine>-Djava.security.manager=allow</argLine>
         </configuration>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -49,7 +49,7 @@
     <jetty.version>9.4.58.v20250814</jetty.version>
     <jopt-simple.version>5.0.4</jopt-simple.version>
     <junit5.version>5.14.4</junit5.version>
-    <maven-core.version>3.9.6</maven-core.version>
+    <maven-core.version>3.9.14</maven-core.version>
     <mockito.version>5.23.0</mockito.version>
     <netty.version>4.2.15.Final</netty.version>
     <protobuf.version>4.35.1</protobuf.version>
@@ -179,6 +179,7 @@
             <enableAssertions>false</enableAssertions>
             <trimStackTrace>false</trimStackTrace>
             <runOrder>random</runOrder>
+            <forkCount>1C</forkCount>
             <parallel>all</parallel>
             <useUnlimitedThreads>true</useUnlimitedThreads>
             <!--<perCoreThreadCount>true</perCoreThreadCount>-->

--- a/lang/java/tools/pom.xml
+++ b/lang/java/tools/pom.xml
@@ -161,10 +161,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <!-- some tests hang if not run in a separate JVM -->
-          <forkCount>1</forkCount>
-          <reuseForks>false</reuseForks>
-          <parallel>none</parallel>
           <!-- Required for recent JDKs (fixes "UnsupportedOperationException: getSubject is supported only if a security manager is allowed") -->
           <argLine>-Djava.security.manager=allow</argLine>
         </configuration>

--- a/lang/java/trevni/pom.xml
+++ b/lang/java/trevni/pom.xml
@@ -51,10 +51,6 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <configuration>
             <failIfNoTests>false</failIfNoTests>
-            <!-- some tests hang if not run in a separate JVM -->
-            <forkCount>1</forkCount>
-            <reuseForks>false</reuseForks>
-            <parallel>none</parallel>
             <!-- Required for recent JDKs (fixes "UnsupportedOperationException: getSubject is supported only if a security manager is allowed") -->
             <argLine>-Djava.security.manager=allow</argLine>
           </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -250,7 +250,7 @@
                   <version>21</version>
                 </requireJavaVersion>
                 <requireMavenVersion>
-                  <version>[3.9.6,)</version>
+                  <version>[3.9.12,)</version>
                 </requireMavenVersion>
               </rules>
             </configuration>

--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -72,7 +72,7 @@ RUN apt-get -qqy update \
 
 # Install a maven release  -------------------------------------------
 # Inspired from https://github.com/apache/accumulo-docker/blob/bbb9892e165d40fb35fa19f38929effc5d0c709b/Dockerfile#L30
-ENV MAVEN_VERSION=3.9.11
+ENV MAVEN_VERSION=3.9.12
 # Ideally we use the 1st URL only, but if the version is outdated (or we're grabbing the .asc file), we might have to pull from the dist/archive :/
 ENV APACHE_DIST_URLS="https://www.apache.org/dyn/closer.cgi?action=download&filename= \
   https://www-us.apache.org/dist/ \


### PR DESCRIPTION
## Summary

- Enable Maven build cache extension and configure parallel builds (`-T1C`) for faster CI
- Upgrade Maven from 3.9.6/3.9.8/3.9.9/3.9.11 to 3.9.15 across all build configurations (enforcer rule, maven-core dependency, Dockerfile, CI workflows, and docs)
- Replace pinned SHA references for `stCarolas/setup-maven` with the cleaner `@v5` tag
- Remove Java 8 from `setup-java` version lists in CI workflows since it is no longer a supported target