### PR TITLE
AVRO-4308: [python] Fix interop build failure from setuptools package discovery

### DIFF
--- a/lang/py/pyproject.toml
+++ b/lang/py/pyproject.toml
@@ -56,6 +56,9 @@ zstandard = ["zstandard"]
 [tool.ruff]
 line-length = 150
 
+[tool.setuptools.packages.find]
+include = ["avro*"]
+
 [tool.setuptools.package-data]
 "avro" = [
   "HandshakeRequest.avsc", "HandshakeResponse.avsc", "LICENSE.txt",


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes the local/Docker Python interop build, which fails with:

```
error: Multiple top-level packages discovered in a flat-layout: ['avro', 'userlogs'].
```

The Hadoop tether tests leave behind a `userlogs/` directory next to the
`avro/` package. Because `pyproject.toml` did not configure package
discovery, setuptools falls back to automatic flat-layout discovery, sees
two top-level packages (`avro` and `userlogs`), and refuses to build. This
does not surface in GitHub Actions because each language is tested in
isolation and the tether tests never create `userlogs/` there.

The fix explicitly scopes setuptools package discovery to `avro*`, so stray
directories such as `userlogs/` are ignored. This resolves AVRO-4308.

## Verifying this change

This change is already covered by the existing interop test targets:

- Reproduced the failure by running `./build.sh interop-data-generate` in
  `lang/py` with a `userlogs/` directory present.
- After the fix, `./build.sh interop-data-generate` and
  `./build.sh interop-data-test` both succeed.
- Confirmed discovery still resolves the expected packages:
  `find_packages(include=["avro*"])` -> `['avro', 'avro.test', 'avro.tether']`.

## Documentation

- Does this pull request introduce a new feature? no
