### PR TITLE
AVRO-4268: BytesWritableConverter should respect logical length

### DIFF
--- a/lang/java/mapred/src/main/java/org/apache/avro/hadoop/io/AvroDatumConverterFactory.java
+++ b/lang/java/mapred/src/main/java/org/apache/avro/hadoop/io/AvroDatumConverterFactory.java
@@ -199,7 +199,7 @@ public class AvroDatumConverterFactory extends Configured {
     /** {@inheritDoc} */
     @Override
     public ByteBuffer convert(BytesWritable input) {
-      return ByteBuffer.wrap(input.getBytes());
+      return ByteBuffer.wrap(input.getBytes(), 0, input.getLength());
     }
 
     /** {@inheritDoc} */

--- a/lang/java/mapred/src/test/java/org/apache/avro/hadoop/io/TestAvroDatumConverterFactory.java
+++ b/lang/java/mapred/src/test/java/org/apache/avro/hadoop/io/TestAvroDatumConverterFactory.java
@@ -90,6 +90,21 @@ public class TestAvroDatumConverterFactory {
   }
 
   @Test
+  void convertBytesWritableRespectsLogicalLength() {
+    AvroDatumConverter<BytesWritable, ByteBuffer> converter = mFactory.create(BytesWritable.class);
+    byte[] backing = new byte[] { 1, 2, 3, 4, 5 };
+    BytesWritable writable = new BytesWritable(backing);
+    writable.setSize(3);
+
+    ByteBuffer bytes = converter.convert(writable);
+
+    assertEquals(3, bytes.remaining());
+    assertEquals(1, bytes.get(0));
+    assertEquals(2, bytes.get(1));
+    assertEquals(3, bytes.get(2));
+  }
+
+  @Test
   void convertByteWritable() {
     AvroDatumConverter<ByteWritable, GenericFixed> converter = mFactory.create(ByteWritable.class);
     assertEquals(42, converter.convert(new ByteWritable((byte) 42)).bytes()[0]);


### PR DESCRIPTION
Closes AVRO-4268

## What was wrong

`BytesWritable` can use a backing array that is larger than the value it
currently contains. The converter used the entire backing array, so unused
bytes could be included in the Avro value.

## What changed

The converter now uses `BytesWritable.getLength()` and includes only the
bytes that belong to the current value.

A regression test covers a five-byte backing array whose logical value is only
three bytes.

## Testing

- Regression test: 1 passed, 0 failed, 0 errors, 0 skipped
- `lang/java/mapred` suite: 110 passed, 0 failed, 0 errors, 0 skipped
- Spotless check passed
- `git diff --check` passed

The commit is signed off using `harsh10822@gmail.com`. Please let me know if
any ASF CLA action is required.
