### PR TITLE
[py] reject negative enum and union index in binary decoder

### DIFF
--- a/lang/py/avro/io.py
+++ b/lang/py/avro/io.py
@@ -765,7 +765,7 @@ class DatumReader:
         """
         # read data
         index_of_symbol = decoder.read_int()
-        if index_of_symbol >= len(writers_schema.symbols):
+        if not 0 <= index_of_symbol < len(writers_schema.symbols):
             raise avro.errors.SchemaResolutionException(
                 f"Can't access enum index {index_of_symbol} for enum with {len(writers_schema.symbols)} symbols", writers_schema, readers_schema
             )
@@ -864,7 +864,7 @@ class DatumReader:
         """
         # schema resolution
         index_of_schema = int(decoder.read_long())
-        if index_of_schema >= len(writers_schema.schemas):
+        if not 0 <= index_of_schema < len(writers_schema.schemas):
             raise avro.errors.SchemaResolutionException(
                 f"Can't access branch index {index_of_schema} for union with {len(writers_schema.schemas)} branches", writers_schema, readers_schema
             )
@@ -875,7 +875,7 @@ class DatumReader:
 
     def skip_union(self, writers_schema: avro.schema.UnionSchema, decoder: BinaryDecoder) -> None:
         index_of_schema = int(decoder.read_long())
-        if index_of_schema >= len(writers_schema.schemas):
+        if not 0 <= index_of_schema < len(writers_schema.schemas):
             raise avro.errors.SchemaResolutionException(
                 f"Can't access branch index {index_of_schema} for union with {len(writers_schema.schemas)} branches", writers_schema
             )

--- a/lang/py/avro/test/test_io.py
+++ b/lang/py/avro/test/test_io.py
@@ -598,6 +598,22 @@ class TestMisc(unittest.TestCase):
         datum_reader = avro.io.DatumReader(writers_schema, readers_schema)
         self.assertRaises(avro.errors.SchemaResolutionException, datum_reader.read, decoder)
 
+    def test_negative_enum_index(self) -> None:
+        # A negative zigzag-encoded index (0x01 -> -1) must be rejected rather than
+        # silently wrapping to symbols[-1] via Python negative indexing.
+        writers_schema = avro.schema.parse(json.dumps({"type": "enum", "name": "Test", "symbols": ["FOO", "BAR"]}))
+        decoder = avro.io.BinaryDecoder(io.BytesIO(b"\x01"))
+        datum_reader = avro.io.DatumReader(writers_schema, writers_schema)
+        self.assertRaises(avro.errors.SchemaResolutionException, datum_reader.read, decoder)
+
+    def test_negative_union_index(self) -> None:
+        # A negative branch index must be rejected rather than selecting schemas[-1]
+        # and decoding the payload with the wrong branch schema.
+        writers_schema = avro.schema.parse(json.dumps(["null", "string", "long"]))
+        decoder = avro.io.BinaryDecoder(io.BytesIO(b"\x01\x08"))
+        datum_reader = avro.io.DatumReader(writers_schema, writers_schema)
+        self.assertRaises(avro.errors.SchemaResolutionException, datum_reader.read, decoder)
+
     def test_no_default_value(self) -> None:
         writers_schema = LONG_RECORD_SCHEMA
         datum_to_write = LONG_RECORD_DATUM


### PR DESCRIPTION
## What is the purpose of the change

`read_enum`, `read_union` and `skip_union` in the Python binary decoder read the enum symbol index / union branch index from the wire and validate it with an upper-bound-only check (`index >= len(...)`). A negative index is not caught. Because the index is then used directly to subscript `writers_schema.symbols` / `writers_schema.schemas`, and Python lists accept negative subscripts, a crafted negative zigzag index passes validation and wraps to an element counted from the end of the list. For an enum this silently returns the wrong symbol; for a union it selects a branch that the writer never declared and decodes the following bytes with that wrong branch schema, which is a decode-time type confusion and desyncs the stream for `skip_union`. Positive out-of-range indices are already rejected, so this only closes the negative side. The check becomes `0 <= index < len(...)` at all three sites.

## Verifying this change

This change added tests and can be verified as follows:

- Added `test_negative_enum_index` and `test_negative_union_index` in `TestMisc`, feeding a single `0x01` byte (zigzag `-1`) as the index. Both assert `SchemaResolutionException`. Against the unpatched decoder the enum read returns `symbols[-1]` and the union read decodes via `schemas[-1]`, so both tests fail before the fix.
- Full `test_io` suite green (152 tests).

## Documentation

- Does this pull request introduce a new feature? no