### PR TITLE
AVRO-4269: [Java] Fix timestamp-nanos conversion before epoch

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/data/TimeConversions.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/data/TimeConversions.java
@@ -235,7 +235,7 @@ public class TimeConversions {
 
       if (seconds < 0 && nanos > 0) {
         long micros = Math.multiplyExact(seconds + 1, 1_000_000_000L);
-        long adjustment = nanos - 1_000_000;
+        long adjustment = nanos - 1_000_000_000L;
 
         return Math.addExact(micros, adjustment);
       } else {

--- a/lang/java/avro/src/test/java/org/apache/avro/data/TestTimeConversions.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/data/TestTimeConversions.java
@@ -33,6 +33,7 @@ import org.apache.avro.data.TimeConversions.TimeMicrosConversion;
 import org.apache.avro.data.TimeConversions.TimeMillisConversion;
 import org.apache.avro.data.TimeConversions.TimestampMicrosConversion;
 import org.apache.avro.data.TimeConversions.TimestampMillisConversion;
+import org.apache.avro.data.TimeConversions.TimestampNanosConversion;
 import org.apache.avro.reflect.ReflectData;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -44,6 +45,7 @@ public class TestTimeConversions {
   public static Schema TIME_MICROS_SCHEMA;
   public static Schema TIMESTAMP_MILLIS_SCHEMA;
   public static Schema TIMESTAMP_MICROS_SCHEMA;
+  public static Schema TIMESTAMP_NANOS_SCHEMA;
 
   @BeforeAll
   public static void createSchemas() {
@@ -53,6 +55,8 @@ public class TestTimeConversions {
     TestTimeConversions.TIMESTAMP_MILLIS_SCHEMA = LogicalTypes.timestampMillis()
         .addToSchema(Schema.create(Schema.Type.LONG));
     TestTimeConversions.TIMESTAMP_MICROS_SCHEMA = LogicalTypes.timestampMicros()
+        .addToSchema(Schema.create(Schema.Type.LONG));
+    TestTimeConversions.TIMESTAMP_NANOS_SCHEMA = LogicalTypes.timestampNanos()
         .addToSchema(Schema.create(Schema.Type.LONG));
   }
 
@@ -189,6 +193,21 @@ public class TestTimeConversions {
     assertEquals(Jul_01_1969_12_00_00_000_123_instant,
         (long) conversion.toLong(Jul_01_1969_12_00_00_000_123, TIMESTAMP_MILLIS_SCHEMA, LogicalTypes.timestampMillis()),
         "Pre 1970 date should be correct");
+  }
+
+  @Test
+  void timestampNanosConversionBeforeEpochWithPositiveNanos() {
+    TimestampNanosConversion conversion = new TimestampNanosConversion();
+
+    // < Epoch
+    long Dec_31_1969_23_59_59_999_999_999_instant = -1L;
+    Instant Dec_31_1969_23_59_59_999_999_999 = ZonedDateTime.of(1969, 12, 31, 23, 59, 59, 999_999_999, ZoneOffset.UTC)
+        .toInstant();
+
+    assertEquals(Dec_31_1969_23_59_59_999_999_999, conversion.fromLong(Dec_31_1969_23_59_59_999_999_999_instant,
+        TIMESTAMP_NANOS_SCHEMA, LogicalTypes.timestampNanos()), "Pre 1970 nanos date should be correct");
+    assertEquals(Dec_31_1969_23_59_59_999_999_999_instant, (long) conversion.toLong(Dec_31_1969_23_59_59_999_999_999,
+        TIMESTAMP_NANOS_SCHEMA, LogicalTypes.timestampNanos()), "Pre 1970 nanos date should be correct");
   }
 
   @Test


### PR DESCRIPTION
<!--

*Thank you very much for contributing to Apache Avro - we are happy that you want to help us improve Avro. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Avro a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/AVRO/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "AVRO-XXXX: [component] Title of the pull request", where *AVRO-XXXX* should be replaced by the actual issue number. 
    The *component* is optional, but can help identify the correct reviewers faster: either the language ("java", "python") or subsystem such as "build" or "doc" are good candidates.  

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests. You can [build the entire project](https://github.com/apache/avro/blob/main/BUILD.md) or just the [language-specific SDK](https://avro.apache.org/project/how-to-contribute/#unit-tests).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Every commit message references Jira issues in their subject lines. In addition, commits follow the guidelines from [How to write a good git commit message](https://chris.beams.io/posts/git-commit/)
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

-->

## What is the purpose of the change

Fixes `TimestampNanosConversion.toLong` for `Instant` values before the Unix epoch with a positive nanosecond component.
The affected code path handles cases where `seconds < 0` and `nanos > 0`. In that branch, the implementation needs to adjust the positive nanosecond component relative to the previous epoch second. 
The previous implementation subtracted `1_000_000`, which is a microsecond-scale constant. Since this conversion handles the `timestamp-nanos` logical type, the adjustment must subtract `1_000_000_000L`, the number of nanoseconds in one second.
For example, `1969-12-31T23:59:59.999999999Z` is one nanosecond before the Unix epoch and should convert to `-1L`. Before this fix, it converted to `998999999L`.
This PR updates the adjustment constant and adds a regression test for the affected pre-epoch nanos case.
Fixes: AVRO-4269

## Verifying this change

This change adds a regression test for timestamp-nanos conversion before the epoch.

This change added tests and can be verified as follows:

- `mvn -Dtest=TestTimeConversions#timestampNanosConversionBeforeEpochWithPositiveNanos test`
- `mvn -Dtest=TestTimeConversions test`

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable