### PR TITLE
MINOR: [c++] reject lone low surrogate U+DFFF in JSON decoder

### DIFF
--- a/lang/c++/impl/json/JsonIO.cc
+++ b/lang/c++/impl/json/JsonIO.cc
@@ -394,7 +394,7 @@ string JsonParser::decodeString(const string &s, bool binary) {
                             throw Exception("Invalid unicode sequence: {}", string(startSeq, it));
                         }
                         n = 0x10000 + (((n - 0xd800) << 10) | (m - 0xdc00));
-                    } else if (n >= 0xdc00 && n < 0xdfff) {
+                    } else if (n >= 0xdc00 && n <= 0xdfff) {
                         throw Exception("Invalid unicode sequence: {}", string(startSeq, it));
                     }
                     if (n < 0x80) {

--- a/lang/c++/test/JsonTests.cc
+++ b/lang/c++/test/JsonTests.cc
@@ -23,6 +23,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "../impl/json/JsonDom.hh"
+#include "Exception.hh"
 
 namespace avro {
 namespace json {
@@ -175,6 +176,14 @@ static void testObject2() {
     BOOST_CHECK_EQUAL(a[1].stringValue(), "v0");
 }
 
+// A low surrogate that is not preceded by a high surrogate is not a valid
+// code point and must be rejected, including the last one (U+DFFF).
+static void testLoneLowSurrogate() {
+    BOOST_CHECK_THROW(loadEntity(R"("\udc00")").stringValue(), Exception);
+    BOOST_CHECK_THROW(loadEntity(R"("\udffe")").stringValue(), Exception);
+    BOOST_CHECK_THROW(loadEntity(R"("\udfff")").stringValue(), Exception);
+}
+
 } // namespace json
 } // namespace avro
 
@@ -207,6 +216,8 @@ init_unit_test_suite(int /* argc */, char * /* argv */[]) {
     ts->add(BOOST_TEST_CASE(&avro::json::testObject0));
     ts->add(BOOST_TEST_CASE(&avro::json::testObject1));
     ts->add(BOOST_TEST_CASE(&avro::json::testObject2));
+
+    ts->add(BOOST_TEST_CASE(&avro::json::testLoneLowSurrogate));
 
     return ts;
 }


### PR DESCRIPTION
## What is the purpose of the change

`JsonParser::decodeString` rejects unpaired low surrogates, but the range check uses an exclusive upper bound (`n >= 0xdc00 && n < 0xdfff`), so the last low surrogate U+DFFF is not caught. It falls through and is emitted as the 3-byte sequence `ED BF BF`, which is not valid UTF-8 (it encodes a surrogate half). Every other lone low surrogate (U+DC00..U+DFFE) is already rejected. The trailing-surrogate check a few lines above already treats U+DFFF as a valid low surrogate (`m > 0xdfff`), so the lone-surrogate branch is off by one. This makes the bound inclusive so U+DFFF is rejected consistently.

## Verifying this change

This change added tests and can be verified as follows:

- Added a JSON decoder test asserting that a lone low surrogate, including `\udfff`, is rejected. It fails on the current code (U+DFFF is accepted) and passes with the fix.

## Documentation

- Does this pull request introduce a new feature? no
