### PR TITLE
AVRO-4286: [csharp] Enforce a maximum decompressed block size

### DIFF
--- a/lang/csharp/src/apache/main/File/Codec.cs
+++ b/lang/csharp/src/apache/main/File/Codec.cs
@@ -112,8 +112,9 @@ namespace Avro.File
                 if (read > maxLength - total)
                 {
                     throw new AvroRuntimeException(
-                        $"Decompressed block size exceeds the maximum allowed of {maxLength} bytes. " +
-                        $"Set the {MaxDecompressLengthEnvVar} environment variable to raise the limit.");
+                        $"Decompressed block size exceeds the maximum allowed of {maxLength} bytes " +
+                        $"(at least {total} bytes already decompressed). " +
+                        $"For data-file reads, the {MaxDecompressLengthEnvVar} environment variable raises the limit.");
                 }
 
                 total += read;

--- a/lang/csharp/src/apache/main/File/Codec.cs
+++ b/lang/csharp/src/apache/main/File/Codec.cs
@@ -30,6 +30,71 @@ namespace Avro.File
     public abstract class Codec
     {
         /// <summary>
+        /// Default upper bound, in bytes, on the size a single data-file block may
+        /// decompress to. A block with a very high compression ratio (or a malformed
+        /// block) can otherwise expand to far more memory than its compressed size.
+        /// Mirrors the Java SDK's decompression limit (AVRO-4247). Overridable with
+        /// the AVRO_MAX_DECOMPRESS_LENGTH environment variable.
+        /// </summary>
+        public const long DefaultMaxDecompressLength = 200L * 1024 * 1024; // 200 MiB
+
+        /// <summary>
+        /// Name of the environment variable used to override the default maximum
+        /// decompressed size of a single block.
+        /// </summary>
+        public const string MaxDecompressLengthEnvVar = "AVRO_MAX_DECOMPRESS_LENGTH";
+
+        /// <summary>
+        /// The maximum number of bytes a single block is allowed to decompress to.
+        /// </summary>
+        /// <returns>The configured limit, honoring the environment override.</returns>
+        public static long GetMaxDecompressLength()
+        {
+            var value = Environment.GetEnvironmentVariable(MaxDecompressLengthEnvVar);
+            if (value != null && long.TryParse(value, out var parsed) && parsed > 0)
+            {
+                return parsed;
+            }
+
+            return DefaultMaxDecompressLength;
+        }
+
+        /// <summary>
+        /// Throws if the given decompressed length exceeds the maximum allowed.
+        /// </summary>
+        /// <param name="length">The number of decompressed bytes.</param>
+        /// <param name="maxLength">The maximum number of decompressed bytes allowed.</param>
+        public static void CheckDecompressLength(long length, long maxLength)
+        {
+            if (length > maxLength)
+            {
+                throw new AvroRuntimeException(
+                    $"Decompressed block size exceeds the maximum allowed of {maxLength} bytes");
+            }
+        }
+
+        /// <summary>
+        /// Copies a decompression stream to the destination, rejecting the block as
+        /// soon as its decompressed size would exceed <paramref name="maxLength"/> so
+        /// an over-large (or malicious) block is not fully materialized in memory.
+        /// </summary>
+        /// <param name="source">The decompression stream to read from.</param>
+        /// <param name="destination">The stream to write the decompressed data to.</param>
+        /// <param name="maxLength">The maximum number of decompressed bytes allowed.</param>
+        public static void CopyBounded(Stream source, Stream destination, long maxLength)
+        {
+            byte[] buffer = new byte[81920];
+            long total = 0;
+            int read;
+            while ((read = source.Read(buffer, 0, buffer.Length)) > 0)
+            {
+                total += read;
+                CheckDecompressLength(total, maxLength);
+                destination.Write(buffer, 0, read);
+            }
+        }
+
+        /// <summary>
         /// Compress data using implemented codec.
         /// </summary>
         /// <param name="uncompressedData">The uncompressed data.</param>

--- a/lang/csharp/src/apache/main/File/Codec.cs
+++ b/lang/csharp/src/apache/main/File/Codec.cs
@@ -71,7 +71,7 @@ namespace Avro.File
             {
                 throw new AvroRuntimeException(
                     $"Decompressed block size {length} exceeds the maximum allowed of {maxLength} bytes. " +
-                    $"Set the {MaxDecompressLengthEnvVar} environment variable to raise the limit.");
+                    $"For data-file reads, the {MaxDecompressLengthEnvVar} environment variable raises the limit.");
             }
         }
 

--- a/lang/csharp/src/apache/main/File/Codec.cs
+++ b/lang/csharp/src/apache/main/File/Codec.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Reflection;
 
@@ -36,7 +37,7 @@ namespace Avro.File
         /// Mirrors the Java SDK's decompression limit (AVRO-4247). Overridable with
         /// the AVRO_MAX_DECOMPRESS_LENGTH environment variable.
         /// </summary>
-        public const long DefaultMaxDecompressLength = 200L * 1024 * 1024; // 200 MiB
+        public static readonly long DefaultMaxDecompressLength = 200L * 1024 * 1024; // 200 MiB
 
         /// <summary>
         /// Name of the environment variable used to override the default maximum
@@ -51,7 +52,7 @@ namespace Avro.File
         public static long GetMaxDecompressLength()
         {
             var value = Environment.GetEnvironmentVariable(MaxDecompressLengthEnvVar);
-            if (value != null && long.TryParse(value, out var parsed) && parsed > 0)
+            if (value != null && long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) && parsed > 0)
             {
                 return parsed;
             }

--- a/lang/csharp/src/apache/main/File/Codec.cs
+++ b/lang/csharp/src/apache/main/File/Codec.cs
@@ -105,8 +105,18 @@ namespace Avro.File
             int read;
             while ((read = source.Read(buffer, 0, buffer.Length)) > 0)
             {
+                // Pre-add bound check: total is always <= maxLength here and
+                // read > 0, so maxLength - total >= 0 and this cannot overflow.
+                // Rejecting before adding stops total from overflowing and
+                // wrapping past the limit for a very large maxLength.
+                if (read > maxLength - total)
+                {
+                    throw new AvroRuntimeException(
+                        $"Decompressed block size exceeds the maximum allowed of {maxLength} bytes. " +
+                        $"Set the {MaxDecompressLengthEnvVar} environment variable to raise the limit.");
+                }
+
                 total += read;
-                CheckDecompressLength(total, maxLength);
                 destination.Write(buffer, 0, read);
             }
         }

--- a/lang/csharp/src/apache/main/File/Codec.cs
+++ b/lang/csharp/src/apache/main/File/Codec.cs
@@ -69,7 +69,8 @@ namespace Avro.File
             if (length > maxLength)
             {
                 throw new AvroRuntimeException(
-                    $"Decompressed block size exceeds the maximum allowed of {maxLength} bytes");
+                    $"Decompressed block size {length} exceeds the maximum allowed of {maxLength} bytes. " +
+                    $"Set the {MaxDecompressLengthEnvVar} environment variable to raise the limit.");
             }
         }
 
@@ -83,6 +84,21 @@ namespace Avro.File
         /// <param name="maxLength">The maximum number of decompressed bytes allowed.</param>
         public static void CopyBounded(Stream source, Stream destination, long maxLength)
         {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            if (destination == null)
+            {
+                throw new ArgumentNullException(nameof(destination));
+            }
+
+            if (maxLength < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxLength), "maxLength must not be negative.");
+            }
+
             byte[] buffer = new byte[81920];
             long total = 0;
             int read;

--- a/lang/csharp/src/apache/main/File/DataFileReader.cs
+++ b/lang/csharp/src/apache/main/File/DataFileReader.cs
@@ -233,7 +233,7 @@ namespace Avro.File
             catch (Exception e)
             {
                 throw new AvroRuntimeException(string.Format(CultureInfo.InvariantCulture,
-                    "Error fetching meta data for key: {0}", key), e);
+                    "Error fetching next object from block: {0}", e.Message), e);
             }
         }
 

--- a/lang/csharp/src/apache/main/File/DataFileReader.cs
+++ b/lang/csharp/src/apache/main/File/DataFileReader.cs
@@ -335,6 +335,11 @@ namespace Avro.File
                     {
                         _currentBlock = NextRawBlock(_currentBlock);
                         _currentBlock.Data = _codec.Decompress(_currentBlock.Data, (int)_blockSize);
+                        // Guard against a block that decompresses to more than the
+                        // allowed maximum (a decompression bomb). The built-in deflate
+                        // codec is already bounded during decompression; this covers
+                        // any codec that returns a fully decompressed buffer.
+                        Codec.CheckDecompressLength(_currentBlock.Data.Length, Codec.GetMaxDecompressLength());
                         _datumDecoder = new BinaryDecoder(_currentBlock.GetDataAsStream());
                     }
                 }

--- a/lang/csharp/src/apache/main/File/DataFileReader.cs
+++ b/lang/csharp/src/apache/main/File/DataFileReader.cs
@@ -233,7 +233,7 @@ namespace Avro.File
             catch (Exception e)
             {
                 throw new AvroRuntimeException(string.Format(CultureInfo.InvariantCulture,
-                    "Error fetching next object from block: {0}", e.Message), e);
+                    "Error fetching meta data for key: {0}", key), e);
             }
         }
 
@@ -348,7 +348,7 @@ namespace Avro.File
             catch (Exception e)
             {
                 throw new AvroRuntimeException(string.Format(CultureInfo.InvariantCulture,
-                    "Error fetching next object from block: {0}", e));
+                    "Error fetching next object from block: {0}", e.Message), e);
             }
         }
 

--- a/lang/csharp/src/apache/main/File/DeflateCodec.cs
+++ b/lang/csharp/src/apache/main/File/DeflateCodec.cs
@@ -63,7 +63,10 @@ namespace Avro.File
             {
                 using (DeflateStream decompress = new DeflateStream(inStream, CompressionMode.Decompress))
                 {
-                    decompress.CopyTo(outStream);
+                    // Bound the decompressed size to guard against a block with a very
+                    // high compression ratio expanding to far more memory than its
+                    // compressed size.
+                    CopyBounded(decompress, outStream, GetMaxDecompressLength());
                 }
                 return outStream.ToArray();
             }

--- a/lang/csharp/src/apache/test/File/FileTests.cs
+++ b/lang/csharp/src/apache/test/File/FileTests.cs
@@ -470,6 +470,17 @@ namespace Avro.Test.File
             }
         }
 
+        [Test]
+        public void TestCopyBoundedValidatesArguments()
+        {
+            using (var stream = new MemoryStream())
+            {
+                Assert.Throws<ArgumentNullException>(() => Codec.CopyBounded(null, stream, 10));
+                Assert.Throws<ArgumentNullException>(() => Codec.CopyBounded(stream, null, 10));
+                Assert.Throws<ArgumentOutOfRangeException>(() => Codec.CopyBounded(stream, stream, -1));
+            }
+        }
+
         /// <summary>
         /// This test is a single test case of
         /// <see cref="TestGenericData(string, object[], Codec.Type)"/> but introduces a

--- a/lang/csharp/src/apache/test/File/FileTests.cs
+++ b/lang/csharp/src/apache/test/File/FileTests.cs
@@ -426,6 +426,51 @@ namespace Avro.Test.File
         }
 
         /// <summary>
+        /// A block with a very high compression ratio can expand to far more memory
+        /// than its compressed size; decompressing such a block must be rejected once
+        /// its decompressed size would exceed the configured maximum.
+        /// </summary>
+        [Test]
+        public void TestDeflateDecompressionLimit()
+        {
+            var codec = new DeflateCodec();
+            byte[] big = new byte[4 * 1024 * 1024]; // 4 MiB of zeros, compresses tiny
+            byte[] compressed = codec.Compress(big);
+
+            var previous = Environment.GetEnvironmentVariable(Codec.MaxDecompressLengthEnvVar);
+            Environment.SetEnvironmentVariable(Codec.MaxDecompressLengthEnvVar, "1048576"); // 1 MiB
+            try
+            {
+                Assert.Throws<AvroRuntimeException>(
+                    () => codec.Decompress(compressed, compressed.Length));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(Codec.MaxDecompressLengthEnvVar, previous);
+            }
+        }
+
+        [Test]
+        public void TestDeflateWithinDecompressionLimit()
+        {
+            var codec = new DeflateCodec();
+            byte[] payload = System.Text.Encoding.UTF8.GetBytes("hello world");
+            byte[] compressed = codec.Compress(payload);
+
+            var previous = Environment.GetEnvironmentVariable(Codec.MaxDecompressLengthEnvVar);
+            Environment.SetEnvironmentVariable(Codec.MaxDecompressLengthEnvVar, "1048576"); // 1 MiB
+            try
+            {
+                byte[] result = codec.Decompress(compressed, compressed.Length);
+                Assert.AreEqual(payload, result);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(Codec.MaxDecompressLengthEnvVar, previous);
+            }
+        }
+
+        /// <summary>
         /// This test is a single test case of
         /// <see cref="TestGenericData(string, object[], Codec.Type)"/> but introduces a
         /// DeflateStream as it is a standard non-seekable Stream that has the same behavior as the

--- a/lang/csharp/src/apache/test/File/FileTests.cs
+++ b/lang/csharp/src/apache/test/File/FileTests.cs
@@ -462,7 +462,7 @@ namespace Avro.Test.File
             try
             {
                 byte[] result = codec.Decompress(compressed, compressed.Length);
-                Assert.AreEqual(payload, result);
+                CollectionAssert.AreEqual(payload, result);
             }
             finally
             {

--- a/lang/csharp/src/apache/test/File/FileTests.cs
+++ b/lang/csharp/src/apache/test/File/FileTests.cs
@@ -434,11 +434,11 @@ namespace Avro.Test.File
         public void TestDeflateDecompressionLimit()
         {
             var codec = new DeflateCodec();
-            byte[] big = new byte[4 * 1024 * 1024]; // 4 MiB of zeros, compresses tiny
+            byte[] big = new byte[128 * 1024]; // 128 KiB of zeros, compresses tiny
             byte[] compressed = codec.Compress(big);
 
             var previous = Environment.GetEnvironmentVariable(Codec.MaxDecompressLengthEnvVar);
-            Environment.SetEnvironmentVariable(Codec.MaxDecompressLengthEnvVar, "1048576"); // 1 MiB
+            Environment.SetEnvironmentVariable(Codec.MaxDecompressLengthEnvVar, "65536"); // 64 KiB
             try
             {
                 Assert.Throws<AvroRuntimeException>(
@@ -458,7 +458,7 @@ namespace Avro.Test.File
             byte[] compressed = codec.Compress(payload);
 
             var previous = Environment.GetEnvironmentVariable(Codec.MaxDecompressLengthEnvVar);
-            Environment.SetEnvironmentVariable(Codec.MaxDecompressLengthEnvVar, "1048576"); // 1 MiB
+            Environment.SetEnvironmentVariable(Codec.MaxDecompressLengthEnvVar, "65536"); // 64 KiB
             try
             {
                 byte[] result = codec.Decompress(compressed, compressed.Length);
@@ -497,7 +497,7 @@ namespace Avro.Test.File
             var recordSchema = schema as RecordSchema;
 
             // A single record whose string field is larger than the limit below.
-            string big = new string('a', 2 * 1024 * 1024); // 2 MiB
+            string big = new string('a', 128 * 1024); // 128 KiB
 
             MemoryStream outStream = new MemoryStream();
             using (var writer = DataFileWriter<GenericRecord>.OpenWriter(
@@ -509,7 +509,7 @@ namespace Avro.Test.File
             MemoryStream inStream = new MemoryStream(outStream.ToArray());
 
             var previous = Environment.GetEnvironmentVariable(Codec.MaxDecompressLengthEnvVar);
-            Environment.SetEnvironmentVariable(Codec.MaxDecompressLengthEnvVar, "1048576"); // 1 MiB
+            Environment.SetEnvironmentVariable(Codec.MaxDecompressLengthEnvVar, "65536"); // 64 KiB
             try
             {
                 Assert.Throws<AvroRuntimeException>(() =>

--- a/lang/csharp/src/apache/test/File/FileTests.cs
+++ b/lang/csharp/src/apache/test/File/FileTests.cs
@@ -516,8 +516,11 @@ namespace Avro.Test.File
                 {
                     using (var reader = DataFileReader<GenericRecord>.OpenReader(inStream, schema))
                     {
+                        // Enumerating forces the block to be read and
+                        // decompressed, which is where the limit is enforced.
                         foreach (var rec in reader.NextEntries)
                         {
+                            Assert.NotNull(rec);
                         }
                     }
                 });

--- a/lang/csharp/src/apache/test/File/FileTests.cs
+++ b/lang/csharp/src/apache/test/File/FileTests.cs
@@ -482,6 +482,53 @@ namespace Avro.Test.File
         }
 
         /// <summary>
+        /// The DataFileReader itself must reject a block whose decompressed size
+        /// exceeds the configured maximum. This covers the safeguard applied to
+        /// every codec that returns a fully materialized buffer (here the Null
+        /// codec, which performs no internally bounded decompression), not just a
+        /// direct call to a codec's Decompress method.
+        /// </summary>
+        [Test]
+        public void TestReaderRejectsOversizedBlock()
+        {
+            const string schemaStr =
+                "{\"type\":\"record\",\"name\":\"n\",\"fields\":[{\"name\":\"f1\",\"type\":\"string\"}]}";
+            Schema schema = Schema.Parse(schemaStr);
+            var recordSchema = schema as RecordSchema;
+
+            // A single record whose string field is larger than the limit below.
+            string big = new string('a', 2 * 1024 * 1024); // 2 MiB
+
+            MemoryStream outStream = new MemoryStream();
+            using (var writer = DataFileWriter<GenericRecord>.OpenWriter(
+                new GenericWriter<GenericRecord>(schema), outStream, Codec.CreateCodec(Codec.Type.Null)))
+            {
+                writer.Append(mkRecord(new object[] { "f1", big }, recordSchema));
+            }
+
+            MemoryStream inStream = new MemoryStream(outStream.ToArray());
+
+            var previous = Environment.GetEnvironmentVariable(Codec.MaxDecompressLengthEnvVar);
+            Environment.SetEnvironmentVariable(Codec.MaxDecompressLengthEnvVar, "1048576"); // 1 MiB
+            try
+            {
+                Assert.Throws<AvroRuntimeException>(() =>
+                {
+                    using (var reader = DataFileReader<GenericRecord>.OpenReader(inStream, schema))
+                    {
+                        foreach (var rec in reader.NextEntries)
+                        {
+                        }
+                    }
+                });
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(Codec.MaxDecompressLengthEnvVar, previous);
+            }
+        }
+
+        /// <summary>
         /// This test is a single test case of
         /// <see cref="TestGenericData(string, object[], Codec.Type)"/> but introduces a
         /// DeflateStream as it is a standard non-seekable Stream that has the same behavior as the


### PR DESCRIPTION
## What is the purpose of the change

The built-in deflate codec is inflated in chunks and bounded before the full output is materialized, and `DataFileReader` additionally checks the decompressed size of every codec's output as a safeguard. Exceeding the limit throws `AvroRuntimeException`.

When reading a data file, each block is decompressed according to the file's codec. A block with a very high compression ratio (or a malformed block) could expand to far more memory than its compressed size (a decompression bomb). This enforces a configurable maximum decompressed size while reading each block, mirroring the Java SDK's decompression limit (AVRO-4247). The limit defaults to 200 MiB and can be overridden with the `AVRO_MAX_DECOMPRESS_LENGTH` environment variable.

This is part of the umbrella issue AVRO-4283.

## Verifying this change

This change added tests and can be verified as follows:

- Added tests in `test/File/FileTests.cs`: a deflate block exceeding the limit is rejected and a within-limit block decodes.
- Run: `cd lang/csharp && dotnet test src/apache/test/Avro.test.csproj`

## Documentation

- Does this pull request introduce a new feature? (no — hardening/robustness)
- If yes, how is the feature documented? (not applicable; the new `AVRO_MAX_DECOMPRESS_LENGTH` environment variable is documented in code comments)
