### PR TITLE
[java] escape backslashes in escapeForJavadoc to stop comment breakout

### DIFF
--- a/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
+++ b/lang/java/compiler/src/main/java/org/apache/avro/compiler/specific/SpecificCompiler.java
@@ -1118,7 +1118,11 @@ public class SpecificCompiler {
    * Utility for template use. Escapes comment end with HTML entities.
    */
   public static String escapeForJavadoc(String s) {
-    return s.replace("*/", "*&#47;").replace("<", "&lt;").replace(">", "&gt;");
+    // Double backslashes first so a value cannot smuggle in a Unicode escape such
+    // as \\u002a\\u002f: javac processes Unicode escapes before comments, so an
+    // unneutralized \\u002a\\u002f would decode to */ inside the generated Javadoc
+    // and let a schema doc break out of the comment into code.
+    return s.replace("\\", "\\\\").replace("*/", "*&#47;").replace("<", "&lt;").replace(">", "&gt;");
   }
 
   /**

--- a/lang/java/compiler/src/test/java/org/apache/avro/compiler/specific/TestSpecificCompiler.java
+++ b/lang/java/compiler/src/test/java/org/apache/avro/compiler/specific/TestSpecificCompiler.java
@@ -1058,6 +1058,27 @@ public class TestSpecificCompiler {
     assertTrue(validAnnotationEmitted, "Valid annotation missing from generated output");
   }
 
+  @Test
+  void docCannotBreakOutViaUnicodeEscape() {
+    // javac decodes Unicode escapes before it strips comments, so a schema doc
+    // carrying a backslash-u escape for the comment terminator decodes to that
+    // terminator inside the generated Javadoc and ends the comment early, turning
+    // the rest of the doc into code. The escaper must neutralize such escapes.
+    String jsonSchema = "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"DocInjected\",\n" + "  \"fields\": [\n"
+        + "    {\"name\": \"value\", \"type\": \"string\", \"doc\": "
+        + "\"\\\\u002a\\\\u002f public static int PWNED = 1; \\\\u002f\\\\u002a\"}\n" + "  ]\n" + "}";
+    Collection<SpecificCompiler.OutputFile> outputs = new SpecificCompiler(SchemaParser.parseSingle(jsonSchema))
+        .compile();
+    // A Unicode escape is only decoded by javac when the leading backslash is
+    // preceded by an even number of backslashes. An eligible escape for a comment
+    // char in the generated source is the breakout; the doubled form is inert.
+    Pattern eligibleEscape = Pattern.compile("(?<!\\\\)(?:\\\\\\\\)*\\\\u002[afAF]");
+    for (SpecificCompiler.OutputFile outputFile : outputs) {
+      assertFalse(eligibleEscape.matcher(outputFile.contents).find(),
+          "Unicode-escape comment breakout present? " + outputFile.contents);
+    }
+  }
+
   private int countOccurrences(Pattern pattern, String textToSearch) {
     int count = 0;
     for (Matcher matcher = pattern.matcher(textToSearch); matcher.find();) {


### PR DESCRIPTION
## What is the purpose of the change

`SpecificCompiler.escapeForJavadoc` embeds untrusted schema `doc` strings into generated Javadoc comments and neutralizes only a literal `*/`, `<` and `>`. javac decodes Unicode escapes before it strips comments (JLS 3.3), so a `doc` value carrying the backslash-u escapes for the comment terminator is emitted verbatim and decoded to `*/` in the generated source, ending the Javadoc early and turning the rest of the doc into code. A field-level doc lands right before the field declaration, so the injected text becomes a clean class member.

The sibling `escapeForJavaString` (used for the `SCHEMA$` literal) already doubles backslashes, so that path is safe; the Javadoc path was the gap. This applies the same neutralization at the single escaping helper, before the existing `*/` replacement, so no eligible Unicode escape can form. Valid docs without backslashes are emitted unchanged.

## Verifying this change

This change added tests and can be verified as follows:

- Added `TestSpecificCompiler#docCannotBreakOutViaUnicodeEscape`, which compiles a record whose field doc contains a backslash-u escape for the comment terminator and asserts no eligible Unicode escape survives in any generated file. It fails on the pre-fix code and passes after.
- Existing `docsAreEscaped_avro4053` and the tools golden-file codegen tests still pass (docs without backslashes are unaffected).

## Documentation

- Does this pull request introduce a new feature? no
