### PR TITLE
AVRO-4260: [C++] Replace fmt with std::format

### DIFF
--- a/.github/workflows/test-lang-c++.yml
+++ b/.github/workflows/test-lang-c++.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Dependencies
-        run: sudo apt update && sudo apt-get install -qqy cppcheck libboost-all-dev libsnappy-dev libfmt-dev zlib1g-dev libzstd-dev cmake
+        run: sudo apt update && sudo apt-get install -qqy cppcheck libboost-all-dev libsnappy-dev zlib1g-dev libzstd-dev cmake
 
       - name: Print Versions
         run: |

--- a/lang/c++/CMakeLists.txt
+++ b/lang/c++/CMakeLists.txt
@@ -83,19 +83,6 @@ if (AVRO_BUILD_TESTS OR AVRO_USE_BOOST)
     find_package (Boost 1.70 REQUIRED CONFIG)
 endif ()
 
-find_package(fmt QUIET)
-if (NOT fmt_FOUND)
-    include(FetchContent)
-    FetchContent_Declare(
-            fmt
-            GIT_REPOSITORY  https://github.com/fmtlib/fmt.git
-            GIT_TAG         10.2.1
-            GIT_PROGRESS    TRUE
-            USES_TERMINAL_DOWNLOAD TRUE
-    )
-    FetchContent_MakeAvailable(fmt)
-endif ()
-
 find_package(Snappy CONFIG)
 if (Snappy_FOUND)
     # Use CONFIG mode to guarantee that Snappy::snappy target exists if found.
@@ -149,7 +136,6 @@ function (setup_avro_lib target lib_type)
     endif ()
     set_target_properties (${target} PROPERTIES VERSION ${AVRO_VERSION})
     target_link_libraries (${target} PUBLIC
-      $<BUILD_INTERFACE:fmt::fmt-header-only>
       $<BUILD_INTERFACE:ZLIB::ZLIB>
       $<BUILD_INTERFACE:$<TARGET_NAME_IF_EXISTS:Snappy::snappy>>
       $<$<BOOL:${zstd_FOUND}>:$<BUILD_INTERFACE:$<TARGET_NAME_IF_EXISTS:${ZSTD_TARGET}>>>

--- a/lang/c++/cmake/avro-cpp-config.cmake.in
+++ b/lang/c++/cmake/avro-cpp-config.cmake.in
@@ -38,7 +38,6 @@ endif()
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
 
 find_dependency(ZLIB REQUIRED)
-find_dependency(fmt REQUIRED)
 if(@Snappy_FOUND@)
     find_dependency(Snappy REQUIRED)
 endif()

--- a/lang/c++/cmake/avro-cpp.pc.in
+++ b/lang/c++/cmake/avro-cpp.pc.in
@@ -29,4 +29,3 @@ Version: @AVRO_VERSION@
 
 Cflags: -I${includedir}
 Libs: -L${libdir} -lavrocpp
-Requires: fmt

--- a/lang/c++/impl/Compiler.cc
+++ b/lang/c++/impl/Compiler.cc
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+#include <cstring>
 #include <sstream>
 #include <unordered_set>
 #include <utility>

--- a/lang/c++/impl/DataFile.cc
+++ b/lang/c++/impl/DataFile.cc
@@ -18,6 +18,7 @@
 
 #include "DataFile.hh"
 #include "Compiler.hh"
+#include <cstring>
 #include "Exception.hh"
 
 #include <random>

--- a/lang/c++/impl/avrogencpp.cc
+++ b/lang/c++/impl/avrogencpp.cc
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstring>
 #ifndef _WIN32
 #include <ctime>
 #endif

--- a/lang/c++/include/avro/Exception.hh
+++ b/lang/c++/include/avro/Exception.hh
@@ -20,7 +20,7 @@
 #define avro_Exception_hh__
 
 #include "Config.hh"
-#include <fmt/core.h>
+#include <format>
 #include <stdexcept>
 
 namespace avro {
@@ -33,8 +33,8 @@ public:
     explicit Exception(const std::string &msg) : std::runtime_error(msg) {}
 
     template<typename... Args>
-    Exception(fmt::format_string<Args...> fmt, Args &&...args)
-        : std::runtime_error(fmt::format(fmt, std::forward<Args>(args)...)) {}
+    Exception(std::format_string<Args...> fmt, Args &&...args)
+        : std::runtime_error(std::format(fmt, std::forward<Args>(args)...)) {}
 };
 
 } // namespace avro

--- a/lang/c++/include/avro/Node.hh
+++ b/lang/c++/include/avro/Node.hh
@@ -22,6 +22,7 @@
 #include "Config.hh"
 
 #include <cassert>
+#include <format>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -223,10 +224,9 @@ inline std::ostream &operator<<(std::ostream &os, const avro::Node &n) {
 } // namespace std
 
 template<>
-struct fmt::formatter<avro::Name> : fmt::formatter<std::string> {
-    template<typename FormatContext>
-    constexpr auto format(const avro::Name &n, FormatContext &ctx) const {
-        return fmt::formatter<std::string>::format(n.fullname(), ctx);
+struct std::formatter<avro::Name, char> : std::formatter<std::string, char> {
+    auto format(const avro::Name &n, std::format_context &ctx) const {
+        return std::formatter<std::string, char>::format(n.fullname(), ctx);
     }
 };
 

--- a/lang/c++/include/avro/Types.hh
+++ b/lang/c++/include/avro/Types.hh
@@ -19,7 +19,7 @@
 #ifndef avro_Types_hh__
 #define avro_Types_hh__
 
-#include <fmt/format.h>
+#include <format>
 #include <iostream>
 
 #include "Config.hh"
@@ -111,10 +111,9 @@ std::ostream &operator<<(std::ostream &os, const Null &null);
 } // namespace avro
 
 template<>
-struct fmt::formatter<avro::Type> : fmt::formatter<std::string> {
-    template<typename FormatContext>
-    constexpr auto format(avro::Type t, FormatContext &ctx) const {
-        return fmt::formatter<std::string>::format(avro::toString(t), ctx);
+struct std::formatter<avro::Type, char> : std::formatter<std::string, char> {
+    auto format(avro::Type t, std::format_context &ctx) const {
+        return std::formatter<std::string, char>::format(avro::toString(t), ctx);
     }
 };
 


### PR DESCRIPTION
## What is the purpose of the change

Now the minimum C++ standard is raised from C++17 to C++20. We can replace the third-party fmt library with C++20 std::format to reduce external dependencies. 

## Verifying this change

This change is already covered by existing tests, such as buffertest, unittest, SchemaTests, CodecTests, DataFileTests, CompilerTests, etc.

## Documentation

- Does this pull request introduce a new feature? no
