### PR TITLE
AVRO-4260: [C++] Upgrade minimum C++ standard from C++17 to C++20

### DIFF
--- a/lang/c++/CMakeLists.txt
+++ b/lang/c++/CMakeLists.txt
@@ -21,11 +21,11 @@ cmake_minimum_required (VERSION 3.20)
 set (CMAKE_LEGACY_CYGWIN_WIN32 0)
 
 if (NOT DEFINED CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 17)
+    set(CMAKE_CXX_STANDARD 20)
 endif()
 
-if (CMAKE_CXX_STANDARD LESS 17)
-    message(FATAL_ERROR "Avro requires at least C++17")
+if (CMAKE_CXX_STANDARD LESS 20)
+    message(FATAL_ERROR "Avro requires at least C++20")
 endif()
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
## What is the purpose of the change

Raise CMAKE_CXX_STANDARD default from 17 to 20 and update the minimum version check accordingly.

## Verifying this change

This change is already covered by existing tests, such as buffertest, unittest, SchemaTests, CodecTests, DataFileTests, CompilerTests, etc.

## Documentation

- Does this pull request introduce a new feature? no
