### PR TITLE
AVRO-4278: [c++] Bound collection size when decoding arrays and maps

### DIFF
--- a/lang/c++/impl/Generic.cc
+++ b/lang/c++/impl/Generic.cc
@@ -17,6 +17,8 @@
  */
 
 #include "Generic.hh"
+#include <cerrno>
+#include <cstdlib>
 #include <utility>
 
 namespace avro {
@@ -26,6 +28,41 @@ using std::string;
 using std::vector;
 
 typedef vector<uint8_t> bytes;
+
+namespace {
+
+// The block count of an array or map is read from the (potentially untrusted or
+// truncated) input and drives allocation of the resulting collection. To guard
+// against unbounded memory allocation from a very large or malformed block
+// count, the number of items in a single decoded array or map is capped. This
+// mirrors the Java SDK's collection item limit. The default can be overridden
+// with the AVRO_MAX_COLLECTION_ITEMS environment variable.
+constexpr size_t DEFAULT_MAX_COLLECTION_ITEMS = (size_t(1) << 31) - 8; // 2^31 - 8
+
+size_t maxCollectionItems() {
+    const char *env = std::getenv("AVRO_MAX_COLLECTION_ITEMS");
+    if (env != nullptr && *env != '\0') {
+        errno = 0;
+        char *end = nullptr;
+        unsigned long long value = std::strtoull(env, &end, 10);
+        if (errno == 0 && end != nullptr && *end == '\0' && value > 0) {
+            return static_cast<size_t>(value);
+        }
+    }
+    return DEFAULT_MAX_COLLECTION_ITEMS;
+}
+
+// Ensure that adding `items` more elements to a collection that already holds
+// `existing` elements would not exceed the configured maximum, before the
+// collection is grown to accommodate them.
+void checkCollectionItems(size_t existing, size_t items) {
+    const size_t limit = maxCollectionItems();
+    if (existing > limit || items > limit - existing) {
+        throw Exception("Cannot read collections larger than {} items", limit);
+    }
+}
+
+} // anonymous namespace
 
 void GenericContainer::assertType(const NodePtr &schema, Type type) {
     if (schema->type() != type) {
@@ -106,6 +143,7 @@ void GenericReader::read(GenericDatum &datum, Decoder &d, bool isResolving) {
             r.resize(0);
             size_t start = 0;
             for (size_t m = d.arrayStart(); m != 0; m = d.arrayNext()) {
+                checkCollectionItems(r.size(), m);
                 r.resize(r.size() + m);
                 for (; start < r.size(); ++start) {
                     r[start] = GenericDatum(nn);
@@ -120,6 +158,7 @@ void GenericReader::read(GenericDatum &datum, Decoder &d, bool isResolving) {
             r.resize(0);
             size_t start = 0;
             for (size_t m = d.mapStart(); m != 0; m = d.mapNext()) {
+                checkCollectionItems(r.size(), m);
                 r.resize(r.size() + m);
                 for (; start < r.size(); ++start) {
                     d.decodeString(r[start].first);

--- a/lang/c++/impl/Generic.cc
+++ b/lang/c++/impl/Generic.cc
@@ -19,6 +19,7 @@
 #include "Generic.hh"
 #include <cerrno>
 #include <cstdlib>
+#include <limits>
 #include <utility>
 
 namespace avro {
@@ -42,10 +43,19 @@ constexpr size_t DEFAULT_MAX_COLLECTION_ITEMS = (size_t(1) << 31) - 8; // 2^31 -
 size_t maxCollectionItems() {
     const char *env = std::getenv("AVRO_MAX_COLLECTION_ITEMS");
     if (env != nullptr && *env != '\0') {
+        // Accept only a run of decimal digits: strtoull would otherwise accept a
+        // leading '-' (wrapping to a huge value) or '+', effectively disabling
+        // the limit.
+        for (const char *p = env; *p != '\0'; ++p) {
+            if (*p < '0' || *p > '9') {
+                return DEFAULT_MAX_COLLECTION_ITEMS;
+            }
+        }
         errno = 0;
         char *end = nullptr;
         unsigned long long value = std::strtoull(env, &end, 10);
-        if (errno == 0 && end != nullptr && *end == '\0' && value > 0) {
+        if (errno == 0 && end != nullptr && *end == '\0' && value > 0 &&
+            value <= std::numeric_limits<size_t>::max()) {
             return static_cast<size_t>(value);
         }
     }

--- a/lang/c++/test/CodecTests.cc
+++ b/lang/c++/test/CodecTests.cc
@@ -27,6 +27,7 @@
 
 #include <boost/bind/bind.hpp>
 #include <cstdint>
+#include <cstdlib>
 #include <functional>
 #include <stack>
 #include <string>
@@ -2145,6 +2146,73 @@ static void testByteCount() {
     BOOST_CHECK_EQUAL(os1->byteCount(), 3);
 }
 
+// AVRO-4278: the block count of an array or map is read from the input and
+// drives allocation of the resulting collection in GenericReader::read(). A
+// very large or malformed block count must be rejected rather than eagerly
+// resizing the collection. These tests cap the limit via the
+// AVRO_MAX_COLLECTION_ITEMS environment variable.
+
+static GenericDatum decodeNullCollection(const char *schemaJson,
+                                         const uint8_t *data, size_t len) {
+    ValidSchema vs = parsing::makeValidSchema(schemaJson);
+    InputStreamPtr is = memoryInputStream(data, len);
+    DecoderPtr d = binaryDecoder();
+    d->init(*is);
+    GenericDatum datum(vs);
+    GenericReader::read(*d, datum);
+    return datum;
+}
+
+static void setCollectionLimit(const char *value) {
+#ifdef _WIN32
+    _putenv_s("AVRO_MAX_COLLECTION_ITEMS", value);
+#else
+    setenv("AVRO_MAX_COLLECTION_ITEMS", value, 1);
+#endif
+}
+
+static void testArrayBlockCountIsBounded() {
+    setCollectionLimit("10");
+    const char *schema = R"({"type": "array", "items": "null"})";
+
+    // A single block declaring 11 items (zigzag(11) = 0x16) exceeds the limit
+    // of 10 and must be rejected before the vector is resized. The null items
+    // occupy no bytes, so a tiny input could otherwise drive a huge allocation.
+    const uint8_t overLimit[] = {0x16, 0x00};
+    BOOST_CHECK_THROW(decodeNullCollection(schema, overLimit, sizeof(overLimit)),
+                      Exception);
+
+    // Two blocks of 6 items (zigzag(6) = 0x0c) exceed the limit cumulatively
+    // even though neither block does on its own.
+    const uint8_t cumulative[] = {0x0c, 0x0c};
+    BOOST_CHECK_THROW(decodeNullCollection(schema, cumulative, sizeof(cumulative)),
+                      Exception);
+
+    // A negative count (zigzag(-11) = 0x15) uses its absolute value (11) as the
+    // item count and is followed by a block byte-size (0x00). It must still be
+    // bounded.
+    const uint8_t negative[] = {0x15, 0x00};
+    BOOST_CHECK_THROW(decodeNullCollection(schema, negative, sizeof(negative)),
+                      Exception);
+
+    // Three items (zigzag(3) = 0x06) then the end-of-array marker (0x00) is
+    // within the limit and decodes successfully.
+    const uint8_t withinLimit[] = {0x06, 0x00};
+    GenericDatum datum =
+        decodeNullCollection(schema, withinLimit, sizeof(withinLimit));
+    BOOST_CHECK_EQUAL(datum.value<GenericArray>().value().size(), 3u);
+}
+
+static void testMapBlockCountIsBounded() {
+    setCollectionLimit("10");
+    const char *schema = R"({"type": "map", "values": "null"})";
+
+    // Block count 11 (zigzag = 0x16) exceeds the limit of 10.
+    const uint8_t overLimit[] = {0x16, 0x00};
+    BOOST_CHECK_THROW(decodeNullCollection(schema, overLimit, sizeof(overLimit)),
+                      Exception);
+}
+
 } // namespace avro
 
 boost::unit_test::test_suite *
@@ -2161,6 +2229,8 @@ init_unit_test_suite(int, char *[]) {
     ts->add(BOOST_TEST_CASE(avro::testJsonCodecReinit));
     ts->add(BOOST_TEST_CASE(avro::testArrayNegativeBlockCount));
     ts->add(BOOST_TEST_CASE(avro::testByteCount));
+    ts->add(BOOST_TEST_CASE(avro::testArrayBlockCountIsBounded));
+    ts->add(BOOST_TEST_CASE(avro::testMapBlockCountIsBounded));
 
     return ts;
 }

--- a/lang/c++/test/CodecTests.cc
+++ b/lang/c++/test/CodecTests.cc
@@ -2171,8 +2171,35 @@ static void setCollectionLimit(const char *value) {
 #endif
 }
 
+// Sets AVRO_MAX_COLLECTION_ITEMS for the current scope and restores the previous
+// value (or unsets it) on destruction so tests do not interfere with each other
+// or with other tests running in the same process.
+struct CollectionLimitGuard {
+    std::string previous_;
+    bool had_;
+    explicit CollectionLimitGuard(const char *value) {
+        const char *p = std::getenv("AVRO_MAX_COLLECTION_ITEMS");
+        had_ = (p != nullptr);
+        if (had_) {
+            previous_ = p;
+        }
+        setCollectionLimit(value);
+    }
+    ~CollectionLimitGuard() {
+        if (had_) {
+            setCollectionLimit(previous_.c_str());
+        } else {
+#ifdef _WIN32
+            _putenv_s("AVRO_MAX_COLLECTION_ITEMS", "");
+#else
+            unsetenv("AVRO_MAX_COLLECTION_ITEMS");
+#endif
+        }
+    }
+};
+
 static void testArrayBlockCountIsBounded() {
-    setCollectionLimit("10");
+    CollectionLimitGuard guard("10");
     const char *schema = R"({"type": "array", "items": "null"})";
 
     // A single block declaring 11 items (zigzag(11) = 0x16) exceeds the limit
@@ -2204,13 +2231,35 @@ static void testArrayBlockCountIsBounded() {
 }
 
 static void testMapBlockCountIsBounded() {
-    setCollectionLimit("10");
+    CollectionLimitGuard guard("10");
     const char *schema = R"({"type": "map", "values": "null"})";
 
-    // Block count 11 (zigzag = 0x16) exceeds the limit of 10.
+    // A single block of 11 pairs (zigzag(11) = 0x16) exceeds the limit of 10.
     const uint8_t overLimit[] = {0x16, 0x00};
     BOOST_CHECK_THROW(decodeNullCollection(schema, overLimit, sizeof(overLimit)),
                       Exception);
+
+    // Two blocks of 6 pairs each (zigzag(6) = 0x0c), all keyed "a"
+    // (key string = 0x02 0x61, null value = no bytes), exceed the limit
+    // cumulatively. This also confirms repeated keys are counted per pair.
+    const uint8_t cumulative[] = {
+        0x0c, 0x02, 0x61, 0x02, 0x61, 0x02, 0x61,
+        0x02, 0x61, 0x02, 0x61, 0x02, 0x61, 0x0c};
+    BOOST_CHECK_THROW(decodeNullCollection(schema, cumulative, sizeof(cumulative)),
+                      Exception);
+
+    // A negative count (zigzag(-11) = 0x15) followed by a block byte-size (0x00)
+    // uses its absolute value (11) and must still be bounded.
+    const uint8_t negative[] = {0x15, 0x00};
+    BOOST_CHECK_THROW(decodeNullCollection(schema, negative, sizeof(negative)),
+                      Exception);
+
+    // Three pairs (zigzag(3) = 0x06) with distinct keys "a", "b", "c" then the
+    // end-of-map marker (0x00) is within the limit and decodes successfully.
+    const uint8_t withinLimit[] = {0x06, 0x02, 0x61, 0x02, 0x62, 0x02, 0x63, 0x00};
+    GenericDatum datum =
+        decodeNullCollection(schema, withinLimit, sizeof(withinLimit));
+    BOOST_CHECK_EQUAL(datum.value<GenericMap>().value().size(), 3u);
 }
 
 } // namespace avro


### PR DESCRIPTION
## What is the purpose of the change

`GenericReader::read()` decodes arrays and maps by calling
`r.resize(r.size() + m)`, where `m` is the block count returned by
`Decoder::arrayStart()` / `mapStart()` / `arrayNext()` / `mapNext()`. Because the
block count is read from the (potentially untrusted or truncated) input, a very
large or malformed count could eagerly allocate an unbounded vector before any
element is read (items such as `null` occupy no bytes on the wire).

This validates the block count — per block and cumulatively — against a
configurable maximum before resizing, mirroring the Java SDK's collection item
limit (`org.apache.avro.limits.collectionItems.maxLength`, AVRO-3819). The limit
defaults to `2^31 - 8` items and can be overridden with the
`AVRO_MAX_COLLECTION_ITEMS` environment variable. Exceeding it throws an
`avro::Exception` before allocating.

This is part of the umbrella issue AVRO-4277.

## Verifying this change

This change added tests and can be verified as follows:

- Added `testArrayBlockCountIsBounded` and `testMapBlockCountIsBounded` in
  `lang/c++/test/CodecTests.cc` covering: a single block count above the limit
  (array and map), a cumulative limit across blocks, a negative block count
  bounded by its absolute value, and a within-limit collection still decoding
  correctly.
- Run: `ctest -R CodecTests` (852 cases pass)

## Documentation

- Does this pull request introduce a new feature? (no — hardening/robustness)
- If yes, how is the feature documented? (not applicable; the new
  `AVRO_MAX_COLLECTION_ITEMS` environment variable is documented in code comments)
