### PR TITLE
AVRO-4270: [C] Fix wrong schema accessor in avro_generic_map_class

### DIFF
--- a/lang/c/src/generic.c
+++ b/lang/c/src/generic.c
@@ -2778,7 +2778,7 @@ static avro_generic_value_iface_t  AVRO_GENERIC_MAP_CLASS =
 static avro_generic_value_iface_t *
 avro_generic_map_class(avro_schema_t schema, memoize_state_t *state)
 {
-	avro_schema_t  child_schema = avro_schema_array_items(schema);
+	avro_schema_t  child_schema = avro_schema_map_values(schema);
 	avro_generic_value_iface_t  *child_giface =
 	    avro_generic_class_from_schema_memoized(child_schema, state);
 	if (child_giface == NULL) {


### PR DESCRIPTION
## What is the purpose of the change

`avro_generic_map_class()` in `lang/c/src/generic.c` incorrectly calls
`avro_schema_array_items(schema)` instead of `avro_schema_map_values(schema)`.
This is a copy-paste bug from the array class implementation.

The wrong accessor reinterprets a MAP schema pointer as an ARRAY schema type.
Under UndefinedBehaviorSanitizer with `-fno-sanitize-recover`, this triggers a
fatal diagnostic when processing MAP schemas. Without sanitizers the code
silently returns the correct value today because `avro_array_schema_t` and
`avro_map_schema_t` share the same memory layout, but this is fragile and will
break if the struct layouts diverge.

This pull request fixes AVRO-4270.

## Verifying this change

This change can be verified as follows:

- Built the C library with ASan + UBSan:
  `-fsanitize=address,undefined -fno-sanitize-recover=undefined -g -O1`
- Ran a custom `value_reader_fuzzer` targeting `avro_value_read()` with a PoC
  input that selects a `{"type":"map","values":"string"}` schema
- Before fix: UBSan aborts in the map value initialization path
- After fix: no UBSan diagnostic; input is processed normally

Discovered by FuzzingBrain @O2Lab.

## Documentation

- Does this pull request introduce a new feature? (yes / no)
  **no**
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  **not applicable**