### PR TITLE
AVRO-4309: [Python][Build] Add uvx to path explicitly

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -39,8 +39,9 @@ change_java_version() {
 
 # ===========================================================================
 
-# This might not have been sourced if the entrypoint is not bash
+# These might not have been sourced if the entrypoint is not bash
 [[ -f "$HOME/.cargo/env" ]] && . "$HOME/.cargo/env"
+[[ -f "$HOME/.local/bin/env" ]] && . "$HOME/.local/bin/env"
 
 set -xe
 cd "${0%/*}"


### PR DESCRIPTION
## What is the purpose of the change

Ensure that `~/.local/bin/` gets added to the path to catch `uvx` even if bash isn't the local entrypoint to the docker.  This is normally added to the path in `.bashrc`.

## Verifying this change

Tested manually.

## Documentation

- Does this pull request introduce a new feature? **no**
- If yes, how is the feature documented? **not applicable**
