### PR TITLE
[c] reject negative size in avro_schema_fixed_ns

### DIFF
--- a/lang/c/src/schema.c
+++ b/lang/c/src/schema.c
@@ -325,6 +325,11 @@ avro_schema_t avro_schema_fixed_ns(const char *name, const char *space,
 		return NULL;
 	}
 
+	if (size < 0) {
+		avro_set_error("Invalid size for fixed schema");
+		return NULL;
+	}
+
 	struct avro_fixed_schema_t *fixed =
 	    (struct avro_fixed_schema_t *) avro_new(struct avro_fixed_schema_t);
 	if (!fixed) {

--- a/lang/c/tests/schema_tests/fail/fixed_negative_size
+++ b/lang/c/tests/schema_tests/fail/fixed_negative_size
@@ -1,0 +1,3 @@
+{"type": "fixed",
+ "name": "F",
+ "size": -1}


### PR DESCRIPTION
validate the fixed size in avro_schema_fixed_ns and reject negatives, otherwise a fixed type from untrusted schema json (e.g. size -2) reaches avro_generic_value_new as a near-SIZE_MAX instance size whose refcount allocation wraps to a couple of bytes and the refcount init writes past it (asan heap-buffer-overflow at generic.c:71); the c++ compiler already rejects size <= 0.