### PR TITLE
AVRO-4290: [python] Enforce a maximum decompressed block size

### DIFF
--- a/lang/py/avro/codecs.py
+++ b/lang/py/avro/codecs.py
@@ -201,10 +201,29 @@ if has_bzip2:
             length = readers_decoder.read_long()
             data = readers_decoder.read(length)
             limit = _max_decompress_length()
+            uncompressed = bytearray()
             decompressor = bz2.BZ2Decompressor()
-            uncompressed = decompressor.decompress(data, limit + 1)
-            if len(uncompressed) > limit:
-                _raise_decompression_too_large(limit)
+            input_data = data
+            while True:
+                # Request enough to detect exceeding the limit without allocating
+                # the full (potentially huge) output.
+                want = limit + 1 - len(uncompressed)
+                if want <= 0:
+                    want = 1
+                uncompressed += decompressor.decompress(input_data, want)
+                input_data = b""  # subsequent calls drain buffered output
+                if len(uncompressed) > limit:
+                    _raise_decompression_too_large(limit)
+                if decompressor.eof:
+                    # Handle concatenated bzip2 streams as bz2.decompress does.
+                    input_data = decompressor.unused_data
+                    if not input_data:
+                        break
+                    decompressor = bz2.BZ2Decompressor()
+                elif decompressor.needs_input:
+                    # All input consumed but the stream did not end: truncated or corrupt.
+                    raise avro.errors.InvalidAvroBinaryEncoding("Truncated or corrupt bzip2 block")
+                # otherwise output was capped for this call; loop to drain more
             return avro.io.BinaryDecoder(io.BytesIO(uncompressed))
 
 

--- a/lang/py/avro/codecs.py
+++ b/lang/py/avro/codecs.py
@@ -29,6 +29,7 @@ converting charsets (https://docs.python.org/3/library/codecs.html).
 import abc
 import binascii
 import io
+import os
 import struct
 import zlib
 from typing import Dict, Tuple, Type
@@ -40,6 +41,55 @@ import avro.io
 # Constants
 #
 STRUCT_CRC32 = struct.Struct(">I")  # big-endian unsigned int
+
+# Name of the environment variable used to override the default maximum size of
+# a single decompressed data-file block.
+MAX_DECOMPRESS_LENGTH_ENV = "AVRO_MAX_DECOMPRESS_LENGTH"
+
+# Default upper bound, in bytes, on the size a single data-file block may
+# decompress to. A block with a very high compression ratio (or a malformed
+# block) can otherwise expand to far more memory than its compressed size.
+# Reading a block that would decompress beyond this limit raises an
+# :class:`avro.errors.AvroDecompressionSizeException`. This mirrors the Java
+# SDK's ``org.apache.avro.limits.decompress.maxLength`` limit (AVRO-4247). The
+# default may be overridden with the ``AVRO_MAX_DECOMPRESS_LENGTH`` environment
+# variable.
+DEFAULT_MAX_DECOMPRESS_LENGTH = 200 * 1024 * 1024  # 200 MiB
+
+
+def _max_decompress_length() -> int:
+    """Return the maximum decompressed block size, honoring the environment override."""
+    value = os.environ.get(MAX_DECOMPRESS_LENGTH_ENV)
+    if value is None:
+        return DEFAULT_MAX_DECOMPRESS_LENGTH
+    try:
+        parsed = int(value)
+    except ValueError:
+        return DEFAULT_MAX_DECOMPRESS_LENGTH
+    return parsed if parsed > 0 else DEFAULT_MAX_DECOMPRESS_LENGTH
+
+
+def _raise_decompression_too_large(limit: int) -> None:
+    raise avro.errors.AvroDecompressionSizeException(f"Decompressed block size exceeds the maximum allowed of {limit} bytes")
+
+
+def _snappy_uncompressed_length(data: bytes) -> "int | None":
+    """Return the uncompressed length declared in a raw Snappy block header.
+
+    The Snappy format prefixes the compressed data with the uncompressed length
+    encoded as a little-endian base-128 varint. Returns ``None`` if the header
+    cannot be parsed.
+    """
+    result = 0
+    shift = 0
+    for byte in data:
+        result |= (byte & 0x7F) << shift
+        if not (byte & 0x80):
+            return result
+        shift += 7
+        if shift > 63:
+            break
+    return None
 
 
 def _check_crc32(bytes_: bytes, checksum: bytes) -> None:
@@ -123,7 +173,16 @@ class DeflateCodec(Codec):
         data = readers_decoder.read_bytes()
         # -15 is the log of the window size; negative indicates
         # "raw" (no zlib headers) decompression.  See zlib.h.
-        uncompressed = zlib.decompress(data, -15)
+        limit = _max_decompress_length()
+        decompressor = zlib.decompressobj(-15)
+        # Request at most limit + 1 bytes so that an over-large block is detected
+        # without allocating the whole (potentially huge) output.
+        uncompressed = decompressor.decompress(data, limit + 1)
+        if len(uncompressed) > limit:
+            _raise_decompression_too_large(limit)
+        uncompressed += decompressor.flush()
+        if len(uncompressed) > limit:
+            _raise_decompression_too_large(limit)
         return avro.io.BinaryDecoder(io.BytesIO(uncompressed))
 
 
@@ -139,7 +198,11 @@ if has_bzip2:
         def decompress(readers_decoder: avro.io.BinaryDecoder) -> avro.io.BinaryDecoder:
             length = readers_decoder.read_long()
             data = readers_decoder.read(length)
-            uncompressed = bz2.decompress(data)
+            limit = _max_decompress_length()
+            decompressor = bz2.BZ2Decompressor()
+            uncompressed = decompressor.decompress(data, limit + 1)
+            if len(uncompressed) > limit:
+                _raise_decompression_too_large(limit)
             return avro.io.BinaryDecoder(io.BytesIO(uncompressed))
 
 
@@ -158,7 +221,15 @@ if has_snappy:
             # Compressed data includes a 4-byte CRC32 checksum
             length = readers_decoder.read_long()
             data = readers_decoder.read(length - 4)
+            limit = _max_decompress_length()
+            # The Snappy block header declares the uncompressed length as a
+            # varint; reject an over-large block before allocating for it.
+            declared = _snappy_uncompressed_length(data)
+            if declared is not None and declared > limit:
+                _raise_decompression_too_large(limit)
             uncompressed = snappy.decompress(data)
+            if len(uncompressed) > limit:
+                _raise_decompression_too_large(limit)
             checksum = readers_decoder.read(4)
             _check_crc32(uncompressed, checksum)
             return avro.io.BinaryDecoder(io.BytesIO(uncompressed))
@@ -176,6 +247,7 @@ if has_zstandard:
         def decompress(readers_decoder: avro.io.BinaryDecoder) -> avro.io.BinaryDecoder:
             length = readers_decoder.read_long()
             data = readers_decoder.read(length)
+            limit = _max_decompress_length()
             uncompressed = bytearray()
             dctx = zstd.ZstdDecompressor()
             with dctx.stream_reader(io.BytesIO(data)) as reader:
@@ -184,6 +256,8 @@ if has_zstandard:
                     if not chunk:
                         break
                     uncompressed.extend(chunk)
+                    if len(uncompressed) > limit:
+                        _raise_decompression_too_large(limit)
             return avro.io.BinaryDecoder(io.BytesIO(uncompressed))
 
 

--- a/lang/py/avro/codecs.py
+++ b/lang/py/avro/codecs.py
@@ -175,14 +175,23 @@ class DeflateCodec(Codec):
         # "raw" (no zlib headers) decompression.  See zlib.h.
         limit = _max_decompress_length()
         decompressor = zlib.decompressobj(-15)
-        # Request at most limit + 1 bytes so that an over-large block is detected
-        # without allocating the whole (potentially huge) output. Accumulate into
-        # a bytearray so the flush() output is appended in place rather than
-        # creating an extra full-size copy of the already-decompressed data.
-        uncompressed = bytearray(decompressor.decompress(data, limit + 1))
-        if len(uncompressed) > limit:
-            _raise_decompression_too_large(limit)
-        uncompressed += decompressor.flush()
+        # Decompress in bounded steps: request at most (limit + 1 - produced)
+        # bytes each call so the accumulated output can never exceed the limit by
+        # more than one byte before being rejected. decompress()'s max_length
+        # leaves unconsumed input in unconsumed_tail, and flush() would otherwise
+        # emit the remainder unbounded, so drain the tail in a loop and bound the
+        # final flush too.
+        uncompressed = bytearray()
+        pending = data
+        while True:
+            want = limit + 1 - len(uncompressed)
+            uncompressed += decompressor.decompress(pending, want)
+            if len(uncompressed) > limit:
+                _raise_decompression_too_large(limit)
+            pending = decompressor.unconsumed_tail
+            if not pending:
+                break
+        uncompressed += decompressor.flush(limit + 1 - len(uncompressed))
         if len(uncompressed) > limit:
             _raise_decompression_too_large(limit)
         if not decompressor.eof:

--- a/lang/py/avro/codecs.py
+++ b/lang/py/avro/codecs.py
@@ -185,6 +185,10 @@ class DeflateCodec(Codec):
         uncompressed += decompressor.flush()
         if len(uncompressed) > limit:
             _raise_decompression_too_large(limit)
+        if not decompressor.eof:
+            # The end-of-stream marker was not reached: the block is truncated or
+            # corrupt. zlib.decompress() used to raise for this; preserve that.
+            raise avro.errors.InvalidAvroBinaryEncoding("Truncated or corrupt deflate block")
         return avro.io.BinaryDecoder(io.BytesIO(uncompressed))
 
 
@@ -241,6 +245,10 @@ if has_snappy:
         def decompress(readers_decoder: avro.io.BinaryDecoder) -> avro.io.BinaryDecoder:
             # Compressed data includes a 4-byte CRC32 checksum
             length = readers_decoder.read_long()
+            if length < 4:
+                raise avro.errors.InvalidAvroBinaryEncoding(
+                    f"Invalid snappy block length {length}: must be at least 4 bytes for the trailing CRC32 checksum"
+                )
             data = readers_decoder.read(length - 4)
             limit = _max_decompress_length()
             # The Snappy block header declares the uncompressed length as a

--- a/lang/py/avro/codecs.py
+++ b/lang/py/avro/codecs.py
@@ -30,6 +30,7 @@ import abc
 import binascii
 import io
 import os
+import sys
 import struct
 import zlib
 from typing import Dict, Tuple, Type
@@ -66,7 +67,13 @@ def _max_decompress_length() -> int:
         parsed = int(value)
     except ValueError:
         return DEFAULT_MAX_DECOMPRESS_LENGTH
-    return parsed if parsed > 0 else DEFAULT_MAX_DECOMPRESS_LENGTH
+    if parsed <= 0:
+        return DEFAULT_MAX_DECOMPRESS_LENGTH
+    # Clamp to sys.maxsize so the value stays a valid Py_ssize_t: it is passed as
+    # the max_length to zlib/bz2 decompress(), which raise OverflowError for a
+    # value that does not fit. sys.maxsize is already far larger than any real
+    # block, so clamping only affects absurd overrides.
+    return min(parsed, sys.maxsize)
 
 
 def _raise_decompression_too_large(limit: int) -> None:

--- a/lang/py/avro/codecs.py
+++ b/lang/py/avro/codecs.py
@@ -176,8 +176,10 @@ class DeflateCodec(Codec):
         limit = _max_decompress_length()
         decompressor = zlib.decompressobj(-15)
         # Request at most limit + 1 bytes so that an over-large block is detected
-        # without allocating the whole (potentially huge) output.
-        uncompressed = decompressor.decompress(data, limit + 1)
+        # without allocating the whole (potentially huge) output. Accumulate into
+        # a bytearray so the flush() output is appended in place rather than
+        # creating an extra full-size copy of the already-decompressed data.
+        uncompressed = bytearray(decompressor.decompress(data, limit + 1))
         if len(uncompressed) > limit:
             _raise_decompression_too_large(limit)
         uncompressed += decompressor.flush()
@@ -255,9 +257,10 @@ if has_zstandard:
                     chunk = reader.read(16384)
                     if not chunk:
                         break
-                    uncompressed.extend(chunk)
-                    if len(uncompressed) > limit:
+                    # Check before extending so the buffer never grows past the limit.
+                    if len(uncompressed) + len(chunk) > limit:
                         _raise_decompression_too_large(limit)
+                    uncompressed.extend(chunk)
             return avro.io.BinaryDecoder(io.BytesIO(uncompressed))
 
 

--- a/lang/py/avro/codecs.py
+++ b/lang/py/avro/codecs.py
@@ -80,6 +80,18 @@ def _raise_decompression_too_large(limit: int) -> None:
     raise avro.errors.AvroDecompressionSizeException(f"Decompressed block size exceeds the maximum allowed of {limit} bytes")
 
 
+def _decompress_read_ceiling(limit: int) -> int:
+    """Return limit + 1 (one byte past the limit, to detect an over-limit block),
+    but never exceeding sys.maxsize so the value stays a valid Py_ssize_t.
+
+    zlib/bz2 decompress() raise OverflowError for a max_length above Py_ssize_t.
+    When the limit is already sys.maxsize (an oversized env override, clamped by
+    _max_decompress_length), no realistic block can exceed it, so returning
+    sys.maxsize instead of sys.maxsize + 1 is safe.
+    """
+    return limit if limit >= sys.maxsize else limit + 1
+
+
 def _snappy_uncompressed_length(data: bytes) -> "int | None":
     """Return the uncompressed length declared in a raw Snappy block header.
 
@@ -188,17 +200,18 @@ class DeflateCodec(Codec):
         # leaves unconsumed input in unconsumed_tail, and flush() would otherwise
         # emit the remainder unbounded, so drain the tail in a loop and bound the
         # final flush too.
+        ceiling = _decompress_read_ceiling(limit)
         uncompressed = bytearray()
         pending = data
         while True:
-            want = limit + 1 - len(uncompressed)
+            want = ceiling - len(uncompressed)
             uncompressed += decompressor.decompress(pending, want)
             if len(uncompressed) > limit:
                 _raise_decompression_too_large(limit)
             pending = decompressor.unconsumed_tail
             if not pending:
                 break
-        uncompressed += decompressor.flush(limit + 1 - len(uncompressed))
+        uncompressed += decompressor.flush(ceiling - len(uncompressed))
         if len(uncompressed) > limit:
             _raise_decompression_too_large(limit)
         if not decompressor.eof:
@@ -221,13 +234,14 @@ if has_bzip2:
             length = readers_decoder.read_long()
             data = readers_decoder.read(length)
             limit = _max_decompress_length()
+            ceiling = _decompress_read_ceiling(limit)
             uncompressed = bytearray()
             decompressor = bz2.BZ2Decompressor()
             input_data = data
             while True:
                 # Request enough to detect exceeding the limit without allocating
                 # the full (potentially huge) output.
-                want = limit + 1 - len(uncompressed)
+                want = ceiling - len(uncompressed)
                 if want <= 0:
                     want = 1
                 uncompressed += decompressor.decompress(input_data, want)

--- a/lang/py/avro/errors.py
+++ b/lang/py/avro/errors.py
@@ -83,6 +83,14 @@ class AvroOutOfScaleException(AvroTypeException):
         return super().__init__(f"The exponent of {datum}, {exponent}, is too large for the schema scale of {scale}")
 
 
+class AvroDecompressionSizeException(AvroException):
+    """Raised when a data-file block decompresses to more than the configured maximum.
+
+    This guards against unbounded memory allocation when a highly compressible
+    (or malformed) block would expand to far more than its compressed size.
+    """
+
+
 class SchemaResolutionException(AvroException):
     def __init__(self, fail_msg, writers_schema=None, readers_schema=None, *args):
         writers_message = f"\nWriter's Schema: {_safe_pretty(writers_schema)}" if writers_schema else ""

--- a/lang/py/avro/test/test_codecs.py
+++ b/lang/py/avro/test/test_codecs.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+
+##
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests that data-file block decompression enforces a maximum output size.
+
+A block with a very high compression ratio (or a malformed block) can expand to
+far more memory than its compressed size; these tests ensure that decompressing
+such a block raises an error instead of allocating without bound.
+"""
+
+import io
+import os
+import unittest
+from typing import Type
+
+import avro.codecs
+import avro.errors
+import avro.io
+
+
+class TestDecompressionSizeLimit(unittest.TestCase):
+    LIMIT = 1024
+
+    def setUp(self) -> None:
+        self._previous = os.environ.get(avro.codecs.MAX_DECOMPRESS_LENGTH_ENV)
+        os.environ[avro.codecs.MAX_DECOMPRESS_LENGTH_ENV] = str(self.LIMIT)
+
+    def tearDown(self) -> None:
+        if self._previous is None:
+            os.environ.pop(avro.codecs.MAX_DECOMPRESS_LENGTH_ENV, None)
+        else:
+            os.environ[avro.codecs.MAX_DECOMPRESS_LENGTH_ENV] = self._previous
+
+    def _decoder_for(self, codec: Type[avro.codecs.Codec], data: bytes) -> avro.io.BinaryDecoder:
+        """Compress `data` with the codec and wrap it as a data-file block."""
+        compressed, _ = codec.compress(data)
+        buffer = io.BytesIO()
+        encoder = avro.io.BinaryEncoder(buffer)
+        encoder.write_long(len(compressed))
+        buffer.write(compressed)
+        return avro.io.BinaryDecoder(io.BytesIO(buffer.getvalue()))
+
+    def _assert_over_limit_rejected(self, codec: Type[avro.codecs.Codec]) -> None:
+        # A block of zeros far larger than the limit but that compresses tiny.
+        decoder = self._decoder_for(codec, b"\x00" * (self.LIMIT * 8))
+        with self.assertRaises(avro.errors.AvroDecompressionSizeException):
+            codec.decompress(decoder)
+
+    def _assert_within_limit_ok(self, codec: Type[avro.codecs.Codec]) -> None:
+        payload = b"the quick brown fox " * 10  # well under the limit
+        decoder = self._decoder_for(codec, payload)
+        self.assertEqual(payload, codec.decompress(decoder).reader.read())
+
+    def test_deflate_over_limit(self) -> None:
+        self._assert_over_limit_rejected(avro.codecs.DeflateCodec)
+
+    def test_deflate_within_limit(self) -> None:
+        self._assert_within_limit_ok(avro.codecs.DeflateCodec)
+
+    @unittest.skipUnless(avro.codecs.has_bzip2, "bzip2 not available")
+    def test_bzip2_over_limit(self) -> None:
+        self._assert_over_limit_rejected(avro.codecs.BZip2Codec)
+
+    @unittest.skipUnless(avro.codecs.has_bzip2, "bzip2 not available")
+    def test_bzip2_within_limit(self) -> None:
+        self._assert_within_limit_ok(avro.codecs.BZip2Codec)
+
+    @unittest.skipUnless(avro.codecs.has_snappy, "snappy not available")
+    def test_snappy_over_limit(self) -> None:
+        self._assert_over_limit_rejected(avro.codecs.SnappyCodec)
+
+    @unittest.skipUnless(avro.codecs.has_snappy, "snappy not available")
+    def test_snappy_within_limit(self) -> None:
+        self._assert_within_limit_ok(avro.codecs.SnappyCodec)
+
+    @unittest.skipUnless(avro.codecs.has_zstandard, "zstandard not available")
+    def test_zstandard_over_limit(self) -> None:
+        self._assert_over_limit_rejected(avro.codecs.ZstandardCodec)
+
+    @unittest.skipUnless(avro.codecs.has_zstandard, "zstandard not available")
+    def test_zstandard_within_limit(self) -> None:
+        self._assert_within_limit_ok(avro.codecs.ZstandardCodec)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lang/py/avro/test/test_codecs.py
+++ b/lang/py/avro/test/test_codecs.py
@@ -81,6 +81,19 @@ class TestDecompressionSizeLimit(unittest.TestCase):
     def test_bzip2_within_limit(self) -> None:
         self._assert_within_limit_ok(avro.codecs.BZip2Codec)
 
+    @unittest.skipUnless(avro.codecs.has_bzip2, "bzip2 not available")
+    def test_bzip2_truncated_block_rejected(self) -> None:
+        """A truncated bzip2 block must be rejected rather than silently accepted."""
+        compressed, _ = avro.codecs.BZip2Codec.compress(b"the quick brown fox " * 10)
+        truncated = compressed[:-4]  # drop the tail so the stream never reaches EOF
+        buffer = io.BytesIO()
+        encoder = avro.io.BinaryEncoder(buffer)
+        encoder.write_long(len(truncated))
+        buffer.write(truncated)
+        decoder = avro.io.BinaryDecoder(io.BytesIO(buffer.getvalue()))
+        with self.assertRaises(avro.errors.InvalidAvroBinaryEncoding):
+            avro.codecs.BZip2Codec.decompress(decoder)
+
     @unittest.skipUnless(avro.codecs.has_snappy, "snappy not available")
     def test_snappy_over_limit(self) -> None:
         self._assert_over_limit_rejected(avro.codecs.SnappyCodec)

--- a/lang/py/avro/test/test_codecs.py
+++ b/lang/py/avro/test/test_codecs.py
@@ -73,6 +73,18 @@ class TestDecompressionSizeLimit(unittest.TestCase):
     def test_deflate_within_limit(self) -> None:
         self._assert_within_limit_ok(avro.codecs.DeflateCodec)
 
+    def test_deflate_truncated_block_rejected(self) -> None:
+        """A truncated deflate block must be rejected rather than silently accepted."""
+        compressed, _ = avro.codecs.DeflateCodec.compress(b"the quick brown fox " * 10)
+        truncated = compressed[:-4]  # drop the tail so the end-of-stream marker is never reached
+        buffer = io.BytesIO()
+        encoder = avro.io.BinaryEncoder(buffer)
+        encoder.write_long(len(truncated))
+        buffer.write(truncated)
+        decoder = avro.io.BinaryDecoder(io.BytesIO(buffer.getvalue()))
+        with self.assertRaises(avro.errors.InvalidAvroBinaryEncoding):
+            avro.codecs.DeflateCodec.decompress(decoder)
+
     @unittest.skipUnless(avro.codecs.has_bzip2, "bzip2 not available")
     def test_bzip2_over_limit(self) -> None:
         self._assert_over_limit_rejected(avro.codecs.BZip2Codec)


### PR DESCRIPTION
## What is the purpose of the change

The deflate and bzip2 codecs are inflated incrementally and rejected once the output would exceed the limit; snappy rejects an over-large declared length up front; zstandard caps its streaming loop. Exceeding the limit raises `avro.errors.AvroDecompressionSizeException`.

When reading a data file, each block is decompressed according to the file's codec. A block with a very high compression ratio (or a malformed block) could expand to far more memory than its compressed size (a decompression bomb). This enforces a configurable maximum decompressed size while reading each block, mirroring the Java SDK's decompression limit (AVRO-4247). The limit defaults to 200 MiB and can be overridden with the `AVRO_MAX_DECOMPRESS_LENGTH` environment variable.

This is part of the umbrella issue AVRO-4283.

## Verifying this change

This change added tests and can be verified as follows:

- Added `avro/test/test_codecs.py` (`TestDecompressionSizeLimit`) covering deflate and bzip2 over-limit rejection and within-limit decoding (snappy/zstandard covered when those optional deps are installed).
- Run: `cd lang/py && python3 -m unittest avro.test.test_codecs`

## Documentation

- Does this pull request introduce a new feature? (no — hardening/robustness)
- If yes, how is the feature documented? (not applicable; the new `AVRO_MAX_DECOMPRESS_LENGTH` environment variable is documented in code comments)
