### PR TITLE
AVRO-4301: [js] Bound collection allocation when decoding arrays and maps

### DIFF
--- a/lang/js/lib/files.js
+++ b/lang/js/lib/files.js
@@ -608,10 +608,19 @@ function tryReadBlock(tap) {
  */
 function createReader(decode, type) {
   if (decode) {
-    return function (tap) { return type._read(tap); };
+    return function (tap) {
+      // Reset the per-datum zero-byte-element budget: this tap is reused across
+      // records, so each record must start with a fresh cumulative count (see
+      // checkCollectionBlock in schemas.js).
+      tap.zeroByteItems = 0;
+      return type._read(tap);
+    };
   } else {
     return (function (skipper) {
       return function (tap) {
+        // Reset the per-datum zero-byte-element budget (the skip path also
+        // enforces it) since this tap is reused across records.
+        tap.zeroByteItems = 0;
         var pos = tap.pos;
         skipper(tap);
         return tap.buf.slice(pos, tap.pos);

--- a/lang/js/lib/schemas.js
+++ b/lang/js/lib/schemas.js
@@ -65,6 +65,26 @@ var PATH = [];
 // Currently active logical type, used for name redirection.
 var LOGICAL_TYPE = null;
 
+// Collection allocation limits, guarding against a block-count DoS.
+//
+// An `array` or `map` block is encoded as an item count followed by that many
+// items. A malicious or truncated input can declare a very large count while
+// carrying little or no data. Elements that encode to zero bytes (e.g. `null`)
+// consume no input, so the block count cannot be bounded by the bytes actually
+// remaining in the buffer alone; such a block is capped by item count instead.
+// Both limits can be overridden (to the same value) via the
+// `AVRO_MAX_COLLECTION_ITEMS` environment variable.
+var MAX_COLLECTION_ITEMS = 10000000; // Zero-byte element cap.
+var MAX_COLLECTION_STRUCTURAL = 2147483639; // Integer.MAX_VALUE - 8.
+if (typeof process !== 'undefined' && process.env &&
+    process.env.AVRO_MAX_COLLECTION_ITEMS) {
+  var envItems = parseInt(process.env.AVRO_MAX_COLLECTION_ITEMS, 10);
+  if (envItems >= 0) {
+    MAX_COLLECTION_ITEMS = envItems;
+    MAX_COLLECTION_STRUCTURAL = envItems;
+  }
+}
+
 
 /**
  * Schema parsing entry point.
@@ -1149,9 +1169,15 @@ MapType.prototype._check = function (val, cb) {
 
 MapType.prototype._read = function (tap) {
   var values = this._values;
+  var minBytes = this._valuesMinBytes !== undefined ?
+    this._valuesMinBytes :
+    1 + getMinBytes(values); // Each entry carries a >=1-byte key.
   var val = {};
+  var total = 0;
   var n;
   while ((n = readArraySize(tap))) {
+    total += n;
+    checkCollectionBlock(tap, n, minBytes, total);
     while (n--) {
       var key = tap.readString();
       val[key] = values._read(tap);
@@ -1162,12 +1188,16 @@ MapType.prototype._read = function (tap) {
 
 MapType.prototype._skip = function (tap) {
   var values = this._values;
+  var minBytes = 1 + getMinBytes(values); // Each entry carries a >=1-byte key.
+  var total = 0;
   var len, n;
   while ((n = tap.readLong())) {
     if (n < 0) {
       len = tap.readLong();
       tap.pos += len;
     } else {
+      total += n;
+      checkCollectionBlock(tap, n, minBytes, total);
       while (n--) {
         tap.skipString();
         values._skip(tap);
@@ -1203,6 +1233,8 @@ MapType.prototype._match = function () {
 MapType.prototype._updateResolver = function (resolver, type, opts) {
   if (type instanceof MapType) {
     resolver._values = this._values.createResolver(type._values, opts);
+    // Bound the block count using the writer's entry size (see ArrayType).
+    resolver._valuesMinBytes = 1 + getMinBytes(type._values);
     resolver._read = this._read;
   }
 };
@@ -1288,13 +1320,19 @@ ArrayType.prototype._check = function (val, cb) {
 
 ArrayType.prototype._read = function (tap) {
   var items = this._items;
+  var minBytes = this._itemsMinBytes !== undefined ?
+    this._itemsMinBytes :
+    getMinBytes(items);
   var val = [];
+  var total = 0;
   var n;
   while ((n = tap.readLong())) {
     if (n < 0) {
       n = -n;
       tap.skipLong(); // Skip size.
     }
+    total += n;
+    checkCollectionBlock(tap, n, minBytes, total);
     while (n--) {
       val.push(items._read(tap));
     }
@@ -1303,14 +1341,19 @@ ArrayType.prototype._read = function (tap) {
 };
 
 ArrayType.prototype._skip = function (tap) {
+  var items = this._items;
+  var minBytes = getMinBytes(items);
+  var total = 0;
   var len, n;
   while ((n = tap.readLong())) {
     if (n < 0) {
       len = tap.readLong();
       tap.pos += len;
     } else {
+      total += n;
+      checkCollectionBlock(tap, n, minBytes, total);
       while (n--) {
-        this._items._skip(tap);
+        items._skip(tap);
       }
     }
   }
@@ -1354,6 +1397,9 @@ ArrayType.prototype._match = function (tap1, tap2) {
 ArrayType.prototype._updateResolver = function (resolver, type, opts) {
   if (type instanceof ArrayType) {
     resolver._items = this._items.createResolver(type._items, opts);
+    // Bound the block count using the writer's element size, which is what is
+    // actually on the wire (the reader/resolved type may be larger).
+    resolver._itemsMinBytes = getMinBytes(type._items);
     resolver._read = this._read;
   }
 };
@@ -2151,6 +2197,74 @@ function readArraySize(tap) {
     tap.skipLong(); // Skip size.
   }
   return n;
+}
+
+/**
+ * Minimum number of bytes a value of the given type can occupy on the wire.
+ *
+ * Used to bound collection block counts against the bytes actually remaining.
+ * Memoized on the type; recursive records are handled with a `seen` guard
+ * (a directly self-referential required field cannot encode in finite bytes,
+ * and self-references reached through an array/map/union already contribute at
+ * least one byte before recursing, so returning 0 on a cycle is safe).
+ */
+function getMinBytes(type, seen) {
+  if (type._minBytes !== undefined) {
+    return type._minBytes;
+  }
+  var mb;
+  if (type instanceof NullType) {
+    mb = 0;
+  } else if (type instanceof FixedType) {
+    mb = type._size;
+  } else if (type instanceof FloatType) {
+    mb = 4;
+  } else if (type instanceof DoubleType) {
+    mb = 8;
+  } else if (type instanceof LogicalType) {
+    mb = getMinBytes(type._underlyingType, seen);
+  } else if (type instanceof RecordType) {
+    seen = seen || [];
+    if (~seen.indexOf(type)) {
+      return 0; // Cycle; see note above.
+    }
+    seen.push(type);
+    mb = 0;
+    var fields = type._fields;
+    for (var i = 0, l = fields.length; i < l; i++) {
+      mb += getMinBytes(fields[i]._type, seen);
+    }
+    seen.pop();
+  } else {
+    // Booleans, ints, longs, strings, bytes, enums (index), unions (index),
+    // and arrays/maps (empty block terminator) all occupy at least one byte.
+    mb = 1;
+  }
+  type._minBytes = mb;
+  return mb;
+}
+
+/**
+ * Reject a collection block whose declared item count cannot be backed by the
+ * input, guarding against unbounded allocation from a tiny payload.
+ *
+ * `total` is the cumulative item count across all blocks read so far (including
+ * the current one). Elements with a positive on-wire minimum are bounded by the
+ * bytes remaining in the buffer; zero-byte elements are bounded by the item
+ * cap; and every collection is bounded by the structural cap.
+ */
+function checkCollectionBlock(tap, n, minBytes, total) {
+  if (total > MAX_COLLECTION_STRUCTURAL) {
+    throw new Error('collection size exceeds maximum allowed');
+  }
+  if (minBytes > 0) {
+    // Divide (rather than multiply) to avoid any overflow on large counts.
+    if (n > (tap.buf.length - tap.pos) / minBytes) {
+      throw new Error('collection size exceeds remaining buffer');
+    }
+  } else if (total > MAX_COLLECTION_ITEMS) {
+    throw new Error('collection of zero-byte items exceeds maximum allowed');
+  }
 }
 
 /**

--- a/lang/js/lib/schemas.js
+++ b/lang/js/lib/schemas.js
@@ -2081,10 +2081,12 @@ function Resolver(readerType) {
   // Add all fields here so that all resolvers share the same hidden class.
   this._readerType = readerType;
   this._items = null;
+  this._itemsMinBytes = undefined;
   this._read = null;
   this._size = 0;
   this._symbols = null;
   this._values = null;
+  this._valuesMinBytes = undefined;
 }
 
 Resolver.prototype.inspect = function () { return '<Resolver>'; };

--- a/lang/js/lib/schemas.js
+++ b/lang/js/lib/schemas.js
@@ -802,7 +802,12 @@ UnionType.prototype._read = function (tap) {
 };
 
 UnionType.prototype._skip = function (tap) {
-  this._types[tap.readLong()]._skip(tap);
+  var index = tap.readLong();
+  var type = this._types[index];
+  if (type === undefined) {
+    throw new Error(f('invalid union index: %s', index));
+  }
+  type._skip(tap);
 };
 
 UnionType.prototype._write = function (tap, val) {

--- a/lang/js/lib/schemas.js
+++ b/lang/js/lib/schemas.js
@@ -1208,6 +1208,16 @@ MapType.prototype._skip = function (tap) {
         // truncation detection.
         throw new Error('negative collection block size');
       }
+      if (len > tap.buf.length - tap.pos) {
+        // The block claims more bytes than remain; skipping it would jump past
+        // the buffer end and misalign subsequent decoding.
+        throw new Error('collection block size exceeds remaining buffer');
+      }
+      if (minBytes > 0 && n > len / minBytes) {
+        // The declared byte-size is too small to hold n entries at their minimum
+        // on-wire size, so skipping len bytes would land mid-entry.
+        throw new Error('collection block size inconsistent with item count');
+      }
       total += n;
       checkCollectionBlock(tap, n, minBytes, total);
       tap.pos += len;
@@ -1372,6 +1382,16 @@ ArrayType.prototype._skip = function (tap) {
         // Tap.isValid() (pos <= buf.length) would not catch, bypassing
         // truncation detection.
         throw new Error('negative collection block size');
+      }
+      if (len > tap.buf.length - tap.pos) {
+        // The block claims more bytes than remain; skipping it would jump past
+        // the buffer end and misalign subsequent decoding.
+        throw new Error('collection block size exceeds remaining buffer');
+      }
+      if (minBytes > 0 && n > len / minBytes) {
+        // The declared byte-size is too small to hold n items at their minimum
+        // on-wire size, so skipping len bytes would land mid-entry.
+        throw new Error('collection block size inconsistent with item count');
       }
       total += n;
       checkCollectionBlock(tap, n, minBytes, total);

--- a/lang/js/lib/schemas.js
+++ b/lang/js/lib/schemas.js
@@ -2252,10 +2252,13 @@ function readArraySize(tap) {
  * Minimum number of bytes a value of the given type can occupy on the wire.
  *
  * Used to bound collection block counts against the bytes actually remaining.
- * Memoized on the type; recursive records are handled with a `seen` guard
- * (a directly self-referential required field cannot encode in finite bytes,
- * and self-references reached through an array/map/union already contribute at
- * least one byte before recursing, so returning 0 on a cycle is safe).
+ * Memoized on the type; recursive records are handled with a `seen` guard that
+ * returns 0 when a cycle is detected. That 0 is a deliberately conservative
+ * lower bound: for a schema whose true minimum can't be determined without
+ * unbounded recursion, under-estimating can only make the bytes-remaining check
+ * more permissive (it never rejects otherwise-valid data), so it is safe for
+ * that check even though it may be smaller than the true minimum for a union
+ * whose only small branch is a recursive record.
  */
 function getMinBytes(type, seen) {
   if (type._minBytes !== undefined) {

--- a/lang/js/lib/schemas.js
+++ b/lang/js/lib/schemas.js
@@ -1197,6 +1197,12 @@ MapType.prototype._skip = function (tap) {
       // encoding the block with a negative (byte-sized) count.
       n = -n;
       len = tap.readLong();
+      if (len < 0) {
+        // A negative byte-size would move the read position backwards, which
+        // Tap.isValid() (pos <= buf.length) would not catch, bypassing
+        // truncation detection.
+        throw new Error('negative collection block size');
+      }
       total += n;
       checkCollectionBlock(tap, n, minBytes, total);
       tap.pos += len;
@@ -1356,6 +1362,12 @@ ArrayType.prototype._skip = function (tap) {
       // encoding the block with a negative (byte-sized) count.
       n = -n;
       len = tap.readLong();
+      if (len < 0) {
+        // A negative byte-size would move the read position backwards, which
+        // Tap.isValid() (pos <= buf.length) would not catch, bypassing
+        // truncation detection.
+        throw new Error('negative collection block size');
+      }
       total += n;
       checkCollectionBlock(tap, n, minBytes, total);
       tap.pos += len;

--- a/lang/js/lib/schemas.js
+++ b/lang/js/lib/schemas.js
@@ -1193,7 +1193,12 @@ MapType.prototype._skip = function (tap) {
   var len, n;
   while ((n = tap.readLong())) {
     if (n < 0) {
+      // Sized block: bound the item count too, so the cap cannot be bypassed by
+      // encoding the block with a negative (byte-sized) count.
+      n = -n;
       len = tap.readLong();
+      total += n;
+      checkCollectionBlock(tap, n, minBytes, total);
       tap.pos += len;
     } else {
       total += n;
@@ -1347,7 +1352,12 @@ ArrayType.prototype._skip = function (tap) {
   var len, n;
   while ((n = tap.readLong())) {
     if (n < 0) {
+      // Sized block: bound the item count too, so the cap cannot be bypassed by
+      // encoding the block with a negative (byte-sized) count.
+      n = -n;
       len = tap.readLong();
+      total += n;
+      checkCollectionBlock(tap, n, minBytes, total);
       tap.pos += len;
     } else {
       total += n;
@@ -2223,6 +2233,19 @@ function getMinBytes(type, seen) {
     mb = 8;
   } else if (type instanceof LogicalType) {
     mb = getMinBytes(type._underlyingType, seen);
+  } else if (type instanceof UnionType) {
+    // A 1-byte branch index plus the smallest branch encoding. A union with a
+    // zero-byte branch (e.g. null) still occupies the index byte, so the
+    // minimum is 1; a union without one (e.g. ['int','long']) is at least 2.
+    var branches = type._types;
+    var branchMin = branches.length ? Infinity : 0;
+    for (var k = 0, bl = branches.length; k < bl; k++) {
+      branchMin = Math.min(branchMin, getMinBytes(branches[k], seen));
+      if (branchMin === 0) {
+        break;
+      }
+    }
+    mb = 1 + branchMin;
   } else if (type instanceof RecordType) {
     seen = seen || [];
     if (~seen.indexOf(type)) {

--- a/lang/js/lib/schemas.js
+++ b/lang/js/lib/schemas.js
@@ -2101,6 +2101,10 @@ Resolver.prototype.inspect = function () { return '<Resolver>'; };
  *
  */
 function readValue(type, tap, resolver, lazy) {
+  // Start a fresh zero-byte-element budget for this datum. The cap is
+  // cumulative across every collection decoded in this datum (see
+  // `checkCollectionBlock`), not per collection.
+  tap.zeroByteItems = 0;
   if (resolver) {
     if (resolver._readerType !== type) {
       throw new Error('invalid resolver');
@@ -2313,10 +2317,13 @@ function getMinBytes(type, seen) {
  * Reject a collection block whose declared item count cannot be backed by the
  * input, guarding against unbounded allocation from a tiny payload.
  *
- * `total` is the cumulative item count across all blocks read so far (including
- * the current one). Elements with a positive on-wire minimum are bounded by the
- * bytes remaining in the buffer; zero-byte elements are bounded by the item
- * cap; and every collection is bounded by the structural cap.
+ * `total` is the cumulative item count within the current collection (across its
+ * blocks). Elements with a positive on-wire minimum are bounded by the bytes
+ * remaining in the buffer; every collection is bounded by the structural cap;
+ * and zero-byte elements are bounded by a cap on their cumulative count across
+ * the whole datum (tracked on the tap), not just this collection, since a record
+ * can declare many such collection fields that are each individually under the
+ * limit but jointly unbounded.
  */
 function checkCollectionBlock(tap, n, minBytes, total) {
   if (total > MAX_COLLECTION_STRUCTURAL) {
@@ -2327,8 +2334,11 @@ function checkCollectionBlock(tap, n, minBytes, total) {
     if (n > (tap.buf.length - tap.pos) / minBytes) {
       throw new Error('collection size exceeds remaining buffer');
     }
-  } else if (total > MAX_COLLECTION_ITEMS) {
-    throw new Error('collection of zero-byte items exceeds maximum allowed');
+  } else {
+    tap.zeroByteItems += n;
+    if (tap.zeroByteItems > MAX_COLLECTION_ITEMS) {
+      throw new Error('collection of zero-byte items exceeds maximum allowed');
+    }
   }
 }
 

--- a/lang/js/lib/utils.js
+++ b/lang/js/lib/utils.js
@@ -335,10 +335,18 @@ Tap.prototype.readInt = Tap.prototype.readLong = function () {
     // Switch to float arithmetic, otherwise we might overflow.
     f = n;
     fk = 268435456; // 2 ** 28.
+    // A 64-bit value uses at most 10 bytes; the integer loop above consumed 4,
+    // so the float loop may read at most 6 more. Reject an overlong varint
+    // rather than reading an unbounded continuation chain.
+    var m = 0;
     do {
+      if (m === 6) {
+        throw new Error('overlong varint');
+      }
       b = buf[this.pos++];
       f += (b & 0x7f) * fk;
       fk *= 128;
+      m++;
     } while (b & 0x80);
     return (f % 2 ? -(f + 1) : f) / 2;
   }
@@ -348,7 +356,13 @@ Tap.prototype.readInt = Tap.prototype.readLong = function () {
 
 Tap.prototype.skipInt = Tap.prototype.skipLong = function () {
   var buf = this.buf;
-  while (buf[this.pos++] & 0x80) {}
+  var m = 0;
+  while (buf[this.pos++] & 0x80) {
+    // At most 10 bytes for a 64-bit varint; reject an overlong encoding.
+    if (++m === 10) {
+      throw new Error('overlong varint');
+    }
+  }
 };
 
 Tap.prototype.writeInt = Tap.prototype.writeLong = function (n) {

--- a/lang/js/lib/utils.js
+++ b/lang/js/lib/utils.js
@@ -285,6 +285,14 @@ OrderedQueue.prototype.pop = function () {
 function Tap(buf, pos) {
   this.buf = buf;
   this.pos = pos | 0;
+  // Cumulative number of zero-byte-encoded collection elements (e.g. an array
+  // of nulls) read from this tap while decoding the current datum. Reset per
+  // top-level read. Such elements consume no input, so the bytes-remaining
+  // check cannot bound them, and a per-collection cap is not enough either: a
+  // record's schema can declare many collection fields, each block under the
+  // limit but jointly unbounded. The cap is therefore applied across the whole
+  // datum. See `checkCollectionBlock` in schemas.js.
+  this.zeroByteItems = 0;
 }
 
 /**

--- a/lang/js/test/test_schemas.js
+++ b/lang/js/test/test_schemas.js
@@ -1030,6 +1030,30 @@ describe('types', function () {
       assert.throws(function () { v2.fromBuffer(buf, resolver); }, /collection/);
     });
 
+    it('bounds a huge negative (sized) block count while skipping', function () {
+      // A negative block count carries a byte-size and is skipped in one step;
+      // the item cap must still apply so it cannot be used to bypass the bound.
+      var v1 = createType({
+        name: 'Foo',
+        type: 'record',
+        fields: [
+          {name: 'array', type: {type: 'array', items: 'null'}},
+          {name: 'val', type: 'int'}
+        ]
+      });
+      var v2 = createType({
+        name: 'Foo',
+        type: 'record',
+        fields: [{name: 'val', type: 'int'}]
+      });
+      // Block count -200,000,000 (zig-zag 0xFF..), a block byte-size of 0, then
+      // the terminator and val.
+      var buf = Buffer.from(
+        [0xff, 0x87, 0xde, 0xbe, 0x01, 0x00, 0x00, 6]);
+      var resolver = v2.createResolver(v1);
+      assert.throws(function () { v2.fromBuffer(buf, resolver); }, /collection/);
+    });
+
     it('bounds a huge block count under resolution', function () {
       var t1 = new types.ArrayType({type: 'array', items: 'null'});
       var t2 = createType({type: 'array', items: ['null', 'long']});

--- a/lang/js/test/test_schemas.js
+++ b/lang/js/test/test_schemas.js
@@ -939,6 +939,18 @@ describe('types', function () {
       assert.strictEqual(t.getName(), undefined);
     });
 
+    it('rejects a huge block count', function () {
+      var t = new types.MapType({type: 'map', values: 'long'});
+      var buf = Buffer.from([0x80, 0x88, 0xde, 0xbe, 0x01, 0x00]);
+      assert.throws(function () { t.fromBuffer(buf); }, /collection/);
+    });
+
+    it('reads a small map', function () {
+      var t = new types.MapType({type: 'map', values: 'int'});
+      var buf = t.toBuffer({a: 1, b: 2});
+      assert.deepEqual(t.fromBuffer(buf), {a: 1, b: 2});
+    });
+
   });
 
   describe('ArrayType', function () {
@@ -969,6 +981,60 @@ describe('types', function () {
       var t = new types.ArrayType({type: 'array', items: 'int'});
       var buf = Buffer.from([1,2,2,0]);
       assert.deepEqual(t.fromBuffer(buf), [1]);
+    });
+
+    it('rejects a huge zero-byte block count', function () {
+      // 6-byte payload declaring a block count of 200,000,000 nulls.
+      var t = new types.ArrayType({type: 'array', items: 'null'});
+      var buf = Buffer.from([0x80, 0x88, 0xde, 0xbe, 0x01, 0x00]);
+      assert.throws(function () { t.fromBuffer(buf); }, /collection/);
+    });
+
+    it('reads a small zero-byte collection', function () {
+      var t = new types.ArrayType({type: 'array', items: 'null'});
+      var buf = Buffer.from([6, 0]); // Block count 3, then terminator.
+      assert.deepEqual(t.fromBuffer(buf), [null, null, null]);
+    });
+
+    it('rejects a block count above the remaining bytes', function () {
+      var t = new types.ArrayType({type: 'array', items: 'long'});
+      var buf = Buffer.from([0x80, 0x88, 0xde, 0xbe, 0x01, 0x00]);
+      assert.throws(function () { t.fromBuffer(buf); }, /collection/);
+    });
+
+    it('bounds a huge zero-byte block count while skipping', function () {
+      var v1 = createType({
+        name: 'Foo',
+        type: 'record',
+        fields: [
+          {name: 'array', type: {type: 'array', items: 'null'}},
+          {name: 'val', type: 'int'}
+        ]
+      });
+      var v2 = createType({
+        name: 'Foo',
+        type: 'record',
+        fields: [{name: 'val', type: 'int'}]
+      });
+      var buf = Buffer.from([0x80, 0x88, 0xde, 0xbe, 0x01, 0x00, 6]);
+      var resolver = v2.createResolver(v1);
+      assert.throws(function () { v2.fromBuffer(buf, resolver); }, /collection/);
+    });
+
+    it('bounds a huge block count under resolution', function () {
+      var t1 = new types.ArrayType({type: 'array', items: 'null'});
+      var t2 = createType({type: 'array', items: ['null', 'long']});
+      var buf = Buffer.from([0x80, 0x88, 0xde, 0xbe, 0x01, 0x00]);
+      var resolver = t2.createResolver(t1);
+      assert.throws(function () { t2.fromBuffer(buf, resolver); }, /collection/);
+    });
+
+    it('reads a small collection under resolution', function () {
+      var t1 = new types.ArrayType({type: 'array', items: 'null'});
+      var t2 = createType({type: 'array', items: ['null', 'long']});
+      var buf = t1.toBuffer([null, null, null, null, null]);
+      var resolver = t2.createResolver(t1);
+      assert.equal(t2.fromBuffer(buf, resolver).length, 5);
     });
 
     it('skip', function () {

--- a/lang/js/test/test_schemas.js
+++ b/lang/js/test/test_schemas.js
@@ -419,6 +419,15 @@ describe('types', function () {
       assert.throws(function () { type.fromBuffer(buf); });
     });
 
+    it('skip invalid index', function () {
+      var type = new types.UnionType(['null', 'int']);
+      var buf = Buffer.alloc(16);
+      var tap = new Tap(buf);
+      tap.writeLong(5); // out of range for a 2-branch union
+      tap.pos = 0;
+      assert.throws(function () { type._skip(tap); }, /invalid union index/);
+    });
+
     it('non wrapped write', function () {
       var type = new types.UnionType(['null', 'int']);
       assert.throws(function () {

--- a/lang/js/test/test_schemas.js
+++ b/lang/js/test/test_schemas.js
@@ -951,6 +951,74 @@ describe('types', function () {
       assert.deepEqual(t.fromBuffer(buf), {a: 1, b: 2});
     });
 
+    it('bounds a huge block count while skipping', function () {
+      var v1 = createType({
+        name: 'Foo',
+        type: 'record',
+        fields: [
+          {name: 'map', type: {type: 'map', values: 'null'}},
+          {name: 'val', type: 'int'}
+        ]
+      });
+      var v2 = createType({
+        name: 'Foo',
+        type: 'record',
+        fields: [{name: 'val', type: 'int'}]
+      });
+      var buf = Buffer.from([0x80, 0x88, 0xde, 0xbe, 0x01, 0x00, 6]);
+      var resolver = v2.createResolver(v1);
+      assert.throws(function () { v2.fromBuffer(buf, resolver); }, /collection/);
+    });
+
+    it('bounds a huge negative (sized) block count while skipping', function () {
+      var v1 = createType({
+        name: 'Foo',
+        type: 'record',
+        fields: [
+          {name: 'map', type: {type: 'map', values: 'null'}},
+          {name: 'val', type: 'int'}
+        ]
+      });
+      var v2 = createType({
+        name: 'Foo',
+        type: 'record',
+        fields: [{name: 'val', type: 'int'}]
+      });
+      // Block count -200,000,000, a block byte-size of 0, then terminator + val.
+      var buf = Buffer.from([0xff, 0x87, 0xde, 0xbe, 0x01, 0x00, 0x00, 6]);
+      var resolver = v2.createResolver(v1);
+      assert.throws(function () { v2.fromBuffer(buf, resolver); }, /collection/);
+    });
+
+    it('rejects a negative block byte-size while skipping', function () {
+      var v1 = createType({
+        name: 'Foo',
+        type: 'record',
+        fields: [
+          {name: 'map', type: {type: 'map', values: 'int'}},
+          {name: 'val', type: 'int'}
+        ]
+      });
+      var v2 = createType({
+        name: 'Foo',
+        type: 'record',
+        fields: [{name: 'val', type: 'int'}]
+      });
+      // Block count -1 followed by a negative byte-size (zig-zag 1 -> 0x01).
+      var buf = Buffer.from([0x01, 0x01, 0x00, 6]);
+      var resolver = v2.createResolver(v1);
+      assert.throws(function () { v2.fromBuffer(buf, resolver); }, /negative/);
+    });
+
+    it('reads a small map under resolution', function () {
+      var t1 = new types.MapType({type: 'map', values: 'int'});
+      var t2 = createType({type: 'map', values: ['null', 'int']});
+      var buf = t1.toBuffer({a: 1, b: 2});
+      var resolver = t2.createResolver(t1);
+      var result = t2.fromBuffer(buf, resolver);
+      assert.deepEqual(Object.keys(result).sort(), ['a', 'b']);
+    });
+
   });
 
   describe('ArrayType', function () {

--- a/lang/js/test/test_schemas.js
+++ b/lang/js/test/test_schemas.js
@@ -996,6 +996,15 @@ describe('types', function () {
       assert.deepEqual(t.fromBuffer(buf), [null, null, null]);
     });
 
+    it('rejects an INT64_MIN block count', function () {
+      // INT64_MIN zig-zags to the 10-byte varint below (then a block byte-size).
+      // Negating it yields ~2^63, which the structural cap rejects.
+      var t = new types.ArrayType({type: 'array', items: 'null'});
+      var buf = Buffer.from(
+        [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01, 0x00]);
+      assert.throws(function () { t.fromBuffer(buf); }, /collection/);
+    });
+
     it('rejects a block count above the remaining bytes', function () {
       var t = new types.ArrayType({type: 'array', items: 'long'});
       var buf = Buffer.from([0x80, 0x88, 0xde, 0xbe, 0x01, 0x00]);

--- a/lang/js/test/test_schemas.js
+++ b/lang/js/test/test_schemas.js
@@ -1073,6 +1073,45 @@ describe('types', function () {
       assert.deepEqual(t.fromBuffer(buf), [null, null, null]);
     });
 
+    it('rejects zero-byte array fields cumulatively across a record', function () {
+      // The zero-byte cap is cumulative across a datum, not per collection: a
+      // record with many array<null> fields, each block under the limit but
+      // jointly unbounded, must be rejected. field a = 1 null, field b declares
+      // 10,000,000 (cumulative 10,000,001 > the 10M cap), rejected before
+      // allocating field b.
+      var t = createType({
+        name: 'R',
+        type: 'record',
+        fields: [
+          {name: 'a', type: {type: 'array', items: 'null'}},
+          {name: 'b', type: {type: 'array', items: 'null'}}
+        ]
+      });
+      // a: block count 1 (0x02) + terminator (0x00); b: block count 10,000,000
+      // (zig-zag varint 0x80 0xda 0xc4 0x09).
+      var buf = Buffer.from([0x02, 0x00, 0x80, 0xda, 0xc4, 0x09]);
+      assert.throws(function () { t.fromBuffer(buf); }, /collection/);
+    });
+
+    it('reads zero-byte array fields within the cumulative cap, resetting per datum', function () {
+      var t = createType({
+        name: 'R',
+        type: 'record',
+        fields: [
+          {name: 'a', type: {type: 'array', items: 'null'}},
+          {name: 'b', type: {type: 'array', items: 'null'}}
+        ]
+      });
+      // a=[null,null], b=[null,null]: block count 2 (0x04) + terminator each.
+      var buf = Buffer.from([0x04, 0x00, 0x04, 0x00]);
+      // Decode twice: the per-datum budget must reset between datums.
+      for (var i = 0; i < 2; i++) {
+        var rec = t.fromBuffer(buf);
+        assert.deepEqual(rec.a, [null, null]);
+        assert.deepEqual(rec.b, [null, null]);
+      }
+    });
+
     it('rejects an INT64_MIN block count', function () {
       // INT64_MIN zig-zags to the 10-byte varint below (then a block byte-size).
       // Negating it yields ~2^63, which the structural cap rejects.

--- a/lang/js/test/test_utils.js
+++ b/lang/js/test/test_utils.js
@@ -166,6 +166,24 @@ describe('utils', function () {
 
       });
 
+      it('read rejects overlong varint', function () {
+        // 10 continuation bytes then a terminator: a 64-bit value uses at most
+        // 10 bytes, so this overlong encoding must be rejected.
+        var bytes = [];
+        for (var i = 0; i < 10; i++) { bytes.push(0x80); }
+        bytes.push(0x01);
+        var buf = Buffer.from(bytes);
+        assert.throws(function () { (new Tap(buf)).readLong(); }, /overlong varint/);
+      });
+
+      it('skip rejects overlong varint', function () {
+        var bytes = [];
+        for (var i = 0; i < 10; i++) { bytes.push(0x80); }
+        bytes.push(0x01);
+        var buf = Buffer.from(bytes);
+        assert.throws(function () { (new Tap(buf)).skipLong(); }, /overlong varint/);
+      });
+
     });
 
     describe('boolean', function () {


### PR DESCRIPTION
## What is the purpose of the change

An `array` or `map` block is encoded as an item count followed by that many items. A malicious or truncated input can declare a very large count while carrying little or no data, which causes a correspondingly large allocation before the shortfall is noticed.

The JavaScript SDK already bounds length-prefixed `bytes`/`string`/`fixed` values against its in-memory buffer (`Tap.readFixed`/`readString` check the position against the buffer length before allocating), which is why it had no available-bytes sub-task under [AVRO-4292](https://issues.apache.org/jira/browse/AVRO-4292). Collections, however, were **not** bounded: `ArrayType._read` and `MapType._read` read the block item count and push elements incrementally into a plain array/object with no cap and no bytes-remaining check.

Because zero-byte elements (e.g. `null`) consume no input, a ~6 byte payload such as `{"type":"array","items":"null"}` declaring a block count of 200,000,000 builds a 200M-entry array and exhausts the heap. Reproduced on `main`:

```
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed -
JavaScript heap out of memory
```

under `node --max-old-space-size=256`. Even truncated non-zero-byte collections are affected, because an out-of-range `Buffer` read returns `undefined` rather than throwing, so the loop runs to the full declared count; the `tap.isValid()` check only happens *after* `_read` returns.

### Fix

`ArrayType._read`/`_skip` and `MapType._read`/`_skip` now bound each block, consistent with the other SDKs:

- reject a block whose element count could not be backed by the bytes remaining, using `getMinBytes()` (the minimum on-wire size of the element schema) so a zero-byte element type is never falsely rejected;
- cap the cumulative count of zero-byte elements (`MAX_COLLECTION_ITEMS`, default 10,000,000);
- apply a structural cap to every collection (`MAX_COLLECTION_STRUCTURAL`, default `Integer.MAX_VALUE - 8`);
- additionally reject overlong varints in `Tap.readLong`/`Tap.skipLong` and bounds-check the branch index on the union skip path (`UnionType._skip`).

When set, the `AVRO_MAX_COLLECTION_ITEMS` environment variable caps both limits. Under schema resolution the minimum is computed from the **writer** element type (what is actually on the wire, precomputed in `_updateResolver`), so legitimate collections are not falsely rejected.

This is a sub-task of [AVRO-4292](https://issues.apache.org/jira/browse/AVRO-4292) and resolves [AVRO-4301](https://issues.apache.org/jira/browse/AVRO-4301).

## Verifying this change

This change added tests and can be verified as follows:

- Extended `lang/js/test/test_schemas.js`: for arrays, a huge zero-byte block count rejected; for both arrays and maps, a huge non-zero-byte block count rejected (above the remaining bytes), a small collection that still decodes, the skip path bounded, and rejection plus a legitimate decode under schema resolution; plus an array INT64_MIN block-count rejection and a union skip invalid-index test. Also added overlong-varint tests in `lang/js/test/test_utils.js`.
- Manually verified against the PoC (`array<null>`, block count 200,000,000) under `--max-old-space-size=256`: rejected with a clean error instead of an OOM crash.
- Run: `cd lang/js && npm test` (391 passing) and `npm run lint` (clean).

## Documentation

- Does this pull request introduce a new feature? (no — hardening / robustness)
- If yes, how is the feature documented? (not applicable; adds the `AVRO_MAX_COLLECTION_ITEMS` environment override, consistent with the other SDKs)

