### PR TITLE
AVRO-4289: [php] Enforce a maximum decompressed block size

### DIFF
--- a/lang/php/lib/DataFile/AvroDataIODecompressionSizeException.php
+++ b/lang/php/lib/DataFile/AvroDataIODecompressionSizeException.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Apache\Avro\DataFile;
+
+/**
+ * Raised when a data-file block decompresses to more than the configured maximum.
+ *
+ * A block with a very high compression ratio (or a malformed block) can expand
+ * to far more memory than its compressed size; this exception guards against
+ * unbounded memory allocation while reading such a block.
+ */
+class AvroDataIODecompressionSizeException extends AvroDataIOException
+{
+    public function __construct(int $maxLength)
+    {
+        parent::__construct(
+            sprintf('Decompressed block size exceeds the maximum allowed of %d bytes.', $maxLength)
+        );
+    }
+}

--- a/lang/php/lib/DataFile/AvroDataIOReader.php
+++ b/lang/php/lib/DataFile/AvroDataIOReader.php
@@ -279,7 +279,7 @@ class AvroDataIOReader
         $length = strlen($compressed);
         for ($offset = 0; $offset < $length; $offset += self::INFLATE_CHUNK_SIZE) {
             $piece = substr($compressed, $offset, self::INFLATE_CHUNK_SIZE);
-            $out = @inflate_add($context, $piece);
+            $out = inflate_add($context, $piece);
             if (false === $out) {
                 throw new AvroException('deflate uncompression failed.');
             }
@@ -288,7 +288,7 @@ class AvroDataIOReader
             self::checkDecompressLength($total, $maxLength);
         }
 
-        $out = @inflate_add($context, '', ZLIB_FINISH);
+        $out = inflate_add($context, '', ZLIB_FINISH);
         if (false === $out) {
             throw new AvroException('deflate uncompression failed.');
         }

--- a/lang/php/lib/DataFile/AvroDataIOReader.php
+++ b/lang/php/lib/DataFile/AvroDataIOReader.php
@@ -370,7 +370,11 @@ class AvroDataIOReader
 
         self::checkDecompressLength(strlen($datum), $maxLength);
 
-        if ($crc32 !== crc32($datum)) {
+        // Compare the CRC32 values in a common unsigned representation:
+        // unpack('N') can yield a float (> PHP_INT_MAX) on 32-bit PHP while
+        // crc32() yields a (possibly negative) int, so a strict/int comparison
+        // would report false mismatches for valid data.
+        if (sprintf('%u', $crc32) !== sprintf('%u', crc32($datum))) {
             throw new AvroException('snappy uncompression failed - crc32 mismatch.');
         }
 

--- a/lang/php/lib/DataFile/AvroDataIOReader.php
+++ b/lang/php/lib/DataFile/AvroDataIOReader.php
@@ -268,11 +268,12 @@ class AvroDataIOReader
             throw new AvroException('gzip uncompression failed.');
         }
 
-        // Inflate in chunks and check the running length after each step so an
-        // over-large (or malicious) block is rejected without materializing the
-        // full output, while genuine decompression errors (inflate_add === false)
-        // are reported distinctly. Pieces are collected and joined once at the
-        // end to avoid repeatedly reallocating a growing result string.
+        // Inflate in chunks and check the running total after each step so an
+        // over-large (or malicious) block is rejected before its whole output is
+        // accumulated (each inflated chunk is still materialized), while genuine
+        // decompression errors (inflate_add === false) are reported distinctly.
+        // Pieces are collected and joined once at the end to avoid repeatedly
+        // reallocating a growing result string.
         $pieces = [];
         $total = 0;
         $length = strlen($compressed);

--- a/lang/php/lib/DataFile/AvroDataIOReader.php
+++ b/lang/php/lib/DataFile/AvroDataIOReader.php
@@ -33,6 +33,17 @@ use Apache\Avro\Schema\AvroSchema;
  */
 class AvroDataIOReader
 {
+    /**
+     * Default upper bound, in bytes, on the size a single data-file block may
+     * decompress to. A block with a very high compression ratio (or a malformed
+     * block) can otherwise expand to far more memory than its compressed size.
+     * Mirrors the Java SDK's decompression limit (AVRO-4247). Overridable with
+     * the AVRO_MAX_DECOMPRESS_LENGTH environment variable.
+     */
+    public const DEFAULT_MAX_DECOMPRESS_LENGTH = 209715200; // 200 MiB
+
+    public const MAX_DECOMPRESS_LENGTH_ENV = 'AVRO_MAX_DECOMPRESS_LENGTH';
+
     public string $sync_marker;
     /**
      * @var array<string, mixed> object container metadata
@@ -221,15 +232,45 @@ class AvroDataIOReader
     }
 
     /**
+     * The maximum number of bytes a single block is allowed to decompress to.
+     */
+    private static function maxDecompressLength(): int
+    {
+        $value = getenv(self::MAX_DECOMPRESS_LENGTH_ENV);
+        if (false !== $value && ctype_digit($value) && (int) $value > 0) {
+            return (int) $value;
+        }
+
+        return self::DEFAULT_MAX_DECOMPRESS_LENGTH;
+    }
+
+    /**
+     * @throws AvroDataIODecompressionSizeException if the length exceeds the limit
+     */
+    private static function checkDecompressLength(int $length, int $maxLength): void
+    {
+        if ($length > $maxLength) {
+            throw new AvroDataIODecompressionSizeException($maxLength);
+        }
+    }
+
+    /**
      * @throws AvroException
      */
     private function gzUncompress(string $compressed): string
     {
-        $datum = gzinflate($compressed);
+        $maxLength = self::maxDecompressLength();
+        // gzinflate caps its output at the given length: a block that would
+        // decompress to more than the limit yields false here without
+        // materializing the full (potentially huge) output. The '@' suppresses
+        // the "insufficient memory" notice zlib emits when the cap is hit.
+        $datum = @gzinflate($compressed, $maxLength + 1);
 
         if (false === $datum) {
-            throw new AvroException('gzip uncompression failed.');
+            throw new AvroDataIODecompressionSizeException($maxLength);
         }
+
+        self::checkDecompressLength(strlen($datum), $maxLength);
 
         return $datum;
     }
@@ -248,6 +289,8 @@ class AvroDataIOReader
             throw new AvroException('zstd uncompression failed.');
         }
 
+        self::checkDecompressLength(strlen($datum), self::maxDecompressLength());
+
         return $datum;
     }
 
@@ -265,6 +308,8 @@ class AvroDataIOReader
             throw new AvroException('bz2 uncompression failed.');
         }
 
+        self::checkDecompressLength(strlen($datum), self::maxDecompressLength());
+
         return $datum;
     }
 
@@ -276,6 +321,13 @@ class AvroDataIOReader
         if (!extension_loaded('snappy')) {
             throw new AvroException('Please install ext-snappy to use snappy compression.');
         }
+        $maxLength = self::maxDecompressLength();
+        // The Snappy block header declares the uncompressed length as a varint;
+        // reject an over-large block before allocating for it.
+        $declared = self::snappyDeclaredLength(substr((string) $compressed, 0, -4));
+        if (null !== $declared) {
+            self::checkDecompressLength($declared, $maxLength);
+        }
         $crc32 = unpack('N', substr((string) $compressed, -4))[1];
         $datum = snappy_uncompress(substr((string) $compressed, 0, -4));
 
@@ -283,10 +335,37 @@ class AvroDataIOReader
             throw new AvroException('snappy uncompression failed.');
         }
 
+        self::checkDecompressLength(strlen($datum), $maxLength);
+
         if ($crc32 !== crc32($datum)) {
             throw new AvroException('snappy uncompression failed - crc32 mismatch.');
         }
 
         return $datum;
+    }
+
+    /**
+     * Return the uncompressed length declared in a raw Snappy block header,
+     * which prefixes the data as a little-endian base-128 varint. Returns null
+     * if the header cannot be parsed.
+     */
+    private static function snappyDeclaredLength(string $data): ?int
+    {
+        $result = 0;
+        $shift = 0;
+        $length = strlen($data);
+        for ($i = 0; $i < $length; $i++) {
+            $byte = ord($data[$i]);
+            $result |= ($byte & 0x7F) << $shift;
+            if (0 === ($byte & 0x80)) {
+                return $result;
+            }
+            $shift += 7;
+            if ($shift > 63) {
+                break;
+            }
+        }
+
+        return null;
     }
 }

--- a/lang/php/lib/DataFile/AvroDataIOReader.php
+++ b/lang/php/lib/DataFile/AvroDataIOReader.php
@@ -345,12 +345,23 @@ class AvroDataIOReader
             throw new AvroException('Please install ext-snappy to use snappy compression.');
         }
         $maxLength = self::maxDecompressLength();
+        // The block is a Snappy payload followed by a 4-byte CRC32 trailer; a
+        // shorter block is malformed and must not be sliced with negative
+        // offsets (which would make unpack() return false below).
+        if (strlen($compressed) < 4) {
+            throw new AvroException('snappy uncompression failed - block too small.');
+        }
+        $payload = substr($compressed, 0, -4);
+        $unpacked = unpack('N', substr($compressed, -4));
+        if (false === $unpacked) {
+            throw new AvroException('snappy uncompression failed - missing crc32 trailer.');
+        }
+        $crc32 = $unpacked[1];
         // The Snappy block header declares the uncompressed length as a varint;
         // reject an over-large block before allocating for it. Parsed with an
         // early cap so it stays correct even if a 32-bit int would overflow.
-        self::ensureSnappyWithinLimit(substr((string) $compressed, 0, -4), $maxLength);
-        $crc32 = unpack('N', substr((string) $compressed, -4))[1];
-        $datum = snappy_uncompress(substr((string) $compressed, 0, -4));
+        self::ensureSnappyWithinLimit($payload, $maxLength);
+        $datum = snappy_uncompress($payload);
 
         if (false === $datum) {
             throw new AvroException('snappy uncompression failed.');
@@ -396,5 +407,10 @@ class AvroDataIOReader
                 throw new AvroException('snappy uncompression failed - malformed length header.');
             }
         }
+
+        // The data ended before a terminating byte (top bit clear) was seen, so
+        // the length header is truncated/malformed; reject it rather than
+        // letting a malformed block bypass the guard.
+        throw new AvroException('snappy uncompression failed - truncated length header.');
     }
 }

--- a/lang/php/lib/DataFile/AvroDataIOReader.php
+++ b/lang/php/lib/DataFile/AvroDataIOReader.php
@@ -271,8 +271,10 @@ class AvroDataIOReader
         // Inflate in chunks and check the running length after each step so an
         // over-large (or malicious) block is rejected without materializing the
         // full output, while genuine decompression errors (inflate_add === false)
-        // are reported distinctly.
-        $datum = '';
+        // are reported distinctly. Pieces are collected and joined once at the
+        // end to avoid repeatedly reallocating a growing result string.
+        $pieces = [];
+        $total = 0;
         $length = strlen($compressed);
         for ($offset = 0; $offset < $length; $offset += self::INFLATE_CHUNK_SIZE) {
             $piece = substr($compressed, $offset, self::INFLATE_CHUNK_SIZE);
@@ -280,18 +282,20 @@ class AvroDataIOReader
             if (false === $out) {
                 throw new AvroException('gzip uncompression failed.');
             }
-            $datum .= $out;
-            self::checkDecompressLength(strlen($datum), $maxLength);
+            $pieces[] = $out;
+            $total += strlen($out);
+            self::checkDecompressLength($total, $maxLength);
         }
 
         $out = @inflate_add($context, '', ZLIB_FINISH);
         if (false === $out) {
             throw new AvroException('gzip uncompression failed.');
         }
-        $datum .= $out;
-        self::checkDecompressLength(strlen($datum), $maxLength);
+        $pieces[] = $out;
+        $total += strlen($out);
+        self::checkDecompressLength($total, $maxLength);
 
-        return $datum;
+        return implode('', $pieces);
     }
 
     /**
@@ -366,9 +370,10 @@ class AvroDataIOReader
      * base-128 varint at the start of the block) exceeds $maxLength, before
      * allocating for it. The running length is compared against the cap after
      * every group, and any wrap to a negative value (32-bit int overflow) is
-     * treated as over the limit, so the guard holds on 32-bit builds too.
+     * treated as over the limit, so the guard holds on 32-bit builds too. A
+     * varint longer than five bytes is malformed and is rejected as well.
      *
-     * @throws AvroDataIODecompressionSizeException if the declared length exceeds the limit
+     * @throws AvroException if the declared length exceeds the limit or is malformed
      */
     private static function ensureSnappyWithinLimit(string $data, int $maxLength): void
     {
@@ -386,7 +391,9 @@ class AvroDataIOReader
             }
             $shift += 7;
             if ($shift > 28) {
-                return; // more than 5 bytes: malformed; the post-decompress check will catch it
+                // A Snappy uncompressed length is a uint32, encoded in at most
+                // five varint bytes; a longer encoding is malformed.
+                throw new AvroException('snappy uncompression failed - malformed length header.');
             }
         }
     }

--- a/lang/php/lib/DataFile/AvroDataIOReader.php
+++ b/lang/php/lib/DataFile/AvroDataIOReader.php
@@ -44,6 +44,9 @@ class AvroDataIOReader
 
     public const MAX_DECOMPRESS_LENGTH_ENV = 'AVRO_MAX_DECOMPRESS_LENGTH';
 
+    /** Chunk size, in bytes, used when streaming inflate so the output can be bounded incrementally. */
+    private const INFLATE_CHUNK_SIZE = 8192;
+
     public string $sync_marker;
     /**
      * @var array<string, mixed> object container metadata
@@ -260,16 +263,32 @@ class AvroDataIOReader
     private function gzUncompress(string $compressed): string
     {
         $maxLength = self::maxDecompressLength();
-        // gzinflate caps its output at the given length: a block that would
-        // decompress to more than the limit yields false here without
-        // materializing the full (potentially huge) output. The '@' suppresses
-        // the "insufficient memory" notice zlib emits when the cap is hit.
-        $datum = @gzinflate($compressed, $maxLength + 1);
-
-        if (false === $datum) {
-            throw new AvroDataIODecompressionSizeException($maxLength);
+        $context = inflate_init(ZLIB_ENCODING_RAW);
+        if (false === $context) {
+            throw new AvroException('gzip uncompression failed.');
         }
 
+        // Inflate in chunks and check the running length after each step so an
+        // over-large (or malicious) block is rejected without materializing the
+        // full output, while genuine decompression errors (inflate_add === false)
+        // are reported distinctly.
+        $datum = '';
+        $length = strlen($compressed);
+        for ($offset = 0; $offset < $length; $offset += self::INFLATE_CHUNK_SIZE) {
+            $piece = substr($compressed, $offset, self::INFLATE_CHUNK_SIZE);
+            $out = @inflate_add($context, $piece);
+            if (false === $out) {
+                throw new AvroException('gzip uncompression failed.');
+            }
+            $datum .= $out;
+            self::checkDecompressLength(strlen($datum), $maxLength);
+        }
+
+        $out = @inflate_add($context, '', ZLIB_FINISH);
+        if (false === $out) {
+            throw new AvroException('gzip uncompression failed.');
+        }
+        $datum .= $out;
         self::checkDecompressLength(strlen($datum), $maxLength);
 
         return $datum;
@@ -323,11 +342,9 @@ class AvroDataIOReader
         }
         $maxLength = self::maxDecompressLength();
         // The Snappy block header declares the uncompressed length as a varint;
-        // reject an over-large block before allocating for it.
-        $declared = self::snappyDeclaredLength(substr((string) $compressed, 0, -4));
-        if (null !== $declared) {
-            self::checkDecompressLength($declared, $maxLength);
-        }
+        // reject an over-large block before allocating for it. Parsed with an
+        // early cap so it stays correct even if a 32-bit int would overflow.
+        self::ensureSnappyWithinLimit(substr((string) $compressed, 0, -4), $maxLength);
         $crc32 = unpack('N', substr((string) $compressed, -4))[1];
         $datum = snappy_uncompress(substr((string) $compressed, 0, -4));
 
@@ -345,27 +362,32 @@ class AvroDataIOReader
     }
 
     /**
-     * Return the uncompressed length declared in a raw Snappy block header,
-     * which prefixes the data as a little-endian base-128 varint. Returns null
-     * if the header cannot be parsed.
+     * Reject a Snappy block whose declared uncompressed length (a little-endian
+     * base-128 varint at the start of the block) exceeds $maxLength, before
+     * allocating for it. The running length is compared against the cap after
+     * every group, and any wrap to a negative value (32-bit int overflow) is
+     * treated as over the limit, so the guard holds on 32-bit builds too.
+     *
+     * @throws AvroDataIODecompressionSizeException if the declared length exceeds the limit
      */
-    private static function snappyDeclaredLength(string $data): ?int
+    private static function ensureSnappyWithinLimit(string $data, int $maxLength): void
     {
         $result = 0;
         $shift = 0;
         $length = strlen($data);
         for ($i = 0; $i < $length; $i++) {
             $byte = ord($data[$i]);
-            $result |= ($byte & 0x7F) << $shift;
+            $result += ($byte & 0x7F) << $shift;
+            if ($result < 0 || $result > $maxLength) {
+                throw new AvroDataIODecompressionSizeException($maxLength);
+            }
             if (0 === ($byte & 0x80)) {
-                return $result;
+                return; // declared length is within the limit
             }
             $shift += 7;
-            if ($shift > 63) {
-                break;
+            if ($shift > 28) {
+                return; // more than 5 bytes: malformed; the post-decompress check will catch it
             }
         }
-
-        return null;
     }
 }

--- a/lang/php/lib/DataFile/AvroDataIOReader.php
+++ b/lang/php/lib/DataFile/AvroDataIOReader.php
@@ -265,7 +265,7 @@ class AvroDataIOReader
         $maxLength = self::maxDecompressLength();
         $context = inflate_init(ZLIB_ENCODING_RAW);
         if (false === $context) {
-            throw new AvroException('gzip uncompression failed.');
+            throw new AvroException('deflate uncompression failed.');
         }
 
         // Inflate in chunks and check the running total after each step so an
@@ -281,7 +281,7 @@ class AvroDataIOReader
             $piece = substr($compressed, $offset, self::INFLATE_CHUNK_SIZE);
             $out = @inflate_add($context, $piece);
             if (false === $out) {
-                throw new AvroException('gzip uncompression failed.');
+                throw new AvroException('deflate uncompression failed.');
             }
             $pieces[] = $out;
             $total += strlen($out);
@@ -290,7 +290,7 @@ class AvroDataIOReader
 
         $out = @inflate_add($context, '', ZLIB_FINISH);
         if (false === $out) {
-            throw new AvroException('gzip uncompression failed.');
+            throw new AvroException('deflate uncompression failed.');
         }
         $pieces[] = $out;
         $total += strlen($out);

--- a/lang/php/lib/autoload.php
+++ b/lang/php/lib/autoload.php
@@ -27,8 +27,8 @@ include __DIR__.'/AvroNotImplementedException.php';
 include __DIR__.'/AvroUtil.php';
 
 include __DIR__.'/DataFile/AvroDataIO.php';
-include __DIR__.'/DataFile/AvroDataIODecompressionSizeException.php';
 include __DIR__.'/DataFile/AvroDataIOException.php';
+include __DIR__.'/DataFile/AvroDataIODecompressionSizeException.php';
 include __DIR__.'/DataFile/AvroDataIOReader.php';
 include __DIR__.'/DataFile/AvroDataIOWriter.php';
 

--- a/lang/php/lib/autoload.php
+++ b/lang/php/lib/autoload.php
@@ -27,6 +27,7 @@ include __DIR__.'/AvroNotImplementedException.php';
 include __DIR__.'/AvroUtil.php';
 
 include __DIR__.'/DataFile/AvroDataIO.php';
+include __DIR__.'/DataFile/AvroDataIODecompressionSizeException.php';
 include __DIR__.'/DataFile/AvroDataIOException.php';
 include __DIR__.'/DataFile/AvroDataIOReader.php';
 include __DIR__.'/DataFile/AvroDataIOWriter.php';

--- a/lang/php/test/DataFileTest.php
+++ b/lang/php/test/DataFileTest.php
@@ -448,6 +448,30 @@ class DataFileTest extends TestCase
         }
     }
 
+    public function test_snappy_block_decompression_limit(): void
+    {
+        if (!extension_loaded('snappy')) {
+            $this->markTestSkipped('snappy extension not available');
+        }
+        $this->assertCodecRejectsOversizedBlock(AvroDataIO::SNAPPY_CODEC);
+    }
+
+    public function test_zstandard_block_decompression_limit(): void
+    {
+        if (!extension_loaded('zstd')) {
+            $this->markTestSkipped('zstd extension not available');
+        }
+        $this->assertCodecRejectsOversizedBlock(AvroDataIO::ZSTANDARD_CODEC);
+    }
+
+    public function test_bzip2_block_decompression_limit(): void
+    {
+        if (!extension_loaded('bz2')) {
+            $this->markTestSkipped('bz2 extension not available');
+        }
+        $this->assertCodecRejectsOversizedBlock(AvroDataIO::BZIP2_CODEC);
+    }
+
     protected function add_data_file(string $data_file): string
     {
         $data_file = "$data_file.".self::current_timestamp();
@@ -471,6 +495,40 @@ class DataFileTest extends TestCase
     {
         if (file_exists($data_file)) {
             unlink($data_file);
+        }
+    }
+
+    /**
+     * Write a single, highly compressible block with the given codec, then read
+     * it back with a small decompression limit and assert it is rejected.
+     */
+    private function assertCodecRejectsOversizedBlock(string $codec): void
+    {
+        $data_file = $this->add_data_file(sprintf('data-decompress-limit-%s.avr', $codec));
+        $dw = AvroDataIO::openFile($data_file, 'w', '"string"', $codec);
+        $dw->append(str_repeat('a', 64 * 1024)); // 64 KiB, compresses tiny
+        $dw->close();
+
+        $previous = getenv(AvroDataIOReader::MAX_DECOMPRESS_LENGTH_ENV);
+        putenv(AvroDataIOReader::MAX_DECOMPRESS_LENGTH_ENV.'=1024');
+
+        try {
+            $dr = AvroDataIO::openFile($data_file);
+            $thrown = false;
+
+            try {
+                $dr->data();
+            } catch (AvroDataIODecompressionSizeException $e) {
+                $thrown = true;
+            }
+            $dr->close();
+            $this->assertTrue($thrown, sprintf('expected a decompression size exception for %s', $codec));
+        } finally {
+            if (false === $previous) {
+                putenv(AvroDataIOReader::MAX_DECOMPRESS_LENGTH_ENV);
+            } else {
+                putenv(AvroDataIOReader::MAX_DECOMPRESS_LENGTH_ENV.'='.$previous);
+            }
         }
     }
 }

--- a/lang/php/test/DataFileTest.php
+++ b/lang/php/test/DataFileTest.php
@@ -388,15 +388,6 @@ class DataFileTest extends TestCase
         }
     }
 
-    protected function add_data_file(string $data_file): string
-    {
-        $data_file = "$data_file.".self::current_timestamp();
-        $full = implode(DIRECTORY_SEPARATOR, [TEST_TEMP_DIR, $data_file]);
-        $this->dataFiles[] = $full;
-
-        return $full;
-    }
-
     /**
      * A block with a very high compression ratio can expand to far more memory
      * than its compressed size; reading such a block must be rejected once its
@@ -410,10 +401,12 @@ class DataFileTest extends TestCase
         $dw->close();
 
         $previous = getenv(AvroDataIOReader::MAX_DECOMPRESS_LENGTH_ENV);
-        putenv(AvroDataIOReader::MAX_DECOMPRESS_LENGTH_ENV . '=1024');
+        putenv(AvroDataIOReader::MAX_DECOMPRESS_LENGTH_ENV.'=1024');
+
         try {
             $dr = AvroDataIO::openFile($data_file);
             $thrown = false;
+
             try {
                 $dr->data();
             } catch (AvroDataIODecompressionSizeException $e) {
@@ -425,7 +418,7 @@ class DataFileTest extends TestCase
             if (false === $previous) {
                 putenv(AvroDataIOReader::MAX_DECOMPRESS_LENGTH_ENV);
             } else {
-                putenv(AvroDataIOReader::MAX_DECOMPRESS_LENGTH_ENV . '=' . $previous);
+                putenv(AvroDataIOReader::MAX_DECOMPRESS_LENGTH_ENV.'='.$previous);
             }
         }
     }
@@ -439,7 +432,8 @@ class DataFileTest extends TestCase
         $dw->close();
 
         $previous = getenv(AvroDataIOReader::MAX_DECOMPRESS_LENGTH_ENV);
-        putenv(AvroDataIOReader::MAX_DECOMPRESS_LENGTH_ENV . '=1048576');
+        putenv(AvroDataIOReader::MAX_DECOMPRESS_LENGTH_ENV.'=1048576');
+
         try {
             $dr = AvroDataIO::openFile($data_file);
             $data = $dr->data();
@@ -449,9 +443,18 @@ class DataFileTest extends TestCase
             if (false === $previous) {
                 putenv(AvroDataIOReader::MAX_DECOMPRESS_LENGTH_ENV);
             } else {
-                putenv(AvroDataIOReader::MAX_DECOMPRESS_LENGTH_ENV . '=' . $previous);
+                putenv(AvroDataIOReader::MAX_DECOMPRESS_LENGTH_ENV.'='.$previous);
             }
         }
+    }
+
+    protected function add_data_file(string $data_file): string
+    {
+        $data_file = "$data_file.".self::current_timestamp();
+        $full = implode(DIRECTORY_SEPARATOR, [TEST_TEMP_DIR, $data_file]);
+        $this->dataFiles[] = $full;
+
+        return $full;
     }
 
     protected function remove_data_files(): void

--- a/lang/php/test/DataFileTest.php
+++ b/lang/php/test/DataFileTest.php
@@ -23,6 +23,8 @@ declare(strict_types=1);
 namespace Apache\Avro\Tests;
 
 use Apache\Avro\DataFile\AvroDataIO;
+use Apache\Avro\DataFile\AvroDataIODecompressionSizeException;
+use Apache\Avro\DataFile\AvroDataIOReader;
 use PHPUnit\Framework\TestCase;
 
 class DataFileTest extends TestCase
@@ -393,6 +395,63 @@ class DataFileTest extends TestCase
         $this->dataFiles[] = $full;
 
         return $full;
+    }
+
+    /**
+     * A block with a very high compression ratio can expand to far more memory
+     * than its compressed size; reading such a block must be rejected once its
+     * decompressed size would exceed the configured maximum.
+     */
+    public function test_deflate_block_decompression_limit(): void
+    {
+        $data_file = $this->add_data_file('data-decompress-limit-deflate.avr');
+        $dw = AvroDataIO::openFile($data_file, 'w', '"string"', AvroDataIO::DEFLATE_CODEC);
+        $dw->append(str_repeat('a', 64 * 1024)); // 64 KiB, compresses tiny
+        $dw->close();
+
+        $previous = getenv(AvroDataIOReader::MAX_DECOMPRESS_LENGTH_ENV);
+        putenv(AvroDataIOReader::MAX_DECOMPRESS_LENGTH_ENV . '=1024');
+        try {
+            $dr = AvroDataIO::openFile($data_file);
+            $thrown = false;
+            try {
+                $dr->data();
+            } catch (AvroDataIODecompressionSizeException $e) {
+                $thrown = true;
+            }
+            $dr->close();
+            $this->assertTrue($thrown, 'expected a decompression size exception');
+        } finally {
+            if (false === $previous) {
+                putenv(AvroDataIOReader::MAX_DECOMPRESS_LENGTH_ENV);
+            } else {
+                putenv(AvroDataIOReader::MAX_DECOMPRESS_LENGTH_ENV . '=' . $previous);
+            }
+        }
+    }
+
+    public function test_deflate_block_within_decompression_limit(): void
+    {
+        $data_file = $this->add_data_file('data-decompress-within-limit.avr');
+        $payload = 'hello world';
+        $dw = AvroDataIO::openFile($data_file, 'w', '"string"', AvroDataIO::DEFLATE_CODEC);
+        $dw->append($payload);
+        $dw->close();
+
+        $previous = getenv(AvroDataIOReader::MAX_DECOMPRESS_LENGTH_ENV);
+        putenv(AvroDataIOReader::MAX_DECOMPRESS_LENGTH_ENV . '=1048576');
+        try {
+            $dr = AvroDataIO::openFile($data_file);
+            $data = $dr->data();
+            $dr->close();
+            $this->assertSame([$payload], $data);
+        } finally {
+            if (false === $previous) {
+                putenv(AvroDataIOReader::MAX_DECOMPRESS_LENGTH_ENV);
+            } else {
+                putenv(AvroDataIOReader::MAX_DECOMPRESS_LENGTH_ENV . '=' . $previous);
+            }
+        }
     }
 
     protected function remove_data_files(): void

--- a/lang/php/test/DataFileTest.php
+++ b/lang/php/test/DataFileTest.php
@@ -405,15 +405,15 @@ class DataFileTest extends TestCase
 
         try {
             $dr = AvroDataIO::openFile($data_file);
-            $thrown = false;
 
             try {
                 $dr->data();
+                $this->fail('expected a decompression size exception');
             } catch (AvroDataIODecompressionSizeException $e) {
-                $thrown = true;
+                // expected
+            } finally {
+                $dr->close();
             }
-            $dr->close();
-            $this->assertTrue($thrown, 'expected a decompression size exception');
         } finally {
             if (false === $previous) {
                 putenv(AvroDataIOReader::MAX_DECOMPRESS_LENGTH_ENV);
@@ -436,9 +436,13 @@ class DataFileTest extends TestCase
 
         try {
             $dr = AvroDataIO::openFile($data_file);
-            $data = $dr->data();
-            $dr->close();
-            $this->assertSame([$payload], $data);
+
+            try {
+                $data = $dr->data();
+                $this->assertSame([$payload], $data);
+            } finally {
+                $dr->close();
+            }
         } finally {
             if (false === $previous) {
                 putenv(AvroDataIOReader::MAX_DECOMPRESS_LENGTH_ENV);
@@ -514,15 +518,15 @@ class DataFileTest extends TestCase
 
         try {
             $dr = AvroDataIO::openFile($data_file);
-            $thrown = false;
 
             try {
                 $dr->data();
+                $this->fail(sprintf('expected a decompression size exception for %s', $codec));
             } catch (AvroDataIODecompressionSizeException $e) {
-                $thrown = true;
+                // expected
+            } finally {
+                $dr->close();
             }
-            $dr->close();
-            $this->assertTrue($thrown, sprintf('expected a decompression size exception for %s', $codec));
         } finally {
             if (false === $previous) {
                 putenv(AvroDataIOReader::MAX_DECOMPRESS_LENGTH_ENV);


### PR DESCRIPTION
## What is the purpose of the change

The deflate codec inflates in bounded chunks (inflate_init/inflate_add) and rejects the block as soon as the accumulated output would exceed the limit, so the allocation is bounded incrementally; snappy rejects an over-large declared length up front; zstandard and bzip2 are checked after decompression. Exceeding the limit throws `AvroDataIODecompressionSizeException`.

When reading a data file, each block is decompressed according to the file's codec. A block with a very high compression ratio (or a malformed block) could expand to far more memory than its compressed size (a decompression bomb). This enforces a configurable maximum decompressed size while reading each block, mirroring the Java SDK's decompression limit (AVRO-4247). The limit defaults to 200 MiB and can be overridden with the `AVRO_MAX_DECOMPRESS_LENGTH` environment variable.

This is part of the umbrella issue AVRO-4283.

## Verifying this change

This change added tests and can be verified as follows:

- Added tests in `test/DataFileTest.php`: a deflate block exceeding the limit is rejected and a within-limit block decodes.
- Run: `composer test` (or `php vendor/bin/phpunit -c lang/php/phpunit.xml --filter DataFileTest`)

## Documentation

- Does this pull request introduce a new feature? (no — hardening/robustness)
- If yes, how is the feature documented? (not applicable; the new `AVRO_MAX_DECOMPRESS_LENGTH` environment variable is documented in code comments)