### PR TITLE
MINOR: [C++] Add missing header <type_traits>

### DIFF
--- a/lang/c++/include/avro/buffer/Buffer.hh
+++ b/lang/c++/include/avro/buffer/Buffer.hh
@@ -22,6 +22,7 @@
 #ifndef _WIN32
 #include <sys/uio.h>
 #endif
+#include <type_traits>
 #include <utility>
 #include <vector>
 


### PR DESCRIPTION
## What is the purpose of the change

Fix avro-cpp builds with C++23 by including `<type_traits>` directly in `Buffer.hh`, which uses `std::is_fundamental`.

## Verifying this change

This change is already covered by existing tests, such as the avro-cpp C++23 build and existing C++ test suite.

- Built `avrocpp_s` with `-DCMAKE_CXX_STANDARD=23`
- Ran the avro-cpp C++ test suite: 13/13 tests passed

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable