### PR TITLE
AVRO-4253: [Java] fix memory leak

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/io/FastReaderBuilder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/FastReaderBuilder.java
@@ -17,6 +17,7 @@ package org.apache.avro.io;
 import org.apache.avro.*;
 import org.apache.avro.Resolver.*;
 import org.apache.avro.Schema.Field;
+
 import org.apache.avro.generic.*;
 import org.apache.avro.generic.GenericData.InstanceSupplier;
 import org.apache.avro.io.FastReaderBuilder.RecordReader.Stage;
@@ -44,28 +45,33 @@ import java.util.function.IntFunction;
 public class FastReaderBuilder {
 
   /**
-   * Generic/SpecificData instance that contains basic functionalities like instantiation of objects
+   * Generic/SpecificData instance that contains basic functionalities like
+   * instantiation of objects
    */
   private final GenericData data;
 
   /**
-   * first schema is reader schema, second is writer schema As the RecordReader holds a strong reference to the reader
-   * cache. We rely on the writer cache being dereferenced, casing the inner map entry to remove the RecordReader. This
-   * in turn allows the outer Map entry to become weakly accessible and reclaimed.
+   * first schema is reader schema, second is writer schema As the RecordReader
+   * holds a strong reference to the reader cache. We rely on the writer cache
+   * being dereferenced, casing the inner map entry to remove the RecordReader.
+   * This in turn allows the outer Map entry to become weakly accessible and
+   * reclaimed.
    * <p>
-   * Its essential that the reader and writer cache are no the same object, and in that case we use the
-   * readerSimpleCache. If we used this cache we would never release the memory, as the value would retain the strong
-   * reference
+   * Its essential that the reader and writer cache are no the same object, and in
+   * that case we use the readerSimpleCache. If we used this cache we would never
+   * release the memory, as the value would retain the strong reference
    * <p>
-   * All access to the readerCache must consider thread safety, and use appropriate concurrent safe APIs
+   * All access to the readerCache must consider thread safety, and use
+   * appropriate concurrent safe APIs
    */
   private final Map<Schema, Map<Schema, RecordReader>> readerCache = new WeakIdentityHashMap<>();
 
   /**
-   * serves the same purpose as readerCache, but specifically used when the reader and writer Schemas are the same
-   * object. For the readerSimpleCache we rely on the holding only a soft reference to the RecordReader, which should
-   * eventually be cleared by the garbage collector. All access to the readerCache must consider thread safety, and use
-   * appropriate concurrent safe APIs
+   * serves the same purpose as readerCache, but specifically used when the reader
+   * and writer Schemas are the same object. For the readerSimpleCache we rely on
+   * the holding only a soft reference to the RecordReader, which should
+   * eventually be cleared by the garbage collector. All access to the readerCache
+   * must consider thread safety, and use appropriate concurrent safe APIs
    */
   private final Map<Schema, SoftRef> readerSimpleCache = new WeakIdentityHashMap<>();
 
@@ -262,32 +268,30 @@ public class FastReaderBuilder {
   private RecordReader getRecordReaderFromCache(Schema readerSchema, Schema writerSchema) {
 
     if (writerSchema != readerSchema) {
-      return readerCache
-          .computeIfAbsent(readerSchema, k -> new WeakIdentityHashMap<>())
-          .computeIfAbsent(writerSchema,
-              k -> new RecordReader());
+      return readerCache.computeIfAbsent(readerSchema, k -> new WeakIdentityHashMap<>()).computeIfAbsent(writerSchema,
+          k -> new RecordReader());
     }
     while (true) {
       // Note - there is a chance that 2 threads concurrently access
       // if they do only one will generate a value (if one is needed), but
-      // getAndClearHardRef may (in theory at least) return null if the hardRef and the SoftRef is enqueued in the race
-      // it seems unlikely, but that the reason we have this loop. If we repeatedly loop, then at least
+      // getAndClearHardRef may (in theory at least) return null if the hardRef and
+      // the SoftRef is enqueued in the race
+      // it seems unlikely, but that the reason we have this loop. If we repeatedly
+      // loop, then at least
       // one thread processes
       SoftRef softRef = readerSimpleCache.compute(readerSchema, (schema, ref) -> {
-            RecordReader result = (ref == null) ? null : ref.get();
-            if (result == null) {
-              return new SoftRef(new RecordReader());
-            }
-            ref.hardRef = result;
-            return ref;
-          }
-      );
+        RecordReader result = (ref == null) ? null : ref.get();
+        if (result == null) {
+          return new SoftRef(new RecordReader());
+        }
+        ref.hardRef = result;
+        return ref;
+      });
       RecordReader result = softRef.getAndClearHardRef();
       if (result != null)
         return result;
     }
   }
-
 
   private FieldReader applyConversions(Schema readerSchema, FieldReader reader, Conversion<?> explicitConversion) {
     Conversion<?> conversion = explicitConversion;

--- a/lang/java/avro/src/main/java/org/apache/avro/io/FastReaderBuilder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/FastReaderBuilder.java
@@ -14,22 +14,6 @@
  */
 package org.apache.avro.io;
 
-import org.apache.avro.*;
-import org.apache.avro.Resolver.*;
-import org.apache.avro.Schema.Field;
-
-import org.apache.avro.generic.*;
-import org.apache.avro.generic.GenericData.InstanceSupplier;
-import org.apache.avro.io.FastReaderBuilder.RecordReader.Stage;
-import org.apache.avro.io.parsing.ResolvingGrammarGenerator;
-import org.apache.avro.reflect.ReflectionUtil;
-import org.apache.avro.specific.SpecificData;
-import org.apache.avro.specific.SpecificRecordBase;
-import org.apache.avro.util.ClassUtils;
-import org.apache.avro.util.Utf8;
-import org.apache.avro.util.WeakIdentityHashMap;
-import org.apache.avro.util.internal.Accessor;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.ref.SoftReference;
@@ -41,6 +25,37 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.IntFunction;
+
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Conversion;
+import org.apache.avro.Conversions;
+import org.apache.avro.Resolver;
+import org.apache.avro.Resolver.Action;
+import org.apache.avro.Resolver.Container;
+import org.apache.avro.Resolver.EnumAdjust;
+import org.apache.avro.Resolver.Promote;
+import org.apache.avro.Resolver.ReaderUnion;
+import org.apache.avro.Resolver.RecordAdjust;
+import org.apache.avro.Resolver.Skip;
+import org.apache.avro.Resolver.WriterUnion;
+import org.apache.avro.Schema;
+import org.apache.avro.Schema.Field;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericData.InstanceSupplier;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericEnumSymbol;
+import org.apache.avro.generic.GenericFixed;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.FastReaderBuilder.RecordReader.Stage;
+import org.apache.avro.io.parsing.ResolvingGrammarGenerator;
+import org.apache.avro.reflect.ReflectionUtil;
+import org.apache.avro.specific.SpecificData;
+import org.apache.avro.specific.SpecificRecordBase;
+import org.apache.avro.util.ClassUtils;
+import org.apache.avro.util.Utf8;
+import org.apache.avro.util.WeakIdentityHashMap;
+import org.apache.avro.util.internal.Accessor;
 
 public class FastReaderBuilder {
 

--- a/lang/java/avro/src/main/java/org/apache/avro/io/FastReaderBuilder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/FastReaderBuilder.java
@@ -14,39 +14,11 @@
  */
 package org.apache.avro.io;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.function.IntFunction;
-
-import org.apache.avro.AvroTypeException;
-import org.apache.avro.Conversion;
-import org.apache.avro.Conversions;
-import org.apache.avro.Resolver;
-import org.apache.avro.Resolver.Action;
-import org.apache.avro.Resolver.Container;
-import org.apache.avro.Resolver.EnumAdjust;
-import org.apache.avro.Resolver.Promote;
-import org.apache.avro.Resolver.ReaderUnion;
-import org.apache.avro.Resolver.RecordAdjust;
-import org.apache.avro.Resolver.Skip;
-import org.apache.avro.Resolver.WriterUnion;
-import org.apache.avro.Schema;
+import org.apache.avro.*;
+import org.apache.avro.Resolver.*;
 import org.apache.avro.Schema.Field;
-import org.apache.avro.generic.GenericArray;
-import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.*;
 import org.apache.avro.generic.GenericData.InstanceSupplier;
-import org.apache.avro.generic.GenericDatumReader;
-import org.apache.avro.generic.GenericEnumSymbol;
-import org.apache.avro.generic.GenericFixed;
-import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.FastReaderBuilder.RecordReader.Stage;
 import org.apache.avro.io.parsing.ResolvingGrammarGenerator;
 import org.apache.avro.reflect.ReflectionUtil;
@@ -57,17 +29,45 @@ import org.apache.avro.util.Utf8;
 import org.apache.avro.util.WeakIdentityHashMap;
 import org.apache.avro.util.internal.Accessor;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.lang.ref.SoftReference;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.IntFunction;
+
 public class FastReaderBuilder {
 
   /**
-   * Generic/SpecificData instance that contains basic functionalities like
-   * instantiation of objects
+   * Generic/SpecificData instance that contains basic functionalities like instantiation of objects
    */
   private final GenericData data;
 
-  /** first schema is reader schema, second is writer schema */
-  private final Map<Schema, Map<Schema, RecordReader>> readerCache = Collections
-      .synchronizedMap(new WeakIdentityHashMap<>());
+  /**
+   * first schema is reader schema, second is writer schema As the RecordReader holds a strong reference to the reader
+   * cache. We rely on the writer cache being dereferenced, casing the inner map entry to remove the RecordReader. This
+   * in turn allows the outer Map entry to become weakly accessible and reclaimed.
+   * <p>
+   * Its essential that the reader and writer cache are no the same object, and in that case we use the
+   * readerSimpleCache. If we used this cache we would never release the memory, as the value would retain the strong
+   * reference
+   * <p>
+   * All access to the readerCache must consider thread safety, and use appropriate concurrent safe APIs
+   */
+  private final Map<Schema, Map<Schema, RecordReader>> readerCache = new WeakIdentityHashMap<>();
+
+  /**
+   * serves the same purpose as readerCache, but specifically used when the reader and writer Schemas are the same
+   * object. For the readerSimpleCache we rely on the holding only a soft reference to the RecordReader, which should
+   * eventually be cleared by the garbage collector. All access to the readerCache must consider thread safety, and use
+   * appropriate concurrent safe APIs
+   */
+  private final Map<Schema, SoftRef> readerSimpleCache = new WeakIdentityHashMap<>();
 
   private boolean keyClassEnabled = true;
 
@@ -242,10 +242,52 @@ public class FastReaderBuilder {
     }
   }
 
-  private RecordReader getRecordReaderFromCache(Schema readerSchema, Schema writerSchema) {
-    return readerCache.computeIfAbsent(readerSchema, k -> new WeakIdentityHashMap<>()).computeIfAbsent(writerSchema,
-        k -> new RecordReader());
+  private static class SoftRef extends SoftReference<RecordReader> {
+    RecordReader hardRef;
+
+    public SoftRef(RecordReader referent) {
+      super(referent);
+      hardRef = referent;
+    }
+
+    RecordReader getAndClearHardRef() {
+      RecordReader result = hardRef;
+      hardRef = null;
+      if (result == null)
+        result = get();
+      return result;
+    }
   }
+
+  private RecordReader getRecordReaderFromCache(Schema readerSchema, Schema writerSchema) {
+
+    if (writerSchema != readerSchema) {
+      return readerCache
+          .computeIfAbsent(readerSchema, k -> new WeakIdentityHashMap<>())
+          .computeIfAbsent(writerSchema,
+              k -> new RecordReader());
+    }
+    while (true) {
+      // Note - there is a chance that 2 threads concurrently access
+      // if they do only one will generate a value (if one is needed), but
+      // getAndClearHardRef may (in theory at least) return null if the hardRef and the SoftRef is enqueued in the race
+      // it seems unlikely, but that the reason we have this loop. If we repeatedly loop, then at least
+      // one thread processes
+      SoftRef softRef = readerSimpleCache.compute(readerSchema, (schema, ref) -> {
+            RecordReader result = (ref == null) ? null : ref.get();
+            if (result == null) {
+              return new SoftRef(new RecordReader());
+            }
+            ref.hardRef = result;
+            return ref;
+          }
+      );
+      RecordReader result = softRef.getAndClearHardRef();
+      if (result != null)
+        return result;
+    }
+  }
+
 
   private FieldReader applyConversions(Schema readerSchema, FieldReader reader, Conversion<?> explicitConversion) {
     Conversion<?> conversion = explicitConversion;

--- a/lang/java/avro/src/main/java/org/apache/avro/util/WeakIdentityHashMap.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/util/WeakIdentityHashMap.java
@@ -37,14 +37,13 @@ import java.util.function.Function;
  * implements the Map interface, it intentionally violates Map's general
  * contract, which mandates the use of the equals method when comparing objects.
  * This class is designed for use only in the rare cases wherein
- * reference-equality semantics are required.
- * It also violates the contract with respect to the {@link Map#entrySet()},
- * {@link Map#keySet()} ()}, {@link Map#values()} methods, which return
- * collections that are snapshots, and not backed by this map
- * *
- * Note that this implementation is not synchronized, but the backing store is a
- * ConcurrentHashMap. Caller must decide what additional protection is required in the case of
- * concurrent access.</b>b>
+ * reference-equality semantics are required. It also violates the contract with
+ * respect to the {@link Map#entrySet()}, {@link Map#keySet()} ()},
+ * {@link Map#values()} methods, which return collections that are snapshots,
+ * and not backed by this map * Note that this implementation is not
+ * synchronized, but the backing store is a ConcurrentHashMap. Caller must
+ * decide what additional protection is required in the case of concurrent
+ * access.</b>b>
  */
 public class WeakIdentityHashMap<K, V> implements Map<K, V> {
   private final ReferenceQueue<K> queue = new ReferenceQueue<>();
@@ -72,8 +71,9 @@ public class WeakIdentityHashMap<K, V> implements Map<K, V> {
     return backingStore.containsValue(value);
   }
 
-  //NOTE - this breaks the general contract in that the returned value is not backed by this object
-  //so changes to this map are not reflected in the value previously returned
+  // NOTE - this breaks the general contract in that the returned value is not
+  // backed by this object
+  // so changes to this map are not reflected in the value previously returned
   @Override
   public Set<Map.Entry<K, V>> entrySet() {
     reap();
@@ -102,8 +102,9 @@ public class WeakIdentityHashMap<K, V> implements Map<K, V> {
     return Collections.unmodifiableSet(ret);
   }
 
-  //NOTE - this breaks the general contract in that the returned value is not backed by this object
-  //so changes to this map are not reflected in the value previously returned
+  // NOTE - this breaks the general contract in that the returned value is not
+  // backed by this object
+  // so changes to this map are not reflected in the value previously returned
   @Override
   public Set<K> keySet() {
     reap();
@@ -122,7 +123,7 @@ public class WeakIdentityHashMap<K, V> implements Map<K, V> {
     if (!(o instanceof WeakIdentityHashMap)) {
       return false;
     }
-    return backingStore.equals(((WeakIdentityHashMap<K,V>) o).backingStore);
+    return backingStore.equals(((WeakIdentityHashMap<K, V>) o).backingStore);
   }
 
   @Override
@@ -171,8 +172,9 @@ public class WeakIdentityHashMap<K, V> implements Map<K, V> {
     return backingStore.size();
   }
 
-  //NOTE - this breaks the general contract in that the returned value is not backed by this object
-  //so changes to this map are not reflected in the value previously returned
+  // NOTE - this breaks the general contract in that the returned value is not
+  // backed by this object
+  // so changes to this map are not reflected in the value previously returned
   @Override
   public Collection<V> values() {
     reap();
@@ -212,13 +214,13 @@ public class WeakIdentityHashMap<K, V> implements Map<K, V> {
   @Override
   public V computeIfPresent(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
     reap();
-    return backingStore.computeIfPresent(makeKey(key), (k,v) -> remappingFunction.apply(key,v));
+    return backingStore.computeIfPresent(makeKey(key), (k, v) -> remappingFunction.apply(key, v));
   }
 
   @Override
   public V compute(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
     reap();
-    return backingStore.compute(makeKey(key), (k,v) -> remappingFunction.apply(key,v));
+    return backingStore.compute(makeKey(key), (k, v) -> remappingFunction.apply(key, v));
   }
 
   @Override

--- a/lang/java/avro/src/main/java/org/apache/avro/util/WeakIdentityHashMap.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/util/WeakIdentityHashMap.java
@@ -41,7 +41,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class WeakIdentityHashMap<K, V> implements Map<K, V> {
   private final ReferenceQueue<K> queue = new ReferenceQueue<>();
-  private Map<IdentityWeakReference, V> backingStore = new ConcurrentHashMap<>();
+  private Map<IdentityWeakReference<K>, V> backingStore = new ConcurrentHashMap<>();
 
   public WeakIdentityHashMap() {
   }
@@ -53,9 +53,10 @@ public class WeakIdentityHashMap<K, V> implements Map<K, V> {
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   public boolean containsKey(Object key) {
     reap();
-    return backingStore.containsKey(new IdentityWeakReference(key));
+    return backingStore.containsKey(new IdentityWeakReference<>((K) key, queue));
   }
 
   @Override
@@ -64,11 +65,13 @@ public class WeakIdentityHashMap<K, V> implements Map<K, V> {
     return backingStore.containsValue(value);
   }
 
+  //NOTE - this breaks the general contract in that the returned value is not backed by this object
+  //so changes to this map are not reflected in the value previously returned
   @Override
   public Set<Map.Entry<K, V>> entrySet() {
     reap();
     Set<Map.Entry<K, V>> ret = new HashSet<>();
-    for (Map.Entry<IdentityWeakReference, V> ref : backingStore.entrySet()) {
+    for (Map.Entry<IdentityWeakReference<K>, V> ref : backingStore.entrySet()) {
       final K key = ref.getKey().get();
       final V value = ref.getValue();
       Map.Entry<K, V> entry = new Map.Entry<K, V>() {
@@ -92,34 +95,39 @@ public class WeakIdentityHashMap<K, V> implements Map<K, V> {
     return Collections.unmodifiableSet(ret);
   }
 
+  //NOTE - this breaks the general contract in that the returned value is not backed by this object
+  //so changes to this map are not reflected in the value previously returned
   @Override
   public Set<K> keySet() {
     reap();
     Set<K> ret = new HashSet<>();
-    for (IdentityWeakReference ref : backingStore.keySet()) {
+    for (IdentityWeakReference<K> ref : backingStore.keySet()) {
       ret.add(ref.get());
     }
     return Collections.unmodifiableSet(ret);
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   public boolean equals(Object o) {
     if (!(o instanceof WeakIdentityHashMap)) {
       return false;
     }
-    return backingStore.equals(((WeakIdentityHashMap) o).backingStore);
+    return backingStore.equals(((WeakIdentityHashMap<K,V>) o).backingStore);
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   public V get(Object key) {
     reap();
-    return backingStore.get(new IdentityWeakReference(key));
+    return backingStore.get(new IdentityWeakReference<>((K)key, queue));
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   public V put(K key, V value) {
     reap();
-    return backingStore.put(new IdentityWeakReference(key), value);
+    return backingStore.put(new IdentityWeakReference<>(key, queue), value);
   }
 
   @Override
@@ -142,7 +150,7 @@ public class WeakIdentityHashMap<K, V> implements Map<K, V> {
   @Override
   public V remove(Object key) {
     reap();
-    return backingStore.remove(new IdentityWeakReference(key));
+    return backingStore.remove(new IdentityWeakReference<>((K) key, queue));
   }
 
   @Override
@@ -151,6 +159,8 @@ public class WeakIdentityHashMap<K, V> implements Map<K, V> {
     return backingStore.size();
   }
 
+  //NOTE - this breaks the general contract in that the returned value is not backed by this object
+  //so changes to this map are not reflected in the value previously returned
   @Override
   public Collection<V> values() {
     reap();
@@ -161,18 +171,17 @@ public class WeakIdentityHashMap<K, V> implements Map<K, V> {
     Object zombie = queue.poll();
 
     while (zombie != null) {
-      IdentityWeakReference victim = (IdentityWeakReference) zombie;
+      IdentityWeakReference<?> victim = (IdentityWeakReference<?>) zombie;
       backingStore.remove(victim);
       zombie = queue.poll();
     }
   }
 
-  class IdentityWeakReference extends WeakReference<K> {
+  static class IdentityWeakReference<K> extends WeakReference<K> {
     int hash;
 
-    @SuppressWarnings("unchecked")
-    IdentityWeakReference(Object obj) {
-      super((K) obj, queue);
+    IdentityWeakReference(K obj, ReferenceQueue<K> queue) {
+      super(obj, queue);
       hash = System.identityHashCode(obj);
     }
 
@@ -189,7 +198,7 @@ public class WeakIdentityHashMap<K, V> implements Map<K, V> {
       if (!(o instanceof WeakIdentityHashMap.IdentityWeakReference)) {
         return false;
       }
-      IdentityWeakReference ref = (IdentityWeakReference) o;
+      IdentityWeakReference<?> ref = (IdentityWeakReference<?>) o;
       return this.get() == ref.get();
     }
   }

--- a/lang/java/avro/src/main/java/org/apache/avro/util/WeakIdentityHashMap.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/util/WeakIdentityHashMap.java
@@ -26,6 +26,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 /**
  * Implements a combination of WeakHashMap and IdentityHashMap. Useful for
@@ -36,12 +38,17 @@ import java.util.concurrent.ConcurrentHashMap;
  * contract, which mandates the use of the equals method when comparing objects.
  * This class is designed for use only in the rare cases wherein
  * reference-equality semantics are required.
- *
- * Note that this implementation is not synchronized. </b>
+ * It also violates the contract with respect to the {@link Map#entrySet()},
+ * {@link Map#keySet()} ()}, {@link Map#values()} methods, which return
+ * collections that are snapshots, and not backed by this map
+ * *
+ * Note that this implementation is not synchronized, but the backing store is a
+ * ConcurrentHashMap. Caller must decide what additional protection is required in the case of
+ * concurrent access.</b>b>
  */
 public class WeakIdentityHashMap<K, V> implements Map<K, V> {
   private final ReferenceQueue<K> queue = new ReferenceQueue<>();
-  private Map<IdentityWeakReference<K>, V> backingStore = new ConcurrentHashMap<>();
+  private final Map<IdentityWeakReference<K>, V> backingStore = new ConcurrentHashMap<>();
 
   public WeakIdentityHashMap() {
   }
@@ -56,7 +63,7 @@ public class WeakIdentityHashMap<K, V> implements Map<K, V> {
   @SuppressWarnings("unchecked")
   public boolean containsKey(Object key) {
     reap();
-    return backingStore.containsKey(new IdentityWeakReference<>((K) key, queue));
+    return backingStore.containsKey(makeKey(key));
   }
 
   @Override
@@ -108,8 +115,10 @@ public class WeakIdentityHashMap<K, V> implements Map<K, V> {
   }
 
   @Override
-  @SuppressWarnings("unchecked")
   public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
     if (!(o instanceof WeakIdentityHashMap)) {
       return false;
     }
@@ -117,17 +126,15 @@ public class WeakIdentityHashMap<K, V> implements Map<K, V> {
   }
 
   @Override
-  @SuppressWarnings("unchecked")
   public V get(Object key) {
     reap();
-    return backingStore.get(new IdentityWeakReference<>((K)key, queue));
+    return backingStore.get(makeKey(key));
   }
 
   @Override
-  @SuppressWarnings("unchecked")
   public V put(K key, V value) {
     reap();
-    return backingStore.put(new IdentityWeakReference<>(key, queue), value);
+    return backingStore.put(makeKey(key), value);
   }
 
   @Override
@@ -150,7 +157,12 @@ public class WeakIdentityHashMap<K, V> implements Map<K, V> {
   @Override
   public V remove(Object key) {
     reap();
-    return backingStore.remove(new IdentityWeakReference<>((K) key, queue));
+    return backingStore.remove(makeKey(key));
+  }
+
+  @SuppressWarnings("unchecked")
+  private IdentityWeakReference<K> makeKey(Object key) {
+    return new IdentityWeakReference<>((K) key, queue);
   }
 
   @Override
@@ -165,6 +177,54 @@ public class WeakIdentityHashMap<K, V> implements Map<K, V> {
   public Collection<V> values() {
     reap();
     return backingStore.values();
+  }
+
+  @Override
+  public V putIfAbsent(K key, V value) {
+    reap();
+    return backingStore.putIfAbsent(makeKey(key), value);
+  }
+
+  @Override
+  public boolean remove(Object key, Object value) {
+    reap();
+    return backingStore.remove(makeKey(key), value);
+  }
+
+  @Override
+  public boolean replace(K key, V oldValue, V newValue) {
+    reap();
+    return backingStore.replace(makeKey(key), oldValue, newValue);
+  }
+
+  @Override
+  public V replace(K key, V value) {
+    reap();
+    return backingStore.replace(makeKey(key), value);
+  }
+
+  @Override
+  public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
+    reap();
+    return backingStore.computeIfAbsent(makeKey(key), k -> mappingFunction.apply(key));
+  }
+
+  @Override
+  public V computeIfPresent(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+    reap();
+    return backingStore.computeIfPresent(makeKey(key), (k,v) -> remappingFunction.apply(key,v));
+  }
+
+  @Override
+  public V compute(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+    reap();
+    return backingStore.compute(makeKey(key), (k,v) -> remappingFunction.apply(key,v));
+  }
+
+  @Override
+  public V merge(K key, V value, BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
+    reap();
+    return backingStore.merge(makeKey(key), value, remappingFunction);
   }
 
   private synchronized void reap() {

--- a/lang/java/avro/src/test/java/FastReaderBuilderCacheRetentionReproducer.java
+++ b/lang/java/avro/src/test/java/FastReaderBuilderCacheRetentionReproducer.java
@@ -1,0 +1,205 @@
+/*
+ * Standalone reproducer for FastReaderBuilder cache retention bug.
+ *
+ * Demonstrates that WeakIdentityHashMap entries in FastReaderBuilder.readerCache
+ * are never evicted because RecordReader.schema holds a strong reference back to
+ * the Schema weak key, preventing GC from clearing the WeakReference.
+ *
+ * Requirements: Apache Avro 1.12.1 (or any version with FastReaderBuilder)
+ * Compile: javac -cp avro-1.12.1.jar FastReaderBuilderCacheRetentionReproducer.java
+ * Run:     java -cp .:avro-1.12.1.jar FastReaderBuilderCacheRetentionReproducer
+ */
+
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.FastReaderBuilder;
+
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Reproducer for: FastReaderBuilder WeakIdentityHashMap cache entries are never GC'd.
+ *
+ * <h2>Problem</h2>
+ * {@link FastReaderBuilder} caches compiled {@code RecordReader} objects in a
+ * {@code WeakIdentityHashMap<Schema, Map<Schema, RecordReader>>}. The intent is that
+ * when a Schema key becomes unreachable, the weak reference allows the cache entry to
+ * be garbage-collected.
+ *
+ * <p>However, each {@code RecordReader} is stored as a <b>value</b> in the cache (via
+ * {@code computeIfAbsent}), and it holds a <b>strong reference</b> back to the Schema
+ * used as the cache key (via its {@code schema} field, set in
+ * {@code finishInitialization()}). The caller discarding the returned {@code DatumReader}
+ * after use is irrelevant — the cache itself retains the {@code RecordReader}, and the
+ * {@code RecordReader} pins the key.
+ *
+ * <p>This is the classic <b>weak-key cache antipattern: value references key</b>.
+ * The {@code WeakIdentityHashMap} can never evict entries because its own values keep
+ * the keys strongly reachable:
+ * <pre>
+ * FastReaderBuilder (application lifetime)
+ *   └─ readerCache (WeakIdentityHashMap)
+ *        └─ entry: weak(Schema_A) → inner map
+ *             └─ entry: weak(Schema_A) → RecordReader  ← cache holds strong ref to value
+ *                  └─ schema → Schema_A                 ← value holds strong ref back to key
+ * </pre>
+ *
+ * <p>For nested records, child {@code RecordReader} objects are captured in
+ * {@code ExecutionStep} lambdas, creating a transitive strong-reference chain that
+ * pins all levels of the schema tree.
+ *
+ * <h2>What this reproducer shows</h2>
+ * <ol>
+ *   <li>Creates a 5-level nested Avro schema (100 fields total)</li>
+ *   <li>Calls {@code FastReaderBuilder.createDatumReader(schema)} 10 times, each time
+ *       with a freshly-parsed Schema (different identity, same structure)</li>
+ *   <li>Releases all Schema references and forces GC</li>
+ *   <li>Observes that the readerCache retains all entries — weak keys are never cleared
+ *       because the cache's own values keep them alive</li>
+ * </ol>
+ *
+ * <h2>Expected behaviour</h2>
+ * After GC, cache entries for unreachable Schema objects should be evicted.
+ *
+ * <h2>Actual behaviour</h2>
+ * Cache entries are never evicted. The cache is self-sustaining — no external reference
+ * to the Schema is needed to keep the entry alive.
+ */
+public class FastReaderBuilderCacheRetentionReproducer {
+
+  private static final int NESTING_DEPTH = 5;
+  private static final int FIELDS_PER_LEVEL = 20;
+  private static final int NUM_SCHEMAS = 10;
+
+  public static void main(String[] args) throws Exception {
+    System.out.println("=== FastReaderBuilder Cache Retention Bug Reproducer ===\n");
+
+    GenericData genericData = new GenericData();
+    genericData.setFastReaderEnabled(true);
+    FastReaderBuilder fastReaderBuilder = genericData.getFastReaderBuilder();
+
+    Schema canonicalSchema = buildNestedSchema(0);
+    String schemaJson = canonicalSchema.toString();
+
+    System.out.println("Schema: " + NESTING_DEPTH + " nesting levels x " + FIELDS_PER_LEVEL
+        + " fields = " + (NESTING_DEPTH * FIELDS_PER_LEVEL) + " total fields");
+    System.out.println("Initial cache: outer=" + getOuterCacheSize(fastReaderBuilder)
+        + " inner=" + getInnerCacheSize(fastReaderBuilder));
+    System.out.println();
+
+    // Track schemas with WeakReferences to verify they are otherwise unreachable
+    List<WeakReference<Schema>> schemaWeakRefs = new ArrayList<>();
+
+    for (int i = 1; i <= NUM_SCHEMAS; i++) {
+      // Parse a fresh Schema — different object identity each time.
+      // This simulates what happens when DataFileStream parses each file's
+      // header independently, or when Schema.Parser is called per-file.
+      Schema freshSchema = new Schema.Parser().parse(schemaJson);
+      schemaWeakRefs.add(new WeakReference<>(freshSchema));
+
+      // Compile a DatumReader via FastReaderBuilder. This is the single-arg form
+      // (writer == reader), which is what GenericDatumReader uses when no separate
+      // reader schema is set. Both outer and inner cache keys are the same identity.
+      DatumReader<?> reader = fastReaderBuilder.createDatumReader(freshSchema);
+
+      // Discard the DatumReader — we don't need it. The cache entry persists.
+      reader = null;
+
+      // Release our reference to the schema.
+      freshSchema = null;
+
+      System.out.println("After schema " + i + ": outer=" + getOuterCacheSize(fastReaderBuilder)
+          + " inner=" + getInnerCacheSize(fastReaderBuilder));
+    }
+
+    System.out.println("\n--- Forcing GC (5 cycles with reap) ---\n");
+
+    for (int gc = 0; gc < 5; gc++) {
+      System.gc();
+      Thread.sleep(200);
+      triggerReap(fastReaderBuilder);
+    }
+
+    int outerSize = getOuterCacheSize(fastReaderBuilder);
+    int innerSize = getInnerCacheSize(fastReaderBuilder);
+    int schemasCollected = 0;
+    for (WeakReference<Schema> ref : schemaWeakRefs) {
+      if (ref.get() == null) schemasCollected++;
+    }
+
+    System.out.println("After GC:");
+    System.out.println("  Outer cache entries (reader schemas): " + outerSize);
+    System.out.println("  Inner cache entries (writer schemas):    " + innerSize);
+    System.out.println("  Schema WeakRefs cleared by GC:           " + schemasCollected + " / " + schemaWeakRefs.size());
+    System.out.println();
+    System.out.println("  Expected if cache eviction works:");
+    System.out.println("    outer=0, inner=0, schemas collected=" + NUM_SCHEMAS);
+    System.out.println("  Expected with retention bug:");
+    System.out.println("    outer=" + NUM_SCHEMAS + ", inner=" + (NUM_SCHEMAS * NESTING_DEPTH)
+        + ", schemas collected=0");
+    System.out.println();
+
+    if (outerSize > 0 || innerSize > 0) {
+      System.out.println("BUG CONFIRMED: Cache retained entries after GC.");
+      System.out.println("  RecordReader.schema holds strong refs to Schema keys,");
+      System.out.println("  preventing WeakIdentityHashMap from clearing entries.");
+      if (schemasCollected == 0) {
+        System.out.println("  Schema objects are NOT being collected (pinned by cache values).");
+      }
+    } else {
+      System.out.println("Bug NOT reproduced — cache was correctly evicted.");
+    }
+  }
+
+  /** Build a nested record schema: each level has FIELDS_PER_LEVEL string fields + optional child. */
+  private static Schema buildNestedSchema(int level) {
+    SchemaBuilder.FieldAssembler<Schema> fields = SchemaBuilder.record("Level_" + level)
+        .namespace("org.apache.avro.test.retention")
+        .fields();
+
+    for (int f = 0; f < FIELDS_PER_LEVEL; f++) {
+      fields = fields.requiredString("field_" + f);
+    }
+    if (level < NESTING_DEPTH - 1) {
+      Schema childSchema = buildNestedSchema(level + 1);
+      fields = fields.name("child").type(childSchema).noDefault();
+    }
+    return fields.endRecord();
+  }
+
+  /** Count entries in the outer WeakIdentityHashMap (one per reader schema). */
+  @SuppressWarnings("unchecked")
+  private static int getOuterCacheSize(FastReaderBuilder builder) throws Exception {
+    Field field = FastReaderBuilder.class.getDeclaredField("readerCache");
+    field.setAccessible(true);
+    Map<Schema, Map<Schema, ?>> cache = (Map<Schema, Map<Schema, ?>>) field.get(builder);
+    return cache.size();
+  }
+
+  /** Count total entries across all inner maps (one per writer schema per reader schema). */
+  @SuppressWarnings("unchecked")
+  private static int getInnerCacheSize(FastReaderBuilder builder) throws Exception {
+    Field field = FastReaderBuilder.class.getDeclaredField("readerCache");
+    field.setAccessible(true);
+    Map<Schema, Map<Schema, ?>> cache = (Map<Schema, Map<Schema, ?>>) field.get(builder);
+    int total = 0;
+    for (Map<Schema, ?> inner : cache.values()) {
+      total += inner.size();
+    }
+    return total;
+  }
+
+  /** Trigger WeakIdentityHashMap.reap() by calling size() on the cache. */
+  @SuppressWarnings("unchecked")
+  private static void triggerReap(FastReaderBuilder builder) throws Exception {
+    Field field = FastReaderBuilder.class.getDeclaredField("readerCache");
+    field.setAccessible(true);
+    Map<Schema, Map<Schema, ?>> cache = (Map<Schema, Map<Schema, ?>>) field.get(builder);
+    cache.size(); // size() calls reap() internally
+  }
+}

--- a/lang/java/avro/src/test/java/FastReaderBuilderCacheRetentionReproducer.java
+++ b/lang/java/avro/src/test/java/FastReaderBuilderCacheRetentionReproducer.java
@@ -1,4 +1,19 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/*
  * Standalone reproducer for FastReaderBuilder cache retention bug.
  *
  * Demonstrates that WeakIdentityHashMap entries in FastReaderBuilder.readerCache
@@ -23,24 +38,28 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Reproducer for: FastReaderBuilder WeakIdentityHashMap cache entries are never GC'd.
+ * Reproducer for: FastReaderBuilder WeakIdentityHashMap cache entries are never
+ * GC'd.
  *
- * <h2>Problem</h2>
- * {@link FastReaderBuilder} caches compiled {@code RecordReader} objects in a
- * {@code WeakIdentityHashMap<Schema, Map<Schema, RecordReader>>}. The intent is that
- * when a Schema key becomes unreachable, the weak reference allows the cache entry to
- * be garbage-collected.
+ * <h2>Problem</h2> {@link FastReaderBuilder} caches compiled
+ * {@code RecordReader} objects in a
+ * {@code WeakIdentityHashMap<Schema, Map<Schema, RecordReader>>}. The intent is
+ * that when a Schema key becomes unreachable, the weak reference allows the
+ * cache entry to be garbage-collected.
  *
- * <p>However, each {@code RecordReader} is stored as a <b>value</b> in the cache (via
- * {@code computeIfAbsent}), and it holds a <b>strong reference</b> back to the Schema
- * used as the cache key (via its {@code schema} field, set in
- * {@code finishInitialization()}). The caller discarding the returned {@code DatumReader}
- * after use is irrelevant — the cache itself retains the {@code RecordReader}, and the
- * {@code RecordReader} pins the key.
+ * <p>
+ * However, each {@code RecordReader} is stored as a <b>value</b> in the cache
+ * (via {@code computeIfAbsent}), and it holds a <b>strong reference</b> back to
+ * the Schema used as the cache key (via its {@code schema} field, set in
+ * {@code finishInitialization()}). The caller discarding the returned
+ * {@code DatumReader} after use is irrelevant — the cache itself retains the
+ * {@code RecordReader}, and the {@code RecordReader} pins the key.
  *
- * <p>This is the classic <b>weak-key cache antipattern: value references key</b>.
- * The {@code WeakIdentityHashMap} can never evict entries because its own values keep
- * the keys strongly reachable:
+ * <p>
+ * This is the classic <b>weak-key cache antipattern: value references key</b>.
+ * The {@code WeakIdentityHashMap} can never evict entries because its own
+ * values keep the keys strongly reachable:
+ *
  * <pre>
  * FastReaderBuilder (application lifetime)
  *   └─ readerCache (WeakIdentityHashMap)
@@ -49,26 +68,27 @@ import java.util.Map;
  *                  └─ schema → Schema_A                 ← value holds strong ref back to key
  * </pre>
  *
- * <p>For nested records, child {@code RecordReader} objects are captured in
- * {@code ExecutionStep} lambdas, creating a transitive strong-reference chain that
- * pins all levels of the schema tree.
+ * <p>
+ * For nested records, child {@code RecordReader} objects are captured in
+ * {@code ExecutionStep} lambdas, creating a transitive strong-reference chain
+ * that pins all levels of the schema tree.
  *
  * <h2>What this reproducer shows</h2>
  * <ol>
- *   <li>Creates a 5-level nested Avro schema (100 fields total)</li>
- *   <li>Calls {@code FastReaderBuilder.createDatumReader(schema)} 10 times, each time
- *       with a freshly-parsed Schema (different identity, same structure)</li>
- *   <li>Releases all Schema references and forces GC</li>
- *   <li>Observes that the readerCache retains all entries — weak keys are never cleared
- *       because the cache's own values keep them alive</li>
+ * <li>Creates a 5-level nested Avro schema (100 fields total)</li>
+ * <li>Calls {@code FastReaderBuilder.createDatumReader(schema)} 10 times, each
+ * time with a freshly-parsed Schema (different identity, same structure)</li>
+ * <li>Releases all Schema references and forces GC</li>
+ * <li>Observes that the readerCache retains all entries — weak keys are never
+ * cleared because the cache's own values keep them alive</li>
  * </ol>
  *
- * <h2>Expected behaviour</h2>
- * After GC, cache entries for unreachable Schema objects should be evicted.
+ * <h2>Expected behaviour</h2> After GC, cache entries for unreachable Schema
+ * objects should be evicted.
  *
- * <h2>Actual behaviour</h2>
- * Cache entries are never evicted. The cache is self-sustaining — no external reference
- * to the Schema is needed to keep the entry alive.
+ * <h2>Actual behaviour</h2> Cache entries are never evicted. The cache is
+ * self-sustaining — no external reference to the Schema is needed to keep the
+ * entry alive.
  */
 public class FastReaderBuilderCacheRetentionReproducer {
 
@@ -86,10 +106,10 @@ public class FastReaderBuilderCacheRetentionReproducer {
     Schema canonicalSchema = buildNestedSchema(0);
     String schemaJson = canonicalSchema.toString();
 
-    System.out.println("Schema: " + NESTING_DEPTH + " nesting levels x " + FIELDS_PER_LEVEL
-        + " fields = " + (NESTING_DEPTH * FIELDS_PER_LEVEL) + " total fields");
-    System.out.println("Initial cache: outer=" + getOuterCacheSize(fastReaderBuilder)
-        + " inner=" + getInnerCacheSize(fastReaderBuilder));
+    System.out.println("Schema: " + NESTING_DEPTH + " nesting levels x " + FIELDS_PER_LEVEL + " fields = "
+        + (NESTING_DEPTH * FIELDS_PER_LEVEL) + " total fields");
+    System.out.println("Initial cache: outer=" + getOuterCacheSize(fastReaderBuilder) + " inner="
+        + getInnerCacheSize(fastReaderBuilder));
     System.out.println();
 
     // Track schemas with WeakReferences to verify they are otherwise unreachable
@@ -113,8 +133,8 @@ public class FastReaderBuilderCacheRetentionReproducer {
       // Release our reference to the schema.
       freshSchema = null;
 
-      System.out.println("After schema " + i + ": outer=" + getOuterCacheSize(fastReaderBuilder)
-          + " inner=" + getInnerCacheSize(fastReaderBuilder));
+      System.out.println("After schema " + i + ": outer=" + getOuterCacheSize(fastReaderBuilder) + " inner="
+          + getInnerCacheSize(fastReaderBuilder));
     }
 
     System.out.println("\n--- Forcing GC (5 cycles with reap) ---\n");
@@ -129,19 +149,21 @@ public class FastReaderBuilderCacheRetentionReproducer {
     int innerSize = getInnerCacheSize(fastReaderBuilder);
     int schemasCollected = 0;
     for (WeakReference<Schema> ref : schemaWeakRefs) {
-      if (ref.get() == null) schemasCollected++;
+      if (ref.get() == null)
+        schemasCollected++;
     }
 
     System.out.println("After GC:");
     System.out.println("  Outer cache entries (reader schemas): " + outerSize);
     System.out.println("  Inner cache entries (writer schemas):    " + innerSize);
-    System.out.println("  Schema WeakRefs cleared by GC:           " + schemasCollected + " / " + schemaWeakRefs.size());
+    System.out
+        .println("  Schema WeakRefs cleared by GC:           " + schemasCollected + " / " + schemaWeakRefs.size());
     System.out.println();
     System.out.println("  Expected if cache eviction works:");
     System.out.println("    outer=0, inner=0, schemas collected=" + NUM_SCHEMAS);
     System.out.println("  Expected with retention bug:");
-    System.out.println("    outer=" + NUM_SCHEMAS + ", inner=" + (NUM_SCHEMAS * NESTING_DEPTH)
-        + ", schemas collected=0");
+    System.out
+        .println("    outer=" + NUM_SCHEMAS + ", inner=" + (NUM_SCHEMAS * NESTING_DEPTH) + ", schemas collected=0");
     System.out.println();
 
     if (outerSize > 0 || innerSize > 0) {
@@ -156,11 +178,13 @@ public class FastReaderBuilderCacheRetentionReproducer {
     }
   }
 
-  /** Build a nested record schema: each level has FIELDS_PER_LEVEL string fields + optional child. */
+  /**
+   * Build a nested record schema: each level has FIELDS_PER_LEVEL string fields +
+   * optional child.
+   */
   private static Schema buildNestedSchema(int level) {
     SchemaBuilder.FieldAssembler<Schema> fields = SchemaBuilder.record("Level_" + level)
-        .namespace("org.apache.avro.test.retention")
-        .fields();
+        .namespace("org.apache.avro.test.retention").fields();
 
     for (int f = 0; f < FIELDS_PER_LEVEL; f++) {
       fields = fields.requiredString("field_" + f);
@@ -181,7 +205,10 @@ public class FastReaderBuilderCacheRetentionReproducer {
     return cache.size();
   }
 
-  /** Count total entries across all inner maps (one per writer schema per reader schema). */
+  /**
+   * Count total entries across all inner maps (one per writer schema per reader
+   * schema).
+   */
   @SuppressWarnings("unchecked")
   private static int getInnerCacheSize(FastReaderBuilder builder) throws Exception {
     Field field = FastReaderBuilder.class.getDeclaredField("readerCache");

--- a/lang/java/avro/src/test/java/org/apache/avro/io/FastReaderBuilderTest.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/io/FastReaderBuilderTest.java
@@ -38,14 +38,12 @@ import static org.junit.jupiter.api.Assertions.*;
  * Memory leak tests for {@link FastReaderBuilder}.
  *
  * <p>
- * These tests verify that the cache eviction mechanism works correctly and prevents memory leaks as described in
- * AVRO-4253. The issue occurs when {@code RecordReader} holds strong references to Schema objects that are cached as
- * weak keys in {@code WeakIdentityHashMap}, preventing garbage collection.
+ * These tests verify that the cache eviction mechanism works correctly and
+ * prevents memory leaks as described in AVRO-4253. The issue occurs when
+ * {@code RecordReader} holds strong references to Schema objects that are
+ * cached as weak keys in {@code WeakIdentityHashMap}, preventing garbage
+ * collection.
  *
- * <p>
- * The fix involves deep-cloning schemas when {@code readerSchema == writerSchema} (same object identity), ensuring that
- * the cached {@code RecordReader} holds a reference to the cloned schema rather than the original weak key, allowing
- * the original to be garbage collected.
  */
 @Isolated
 class TestFastReaderBuilder {
@@ -77,8 +75,8 @@ class TestFastReaderBuilder {
   // ============================================================================
 
   /**
-   * Tests for the case where reader and writer schemas are the same object. This uses the readerSimpleCache
-   * (soft-referenced) to prevent memory leaks.
+   * Tests for the case where reader and writer schemas are the same object. This
+   * uses the readerSimpleCache (soft-referenced) to prevent memory leaks.
    */
   @Nested
   class WhenSchemasIdentical {
@@ -98,7 +96,8 @@ class TestFastReaderBuilder {
         Schema freshSchema = new Schema.Parser().parse(schemaJson);
         schemaRefs.add(new WeakReference<>(freshSchema));
 
-        // This calls createDatumReader(schema, schema) where both args are the same object
+        // This calls createDatumReader(schema, schema) where both args are the same
+        // object
         DatumReader<?> reader = builder.createDatumReader(freshSchema);
         assertNotNull(reader, "Reader should be created");
 
@@ -119,9 +118,8 @@ class TestFastReaderBuilder {
       }
 
       // Verify both caches are cleared
-      assertTrue(collectedCount > 0,
-          "At least some schemas should be garbage collected. "
-              + collectedCount + " / " + schemaRefs.size() + " collected");
+      assertTrue(collectedCount > 0, "At least some schemas should be garbage collected. " + collectedCount + " / "
+          + schemaRefs.size() + " collected");
       assertAllCachesCleared();
     }
 
@@ -219,8 +217,9 @@ class TestFastReaderBuilder {
   // ============================================================================
 
   /**
-   * Tests for the case where reader and writer schemas are different objects. This uses the readerCache (weak
-   * references) which should allow eviction when schemas are no longer externally referenced.
+   * Tests for the case where reader and writer schemas are different objects.
+   * This uses the readerCache (weak references) which should allow eviction when
+   * schemas are no longer externally referenced.
    */
   @Nested
   class WhenSchemasDifferent {
@@ -263,10 +262,12 @@ class TestFastReaderBuilder {
       int collectedWriters = 0;
       int collectedReaders = 0;
       for (WeakReference<Schema> ref : writerRefs) {
-        if (ref.get() == null) collectedWriters++;
+        if (ref.get() == null)
+          collectedWriters++;
       }
       for (WeakReference<Schema> ref : readerRefs) {
-        if (ref.get() == null) collectedReaders++;
+        if (ref.get() == null)
+          collectedReaders++;
       }
 
       // Both sets of schemas should be evictable
@@ -276,6 +277,7 @@ class TestFastReaderBuilder {
       // Verify both caches are cleared
       assertAllCachesCleared();
     }
+
     @Test
     void testCache() throws Exception {
       Schema baseWriterSchema = buildNestedWriterSchema(0);
@@ -373,12 +375,12 @@ class TestFastReaderBuilder {
   }
 
   /**
-   * Build a nested record schema with specified depth. Each level has 10 string fields and an optional child record.
+   * Build a nested record schema with specified depth. Each level has 10 string
+   * fields and an optional child record.
    */
   private Schema buildNestedWriterSchema(int level) {
     SchemaBuilder.FieldAssembler<Schema> fields = SchemaBuilder.record("Level_" + level)
-        .namespace("org.apache.avro.test.retention")
-        .fields();
+        .namespace("org.apache.avro.test.retention").fields();
 
     for (int f = 0; f < 10; f++) {
       fields = fields.requiredString("field_" + f);
@@ -391,13 +393,14 @@ class TestFastReaderBuilder {
 
     return fields.endRecord();
   }
+
   /**
-   * Build a nested record schema with specified depth. Each level has 5 string fields and an optional child record.
+   * Build a nested record schema with specified depth. Each level has 5 string
+   * fields and an optional child record.
    */
   private Schema buildNestedReaderSchema(int level) {
     SchemaBuilder.FieldAssembler<Schema> fields = SchemaBuilder.record("Level_" + level)
-        .namespace("org.apache.avro.test.retention")
-        .fields();
+        .namespace("org.apache.avro.test.retention").fields();
 
     for (int f = 0; f < 5; f++) {
       fields = fields.requiredString("field_" + f);
@@ -412,7 +415,8 @@ class TestFastReaderBuilder {
   }
 
   /**
-   * Get the number of entries in the outer WeakIdentityHashMap (one per unique reader schema).
+   * Get the number of entries in the outer WeakIdentityHashMap (one per unique
+   * reader schema).
    */
   @SuppressWarnings("unchecked")
   private int getOuterCacheSize() {
@@ -442,7 +446,8 @@ class TestFastReaderBuilder {
   }
 
   /**
-   * Get the number of entries in the simple cache (used for identical reader/writer schemas).
+   * Get the number of entries in the simple cache (used for identical
+   * reader/writer schemas).
    */
   @SuppressWarnings("unchecked")
   private int getSimpleCacheSize() {
@@ -485,7 +490,7 @@ class TestFastReaderBuilder {
         memory.add(new byte[1024 * 1024 * 1024]); // Allocate 1GB blocks to fill up memory and clear soft references
       }
     } catch (OutOfMemoryError e) {
-      //ignored
+      // ignored
     }
   }
 }

--- a/lang/java/avro/src/test/java/org/apache/avro/io/FastReaderBuilderTest.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/io/FastReaderBuilderTest.java
@@ -1,0 +1,491 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.avro.io;
+
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BooleanSupplier;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Memory leak tests for {@link FastReaderBuilder}.
+ *
+ * <p>
+ * These tests verify that the cache eviction mechanism works correctly and prevents memory leaks as described in
+ * AVRO-4253. The issue occurs when {@code RecordReader} holds strong references to Schema objects that are cached as
+ * weak keys in {@code WeakIdentityHashMap}, preventing garbage collection.
+ *
+ * <p>
+ * The fix involves deep-cloning schemas when {@code readerSchema == writerSchema} (same object identity), ensuring that
+ * the cached {@code RecordReader} holds a reference to the cloned schema rather than the original weak key, allowing
+ * the original to be garbage collected.
+ */
+@Isolated
+class TestFastReaderBuilder {
+
+  private static final Field READER_CACHE_FIELD;
+  private static final Field READER_SIMPLE_CACHE_FIELD;
+
+  static {
+    try {
+      READER_CACHE_FIELD = FastReaderBuilder.class.getDeclaredField("readerCache");
+      READER_CACHE_FIELD.setAccessible(true);
+
+      READER_SIMPLE_CACHE_FIELD = FastReaderBuilder.class.getDeclaredField("readerSimpleCache");
+      READER_SIMPLE_CACHE_FIELD.setAccessible(true);
+    } catch (NoSuchFieldException e) {
+      throw new ExceptionInInitializerError(e);
+    }
+  }
+
+  private FastReaderBuilder builder;
+
+  @BeforeEach
+  void setUp() {
+    builder = new FastReaderBuilder(GenericData.get());
+  }
+
+  // ============================================================================
+  // Tests for Identical Schemas (reader == writer)
+  // ============================================================================
+
+  /**
+   * Tests for the case where reader and writer schemas are the same object. This uses the readerSimpleCache
+   * (soft-referenced) to prevent memory leaks.
+   */
+  @Nested
+  class WhenSchemasIdentical {
+    void forceGCAndReap() throws Exception {
+      forceGCAndReapUntil(() -> getSimpleCacheSize() == 0);
+    }
+
+    @Test
+    void testCacheEviction() throws Exception {
+      Schema schema = buildNestedWriterSchema(0);
+      String schemaJson = schema.toString();
+
+      List<WeakReference<Schema>> schemaRefs = new ArrayList<>();
+
+      // Create 5 identical schemas (different objects, same structure)
+      for (int i = 0; i < 5; i++) {
+        Schema freshSchema = new Schema.Parser().parse(schemaJson);
+        schemaRefs.add(new WeakReference<>(freshSchema));
+
+        // This calls createDatumReader(schema, schema) where both args are the same object
+        DatumReader<?> reader = builder.createDatumReader(freshSchema);
+        assertNotNull(reader, "Reader should be created");
+
+        // Discard references
+        reader = null;
+        freshSchema = null;
+      }
+
+      forceClearSoftReferences();
+      forceGCAndReap();
+
+      // Count how many schemas were garbage collected
+      int collectedCount = 0;
+      for (WeakReference<Schema> ref : schemaRefs) {
+        if (ref.get() == null) {
+          collectedCount++;
+        }
+      }
+
+      // Verify both caches are cleared
+      assertTrue(collectedCount > 0,
+          "At least some schemas should be garbage collected. "
+              + collectedCount + " / " + schemaRefs.size() + " collected");
+      assertAllCachesCleared();
+    }
+
+    private void assertAllCachesCleared() throws Exception {
+      assertEquals(0, getSimpleCacheSize(), "Simple cache should be cleared after GC");
+      assertEquals(0, getOuterCacheSize(), "Outer cache should not be used");
+      assertEquals(0, getInnerCacheSize(), "Inner cache should not be used");
+    }
+
+    @Test
+    void testBothCachesClearedAfterGC() throws Exception {
+      Schema schema = buildNestedWriterSchema(0);
+      String schemaJson = schema.toString();
+
+      // Create readers for multiple identical schemas
+      for (int i = 0; i < 3; i++) {
+        Schema freshSchema = new Schema.Parser().parse(schemaJson);
+        DatumReader<?> reader = builder.createDatumReader(freshSchema);
+        assertNotNull(reader);
+        reader = null;
+        freshSchema = null;
+      }
+
+      // Verify caches have entries
+      assertTrue(getSimpleCacheSize() > 0, "Simple cache should have entries");
+
+      // Force GC and clear soft references
+      forceClearSoftReferences();
+      forceGCAndReap();
+
+      // Verify both caches are cleared
+      assertAllCachesCleared();
+    }
+
+    @Test
+    void testCache() throws Exception {
+      Schema baseSchema = buildNestedWriterSchema(0);
+      DatumReader<?> reader1 = builder.createDatumReader(baseSchema);
+      assertNotNull(reader1);
+
+      DatumReader<?> reader2 = builder.createDatumReader(baseSchema);
+      assertNotNull(reader2);
+
+      assertSame(reader1, reader2);
+    }
+
+    @Test
+    void testRepeatedReaderCreationMemoryBounded() throws Exception {
+      Schema baseSchema = buildNestedWriterSchema(0);
+      String schemaJson = baseSchema.toString();
+
+      // Create many readers with independently parsed identical schemas
+      for (int i = 0; i < 30; i++) {
+        Schema freshSchema = new Schema.Parser().parse(schemaJson);
+        DatumReader<?> reader = builder.createDatumReader(freshSchema);
+        assertNotNull(reader);
+
+        reader = null;
+        freshSchema = null;
+
+        if (i % 10 == 0) {
+          forceGCAndReap();
+        }
+      }
+
+      forceClearSoftReferences();
+      forceGCAndReap();
+
+      // Verify both caches are cleared
+      assertAllCachesCleared();
+    }
+
+    @Test
+    void testNestedIdenticalSchemasCleared() throws Exception {
+      Schema deepSchema = buildNestedWriterSchema(0);
+      String schemaJson = deepSchema.toString();
+
+      // Create readers for deeply nested schemas
+      for (int i = 0; i < 5; i++) {
+        Schema freshSchema = new Schema.Parser().parse(schemaJson);
+        DatumReader<?> reader = builder.createDatumReader(freshSchema);
+        assertNotNull(reader);
+      }
+
+      forceClearSoftReferences();
+      forceGCAndReap();
+
+      // Verify both caches are cleared
+      assertAllCachesCleared();
+    }
+  }
+
+  // ============================================================================
+  // Tests for Different Schemas (reader != writer)
+  // ============================================================================
+
+  /**
+   * Tests for the case where reader and writer schemas are different objects. This uses the readerCache (weak
+   * references) which should allow eviction when schemas are no longer externally referenced.
+   */
+  @Nested
+  class WhenSchemasDifferent {
+
+    private void assertAllCachesCleared() throws Exception {
+      assertEquals(0, getSimpleCacheSize(), "Simple cache should not be used");
+      assertEquals(0, getOuterCacheSize(), "Outer cache should should be cleared after GC");
+      assertEquals(0, getInnerCacheSize(), "Inner cache should should be cleared after GC");
+    }
+
+    void forceGCAndReap() throws Exception {
+      forceGCAndReapUntil(() -> getOuterCacheSize() + getInnerCacheSize() == 0);
+    }
+
+    @Test
+    void testCacheEviction() throws Exception {
+      Schema baseWriterSchema = buildNestedWriterSchema(0);
+      String writerSchemaJson = baseWriterSchema.toString();
+
+      Schema baseReaderSchema = buildNestedReaderSchema(0);
+      String readerSchemaJson = baseReaderSchema.toString();
+
+      List<WeakReference<Schema>> writerRefs = new ArrayList<>();
+      List<WeakReference<Schema>> readerRefs = new ArrayList<>();
+
+      // Create readers with different writer and reader schemas
+      for (int i = 0; i < 5; i++) {
+        Schema writerSchema = new Schema.Parser().parse(writerSchemaJson);
+        Schema readerSchema = new Schema.Parser().parse(readerSchemaJson);
+        writerRefs.add(new WeakReference<>(writerSchema));
+        readerRefs.add(new WeakReference<>(readerSchema));
+
+        DatumReader<?> reader = builder.createDatumReader(writerSchema, readerSchema);
+        assertNotNull(reader, "Reader should be created");
+      }
+
+      forceGCAndReap();
+
+      // Count collected schemas
+      int collectedWriters = 0;
+      int collectedReaders = 0;
+      for (WeakReference<Schema> ref : writerRefs) {
+        if (ref.get() == null) collectedWriters++;
+      }
+      for (WeakReference<Schema> ref : readerRefs) {
+        if (ref.get() == null) collectedReaders++;
+      }
+
+      // Both sets of schemas should be evictable
+      assertTrue(collectedWriters > 0, "Writer schemas should be garbage collected");
+      assertTrue(collectedReaders > 0, "Reader schemas should be garbage collected");
+
+      // Verify both caches are cleared
+      assertAllCachesCleared();
+    }
+    @Test
+    void testCache() throws Exception {
+      Schema baseWriterSchema = buildNestedWriterSchema(0);
+
+      Schema baseReaderSchema = buildNestedReaderSchema(0);
+
+      DatumReader<?> reader1 = builder.createDatumReader(baseWriterSchema, baseReaderSchema);
+      assertNotNull(reader1);
+
+      DatumReader<?> reader2 = builder.createDatumReader(baseWriterSchema, baseReaderSchema);
+      assertNotNull(reader2);
+
+      assertSame(reader1, reader2);
+    }
+
+    @Test
+    void testBothCachesClearedWithDifferentSchemas() throws Exception {
+      Schema baseWriterSchema = buildNestedWriterSchema(0);
+      String writerSchemaJson = baseWriterSchema.toString();
+
+      Schema baseReaderSchema = buildNestedReaderSchema(0);
+      String readerSchemaJson = baseReaderSchema.toString();
+
+      // Create readers with different schemas
+      for (int i = 0; i < 3; i++) {
+        Schema writerSchema = new Schema.Parser().parse(writerSchemaJson);
+        Schema readerSchema = new Schema.Parser().parse(readerSchemaJson);
+        DatumReader<?> reader = builder.createDatumReader(writerSchema, readerSchema);
+        assertNotNull(reader);
+      }
+
+      // Verify caches have entries
+      assertTrue(getOuterCacheSize() > 0, "Outer cache should have entries");
+      assertTrue(getInnerCacheSize() > 0, "Inner cache should have entries");
+
+      // Force GC and reap
+      forceGCAndReap();
+
+      // Verify both caches are cleared
+      assertAllCachesCleared();
+    }
+
+    @Test
+    void testRepeatedDifferentSchemasMemoryBounded() throws Exception {
+      Schema baseWriterSchema = buildNestedWriterSchema(0);
+      String writerSchemaJson = baseWriterSchema.toString();
+
+      Schema baseReaderSchema = buildNestedReaderSchema(0);
+      String readerSchemaJson = baseReaderSchema.toString();
+
+      // Create many readers with different schemas
+      for (int i = 0; i < 30; i++) {
+        Schema writerSchema = new Schema.Parser().parse(writerSchemaJson);
+        Schema readerSchema = new Schema.Parser().parse(readerSchemaJson);
+        DatumReader<?> reader = builder.createDatumReader(writerSchema, readerSchema);
+        assertNotNull(reader);
+
+        reader = null;
+        writerSchema = null;
+        readerSchema = null;
+
+        if (i % 10 == 0) {
+          forceGCAndReap();
+        }
+      }
+
+      forceGCAndReap();
+
+      // Verify both caches are cleared
+      assertAllCachesCleared();
+    }
+
+    @Test
+    void testNestedDifferentSchemasCleared() throws Exception {
+      Schema baseWriterSchema = buildNestedWriterSchema(0);
+      String writerSchemaJson = baseWriterSchema.toString();
+
+      Schema baseReaderSchema = buildNestedReaderSchema(0);
+      String readerSchemaJson = baseReaderSchema.toString();
+
+      // Create readers with deeply nested different schemas
+      for (int i = 0; i < 5; i++) {
+        Schema writerSchema = new Schema.Parser().parse(writerSchemaJson);
+        Schema readerSchema = new Schema.Parser().parse(readerSchemaJson);
+        DatumReader<?> reader = builder.createDatumReader(writerSchema, readerSchema);
+        assertNotNull(reader);
+      }
+
+      forceGCAndReap();
+
+      // Verify all caches are cleared
+      // Verify both caches are cleared
+      assertAllCachesCleared();
+    }
+  }
+
+  /**
+   * Build a nested record schema with specified depth. Each level has 10 string fields and an optional child record.
+   */
+  private Schema buildNestedWriterSchema(int level) {
+    SchemaBuilder.FieldAssembler<Schema> fields = SchemaBuilder.record("Level_" + level)
+        .namespace("org.apache.avro.test.retention")
+        .fields();
+
+    for (int f = 0; f < 10; f++) {
+      fields = fields.requiredString("field_" + f);
+    }
+
+    if (level < 3) {
+      Schema childSchema = buildNestedWriterSchema(level + 1);
+      fields = fields.name("child").type(childSchema).noDefault();
+    }
+
+    return fields.endRecord();
+  }
+  /**
+   * Build a nested record schema with specified depth. Each level has 5 string fields and an optional child record.
+   */
+  private Schema buildNestedReaderSchema(int level) {
+    SchemaBuilder.FieldAssembler<Schema> fields = SchemaBuilder.record("Level_" + level)
+        .namespace("org.apache.avro.test.retention")
+        .fields();
+
+    for (int f = 0; f < 5; f++) {
+      fields = fields.requiredString("field_" + f);
+    }
+
+    if (level < 3) {
+      Schema childSchema = buildNestedReaderSchema(level + 1);
+      fields = fields.name("child").type(childSchema).noDefault();
+    }
+
+    return fields.endRecord();
+  }
+
+  /**
+   * Get the number of entries in the outer WeakIdentityHashMap (one per unique reader schema).
+   */
+  @SuppressWarnings("unchecked")
+  private int getOuterCacheSize() {
+    try {
+      Map<Schema, Map<Schema, ?>> cache = (Map<Schema, Map<Schema, ?>>) READER_CACHE_FIELD.get(builder);
+      return cache.size();
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Get the total number of entries across all inner maps in the readerCache.
+   */
+  @SuppressWarnings("unchecked")
+  private int getInnerCacheSize() {
+    try {
+      Map<Schema, Map<Schema, ?>> cache = (Map<Schema, Map<Schema, ?>>) READER_CACHE_FIELD.get(builder);
+      int total = 0;
+      for (Map<Schema, ?> inner : cache.values()) {
+        total += inner.size();
+      }
+      return total;
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Get the number of entries in the simple cache (used for identical reader/writer schemas).
+   */
+  @SuppressWarnings("unchecked")
+  private int getSimpleCacheSize() {
+    try {
+      Map<Schema, ?> cache = (Map<Schema, ?>) READER_SIMPLE_CACHE_FIELD.get(builder);
+      return cache.size();
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Trigger the reap() method in WeakIdentityHashMap by calling size().
+   */
+  @SuppressWarnings("unchecked")
+  private void triggerReap() throws Exception {
+    Map<Schema, Map<Schema, ?>> cache = (Map<Schema, Map<Schema, ?>>) READER_CACHE_FIELD.get(builder);
+    cache.size(); // size() calls reap() internally
+  }
+
+  /**
+   * Force garbage collection and trigger reap cycle multiple times.
+   */
+  private void forceGCAndReapUntil(BooleanSupplier check) throws Exception {
+    for (int i = 0; i < 20 && !check.getAsBoolean(); i++) {
+      System.gc();
+      System.runFinalization();
+      Thread.sleep(100);
+      triggerReap();
+    }
+  }
+
+  /**
+   * Force garbage collection and trigger reap cycle multiple times.
+   */
+  private void forceClearSoftReferences() {
+    try {
+      ArrayList<Object> memory = new ArrayList<>();
+      while (true) {
+        memory.add(new byte[1024 * 1024 * 1024]); // Allocate 1GB blocks to fill up memory and clear soft references
+      }
+    } catch (OutOfMemoryError e) {
+      //ignored
+    }
+  }
+}


### PR DESCRIPTION
## What is the purpose of the change
Primary - to fix the memory leak described in AVRO-4253, a memory leak in FastReaderBuilder

Also improves the implementation and documentation of WeakIdentityHashMap. 

Unfortunately the main fix depends on this, so needed do it as an enabler. We could do this a s seperate PR and layer the memory leak on top, but the complexity of the PR isnt that high, so though it was better to address both concens in a sinple PR 
## Verifying this change

*(Please pick one of the following options)*
This change added unit test
## Documentation
No new feature added 


