### PR TITLE
AVRO-4209: [java] Reflect correctly on recursive schemas

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectData.java
@@ -739,6 +739,7 @@ public class ReflectData extends SpecificData {
           boolean error = Throwable.class.isAssignableFrom(c);
           schema = Schema.createRecord(name, doc, space, error);
           consumeAvroAliasAnnotation(c, schema);
+          names.put(fullName, schema);
           for (Field field : getCachedFields(c))
             if ((field.getModifiers() & (Modifier.TRANSIENT | Modifier.STATIC)) == 0
                 && !field.isAnnotationPresent(AvroIgnore.class)) {
@@ -781,6 +782,9 @@ public class ReflectData extends SpecificData {
             }
             schema.addProp(meta.key(), meta.value());
           }
+          // This is added immediately back into the names to ensure that the discoverable
+          // order is maintained if its a LinkedHashMap.
+          names.remove(fullName, schema);
         }
         names.put(fullName, schema);
       }

--- a/lang/java/avro/src/test/java/org/apache/avro/reflect/TestReflect.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/reflect/TestReflect.java
@@ -1441,6 +1441,12 @@ public class TestReflect {
         return false;
       return true;
     }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(value, left, right);
+    }
+
   }
 
   @Test

--- a/lang/java/avro/src/test/java/org/apache/avro/reflect/TestReflect.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/reflect/TestReflect.java
@@ -33,6 +33,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
 import org.apache.avro.AvroRuntimeException;
@@ -1416,4 +1417,55 @@ public class TestReflect {
             + "{\"name\":\"foo\",\"type\":\"int\",\"doc\":\"Some Documentation\"}" + "]}");
   }
 
+  // test recursive record schema
+  public static class TreeNode {
+    public int value = 0;
+    @Nullable
+    public TreeNode left;
+    @Nullable
+    public TreeNode right;
+
+    public TreeNode() {
+    }
+
+    public TreeNode(int value) {
+      this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (!(o instanceof TreeNode))
+        return false;
+      TreeNode that = (TreeNode) o;
+      if (value != that.value || !Objects.equals(left, that.left) || !Objects.equals(right, that.right))
+        return false;
+      return true;
+    }
+  }
+
+  @Test
+  void recursiveRecord() throws Exception {
+    Schema schema = ReflectData.get().getSchema(TreeNode.class);
+    assertEquals("TreeNode", schema.getName());
+    assertEquals(3, schema.getFields().size());
+
+    // Verify that the left tree node contains the parent schema
+    Schema leftSchema = schema.getField("left").schema();
+    assertEquals(Schema.Type.UNION, leftSchema.getType());
+    assertEquals(2, leftSchema.getTypes().size());
+    assertEquals(Schema.Type.NULL, leftSchema.getTypes().get(0).getType());
+    assertEquals(schema, leftSchema.getTypes().get(1));
+
+    // Verify that the right tree node is the same union
+    Schema rightSchema = schema.getField("right").schema();
+    assertEquals(leftSchema, rightSchema);
+
+    // Test serialization with actual recursive data
+    TreeNode root = new TreeNode(100);
+    root.left = new TreeNode(90);
+    root.right = new TreeNode(101);
+    root.left.left = new TreeNode(-100);
+
+    checkReadWrite(root);
+  }
 }


### PR DESCRIPTION
## What is the purpose of the change

When reflecting on a class with a recursive reference, make sure that the schemas are parsed and emitted in the correct order.

Currently after #3304, schemas are defined to be emitted when they are completely resolved (i.e. a RECORD schema is put into the context after all its fields have also been completely resolved).  Unfortunately for recursive data where a field is the same class as a parent structure, this causes a stack overflow.

This can be resolved by noting that the record schema is "in progress" by adding it to the list *before* it is fully resolved.  In order to keep the right order in the map in the end, it needs to be removed and re-added after the fields are finished resolving.

## Verifying this change

*(Please pick one of the following options)*

This change added tests to `TestReflect`. Current tests that check the schema order still pass.

## Documentation

- Does this pull request introduce a new feature? **no**
- If yes, how is the feature documented? **not applicable**
