### PR TITLE
AVRO-4276: [C++] Fix INT64_MIN overflow in doDecodeItemCount()

### DIFF
--- a/lang/c++/impl/BinaryDecoder.cc
+++ b/lang/c++/impl/BinaryDecoder.cc
@@ -163,8 +163,11 @@ size_t BinaryDecoder::arrayStart() {
 size_t BinaryDecoder::doDecodeItemCount() {
     auto result = doDecodeLong();
     if (result < 0) {
+        if (result == INT64_MIN) {
+            throw Exception("Invalid negative block count: {}", result);
+        }
         doDecodeLong();
-        return static_cast<size_t>(-(result + 1)) + 1;
+        return static_cast<size_t>(-result);
     }
     return static_cast<size_t>(result);
 }

--- a/lang/c++/test/CodecTests.cc
+++ b/lang/c++/test/CodecTests.cc
@@ -2145,6 +2145,37 @@ static void testByteCount() {
     BOOST_CHECK_EQUAL(os1->byteCount(), 3);
 }
 
+static void testArrayInt64MinBlockCount() {
+    // INT64_MIN encoded as a zigzag varint is the 10-byte sequence:
+    // FF FF FF FF FF FF FF FF FF 01
+    // When used as an array block count, the decoder should reject it
+    // rather than returning 2^63 as the item count.
+    const uint8_t data[] = {
+        0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0xff, 0x01
+    };
+
+    InputStreamPtr is = memoryInputStream(data, sizeof(data));
+    DecoderPtr d = binaryDecoder();
+    d->init(*is);
+
+    BOOST_CHECK_THROW(d->arrayStart(), Exception);
+}
+
+static void testMapInt64MinBlockCount() {
+    // Same INT64_MIN varint, but as a map block count.
+    const uint8_t data[] = {
+        0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0xff, 0x01
+    };
+
+    InputStreamPtr is = memoryInputStream(data, sizeof(data));
+    DecoderPtr d = binaryDecoder();
+    d->init(*is);
+
+    BOOST_CHECK_THROW(d->mapStart(), Exception);
+}
+
 } // namespace avro
 
 boost::unit_test::test_suite *
@@ -2161,6 +2192,8 @@ init_unit_test_suite(int, char *[]) {
     ts->add(BOOST_TEST_CASE(avro::testJsonCodecReinit));
     ts->add(BOOST_TEST_CASE(avro::testArrayNegativeBlockCount));
     ts->add(BOOST_TEST_CASE(avro::testByteCount));
+    ts->add(BOOST_TEST_CASE(avro::testArrayInt64MinBlockCount));
+    ts->add(BOOST_TEST_CASE(avro::testMapInt64MinBlockCount));
 
     return ts;
 }


### PR DESCRIPTION
## Summary

Fix signed integer overflow in `BinaryDecoder::doDecodeItemCount()` when the decoded block count equals `INT64_MIN`.

## Problem

The existing negation idiom `-(result + 1) + 1` still overflows on the final `+ 1` when `result == INT64_MIN` (since `-INT64_MIN` is not representable in `int64_t`). This is undefined behavior in C++ and could result in the decoder returning `2^63` as the item count for both arrays and maps.

## Fix

- Add an explicit guard: if `result == INT64_MIN`, throw an `Exception` immediately.
- For all other negative values, use simple `-result` which is well-defined.

## Tests

Added two new test cases:
- `testArrayInt64MinBlockCount` — verifies `arrayStart()` throws on a zigzag-encoded `INT64_MIN` block count.
- `testMapInt64MinBlockCount` — verifies `mapStart()` throws on the same input.

This is the C++ counterpart to the C fix in commit 271de63230.