### PR TITLE
AVRO-4258: [java] remove some allocations from decoder.getBytes() and Utf8 handling 

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/Conversions.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/Conversions.java
@@ -190,8 +190,7 @@ public class Conversions {
 
       try {
         BigInteger bg = null;
-        ByteBuffer buffer = decoder.readBytes(null);
-        byte[] array = buffer.array();
+        byte[] array = decoder.readBytes();
         if (array.length > 0) {
           bg = new BigInteger(array);
         }

--- a/lang/java/avro/src/main/java/org/apache/avro/file/DataFileReader12.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/file/DataFileReader12.java
@@ -75,9 +75,7 @@ public class DataFileReader12<D> implements FileReader<D>, Closeable {
       do {
         for (long i = 0; i < l; i++) {
           String key = vin.readString(null).toString();
-          ByteBuffer value = vin.readBytes(null);
-          byte[] bb = new byte[value.remaining()];
-          value.get(bb);
+          byte[] bb = vin.readBytes();
           meta.put(key, bb);
         }
       } while ((l = vin.mapNext()) != 0);

--- a/lang/java/avro/src/main/java/org/apache/avro/file/DataFileReader12.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/file/DataFileReader12.java
@@ -19,7 +19,6 @@ package org.apache.avro.file;
 
 import java.io.IOException;
 import java.io.Closeable;
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;

--- a/lang/java/avro/src/main/java/org/apache/avro/file/DataFileStream.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/file/DataFileStream.java
@@ -128,9 +128,7 @@ public class DataFileStream<D> implements Iterator<D>, Iterable<D>, Closeable {
       do {
         for (long i = 0; i < l; i++) {
           String key = vin.readString(null).toString();
-          ByteBuffer value = vin.readBytes(null);
-          byte[] bb = new byte[value.remaining()];
-          value.get(bb);
+          byte[] bb = vin.readBytes();
           header.meta.put(key, bb);
           header.metaKeyList.add(key);
         }

--- a/lang/java/avro/src/main/java/org/apache/avro/io/BinaryDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/BinaryDecoder.java
@@ -335,6 +335,18 @@ public class BinaryDecoder extends Decoder {
   }
 
   @Override
+  public byte[] readBytes() throws IOException {
+    int length = SystemLimitException.checkMaxBytesLength(readLong());
+    ensureAvailableBytes(length);
+    if (length == 0) {
+      return EMPTY_BYTES;
+    }
+    byte[] result = new byte[length];
+    doReadBytes(result, 0, result.length);
+    return result;
+  }
+
+  @Override
   public void skipBytes() throws IOException {
     doSkipBytes(readLong());
   }

--- a/lang/java/avro/src/main/java/org/apache/avro/io/BinaryDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/BinaryDecoder.java
@@ -335,6 +335,14 @@ public class BinaryDecoder extends Decoder {
   }
 
   @Override
+  public byte[] readBytes() throws IOException {
+    int length = SystemLimitException.checkMaxBytesLength(readLong());
+    final byte[] result = new byte[length];
+    doReadBytes(result, 0, length);
+    return result;
+  }
+
+  @Override
   public void skipBytes() throws IOException {
     doSkipBytes(readLong());
   }

--- a/lang/java/avro/src/main/java/org/apache/avro/io/Decoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/Decoder.java
@@ -20,7 +20,7 @@ package org.apache.avro.io;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import org.apache.avro.SystemLimitException;
+import org.apache.avro.AvroTypeException;
 import org.apache.avro.util.Utf8;
 
 /**
@@ -41,8 +41,6 @@ import org.apache.avro.util.Utf8;
  */
 
 public abstract class Decoder {
-
-  private static final byte[] EMPTY_BYTES = new byte[0];
 
   /**
    * "Reads" a null value. (Doesn't actually read anything, but advances the state
@@ -134,7 +132,7 @@ public abstract class Decoder {
    * <p>
    * This is useful when you want to avoid the creation of a ByteBuffer, and only
    * want the byte[], e.g.:
-   * 
+   *
    * <pre>
    * ByteBuffer buffer = decoder.readBytes(null);
    * byte[] array = buffer.array();
@@ -143,15 +141,7 @@ public abstract class Decoder {
    * @throws AvroTypeException If this is a stateful reader and byte-string is not
    *                           the type of the next value to be read
    */
-  public byte[] readBytes() throws IOException {
-    int length = SystemLimitException.checkMaxBytesLength(readLong());
-    if (length == 0) {
-      return EMPTY_BYTES;
-    }
-    byte[] result = new byte[length];
-    readFixed(result);
-    return result;
-  }
+  public abstract byte[] readBytes() throws IOException;
 
   /**
    * Discards a byte-string written by {@link Encoder#writeBytes}.

--- a/lang/java/avro/src/main/java/org/apache/avro/io/Decoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/Decoder.java
@@ -20,6 +20,7 @@ package org.apache.avro.io;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
+import org.apache.avro.SystemLimitException;
 import org.apache.avro.util.Utf8;
 
 /**
@@ -40,6 +41,8 @@ import org.apache.avro.util.Utf8;
  */
 
 public abstract class Decoder {
+
+  private static final byte[] EMPTY_BYTES = new byte[0];
 
   /**
    * "Reads" a null value. (Doesn't actually read anything, but advances the state
@@ -125,6 +128,28 @@ public abstract class Decoder {
    *                           the type of the next value to be read
    */
   public abstract ByteBuffer readBytes(ByteBuffer old) throws IOException;
+
+  /**
+   * Reads a byte-string written by {@link Encoder#writeBytes}.
+   * <p>
+   * This is useful when you want to avoid the creation of a ByteBuffer, and only want the byte[], e.g.:
+   * <pre>
+   *     ByteBuffer buffer = decoder.readBytes(null);
+   *     byte[] array = buffer.array();
+   * </pre>
+   *
+   * @throws AvroTypeException If this is a stateful reader and byte-string is not the type of the next value to be
+   *                           read
+   */
+  public byte[] readBytes() throws IOException {
+    int length = SystemLimitException.checkMaxBytesLength(readLong());
+    if (length == 0) {
+      return EMPTY_BYTES;
+    }
+    byte[] result = new byte[length];
+    readFixed(result);
+    return result;
+  }
 
   /**
    * Discards a byte-string written by {@link Encoder#writeBytes}.

--- a/lang/java/avro/src/main/java/org/apache/avro/io/Decoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/Decoder.java
@@ -132,14 +132,16 @@ public abstract class Decoder {
   /**
    * Reads a byte-string written by {@link Encoder#writeBytes}.
    * <p>
-   * This is useful when you want to avoid the creation of a ByteBuffer, and only want the byte[], e.g.:
+   * This is useful when you want to avoid the creation of a ByteBuffer, and only
+   * want the byte[], e.g.:
+   * 
    * <pre>
-   *     ByteBuffer buffer = decoder.readBytes(null);
-   *     byte[] array = buffer.array();
+   * ByteBuffer buffer = decoder.readBytes(null);
+   * byte[] array = buffer.array();
    * </pre>
    *
-   * @throws AvroTypeException If this is a stateful reader and byte-string is not the type of the next value to be
-   *                           read
+   * @throws AvroTypeException If this is a stateful reader and byte-string is not
+   *                           the type of the next value to be read
    */
   public byte[] readBytes() throws IOException {
     int length = SystemLimitException.checkMaxBytesLength(readLong());

--- a/lang/java/avro/src/main/java/org/apache/avro/io/Decoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/Decoder.java
@@ -20,7 +20,6 @@ package org.apache.avro.io;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import org.apache.avro.SystemLimitException;
 import org.apache.avro.util.Utf8;
 
 /**
@@ -42,7 +41,7 @@ import org.apache.avro.util.Utf8;
 
 public abstract class Decoder {
 
-  private static final byte[] EMPTY_BYTES = new byte[0];
+  protected static final byte[] EMPTY_BYTES = new byte[0];
 
   /**
    * "Reads" a null value. (Doesn't actually read anything, but advances the state
@@ -134,7 +133,7 @@ public abstract class Decoder {
    * <p>
    * This is useful when you want to avoid the creation of a ByteBuffer, and only
    * want the byte[], e.g.:
-   * 
+   *
    * <pre>
    * ByteBuffer buffer = decoder.readBytes(null);
    * byte[] array = buffer.array();
@@ -143,15 +142,7 @@ public abstract class Decoder {
    * @throws AvroTypeException If this is a stateful reader and byte-string is not
    *                           the type of the next value to be read
    */
-  public byte[] readBytes() throws IOException {
-    int length = SystemLimitException.checkMaxBytesLength(readLong());
-    if (length == 0) {
-      return EMPTY_BYTES;
-    }
-    byte[] result = new byte[length];
-    readFixed(result);
-    return result;
-  }
+  public abstract byte[] readBytes() throws IOException;
 
   /**
    * Discards a byte-string written by {@link Encoder#writeBytes}.

--- a/lang/java/avro/src/main/java/org/apache/avro/io/Decoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/Decoder.java
@@ -20,7 +20,6 @@ package org.apache.avro.io;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import org.apache.avro.AvroTypeException;
 import org.apache.avro.util.Utf8;
 
 /**

--- a/lang/java/avro/src/main/java/org/apache/avro/io/DirectBinaryDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/DirectBinaryDecoder.java
@@ -51,6 +51,15 @@ class DirectBinaryDecoder extends BinaryDecoder {
       result.limit(length);
       return result;
     }
+
+    public byte[] read(int length) throws IOException {
+      if (length == 0) {
+        return EMPTY_BYTES;
+      }
+      final byte[] result = new byte[length];
+      doReadBytes(result, 0, length);
+      return result;
+    }
   }
 
   private class ReuseByteReader extends ByteReader {
@@ -157,6 +166,12 @@ class DirectBinaryDecoder extends BinaryDecoder {
   public ByteBuffer readBytes(ByteBuffer old) throws IOException {
     long length = readLong();
     return byteReader.read(old, SystemLimitException.checkMaxBytesLength(length));
+  }
+
+  @Override
+  public byte[] readBytes() throws IOException {
+    long length = readLong();
+    return byteReader.read(SystemLimitException.checkMaxBytesLength(length));
   }
 
   @Override

--- a/lang/java/avro/src/main/java/org/apache/avro/io/FastReaderBuilder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/FastReaderBuilder.java
@@ -385,18 +385,14 @@ public class FastReaderBuilder {
   private FieldReader createBytesPromotingToStringReader(Schema readerSchema) {
     String stringProperty = readerSchema.getProp(GenericData.STRING_PROP);
     if (GenericData.StringType.String.name().equals(stringProperty)) {
-      return (old, decoder) -> getStringFromByteBuffer(decoder.readBytes(null));
+      return (old, decoder) -> new String(decoder.readBytes(), StandardCharsets.UTF_8);
     } else {
-      return (old, decoder) -> getUtf8FromByteBuffer(old, decoder.readBytes(null));
+      return (old, decoder) -> getUtf8FromByteArray(old, decoder.readBytes());
     }
   }
 
-  private String getStringFromByteBuffer(ByteBuffer buffer) {
-    return new String(buffer.array(), buffer.position(), buffer.remaining(), StandardCharsets.UTF_8);
-  }
-
-  private Utf8 getUtf8FromByteBuffer(Object old, ByteBuffer buffer) {
-    return (old instanceof Utf8) ? ((Utf8) old).set(new Utf8(buffer.array())) : new Utf8(buffer.array());
+  private Utf8 getUtf8FromByteArray(Object old, byte[] bytes) {
+    return (old instanceof Utf8) ? ((Utf8) old).set(bytes) : new Utf8(bytes);
   }
 
   private FieldReader createUnionReader(WriterUnion action) throws IOException {

--- a/lang/java/avro/src/main/java/org/apache/avro/io/JsonDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/JsonDecoder.java
@@ -311,6 +311,18 @@ public class JsonDecoder extends ParsingDecoder implements Parser.ActionHandler 
     }
   }
 
+  @Override
+  public byte[] readBytes() throws IOException {
+    advance(Symbol.BYTES);
+    if (in.getCurrentToken() == JsonToken.VALUE_STRING) {
+      byte[] result = readByteArray();
+      in.nextToken();
+      return result;
+    } else {
+      throw error("bytes");
+    }
+  }
+
   private byte[] readByteArray() throws IOException {
     return in.getText().getBytes(StandardCharsets.ISO_8859_1);
   }

--- a/lang/java/avro/src/main/java/org/apache/avro/io/ResolvingDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/ResolvingDecoder.java
@@ -244,6 +244,18 @@ public class ResolvingDecoder extends ValidatingDecoder {
   }
 
   @Override
+  public byte[] readBytes() throws IOException {
+    Symbol actual = parser.advance(Symbol.BYTES);
+    if (actual == Symbol.STRING) {
+      Utf8 s = in.readString(null);
+      return s.getBytes();
+    } else {
+      assert actual == Symbol.BYTES;
+      return in.readBytes();
+    }
+  }
+
+  @Override
   public void skipBytes() throws IOException {
     Symbol actual = parser.advance(Symbol.BYTES);
     if (actual == Symbol.STRING) {

--- a/lang/java/avro/src/main/java/org/apache/avro/io/ResolvingDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/ResolvingDecoder.java
@@ -202,7 +202,7 @@ public class ResolvingDecoder extends ValidatingDecoder {
   public Utf8 readString(Utf8 old) throws IOException {
     Symbol actual = parser.advance(Symbol.STRING);
     if (actual == Symbol.BYTES) {
-      return new Utf8(in.readBytes(null).array());
+      return old == null? new Utf8(in.readBytes()) : old.set(in.readBytes());
     } else {
       assert actual == Symbol.STRING;
       return in.readString(old);
@@ -213,7 +213,7 @@ public class ResolvingDecoder extends ValidatingDecoder {
   public String readString() throws IOException {
     Symbol actual = parser.advance(Symbol.STRING);
     if (actual == Symbol.BYTES) {
-      return new String(in.readBytes(null).array(), StandardCharsets.UTF_8);
+      return new String(in.readBytes(), StandardCharsets.UTF_8);
     } else {
       assert actual == Symbol.STRING;
       return in.readString();

--- a/lang/java/avro/src/main/java/org/apache/avro/io/ResolvingDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/ResolvingDecoder.java
@@ -202,7 +202,7 @@ public class ResolvingDecoder extends ValidatingDecoder {
   public Utf8 readString(Utf8 old) throws IOException {
     Symbol actual = parser.advance(Symbol.STRING);
     if (actual == Symbol.BYTES) {
-      return old == null? new Utf8(in.readBytes()) : old.set(in.readBytes());
+      return old == null ? new Utf8(in.readBytes()) : old.set(in.readBytes());
     } else {
       assert actual == Symbol.STRING;
       return in.readString(old);

--- a/lang/java/avro/src/main/java/org/apache/avro/io/ResolvingDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/ResolvingDecoder.java
@@ -244,6 +244,18 @@ public class ResolvingDecoder extends ValidatingDecoder {
   }
 
   @Override
+  public byte[] readBytes() throws IOException {
+    Symbol actual = parser.advance(Symbol.BYTES);
+    if (actual == Symbol.STRING) {
+      Utf8 s = in.readString(null);
+      return s.getBytes(); // readString(null) allocated an exactly fitting byte[]
+    } else {
+      assert actual == Symbol.BYTES;
+      return in.readBytes();
+    }
+  }
+
+  @Override
   public void skipBytes() throws IOException {
     Symbol actual = parser.advance(Symbol.BYTES);
     if (actual == Symbol.STRING) {

--- a/lang/java/avro/src/main/java/org/apache/avro/io/ValidatingDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/ValidatingDecoder.java
@@ -36,7 +36,7 @@ import org.apache.avro.util.Utf8;
  * and configure.
  * <p/>
  * ValidatingDecoder is not thread-safe.
- * 
+ *
  * @see Decoder
  * @see DecoderFactory
  */
@@ -122,6 +122,12 @@ public class ValidatingDecoder extends ParsingDecoder implements Parser.ActionHa
   public ByteBuffer readBytes(ByteBuffer old) throws IOException {
     parser.advance(Symbol.BYTES);
     return in.readBytes(old);
+  }
+
+  @Override
+  public byte[] readBytes() throws IOException {
+    parser.advance(Symbol.BYTES);
+    return in.readBytes();
   }
 
   @Override

--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectDatumReader.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectDatumReader.java
@@ -244,14 +244,11 @@ public class ReflectDatumReader<T> extends SpecificDatumReader<T> {
 
   @Override
   protected Object readBytes(Object old, Schema s, Decoder in) throws IOException {
-    ByteBuffer bytes = in.readBytes(null);
     Class<?> c = ReflectData.getClassProp(s, SpecificData.CLASS_PROP);
     if (c != null && c.isArray()) {
-      byte[] result = new byte[bytes.remaining()];
-      bytes.get(result);
-      return result;
+      return in.readBytes();
     } else {
-      return bytes;
+      return in.readBytes(null);
     }
   }
 

--- a/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectDatumReader.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectDatumReader.java
@@ -19,7 +19,6 @@ package org.apache.avro.reflect;
 
 import java.io.IOException;
 import java.lang.reflect.Array;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.HashMap;
@@ -132,11 +131,11 @@ public class ReflectDatumReader<T> extends SpecificDatumReader<T> {
     throw new AvroRuntimeException("reflectDatumReader does not use addToArray");
   }
 
-  @Override
   /**
    * Called to read an array instance. May be overridden for alternate array
    * representations.
    */
+  @Override
   protected Object readArray(Object old, Schema expected, ResolvingDecoder in) throws IOException {
     Schema expectedType = expected.getElementType();
     long l = in.readArrayStart();

--- a/lang/java/avro/src/main/java/org/apache/avro/util/Utf8.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/util/Utf8.java
@@ -134,8 +134,7 @@ public class Utf8 implements Comparable<Utf8>, CharSequence, Externalizable {
 
   public Utf8 set(byte[] bytes) {
     this.bytes = bytes;
-    this.length = SystemLimitException.checkMaxStringLength(length);
-    ;
+    this.length = SystemLimitException.checkMaxStringLength(bytes.length);
     this.hash = 0;
     return this;
   }

--- a/lang/java/avro/src/main/java/org/apache/avro/util/Utf8.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/util/Utf8.java
@@ -134,7 +134,8 @@ public class Utf8 implements Comparable<Utf8>, CharSequence, Externalizable {
 
   public Utf8 set(byte[] bytes) {
     this.bytes = bytes;
-    this.length = SystemLimitException.checkMaxStringLength(length);;
+    this.length = SystemLimitException.checkMaxStringLength(length);
+    ;
     this.hash = 0;
     return this;
   }

--- a/lang/java/avro/src/main/java/org/apache/avro/util/Utf8.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/util/Utf8.java
@@ -132,6 +132,13 @@ public class Utf8 implements Comparable<Utf8>, CharSequence, Externalizable {
     return this;
   }
 
+  public Utf8 set(byte[] bytes) {
+    this.bytes = bytes;
+    this.length = SystemLimitException.checkMaxStringLength(length);;
+    this.hash = 0;
+    return this;
+  }
+
   public Utf8 set(Utf8 other) {
     if (this.bytes.length < other.length) {
       this.bytes = new byte[other.length];

--- a/lang/java/avro/src/main/java/org/apache/avro/util/Utf8.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/util/Utf8.java
@@ -134,8 +134,8 @@ public class Utf8 implements Comparable<Utf8>, CharSequence, Externalizable {
 
   public Utf8 set(byte[] bytes) {
     this.bytes = bytes;
-    this.length = SystemLimitException.checkMaxStringLength(length);
-    ;
+    this.length = SystemLimitException.checkMaxStringLength(bytes.length);
+    this.string = null;
     this.hash = 0;
     return this;
   }

--- a/lang/java/avro/src/test/java/org/apache/avro/io/TestBinaryDecoder.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/io/TestBinaryDecoder.java
@@ -430,6 +430,7 @@ public class TestBinaryDecoder {
         () -> this.newDecoder(useDirect, -1).readBytes(null));
     Assertions.assertEquals(ERROR_NEGATIVE, ex.getMessage());
   }
+
   @ParameterizedTest
   @ValueSource(booleans = { true, false })
   public void testBytesNegativeLengthRaw(boolean useDirect) throws IOException {

--- a/lang/java/avro/src/test/java/org/apache/avro/io/TestBinaryDecoder.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/io/TestBinaryDecoder.java
@@ -149,6 +149,12 @@ public class TestBinaryDecoder {
 
   @ParameterizedTest
   @ValueSource(booleans = { true, false })
+  void eofBytesRaw(boolean useDirect) {
+    Assertions.assertThrows(EOFException.class, () -> newDecoderWithNoData(useDirect).readBytes());
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = { true, false })
   void eofString(boolean useDirect) {
     Assertions.assertThrows(EOFException.class, () -> newDecoderWithNoData(useDirect).readString(new Utf8("a")));
   }
@@ -424,12 +430,27 @@ public class TestBinaryDecoder {
         () -> this.newDecoder(useDirect, -1).readBytes(null));
     Assertions.assertEquals(ERROR_NEGATIVE, ex.getMessage());
   }
+  @ParameterizedTest
+  @ValueSource(booleans = { true, false })
+  public void testBytesNegativeLengthRaw(boolean useDirect) throws IOException {
+    Exception ex = Assertions.assertThrows(AvroRuntimeException.class,
+        () -> this.newDecoder(useDirect, -1).readBytes());
+    Assertions.assertEquals(ERROR_NEGATIVE, ex.getMessage());
+  }
 
   @ParameterizedTest
   @ValueSource(booleans = { true, false })
   public void testBytesVmMaxSize(boolean useDirect) throws IOException {
     Exception ex = Assertions.assertThrows(UnsupportedOperationException.class,
         () -> this.newDecoder(useDirect, MAX_ARRAY_VM_LIMIT + 1).readBytes(null));
+    Assertions.assertEquals(ERROR_VM_LIMIT_BYTES, ex.getMessage());
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = { true, false })
+  public void testBytesVmMaxSizeRaw(boolean useDirect) throws IOException {
+    Exception ex = Assertions.assertThrows(UnsupportedOperationException.class,
+        () -> this.newDecoder(useDirect, MAX_ARRAY_VM_LIMIT + 1).readBytes());
     Assertions.assertEquals(ERROR_VM_LIMIT_BYTES, ex.getMessage());
   }
 

--- a/lang/java/avro/src/test/java/org/apache/avro/util/TestUtf8.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/util/TestUtf8.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 
 import org.apache.avro.SystemLimitException;
 import org.apache.avro.TestSystemLimitException;
@@ -97,6 +98,20 @@ public class TestUtf8 {
     assertEquals(127791473, u.hashCode());
     u.setByteLength(4);
     assertEquals(4122302, u.hashCode());
+
+    u.set(getTrimmedBytes(new Utf8("zz")));
+    assertEquals(4865, u.hashCode());
+    u.setByteLength(1);
+    assertEquals(153, u.hashCode());
+
+    u.set(getTrimmedBytes(new Utf8("hello")));
+    assertEquals(127791473, u.hashCode());
+    u.setByteLength(4);
+    assertEquals(4122302, u.hashCode());
+  }
+
+  private byte[] getTrimmedBytes(Utf8 utf8) {
+    return Arrays.copyOf(utf8.getBytes(), utf8.getByteLength());
   }
 
   /**


### PR DESCRIPTION
## Contribution Checklist
## What is the purpose of the change
To reduce some allocations found during profiling for other changes (https://github.com/apache/avro/pull/3746)
## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
There is some trivial addition to the tests but only to ensure the methods are called

Note - I can't verify the change locally as Arvo doesn't build for me locally
## Documentation

- Does this pull request introduce a new feature? (no)
