### PR TITLE
AVRO-4313: [java] Tighten javaAnnotation string-literal validation in SpecificCompiler

### DIFF
--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
@@ -1054,7 +1054,11 @@ public class SpecificCompiler {
   private static final String PATTERN_IDENTIFIER_PART = "\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*";
   private static final String PATTERN_IDENTIFIER = String.format("(?:%s(?:\\.%s)*)", PATTERN_IDENTIFIER_PART,
       PATTERN_IDENTIFIER_PART);
-  private static final String PATTERN_STRING = "\"(?:\\\\[\\\\\"ntfb]|(?<!\\\\).)*\"";
+  // A string literal is a quote, a body of escape sequences or characters that
+  // are not a quote, backslash or line terminator, and a closing quote. The body
+  // must not be able to contain an unescaped quote, otherwise a single literal
+  // could span past the intended closing quote and swallow surrounding tokens.
+  private static final String PATTERN_STRING = "\"(?:\\\\[\\\\\"ntfb]|[^\"\\\\\\r\\n])*\"";
   private static final String PATTERN_NUMBER = "(?:\\((?:byte|char|short|int|long|float|double)\\))?[x0-9_.]*[fl]?";
   private static final String PATTERN_LITERAL_VALUE = String.format("(?:%s|%s|true|false)", PATTERN_STRING,
       PATTERN_NUMBER);

--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
@@ -1058,7 +1058,9 @@ public class SpecificCompiler {
   // are not a quote, backslash or line terminator, and a closing quote. The body
   // must not be able to contain an unescaped quote, otherwise a single literal
   // could span past the intended closing quote and swallow surrounding tokens.
-  private static final String PATTERN_STRING = "\"(?:\\\\[\\\\\"ntfb]|[^\"\\\\\\r\\n])*\"";
+  // Line terminators (CR, LF, NEL, LS, PS) are excluded so a value cannot break
+  // across lines in the generated source.
+  private static final String PATTERN_STRING = "\"(?:\\\\[\\\\\"ntfb]|[^\"\\\\\\r\\n\\x85\\x{2028}\\x{2029}])*\"";
   private static final String PATTERN_NUMBER = "(?:\\((?:byte|char|short|int|long|float|double)\\))?[x0-9_.]*[fl]?";
   private static final String PATTERN_LITERAL_VALUE = String.format("(?:%s|%s|true|false)", PATTERN_STRING,
       PATTERN_NUMBER);

--- a/lang/java/compiler/src/test/java/org/apache/avro/compiler/specific/TestSpecificCompiler.java
+++ b/lang/java/compiler/src/test/java/org/apache/avro/compiler/specific/TestSpecificCompiler.java
@@ -1044,16 +1044,18 @@ public class TestSpecificCompiler {
         + "    {\"name\": \"value\", \"type\": \"string\"}\n" + "  ]\n" + "}";
     Collection<SpecificCompiler.OutputFile> outputs = new SpecificCompiler(SchemaParser.parseSingle(jsonSchema))
         .compile();
+    boolean validAnnotationEmitted = false;
     for (SpecificCompiler.OutputFile outputFile : outputs) {
       // The payload is echoed (safely escaped) inside the SCHEMA$ string constant,
       // so we must distinguish that from a verbatim emission as code. Real injected
       // code would carry unescaped quotes; the schema literal escapes them as \".
+      // The injection must be absent from every generated file.
       assertFalse(outputFile.contents.contains("SuppressWarnings(\"x\") static { System.exit(1); }"),
           "Code injection present? " + outputFile.contents);
-      // The legitimate annotation in the same list must still be emitted.
-      assertTrue(outputFile.contents.contains("@SuppressWarnings(\"unchecked\")"),
-          "Valid annotation missing? " + outputFile.contents);
+      validAnnotationEmitted |= outputFile.contents.contains("@SuppressWarnings(\"unchecked\")");
     }
+    // The legitimate annotation in the same list must still be emitted somewhere.
+    assertTrue(validAnnotationEmitted, "Valid annotation missing from generated output");
   }
 
   private int countOccurrences(Pattern pattern, String textToSearch) {

--- a/lang/java/compiler/src/test/java/org/apache/avro/compiler/specific/TestSpecificCompiler.java
+++ b/lang/java/compiler/src/test/java/org/apache/avro/compiler/specific/TestSpecificCompiler.java
@@ -1031,6 +1031,31 @@ public class TestSpecificCompiler {
     }
   }
 
+  @Test
+  void annotationCannotBreakOutViaStringLiteral() {
+    // A crafted javaAnnotation value tries to terminate the first annotation,
+    // inject arbitrary declarations plus a static initializer, then reopen a
+    // second valid annotation. It relies on a string literal spanning past its
+    // intended closing quote. Such values must be rejected, not emitted verbatim.
+    String jsonSchema = "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"Injected\",\n"
+        + "  \"javaAnnotation\": [\n"
+        + "    \"java.lang.SuppressWarnings(\\\"x\\\") static { System.exit(1); } @java.lang.SuppressWarnings(\\\"y\\\")\",\n"
+        + "    \"SuppressWarnings(\\\"unchecked\\\")\"\n" + "  ],\n" + "  \"fields\": [\n"
+        + "    {\"name\": \"value\", \"type\": \"string\"}\n" + "  ]\n" + "}";
+    Collection<SpecificCompiler.OutputFile> outputs = new SpecificCompiler(SchemaParser.parseSingle(jsonSchema))
+        .compile();
+    for (SpecificCompiler.OutputFile outputFile : outputs) {
+      // The payload is echoed (safely escaped) inside the SCHEMA$ string constant,
+      // so we must distinguish that from a verbatim emission as code. Real injected
+      // code would carry unescaped quotes; the schema literal escapes them as \".
+      assertFalse(outputFile.contents.contains("SuppressWarnings(\"x\") static { System.exit(1); }"),
+          "Code injection present? " + outputFile.contents);
+      // The legitimate annotation in the same list must still be emitted.
+      assertTrue(outputFile.contents.contains("@SuppressWarnings(\"unchecked\")"),
+          "Valid annotation missing? " + outputFile.contents);
+    }
+  }
+
   private int countOccurrences(Pattern pattern, String textToSearch) {
     int count = 0;
     for (Matcher matcher = pattern.matcher(textToSearch); matcher.find();) {


### PR DESCRIPTION
## What is the purpose of the change

Avro copies a schema's `javaAnnotation` property **verbatim** into the Java
source it generates (e.g. `@Deprecated`, `@SuppressWarnings("unchecked")`).
Before doing so, `SpecificCompiler` checks the value with a regex to make sure
it only looks like a Java annotation and nothing more.

That check had a hole. The sub-pattern for a quoted string (like `"unchecked"`)
accepted an **unescaped double-quote inside the string body**. So a single
string literal could run past its closing quote and swallow whatever came after
it, while the whole value still matched the "valid annotation" shape.

A crafted value like:

    java.lang.SuppressWarnings("x") static { System.exit(1); } @java.lang.SuppressWarnings("y")

therefore passed validation and was written straight into the generated class —
a code-injection at code-generation time.

## What this PR changes

Tighten the string-literal grammar so its body may only contain:

- a recognized escape sequence: `\\  \"  \n  \t  \f  \b`, or
- any character that is **not** a quote, backslash, or line terminator.

Now an unescaped quote ends the literal, so the injected trailing tokens fail
validation and the value is rejected instead of emitted. Line terminators
(CR, LF, NEL, LS, PS) are excluded too, so a value can't span multiple lines in
the generated source.

Legitimate annotations still validate: `SuppressWarnings("unchecked")`,
`Deprecated(forRemoval = true, since = "forever")`, and values with escaped
quotes.

## Verifying this change

- Added `annotationCannotBreakOutViaStringLiteral` in `TestSpecificCompiler`:
  it feeds the crafted value above alongside a normal annotation, and asserts
  the injected code is absent from every generated file while the valid
  annotation is still emitted. It fails on the old grammar and passes on the new.
- The existing `docsAreEscaped_avro4053` test and the full `compiler` module
  suite continue to pass.

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)
