### PR TITLE
AVRO-4262: [avro-tools] recodec fix to use correct default codec compression level for gzip, xz and zstd 

### DIFF
--- a/lang/java/tools/src/main/java/org/apache/avro/tool/Util.java
+++ b/lang/java/tools/src/main/java/org/apache/avro/tool/Util.java
@@ -272,14 +272,15 @@ class Util {
   static CodecFactory codecFactory(OptionSet opts, OptionSpec<String> codec, OptionSpec<Integer> level,
       String defaultCodec) {
     String codecName = opts.hasArgument(codec) ? codec.value(opts) : defaultCodec;
+    boolean levelSet = opts.hasArgument(level);
     if (codecName.equals(DEFLATE_CODEC)) {
-      return CodecFactory.deflateCodec(level.value(opts));
+      return CodecFactory.deflateCodec(levelSet ? level.value(opts) : CodecFactory.DEFAULT_DEFLATE_LEVEL);
     } else if (codecName.equals(DataFileConstants.XZ_CODEC)) {
-      return CodecFactory.xzCodec(level.value(opts));
+      return CodecFactory.xzCodec(levelSet ? level.value(opts) : CodecFactory.DEFAULT_XZ_LEVEL);
     } else if (codecName.equals(DataFileConstants.ZSTANDARD_CODEC)) {
-      return CodecFactory.zstandardCodec(level.value(opts));
+      return CodecFactory.zstandardCodec(levelSet ? level.value(opts) : CodecFactory.DEFAULT_ZSTANDARD_LEVEL);
     } else {
-      return CodecFactory.fromString(codec.value(opts));
+      return CodecFactory.fromString(codecName);
     }
   }
 


### PR DESCRIPTION
[AVRO-4262](https://issues.apache.org/jira/browse/AVRO-4262) avro-tools recodec should explicitly set the default codec compression level for the gzip, xz and zstd codecs when the level parameter is not provided. The level defaults to -1 for all 3 of these codecs, which is fine for gzip but is an invalid level for xz and 3 is the default for zstd - so when you expect the default level 3 compression but end up with -1  level and wondering why compression is so poor.

There are default level constants per codec already defined in the sources.

<!--

*Thank you very much for contributing to Apache Avro - we are happy that you want to help us improve Avro. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Avro a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/AVRO/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "AVRO-XXXX: [component] Title of the pull request", where *AVRO-XXXX* should be replaced by the actual issue number. 
    The *component* is optional, but can help identify the correct reviewers faster: either the language ("java", "python") or subsystem such as "build" or "doc" are good candidates.  

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests. You can [build the entire project](https://github.com/apache/avro/blob/main/BUILD.md) or just the [language-specific SDK](https://avro.apache.org/project/how-to-contribute/#unit-tests).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Every commit message references Jira issues in their subject lines. In addition, commits follow the guidelines from [How to write a good git commit message](https://chris.beams.io/posts/git-commit/)
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

-->

## What is the purpose of the change

These changes explicitly set the default codec compression level for the gzip, xz and zstd codecs when the level parameter is not provided. So no more errors on xz or silently setting the incorrect default compression level for zstd. 


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

```
java -jar avro-tools-1.12.1.jar recodec --codec xz input.avro output_conv_xz.avro
Exception in thread "main" org.tukaani.xz.UnsupportedOptionsException: Unsupported preset: -1
at org.tukaani.xz.LZMA2Options.setPreset(LZMA2Options.java:196)
at org.tukaani.xz.LZMA2Options.<init>(LZMA2Options.java:157)
at org.apache.commons.compress.compressors.xz.XZCompressorOutputStream.<init>(XZCompressorOutputStream.java:148)
at org.apache.avro.file.XZCodec.compress(XZCodec.java:62)
at org.apache.avro.file.DataFileStream$DataBlock.compressUsing(DataFileStream.java:384)
at org.apache.avro.file.DataFileWriter.appendAllFrom(DataFileWriter.java:403)
at org.apache.avro.tool.RecodecTool.run(RecodecTool.java:80)
at org.apache.avro.tool.Main.run(Main.java:67)
at org.apache.avro.tool.Main.main(Main.java:56)
 
Working with patch
java -jar avro-tools-1.13.0-SNAPSHOT.jar recodec --codec xz input.avro output_conv_xz.avro

java -jar avro-tools-1.13.0-SNAPSHOT.jar getmeta output_conv_xz.avro | grep codec
avro.codec    xz
```


## Documentation

- Does this pull request introduce a new feature? (yes / no) no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
