### PR TITLE
reject out-of-range enum index in read_value

### DIFF
--- a/lang/c/src/value-read.c
+++ b/lang/c/src/value-read.c
@@ -329,10 +329,16 @@ read_value(avro_reader_t reader, avro_value_t *dest)
 
 		case AVRO_ENUM:
 		{
+			avro_schema_t  schema = avro_value_get_schema(dest);
 			int64_t  val;
 			check_prefix(rval, avro_binary_encoding.
 				     read_long(reader, &val),
 				     "Cannot read enum value: ");
+			if (val < 0 ||
+			    val >= avro_schema_enum_number_of_symbols(schema)) {
+				avro_set_error("Invalid enum value: %" PRId64, val);
+				return EINVAL;
+			}
 			return avro_value_set_enum(dest, val);
 		}
 

--- a/lang/c/tests/test_avro_values.c
+++ b/lang/c/tests/test_avro_values.c
@@ -965,6 +965,23 @@ test_enum(void)
 		avro_value_decref(&val);
 	}
 
+	/* A symbol index read from the wire that falls outside the declared
+	 * symbols must be rejected, otherwise it is stored as-is and later
+	 * dereferenced by avro_schema_enum_get. */
+	{
+		/* zig-zag long 99 => {0xC6, 0x01}; "suits" has only 4 symbols */
+		char  bad_enum[] = { (char) 0xC6, 0x01 };
+		avro_reader_t  reader =
+		    avro_reader_memory(bad_enum, sizeof(bad_enum));
+		avro_value_t  val;
+		try(avro_generic_value_new(enum_class, &val),
+		    "Cannot create enum");
+		try(!avro_value_read(reader, &val),
+		    "Expected error reading out-of-range enum index");
+		avro_value_decref(&val);
+		avro_reader_free(reader);
+	}
+
 	avro_schema_decref(enum_schema);
 	avro_value_iface_decref(enum_class);
 	return 0;


### PR DESCRIPTION
## What is the purpose of the change

`read_value` reads an enum's symbol index from the wire with `read_long` and stores it through `avro_value_set_enum` without checking it against the schema's symbol count, so a negative or out-of-range index from an untrusted Avro file or datum is kept as-is and later reaches `avro_schema_enum_get`, where an `st_lookup` miss leaves the returned `char *` uninitialized and the json writer dereferences it. The union branch directly above already range-checks its discriminant, and the C++ `ValidatingDecoder` does the same for enums, so apply the matching check and return `EINVAL` before the bad index is stored.

## Verifying this change

This change added tests and can be verified as follows:
- extended the `test_avro_values` enum test to read an out-of-range symbol index (`{0xC6, 0x01}` against a 4-symbol enum); it fails on the unpatched tree and passes with the fix, and the full `ctest` suite stays green

## Documentation

- Does this pull request introduce a new feature? no