### PR TITLE
AVRO-4314: [csharp] Validate names against the Avro name grammar

### DIFF
--- a/lang/csharp/src/apache/main/Protocol/Message.cs
+++ b/lang/csharp/src/apache/main/Protocol/Message.cs
@@ -76,6 +76,7 @@ namespace Avro
         public Message(string name, string doc, RecordSchema request, Schema response, UnionSchema error, bool? oneway)
         {
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name), "name cannot be null.");
+            SchemaName.ValidateName(name, "message");
             this.Request = request;
             this.Response = response;
             this.Error = error;

--- a/lang/csharp/src/apache/main/Schema/Field.cs
+++ b/lang/csharp/src/apache/main/Schema/Field.cs
@@ -155,6 +155,14 @@ namespace Avro
 
             SchemaName.ValidateName(name, "field");
 
+            if (aliases != null)
+            {
+                foreach (string alias in aliases)
+                {
+                    SchemaName.ValidateName(alias, "field alias");
+                }
+            }
+
             Schema = schema ?? throw new ArgumentNullException("type", "type cannot be null.");
             Name = name;
             Aliases = aliases;

--- a/lang/csharp/src/apache/main/Schema/Field.cs
+++ b/lang/csharp/src/apache/main/Schema/Field.cs
@@ -153,6 +153,8 @@ namespace Avro
                 throw new ArgumentNullException(nameof(name), "name cannot be null.");
             }
 
+            SchemaName.ValidateName(name, "field");
+
             Schema = schema ?? throw new ArgumentNullException("type", "type cannot be null.");
             Name = name;
             Aliases = aliases;

--- a/lang/csharp/src/apache/main/Schema/SchemaName.cs
+++ b/lang/csharp/src/apache/main/Schema/SchemaName.cs
@@ -17,6 +17,8 @@
  */
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
 
 namespace Avro
 {
@@ -41,7 +43,7 @@ namespace Avro
             if (string.IsNullOrEmpty(name)
                 || !(char.IsLetter(name[0]) || name[0] == '_'))
             {
-                throw new SchemaParseException($"Invalid {what} name: {name}");
+                throw new SchemaParseException($"Invalid {what} name: {Quote(name)}");
             }
 
             for (int i = 1; i < name.Length; i++)
@@ -49,9 +51,50 @@ namespace Avro
                 char c = name[i];
                 if (!(char.IsLetterOrDigit(c) || c == '_'))
                 {
-                    throw new SchemaParseException($"Invalid {what} name: {name}");
+                    throw new SchemaParseException($"Invalid {what} name: {Quote(name)}");
                 }
             }
+        }
+
+        /// <summary>
+        /// Returns a quoted representation of the given value with control
+        /// characters escaped, so that an invalid name embedded in an error
+        /// message cannot inject newlines or other control characters.
+        /// </summary>
+        private static string Quote(string value)
+        {
+            if (value == null)
+            {
+                return "null";
+            }
+
+            var sb = new StringBuilder(value.Length + 2);
+            sb.Append('"');
+            foreach (char c in value)
+            {
+                switch (c)
+                {
+                    case '"': sb.Append("\\\""); break;
+                    case '\\': sb.Append("\\\\"); break;
+                    case '\r': sb.Append("\\r"); break;
+                    case '\n': sb.Append("\\n"); break;
+                    case '\t': sb.Append("\\t"); break;
+                    default:
+                        if (char.IsControl(c))
+                        {
+                            sb.AppendFormat(CultureInfo.InvariantCulture, "\\u{0:x4}", (int)c);
+                        }
+                        else
+                        {
+                            sb.Append(c);
+                        }
+
+                        break;
+                }
+            }
+
+            sb.Append('"');
+            return sb.ToString();
         }
 
         // cache the full name, so it won't allocate new strings on each call

--- a/lang/csharp/src/apache/main/Schema/SchemaName.cs
+++ b/lang/csharp/src/apache/main/Schema/SchemaName.cs
@@ -25,6 +25,35 @@ namespace Avro
     /// </summary>
     public class SchemaName
     {
+        /// <summary>
+        /// Validates that a simple (unqualified) name conforms to the Avro name
+        /// grammar: a non-empty string whose first character is a letter or '_'
+        /// and whose remaining characters are letters, digits or '_'. Letters and
+        /// digits are recognized in a Unicode-aware way, matching the default
+        /// behavior of the Java SDK (and the C# SDK's existing support for
+        /// non-ASCII field names). Throws <see cref="SchemaParseException"/> when
+        /// the name is invalid.
+        /// </summary>
+        /// <param name="name">the simple name to validate</param>
+        /// <param name="what">description of the kind of name, used in error messages</param>
+        internal static void ValidateName(string name, string what)
+        {
+            if (string.IsNullOrEmpty(name)
+                || !(char.IsLetter(name[0]) || name[0] == '_'))
+            {
+                throw new SchemaParseException($"Invalid {what} name: {name}");
+            }
+
+            for (int i = 1; i < name.Length; i++)
+            {
+                char c = name[i];
+                if (!(char.IsLetterOrDigit(c) || c == '_'))
+                {
+                    throw new SchemaParseException($"Invalid {what} name: {name}");
+                }
+            }
+        }
+
         // cache the full name, so it won't allocate new strings on each call
         private String fullName;
         
@@ -88,6 +117,16 @@ namespace Avro
 
             Documentation = documentation;
             fullName = string.IsNullOrEmpty(Namespace) ? Name : Namespace + "." + Name;
+
+            // Validate the simple name only. Namespaces are intentionally not
+            // validated here: the code generator's namespace-mapping feature
+            // rewrites schema namespaces to C#-specific values (for example
+            // "@return" for reserved words) and re-parses the schema, so a
+            // namespace component may legitimately not match the Avro name grammar.
+            if (Name != null)
+            {
+                ValidateName(Name, "schema");
+            }
         }
 
         /// <summary>

--- a/lang/csharp/src/apache/main/Schema/SchemaName.cs
+++ b/lang/csharp/src/apache/main/Schema/SchemaName.cs
@@ -31,7 +31,8 @@ namespace Avro
         /// Validates that a simple (unqualified) name conforms to the Avro name
         /// grammar: a non-empty string whose first character is a letter or '_'
         /// and whose remaining characters are letters, digits or '_'. Letters and
-        /// digits are recognized in a Unicode-aware way, matching the default
+        /// digits are recognized in a Unicode-aware way (including supplementary
+        /// characters represented by surrogate pairs), matching the default
         /// behavior of the Java SDK (and the C# SDK's existing support for
         /// non-ASCII field names). Throws <see cref="SchemaParseException"/> when
         /// the name is invalid.
@@ -41,15 +42,21 @@ namespace Avro
         internal static void ValidateName(string name, string what)
         {
             if (string.IsNullOrEmpty(name)
-                || !(char.IsLetter(name[0]) || name[0] == '_'))
+                || !(name[0] == '_' || char.IsLetter(name, 0)))
             {
                 throw new SchemaParseException($"Invalid {what} name: {Quote(name)}");
             }
 
-            for (int i = 1; i < name.Length; i++)
+            // Iterate by Unicode scalar value so supplementary-plane letters and
+            // digits (encoded as surrogate pairs) are handled correctly.
+            int i = char.IsSurrogatePair(name, 0) ? 2 : 1;
+            while (i < name.Length)
             {
-                char c = name[i];
-                if (!(char.IsLetterOrDigit(c) || c == '_'))
+                if (name[i] == '_' || char.IsLetterOrDigit(name, i))
+                {
+                    i += char.IsSurrogatePair(name, i) ? 2 : 1;
+                }
+                else
                 {
                     throw new SchemaParseException($"Invalid {what} name: {Quote(name)}");
                 }

--- a/lang/csharp/src/apache/test/Protocol/ProtocolTest.cs
+++ b/lang/csharp/src/apache/test/Protocol/ProtocolTest.cs
@@ -181,6 +181,23 @@ namespace Avro.Test
             Assert.AreEqual(json,json2);
         }
 
+        [TestCase(@"{
+  ""protocol"": ""P"",
+  ""namespace"": ""com.acme"",
+  ""types"": [],
+  ""messages"": { ""bad name"": { ""request"": [], ""response"": ""null"" } }
+}", TestName = "MessageNameWithSpace")]
+        [TestCase(@"{
+  ""protocol"": ""P"",
+  ""namespace"": ""com.acme"",
+  ""types"": [],
+  ""messages"": { ""x; int y"": { ""request"": [], ""response"": ""null"" } }
+}", TestName = "MessageNameInjection")]
+        public static void TestInvalidMessageName(string str)
+        {
+            Assert.Throws<ProtocolParseException>(() => Protocol.Parse(str));
+        }
+
         // Protocols match
         [TestCase(
 @"{

--- a/lang/csharp/src/apache/test/Schema/SchemaTests.cs
+++ b/lang/csharp/src/apache/test/Schema/SchemaTests.cs
@@ -388,6 +388,17 @@ namespace Avro.Test
 
             Field f = recordSchema.Fields[0];
             Assert.AreEqual("歳以上", f.Name);
+
+            // A supplementary-plane letter (U+20000, encoded as a surrogate pair)
+            // is a valid name character and must be accepted.
+            const string astralName = "\U00020000field";
+            var astralFields = new List<Field>
+                {
+                    new Field(PrimitiveSchema.Create(Schema.Type.Long), astralName, null, 0, null, null,
+                        Field.SortOrder.ignore, null)
+                };
+            var astralRecord = RecordSchema.Create("AstralRecord", astralFields);
+            Assert.AreEqual(astralName, astralRecord.Fields[0].Name);
         }
 
         [TestCase]

--- a/lang/csharp/src/apache/test/Schema/SchemaTests.cs
+++ b/lang/csharp/src/apache/test/Schema/SchemaTests.cs
@@ -117,6 +117,8 @@ namespace Avro.Test
             typeof(SchemaParseException), Description = "Field name with a space")]
         [TestCase("{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"x; int y\",\"type\":\"long\"}]}",
             typeof(SchemaParseException), Description = "Field name attempting identifier injection")]
+        [TestCase("{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"valid\",\"aliases\":[\"bad alias\"],\"type\":\"long\"}]}",
+            typeof(SchemaParseException), Description = "Field alias with a space")]
         public void TestBasic(string s, Type expectedExceptionType = null)
         {
             if (expectedExceptionType != null)

--- a/lang/csharp/src/apache/test/Schema/SchemaTests.cs
+++ b/lang/csharp/src/apache/test/Schema/SchemaTests.cs
@@ -109,6 +109,14 @@ namespace Avro.Test
         [TestCase("{\"type\": \"fixed\", \"name\": \"Missing size\"}", typeof(SchemaParseException))]
         [TestCase("{\"type\": \"fixed\", \"size\": 314}",
             typeof(SchemaParseException), Description = "No name")]
+
+        // Names outside the Avro name grammar
+        [TestCase("{\"type\":\"record\",\"name\":\"Bad Name\",\"fields\":[]}",
+            typeof(SchemaParseException), Description = "Record name with a space")]
+        [TestCase("{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"in valid\",\"type\":\"long\"}]}",
+            typeof(SchemaParseException), Description = "Field name with a space")]
+        [TestCase("{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"x; int y\",\"type\":\"long\"}]}",
+            typeof(SchemaParseException), Description = "Field name attempting identifier injection")]
         public void TestBasic(string s, Type expectedExceptionType = null)
         {
             if (expectedExceptionType != null)


### PR DESCRIPTION
## What is the purpose of the change

Record/fixed/enum names, record field names and protocol message names were
accepted verbatim when parsing, unlike enum symbols which were already
validated. Because the code generator splices some of these values directly
into generated C# source (for example protocol message names into a `case`
label and field names into `Get`/`Put` switch bodies), an out-of-spec name
produced malformed or unexpected generated code.

This change adds a shared, Unicode-aware name validator (first character a
letter or `_`, remaining characters letters, digits or `_`) and applies it to
schema names, field names and message names during parsing.

Notes:
- The rule is Unicode-aware to preserve the existing support for non-ASCII
  names (e.g. the `TestRecordFieldNames` case).
- Namespaces are intentionally not validated, because the code generator's
  namespace-mapping feature rewrites them to C#-specific values (such as
  `@return` for reserved words) and re-parses the schema.

## Verifying this change

This change added tests and can be verified as follows:

- Added negative cases to `Schema/SchemaTests.cs` (invalid record name, invalid
  field name, and a field name attempting identifier injection) and
  `Protocol/ProtocolTest.cs` (`TestInvalidMessageName`).
- Verified locally: the full `Avro.test` suite (1526 tests) passes, including
  the AvroGen code-generation tests.

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable


