### PR TITLE
MINOR: [C++] fix missing format_context when compiled with C++23

### DIFF
--- a/lang/c++/include/avro/Node.hh
+++ b/lang/c++/include/avro/Node.hh
@@ -225,7 +225,8 @@ inline std::ostream &operator<<(std::ostream &os, const avro::Node &n) {
 
 template<>
 struct std::formatter<avro::Name, char> : std::formatter<std::string, char> {
-    auto format(const avro::Name &n, std::format_context &ctx) const {
+    template<typename FormatContext>
+    auto format(const avro::Name &n, FormatContext &ctx) const {
         return std::formatter<std::string, char>::format(n.fullname(), ctx);
     }
 };

--- a/lang/c++/include/avro/Types.hh
+++ b/lang/c++/include/avro/Types.hh
@@ -112,7 +112,8 @@ std::ostream &operator<<(std::ostream &os, const Null &null);
 
 template<>
 struct std::formatter<avro::Type, char> : std::formatter<std::string, char> {
-    auto format(avro::Type t, std::format_context &ctx) const {
+    template<typename FormatContext>
+    auto format(avro::Type t, FormatContext &ctx) const {
         return std::formatter<std::string, char>::format(avro::toString(t), ctx);
     }
 };


### PR DESCRIPTION
## What is the purpose of the change

The fix avoids referring directly to `std::format_context` in the `std::formatter` specializations.

With libc++ 21, `<format>` may expose `std::formatter` before the `std::format_context` alias is visible in this include chain. That made headers like `Types.hh` fail to compile with:

```text
missing '#include <__format/format_context.h>'; 'format_context' must be declared before it is used
```

Instead of depending on libc++’s internal header, the formatter `format` methods now take a templated context:

```cpp
template<typename FormatContext>
auto format(avro::Type t, FormatContext &ctx) const
```

This is the standard formatter pattern: the library supplies the concrete formatting context, and the code no longer needs `std::format_context` to be named at header parse time.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Documentation

- Does this pull request introduce a new feature? no
