### PR TITLE
AVRO-4176: Java parser allows field type to be object with custom type

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/Schema.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Schema.java
@@ -1842,8 +1842,9 @@ public abstract class Schema extends JsonProperties implements Serializable {
         return parseMap(schema, context, currentNameSpace);
       } else if ("fixed".equals(type)) { // fixed
         return parseFixed(schema, context, currentNameSpace);
-      } else { // For unions with self reference
-        return context.find(type, currentNameSpace);
+      } else {
+        throw new SchemaParseException("A schema \"type\" MUST be a primitive type or one of"
+            + " \"enum\", \"fixed\", \"record\", \"error\", \"array\" or \"map\".");
       }
     } else if (schema.isArray()) { // union
       return parseUnion(schema, context, currentNameSpace);

--- a/lang/java/avro/src/test/java/org/apache/avro/TestSchema.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestSchema.java
@@ -648,6 +648,15 @@ public class TestSchema {
     new Schema.Parser((NameValidator) null).parse("{\"type\":\"record\",\"name\":\"\",\"fields\":[]}"); // Empty name
   }
 
+  @Test
+  void disallowTypeObjectForNamedType() {
+    String withTypeObjectWithNamedType = "{"
+        + "\"namespace\":\"tests\",\"type\":\"record\",\"name\":\"Invalid\",\"fields\":["
+        + "{\"name\":\"good\",\"type\":{\"type\":\"fixed\",\"name\":\"Hash\",\"size\":16}},"
+        + "{\"name\":\"right\",\"type\":{\"type\":\"Hash\"}}]}";
+    assertThrows(SchemaParseException.class, () -> new SchemaParser().parse(withTypeObjectWithNamedType).mainSchema());
+  }
+
   /**
    * Tests when a user tries to write a record with an invalid enum symbol value
    * that the exception returned is more descriptive than just a NPE or an

--- a/lang/java/avro/src/test/java/org/apache/avro/TestUnionSelfReference.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestUnionSelfReference.java
@@ -31,20 +31,15 @@ public class TestUnionSelfReference {
   @SuppressWarnings("unused")
   private static final Logger LOG = LoggerFactory.getLogger(TestUnionSelfReference.class);
 
-  private static final String SIMPLE_BINARY_TREE = "{" + "    \"namespace\": \"tree\"," + "    \"type\": \"record\","
-      + "    \"name\": \"Node\"," + "    \"fields\": [" + "      {" + "        \"name\": \"left\","
-      + "        \"type\": [" + "          \"null\"," + "          {" + "            \"type\": \"Node\"" + "          }"
-      + "        ]," + "        \"default\": null" + "      }," + "      {" + "        \"name\": \"right\","
-      + "        \"type\": [" + "          \"null\"," + "          {" + "            \"type\": \"Node\"" + "          }"
-      + "        ]," + "        \"default\": null" + "      }" + "    ]" + "  }";
+  private static final String SIMPLE_BINARY_TREE = "{"
+      + "\"namespace\":\"tree\",\"type\":\"record\",\"name\":\"Node\",\"fields\":["
+      + "{\"name\":\"left\",\"type\":[\"null\",\"Node\"],\"default\":null},"
+      + "{\"name\":\"right\",\"type\":[\"null\",\"Node\"],\"default\":null}]}";
 
-  private static final String THREE_TYPE_UNION = "{" + "    \"namespace\": \"tree\"," + "    \"type\": \"record\","
-      + "    \"name\": \"Node\"," + "    \"fields\": [" + "      {" + "        \"name\": \"left\","
-      + "        \"type\": [" + "          \"null\"," + "          \"string\"," + "          {"
-      + "            \"type\": \"Node\"" + "          }" + "        ]," + "        \"default\": null" + "      },"
-      + "      {" + "        \"name\": \"right\"," + "        \"type\": [" + "          \"null\","
-      + "          \"string\"," + "          {" + "            \"type\": \"Node\"" + "          }" + "        ],"
-      + "        \"default\": null" + "      }" + "    ]" + "  }";
+  private static final String THREE_TYPE_UNION = "{"
+      + "\"namespace\":\"tree\",\"type\":\"record\",\"name\":\"Node\",\"fields\":["
+      + "{\"name\":\"left\",\"type\":[\"null\",\"string\",\"Node\"],\"default\":null},"
+      + "{\"name\":\"right\",\"type\":[\"null\",\"string\",\"Node\"],\"default\":null}]}";
 
   @Test
   void selfReferenceInUnion() {


### PR DESCRIPTION
<!--

*Thank you very much for contributing to Apache Avro - we are happy that you want to help us improve Avro. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Avro a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/AVRO/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "AVRO-XXXX: [component] Title of the pull request", where *AVRO-XXXX* should be replaced by the actual issue number. 
    The *component* is optional, but can help identify the correct reviewers faster: either the language ("java", "python") or subsystem such as "build" or "doc" are good candidates.  

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests. You can [build the entire project](https://github.com/apache/avro/blob/main/BUILD.md) or just the [language-specific SDK](https://avro.apache.org/project/how-to-contribute/#unit-tests).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Every commit message references Jira issues in their subject lines. In addition, commits follow the guidelines from [How to write a good git commit message](https://chris.beams.io/posts/git-commit/)
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

-->

## What is the purpose of the change

This PR fixes AVRO-4176: Java parser allows field type to be object with custom type.

## Verifying this change

The description of the bug points to the change in `Schema.java`, and a test was added to `TestSchema` to prove the fix.

The change in `TestUnionSelfReference` was needed because it contained the same bug as mentioned in the Jira issue: it used `{"type": "Node"}` as a type reference.


## Documentation

- Does this pull request introduce a new feature? (~yes~ / **no**)
- If yes, how is the feature documented? (**not applicable** / ~docs / JavaDocs / not documented~)
