### PR TITLE
AVRO-4254: [Java] Avoid logging datum values in UnresolvedUnionException

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/UnresolvedUnionException.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/UnresolvedUnionException.java
@@ -24,13 +24,14 @@ public class UnresolvedUnionException extends AvroRuntimeException {
   private Schema unionSchema;
 
   public UnresolvedUnionException(Schema unionSchema, Object unresolvedDatum) {
-    super("Not in union " + unionSchema + ": " + unresolvedDatum);
+    super("Not in union " + unionSchema + ": " + datumTypeDescription(unresolvedDatum));
     this.unionSchema = unionSchema;
     this.unresolvedDatum = unresolvedDatum;
   }
 
   public UnresolvedUnionException(Schema unionSchema, Schema.Field field, Object unresolvedDatum) {
-    super("Not in union " + unionSchema + ": " + unresolvedDatum + " (field=" + field.name() + ")");
+    super(
+        "Not in union " + unionSchema + ": " + datumTypeDescription(unresolvedDatum) + " (field=" + field.name() + ")");
     this.unionSchema = unionSchema;
     this.unresolvedDatum = unresolvedDatum;
   }
@@ -41,5 +42,9 @@ public class UnresolvedUnionException extends AvroRuntimeException {
 
   public Schema getUnionSchema() {
     return unionSchema;
+  }
+
+  private static String datumTypeDescription(Object datum) {
+    return datum == null ? "null" : datum.getClass().getName();
   }
 }

--- a/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericDatumWriter.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericDatumWriter.java
@@ -56,7 +56,7 @@ public class TestGenericDatumWriter {
       new GenericDatumWriter<>(s).write(r, EncoderFactory.get().jsonEncoder(s, bao));
       fail();
     } catch (final UnresolvedUnionException uue) {
-      assertEquals("Not in union [\"null\",\"string\"]: 100 (field=f)", uue.getMessage());
+      assertEquals("Not in union [\"null\",\"string\"]: java.lang.Integer (field=f)", uue.getMessage());
     }
   }
 


### PR DESCRIPTION
## Summary

- `UnresolvedUnionException` previously included the full `toString()` of the unresolved datum in its exception message. When this exception propagates to generic error handlers or gets logged, the datum value — which may contain sensitive user data — gets written to application logs.
- Replace the datum's `toString()` with its class name in the exception message. The actual datum object remains accessible via `getUnresolvedDatum()` for callers that need programmatic access.

## Motivation

When an `UnresolvedUnionException` is thrown during serialization, it is common for upstream frameworks to catch and log the full exception message. Since the message contains the raw datum value, this can result in sensitive data being written to application logs — a data leak.

The fix is minimal and backwards-compatible:
- The exception message now shows the **type** of the datum (e.g. `java.lang.Integer`) instead of its **value**
- The `getUnresolvedDatum()` accessor still returns the original object for any caller that needs the actual value

## Test plan

- [x] Updated existing test `TestGenericDatumWriter.unionUnresolvedExceptionExplicitWhichField` to assert new message format
- [x] All 15 tests in `TestGenericDatumWriter` pass