### PR TITLE
[c++] bounds-check reader default lookup in schema resolution

### DIFF
--- a/lang/c++/include/avro/NodeImpl.hh
+++ b/lang/c++/include/avro/NodeImpl.hh
@@ -341,6 +341,9 @@ public:
     }
 
     const GenericDatum &defaultValueAt(size_t index) override {
+        if (index >= fieldsDefaultValues_.size()) {
+            throw Exception("No default value at: {}", index);
+        }
         return fieldsDefaultValues_[index];
     }
 

--- a/lang/c++/test/SchemaTests.cc
+++ b/lang/c++/test/SchemaTests.cc
@@ -17,8 +17,10 @@
  */
 
 #include "Compiler.hh"
+#include "Decoder.hh"
 #include "GenericDatum.hh"
 #include "NodeImpl.hh"
+#include "Schema.hh"
 #include "ValidSchema.hh"
 
 #include <boost/algorithm/string/replace.hpp>
@@ -924,6 +926,23 @@ static void testCustomAttributesSchema2Json2Schema() {
     }
 }
 
+// A reader record built with the programmatic API (RecordSchema::addField)
+// carries no default values, so fieldsDefaultValues_ is empty. When the writer
+// schema omits a field the reader declares, resolution asks the reader for that
+// field's default and previously indexed the empty vector out of bounds. It must
+// throw instead.
+void testResolveReaderFieldWithoutDefault() {
+    ValidSchema writer = compileJsonSchemaFromString(
+        R"({"type":"record","name":"R","fields":[{"name":"a","type":"int"}]})");
+
+    RecordSchema readerRecord("R");
+    readerRecord.addField("a", IntSchema());
+    readerRecord.addField("b", IntSchema());
+    ValidSchema reader(readerRecord);
+
+    BOOST_CHECK_THROW(resolvingDecoder(writer, reader, binaryDecoder()), Exception);
+}
+
 } // namespace schema
 } // namespace avro
 
@@ -952,5 +971,6 @@ init_unit_test_suite(int /*argc*/, char * /*argv*/[]) {
     ts->add(BOOST_TEST_CASE(&avro::schema::testAddCustomAttributes));
     ts->add(BOOST_TEST_CASE(&avro::schema::testCustomAttributesJson2Schema2Json));
     ts->add(BOOST_TEST_CASE(&avro::schema::testCustomAttributesSchema2Json2Schema));
+    ts->add(BOOST_TEST_CASE(&avro::schema::testResolveReaderFieldWithoutDefault));
     return ts;
 }


### PR DESCRIPTION
## What is the purpose of the change

`NodeRecord::defaultValueAt` returns `fieldsDefaultValues_[index]` with no bounds check. A record reader schema constructed through the public programmatic API (`RecordSchema::addField`) never populates `fieldsDefaultValues_`, so that vector stays empty while the record gains leaves. During schema resolution, when a data file's writer schema omits a field that the reader schema declares, `ResolvingGrammarGenerator::resolveRecords` calls `reader->defaultValueAt(ri)` to fetch the reader field's default and reads past the empty vector. The out-of-bounds `GenericDatum` is then dereferenced by `getAvroBinary` / `GenericWriter::write` (`GenericDatum::isUnion`), which is an out-of-bounds read that crashes. Because the writer schema is attacker-controlled bytes inside the data file header, opening such a file with a programmatically-built reader schema is enough to trigger it. I hit it while reading a corpus file whose writer had dropped a field. The base `Node::defaultValueAt` already throws `Exception("No default value at")` for this case, and the sibling `customAttributesAt` already guards its index the same way, so this brings `defaultValueAt` in line with both. A missing reader default now surfaces as a normal resolution error instead of a memory fault.

## Verifying this change

This change added tests and can be verified as follows:

- Added a schema test that builds a reader record via `RecordSchema::addField` with a field absent from the writer schema and asserts that `resolvingDecoder` throws `Exception`. It crashes (SEGV, confirmed under ASan) on the current code and passes with the fix.

## Documentation

- Does this pull request introduce a new feature? no
