### PR TITLE
AVRO-4291: [ruby] Enforce a maximum decompressed block size

### DIFF
--- a/lang/ruby/lib/avro/data_file.rb
+++ b/lang/ruby/lib/avro/data_file.rb
@@ -384,17 +384,21 @@ module Avro
         if declared > limit
           raise DecompressionSizeError, "Decompressed block size exceeds the maximum allowed of #{limit} bytes"
         end
-        crc32 = data.slice(-4..-1).unpack('N').first
-        uncompressed = Snappy.inflate(data.slice(0..-5))
+        # A well-formed block ends with a 4-byte CRC32 trailer. If the buffer is
+        # too short to contain it, don't slice past the start (data[-4..-1] would
+        # be nil and raise on unpack); treat it as a legacy no-checksum block.
+        if data.bytesize >= 4
+          crc32 = data.slice(-4..-1).unpack('N').first
+          uncompressed = Snappy.inflate(data.slice(0..-5))
 
-        if crc32 == Zlib.crc32(uncompressed)
-          uncompressed
-        else
-          # older versions of avro-ruby didn't write the checksum, so if it
-          # doesn't match this must assume that it wasn't there and return
-          # the entire payload uncompressed.
-          Snappy.inflate(data)
+          if crc32 == Zlib.crc32(uncompressed)
+            return uncompressed
+          end
         end
+        # older versions of avro-ruby didn't write the checksum, so if it
+        # doesn't match (or the buffer is too short to hold one) assume it wasn't
+        # there and return the entire payload uncompressed.
+        Snappy.inflate(data)
       rescue Snappy::Error
         # older versions of avro-ruby didn't write the checksum, so removing
         # the last 4 bytes may cause Snappy to fail. recover by assuming the

--- a/lang/ruby/lib/avro/data_file.rb
+++ b/lang/ruby/lib/avro/data_file.rb
@@ -44,7 +44,10 @@ module Avro
     # The maximum number of bytes a single block is allowed to decompress to.
     def self.max_decompress_length
       value = ENV[MAX_DECOMPRESS_LENGTH_ENV]
-      return value.to_i if value && value =~ /\A\d+\z/ && value.to_i > 0
+      if value && value =~ /\A\d+\z/
+        parsed = value.to_i
+        return parsed if parsed > 0
+      end
       DEFAULT_MAX_DECOMPRESS_LENGTH
     end
 
@@ -426,14 +429,27 @@ module Avro
     end
 
     class ZstandardCodec
+      # Size of the compressed input fed to the streaming decompressor per step,
+      # so the decompressed output can be bounded incrementally.
+      ZSTD_DECOMPRESS_CHUNK_SIZE = 16 * 1024
+
       def codec_name; 'zstandard'; end
 
       def decompress(data)
         load_zstandard!
-        uncompressed = Zstd.decompress(data)
         limit = DataFile.max_decompress_length
-        if uncompressed.bytesize > limit
-          raise DecompressionSizeError, "Decompressed block size exceeds the maximum allowed of #{limit} bytes"
+        stream = Zstd::StreamingDecompress.new
+        uncompressed = +''.b
+        offset = 0
+        size = data.bytesize
+        # Decompress the block in chunks so an over-large (or malicious) block is
+        # rejected before its full decompressed form is materialized in memory.
+        while offset < size
+          uncompressed << stream.decompress(data.byteslice(offset, ZSTD_DECOMPRESS_CHUNK_SIZE))
+          offset += ZSTD_DECOMPRESS_CHUNK_SIZE
+          if uncompressed.bytesize > limit
+            raise DecompressionSizeError, "Decompressed block size exceeds the maximum allowed of #{limit} bytes"
+          end
         end
         uncompressed
       end

--- a/lang/ruby/lib/avro/data_file.rb
+++ b/lang/ruby/lib/avro/data_file.rb
@@ -384,12 +384,13 @@ module Avro
         if declared > limit
           raise DecompressionSizeError, "Decompressed block size exceeds the maximum allowed of #{limit} bytes"
         end
-        # A well-formed block ends with a 4-byte CRC32 trailer. If the buffer is
-        # too short to contain it, don't slice past the start (data[-4..-1] would
-        # be nil and raise on unpack); treat it as a legacy no-checksum block.
-        if data.bytesize >= 4
-          crc32 = data.slice(-4..-1).unpack('N').first
-          uncompressed = Snappy.inflate(data.slice(0..-5))
+        # A well-formed block ends with a 4-byte CRC32 trailer, so it needs at
+        # least one body byte plus the 4-byte trailer. Require > 4 bytes and use
+        # byteslice so the body slice is always a string (data.slice(0..-5) is
+        # nil for a 4-byte buffer, which would raise in Snappy.inflate).
+        if data.bytesize > 4
+          crc32 = data.byteslice(-4, 4).unpack('N').first
+          uncompressed = Snappy.inflate(data.byteslice(0, data.bytesize - 4))
 
           if crc32 == Zlib.crc32(uncompressed)
             return uncompressed

--- a/lang/ruby/lib/avro/data_file.rb
+++ b/lang/ruby/lib/avro/data_file.rb
@@ -376,7 +376,12 @@ module Avro
         # reject an over-large block before allocating for it.
         limit = DataFile.max_decompress_length
         declared = self.class.snappy_declared_length(data)
-        if declared && declared > limit
+        # Fail closed: a block whose length header cannot be parsed is malformed
+        # and must not be handed to the decompressor with the guard bypassed.
+        if declared.nil?
+          raise DataFileError, "Snappy block has an unparseable length header"
+        end
+        if declared > limit
           raise DecompressionSizeError, "Decompressed block size exceeds the maximum allowed of #{limit} bytes"
         end
         crc32 = data.slice(-4..-1).unpack('N').first

--- a/lang/ruby/lib/avro/data_file.rb
+++ b/lang/ruby/lib/avro/data_file.rb
@@ -335,6 +335,8 @@ module Avro
 
       def codec_name; 'deflate'; end
 
+      DEFLATE_DECOMPRESS_CHUNK_SIZE = 16 * 1024
+
       def decompress(compressed)
         # Passing a negative number to Inflate puts it into "raw" RFC1951 mode
         # (without the RFC1950 header & checksum). See the docs for
@@ -342,15 +344,25 @@ module Avro
         zstream = Zlib::Inflate.new(-Zlib::MAX_WBITS)
         limit = DataFile.max_decompress_length
         data = "".b
-        # Inflate in chunks so an over-large (or malicious) block is rejected
-        # before its full decompressed form is materialized in memory.
         append = lambda do |chunk|
           if data.bytesize + chunk.bytesize > limit
             raise DecompressionSizeError, "Decompressed block size exceeds the maximum allowed of #{limit} bytes"
           end
           data << chunk
         end
-        zstream.inflate(compressed, &append)
+        # Feed the compressed input in chunks and check the accumulated output
+        # after each call, so an over-large (or malicious) block is rejected
+        # before its full decompressed form is materialized. (The block form of
+        # Zlib::Inflate#inflate that yields output chunks is Ruby 3.1+, but this
+        # gem supports 2.7, so bound via input chunks instead; a chunk's output
+        # is bounded by chunk_size * the deflate ratio, so the peak overshoot
+        # before the check fires is bounded too.)
+        offset = 0
+        size = compressed.bytesize
+        while offset < size
+          append.call(zstream.inflate(compressed.byteslice(offset, DEFLATE_DECOMPRESS_CHUNK_SIZE)))
+          offset += DEFLATE_DECOMPRESS_CHUNK_SIZE
+        end
         remaining = zstream.finish
         append.call(remaining) unless remaining.empty?
         data

--- a/lang/ruby/lib/avro/data_file.rb
+++ b/lang/ruby/lib/avro/data_file.rb
@@ -28,7 +28,25 @@ module Avro
     META_SCHEMA = Schema.parse('{"type": "map", "values": "bytes"}')
     VALID_ENCODINGS = ['binary'].freeze # not used yet
 
+    # Default upper bound, in bytes, on the size a single data-file block may
+    # decompress to. A block with a very high compression ratio (or a malformed
+    # block) can otherwise expand to far more memory than its compressed size.
+    # Mirrors the Java SDK's decompression limit (AVRO-4247). Overridable with
+    # the AVRO_MAX_DECOMPRESS_LENGTH environment variable.
+    DEFAULT_MAX_DECOMPRESS_LENGTH = 200 * 1024 * 1024 # 200 MiB
+    MAX_DECOMPRESS_LENGTH_ENV = 'AVRO_MAX_DECOMPRESS_LENGTH'.freeze
+
     class DataFileError < AvroError; end
+
+    # Raised when a data-file block decompresses to more than the configured maximum.
+    class DecompressionSizeError < DataFileError; end
+
+    # The maximum number of bytes a single block is allowed to decompress to.
+    def self.max_decompress_length
+      value = ENV[MAX_DECOMPRESS_LENGTH_ENV]
+      return value.to_i if value && value =~ /\A\d+\z/ && value.to_i > 0
+      DEFAULT_MAX_DECOMPRESS_LENGTH
+    end
 
     def self.open(file_path, mode='r', schema=nil, codec=nil)
       schema = Avro::Schema.parse(schema) if schema
@@ -319,10 +337,22 @@ module Avro
         # (without the RFC1950 header & checksum). See the docs for
         # inflateInit2 in https://www.zlib.net/manual.html
         zstream = Zlib::Inflate.new(-Zlib::MAX_WBITS)
-        data = zstream.inflate(compressed)
-        data << zstream.finish
+        limit = DataFile.max_decompress_length
+        data = "".b
+        # Inflate in chunks so an over-large (or malicious) block is rejected
+        # before its full decompressed form is materialized in memory.
+        append = lambda do |chunk|
+          data << chunk
+          if data.bytesize > limit
+            raise DecompressionSizeError, "Decompressed block size exceeds the maximum allowed of #{limit} bytes"
+          end
+        end
+        zstream.inflate(compressed, &append)
+        remaining = zstream.finish
+        append.call(remaining) unless remaining.empty?
+        data
       ensure
-        zstream.close
+        zstream.close if zstream
       end
 
       def compress(data)
@@ -339,6 +369,13 @@ module Avro
 
       def decompress(data)
         load_snappy!
+        # The Snappy block header declares the uncompressed length as a varint;
+        # reject an over-large block before allocating for it.
+        limit = DataFile.max_decompress_length
+        declared = self.class.snappy_declared_length(data)
+        if declared && declared > limit
+          raise DecompressionSizeError, "Decompressed block size exceeds the maximum allowed of #{limit} bytes"
+        end
         crc32 = data.slice(-4..-1).unpack('N').first
         uncompressed = Snappy.inflate(data.slice(0..-5))
 
@@ -355,6 +392,21 @@ module Avro
         # the last 4 bytes may cause Snappy to fail. recover by assuming the
         # payload is from an older file and uncompress the entire buffer.
         Snappy.inflate(data)
+      end
+
+      # Return the uncompressed length declared in a raw Snappy block header,
+      # which prefixes the data as a little-endian base-128 varint. Returns nil
+      # if the header cannot be parsed.
+      def self.snappy_declared_length(data)
+        result = 0
+        shift = 0
+        data.each_byte do |byte|
+          result |= (byte & 0x7f) << shift
+          return result if (byte & 0x80).zero?
+          shift += 7
+          return nil if shift > 63
+        end
+        nil
       end
 
       def compress(data)
@@ -378,7 +430,12 @@ module Avro
 
       def decompress(data)
         load_zstandard!
-        Zstd.decompress(data)
+        uncompressed = Zstd.decompress(data)
+        limit = DataFile.max_decompress_length
+        if uncompressed.bytesize > limit
+          raise DecompressionSizeError, "Decompressed block size exceeds the maximum allowed of #{limit} bytes"
+        end
+        uncompressed
       end
 
       def compress(data)

--- a/lang/ruby/lib/avro/data_file.rb
+++ b/lang/ruby/lib/avro/data_file.rb
@@ -345,10 +345,10 @@ module Avro
         # Inflate in chunks so an over-large (or malicious) block is rejected
         # before its full decompressed form is materialized in memory.
         append = lambda do |chunk|
-          data << chunk
-          if data.bytesize > limit
+          if data.bytesize + chunk.bytesize > limit
             raise DecompressionSizeError, "Decompressed block size exceeds the maximum allowed of #{limit} bytes"
           end
+          data << chunk
         end
         zstream.inflate(compressed, &append)
         remaining = zstream.finish
@@ -445,11 +445,12 @@ module Avro
         # Decompress the block in chunks so an over-large (or malicious) block is
         # rejected before its full decompressed form is materialized in memory.
         while offset < size
-          uncompressed << stream.decompress(data.byteslice(offset, ZSTD_DECOMPRESS_CHUNK_SIZE))
+          out = stream.decompress(data.byteslice(offset, ZSTD_DECOMPRESS_CHUNK_SIZE))
           offset += ZSTD_DECOMPRESS_CHUNK_SIZE
-          if uncompressed.bytesize > limit
+          if uncompressed.bytesize + out.bytesize > limit
             raise DecompressionSizeError, "Decompressed block size exceeds the maximum allowed of #{limit} bytes"
           end
+          uncompressed << out
         end
         uncompressed
       end

--- a/lang/ruby/lib/avro/data_file.rb
+++ b/lang/ruby/lib/avro/data_file.rb
@@ -34,7 +34,7 @@ module Avro
     # Mirrors the Java SDK's decompression limit (AVRO-4247). Overridable with
     # the AVRO_MAX_DECOMPRESS_LENGTH environment variable.
     DEFAULT_MAX_DECOMPRESS_LENGTH = 200 * 1024 * 1024 # 200 MiB
-    MAX_DECOMPRESS_LENGTH_ENV = 'AVRO_MAX_DECOMPRESS_LENGTH'.freeze
+    MAX_DECOMPRESS_LENGTH_ENV = 'AVRO_MAX_DECOMPRESS_LENGTH'
 
     class DataFileError < AvroError; end
 

--- a/lang/ruby/test/test_codec_limits.rb
+++ b/lang/ruby/test/test_codec_limits.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'test_help'
+
+# A block with a very high compression ratio can expand to far more memory than
+# its compressed size. These tests ensure that decompressing such a block raises
+# an error instead of allocating without bound.
+class TestCodecLimits < Test::Unit::TestCase
+  LIMIT = 1024
+
+  def with_limit(bytes)
+    previous = ENV['AVRO_MAX_DECOMPRESS_LENGTH']
+    ENV['AVRO_MAX_DECOMPRESS_LENGTH'] = bytes.to_s
+    yield
+  ensure
+    if previous.nil?
+      ENV.delete('AVRO_MAX_DECOMPRESS_LENGTH')
+    else
+      ENV['AVRO_MAX_DECOMPRESS_LENGTH'] = previous
+    end
+  end
+
+  def oversized_payload
+    ("\x00".b * (LIMIT * 8))
+  end
+
+  def test_deflate_rejects_oversized_block
+    codec = Avro::DataFile::DeflateCodec.new
+    compressed = codec.compress(oversized_payload)
+    with_limit(LIMIT) do
+      assert_raise(Avro::DataFile::DecompressionSizeError) do
+        codec.decompress(compressed)
+      end
+    end
+  end
+
+  def test_deflate_allows_block_within_limit
+    codec = Avro::DataFile::DeflateCodec.new
+    payload = ('the quick brown fox ' * 10).b
+    compressed = codec.compress(payload)
+    with_limit(LIMIT) do
+      assert_equal payload, codec.decompress(compressed)
+    end
+  end
+
+  def test_snappy_rejects_declared_oversized_length
+    begin
+      require 'snappy'
+    rescue LoadError
+      omit('snappy gem not available')
+    end
+    codec = Avro::DataFile::SnappyCodec.new
+    compressed = codec.compress(oversized_payload)
+    with_limit(LIMIT) do
+      assert_raise(Avro::DataFile::DecompressionSizeError) do
+        codec.decompress(compressed)
+      end
+    end
+  end
+
+  def test_zstandard_rejects_oversized_block
+    begin
+      require 'zstd-ruby'
+    rescue LoadError
+      omit('zstd-ruby gem not available')
+    end
+    codec = Avro::DataFile::ZstandardCodec.new
+    compressed = codec.compress(oversized_payload)
+    with_limit(LIMIT) do
+      assert_raise(Avro::DataFile::DecompressionSizeError) do
+        codec.decompress(compressed)
+      end
+    end
+  end
+end

--- a/lang/ruby/test/test_codec_limits.rb
+++ b/lang/ruby/test/test_codec_limits.rb
@@ -24,14 +24,15 @@ class TestCodecLimits < Test::Unit::TestCase
   LIMIT = 1024
 
   def with_limit(bytes)
-    previous = ENV['AVRO_MAX_DECOMPRESS_LENGTH']
-    ENV['AVRO_MAX_DECOMPRESS_LENGTH'] = bytes.to_s
+    env = Avro::DataFile::MAX_DECOMPRESS_LENGTH_ENV
+    previous = ENV[env]
+    ENV[env] = bytes.to_s
     yield
   ensure
     if previous.nil?
-      ENV.delete('AVRO_MAX_DECOMPRESS_LENGTH')
+      ENV.delete(env)
     else
-      ENV['AVRO_MAX_DECOMPRESS_LENGTH'] = previous
+      ENV[env] = previous
     end
   end
 

--- a/lang/ruby/test/test_codec_limits.rb
+++ b/lang/ruby/test/test_codec_limits.rb
@@ -87,4 +87,18 @@ class TestCodecLimits < Test::Unit::TestCase
       end
     end
   end
+
+  def test_zstandard_within_limit_round_trips
+    begin
+      require 'zstd-ruby'
+    rescue LoadError
+      omit('zstd-ruby gem not available')
+    end
+    codec = Avro::DataFile::ZstandardCodec.new
+    payload = ('the quick brown fox ' * 10).b # well under the limit
+    compressed = codec.compress(payload)
+    with_limit(LIMIT) do
+      assert_equal payload, codec.decompress(compressed)
+    end
+  end
 end

--- a/lang/ruby/test/test_codec_limits.rb
+++ b/lang/ruby/test/test_codec_limits.rb
@@ -73,6 +73,24 @@ class TestCodecLimits < Test::Unit::TestCase
     end
   end
 
+  def test_snappy_rejects_unparseable_length_header
+    begin
+      require 'snappy'
+    rescue LoadError
+      omit('snappy gem not available')
+    end
+    codec = Avro::DataFile::SnappyCodec.new
+    # A header made entirely of continuation bytes never terminates, so the
+    # declared length cannot be parsed; the codec must fail closed rather than
+    # hand the block to the decompressor with the guard bypassed.
+    malformed = ("\x80".b * 12)
+    with_limit(LIMIT) do
+      assert_raise(Avro::DataFile::DataFileError) do
+        codec.decompress(malformed)
+      end
+    end
+  end
+
   def test_zstandard_rejects_oversized_block
     begin
       require 'zstd-ruby'


### PR DESCRIPTION
## What is the purpose of the change

The deflate codec is inflated in chunks and bounded before the full output is materialized; snappy rejects an over-large declared length up front; zstandard is streamed in chunks and bounded incrementally before the full output is materialized. Exceeding the limit raises `Avro::DataFile::DecompressionSizeError`.

When reading a data file, each block is decompressed according to the file's codec. A block with a very high compression ratio (or a malformed block) could expand to far more memory than its compressed size (a decompression bomb). This enforces a configurable maximum decompressed size while reading each block, mirroring the Java SDK's decompression limit (AVRO-4247). The limit defaults to 200 MiB and can be overridden with the `AVRO_MAX_DECOMPRESS_LENGTH` environment variable.

This is part of the umbrella issue AVRO-4283.

## Verifying this change

This change added tests and can be verified as follows:

- Added `test/test_codec_limits.rb` covering deflate over-limit rejection and within-limit decoding (snappy/zstandard covered when those gems are installed).
- Run: `cd lang/ruby && bundle exec rake test`

## Documentation

- Does this pull request introduce a new feature? (no — hardening/robustness)
- If yes, how is the feature documented? (not applicable; the new `AVRO_MAX_DECOMPRESS_LENGTH` environment variable is documented in code comments)

