### PR TITLE
AVRO-4271: [ruby] Use json instead of multi_json

### DIFF
--- a/lang/ruby/avro.gemspec
+++ b/lang/ruby/avro.gemspec
@@ -39,5 +39,5 @@ Gem::Specification.new do |s|
   s.test_files = files.select { |f| f.start_with?("test/") }
   s.require_paths = ["lib"]
 
-  s.add_dependency("multi_json", "~> 1.0")
+  s.add_dependency("json", ">= 2.0")
 end

--- a/lang/ruby/avro.gemspec
+++ b/lang/ruby/avro.gemspec
@@ -40,4 +40,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency("json", ">= 2.0")
+  s.add_dependency("bigdecimal") # not part of default gems since Ruby 3.4.0
 end

--- a/lang/ruby/lib/avro.rb
+++ b/lang/ruby/lib/avro.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'multi_json'
+require 'json'
 require 'set'
 require 'digest/md5'
 require 'net/http'

--- a/lang/ruby/lib/avro/protocol.rb
+++ b/lang/ruby/lib/avro/protocol.rb
@@ -23,7 +23,7 @@ module Avro
 
     attr_reader :name, :namespace, :types, :messages, :md5, :doc
     def self.parse(protocol_string)
-      json_data = MultiJson.load(protocol_string)
+      json_data = JSON.parse(protocol_string, create_additions: false, quirks_mode: true)
 
       if json_data.is_a? Hash
         name = json_data['protocol']
@@ -61,7 +61,7 @@ module Avro
     end
 
     def to_s
-      MultiJson.dump to_avro
+      JSON.dump to_avro
     end
 
     def ==(other)
@@ -136,7 +136,7 @@ module Avro
       end
 
       def to_s
-        Yajl.dump to_avro
+        JSON.dump to_avro
       end
 
       def parse_request(request, names)

--- a/lang/ruby/lib/avro/protocol.rb
+++ b/lang/ruby/lib/avro/protocol.rb
@@ -23,7 +23,8 @@ module Avro
 
     attr_reader :name, :namespace, :types, :messages, :md5, :doc
     def self.parse(protocol_string)
-      json_data = JSON.parse(protocol_string, create_additions: false, quirks_mode: true)
+      # `create_additions`` is false by default, quirks_mode no longer existing since json 2.0
+      json_data = JSON.parse(protocol_string)
 
       if json_data.is_a? Hash
         name = json_data['protocol']

--- a/lang/ruby/lib/avro/schema.rb
+++ b/lang/ruby/lib/avro/schema.rb
@@ -42,7 +42,7 @@ module Avro
     DECIMAL_LOGICAL_TYPE = 'decimal'
 
     def self.parse(json_string)
-      real_parse(MultiJson.load(json_string), {})
+      real_parse(JSON.parse(json_string, create_additions: false, quirks_mode: true), {})
     end
 
     # Build Avro Schema from data parsed out of JSON string.
@@ -236,7 +236,7 @@ module Avro
     end
 
     def to_s
-      MultiJson.dump to_avro
+      JSON.dump to_avro
     end
 
     def validate_aliases!

--- a/lang/ruby/lib/avro/schema.rb
+++ b/lang/ruby/lib/avro/schema.rb
@@ -42,7 +42,7 @@ module Avro
     DECIMAL_LOGICAL_TYPE = 'decimal'
 
     def self.parse(json_string)
-      real_parse(JSON.parse(json_string, create_additions: false, quirks_mode: true), {})
+      real_parse(JSON.parse(json_string), {})
     end
 
     # Build Avro Schema from data parsed out of JSON string.

--- a/lang/ruby/lib/avro/schema_normalization.rb
+++ b/lang/ruby/lib/avro/schema_normalization.rb
@@ -26,7 +26,7 @@ module Avro
     end
 
     def to_parsing_form(schema)
-      MultiJson.dump(normalize_schema(schema))
+      JSON.dump(normalize_schema(schema))
     end
 
     private

--- a/lang/ruby/test/test_datafile.rb
+++ b/lang/ruby/test/test_datafile.rb
@@ -109,9 +109,9 @@ JSON
     end
 
     %w[fixed enum record error array map union].each do |s|
-      reader = MultiJson.load(writer_schema)
+      reader = JSON.parse(writer_schema)
       reader['fields'] = reader['fields'].reject{|f| f['type']['type'] == s}
-      Avro::DataFile.open('data.avr', 'r', MultiJson.dump(reader)) do |dr|
+      Avro::DataFile.open('data.avr', 'r', JSON.dump(reader)) do |dr|
         dr.each_with_index do |obj, i|
           reader['fields'].each do |field|
             assert_equal data[i][field['name']], obj[field['name']]

--- a/lang/ruby/test/test_io.rb
+++ b/lang/ruby/test/test_io.rb
@@ -561,8 +561,8 @@ EOS
 
      # test that the round-trip didn't mess up anything
     # NB: I don't think we should do this. Why enforce ordering?
-    assert_equal(MultiJson.load(str),
-                  MultiJson.load(parsed_string))
+    assert_equal(JSON.parse(str, quirks_mode: true),
+                  JSON.parse(parsed_string, quirks_mode: true))
 
     # test __eq__
     assert_equal(schema, Avro::Schema.parse(str))

--- a/lang/ruby/test/test_io.rb
+++ b/lang/ruby/test/test_io.rb
@@ -561,8 +561,7 @@ EOS
 
      # test that the round-trip didn't mess up anything
     # NB: I don't think we should do this. Why enforce ordering?
-    assert_equal(JSON.parse(str, quirks_mode: true),
-                  JSON.parse(parsed_string, quirks_mode: true))
+    assert_equal(JSON.parse(str), JSON.parse(parsed_string))
 
     # test __eq__
     assert_equal(schema, Avro::Schema.parse(str))


### PR DESCRIPTION
## What is the purpose of the change

This resolves AVRO-4271 by switching the Ruby runtime dependency from
`multi_json` to the `json` gem and updating Ruby JSON parsing/generation calls
to use `JSON` directly. It also removes the stale `Yajl.dump` call in protocol
message serialization.

The parsing calls do not pass the obsolete `quirks_mode` option or an explicit
`create_additions: false`, because `quirks_mode` has not been needed since
`json` 2.0 and `JSON.parse` disables additions by default.

This also adds `bigdecimal` as an explicit dependency because it is no longer a
default gem as of Ruby 3.4.

## Verifying this change

This change is already covered by existing tests. The following targeted tests
were run locally:

- `ruby -Ilib:test test/test_schema.rb`
- `ruby -Ilib:test test/test_schema_normalization.rb`
- `ruby -Ilib:test test/test_protocol.rb`
- `ruby -Ilib:test test/test_datafile.rb --name test_differing_schemas_with_complex_objects`
- `ruby -Ilib:test test/test_io.rb --name '/test_(null|boolean|string|bytes|int|long|float|double)/'`

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable
