### PR TITLE
MINOR: [c] reject out-of-range union discriminant in resolver.c

### DIFF
--- a/lang/c/src/resolver.c
+++ b/lang/c/src/resolver.c
@@ -1116,6 +1116,13 @@ avro_resolver_union_branch(avro_consumer_t *consumer,
 
 	debug("Retrieving resolver for writer branch %u", discriminant);
 
+	if (discriminant >= resolver->num_children) {
+		avro_set_error("Writer union branch %u out of range "
+			       "(writer union has %zu branches)",
+			       discriminant, resolver->num_children);
+		return EILSEQ;
+	}
+
 	if (!resolver->child_resolvers[discriminant]) {
 		avro_set_error("Writer union branch %u is incompatible "
 			       "with reader schema \"%s\"",

--- a/lang/c/tests/CMakeLists.txt
+++ b/lang/c/tests/CMakeLists.txt
@@ -82,6 +82,7 @@ add_avro_test_checkmem(test_avro_1279)
 add_avro_test_checkmem(test_avro_1405)
 add_avro_test_checkmem(test_avro_1572)
 add_avro_test(test_avro_data) # Skip memory check for datum. Deprecated and has a lot of memory issues
+add_avro_test(test_avro_resolver_union_bounds) # Uses the deprecated datum consumer API
 add_avro_test_checkmem(test_refcount)
 add_avro_test_checkmem(test_avro_1379)
 add_avro_test_checkmem(test_avro_1691)

--- a/lang/c/tests/test_avro_resolver_union_bounds.c
+++ b/lang/c/tests/test_avro_resolver_union_bounds.c
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <avro.h>
+#include <avro/consumer.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/*
+ * A crafted binary datum can carry a union discriminant larger than the
+ * number of writer branches. avro_resolver_union_branch used that value to
+ * index child_resolvers directly, so an out-of-range discriminant read past
+ * the array and handed avro_consume_binary a wild avro_consumer_t pointer.
+ * Reading such a datum must fail cleanly instead.
+ */
+
+int main(void)
+{
+	const char *json = "[\"null\",\"string\"]";
+
+	avro_schema_t writer = NULL;
+	avro_schema_t reader = NULL;
+
+	if (avro_schema_from_json_length(json, strlen(json), &writer)) {
+		fprintf(stderr, "Cannot parse writer schema: %s\n",
+			avro_strerror());
+		exit(EXIT_FAILURE);
+	}
+	if (avro_schema_from_json_length(json, strlen(json), &reader)) {
+		fprintf(stderr, "Cannot parse reader schema: %s\n",
+			avro_strerror());
+		exit(EXIT_FAILURE);
+	}
+
+	avro_consumer_t *resolver = avro_resolver_new(writer, reader);
+	if (resolver == NULL) {
+		fprintf(stderr, "Cannot create resolver: %s\n",
+			avro_strerror());
+		exit(EXIT_FAILURE);
+	}
+
+	/* Union discriminant 100, encoded as the long 0xC8 0x01. The writer
+	 * union only has two branches. */
+	char buf[] = { (char) 0xC8, 0x01 };
+	avro_reader_t rdr = avro_reader_memory(buf, sizeof(buf));
+
+	int rc = avro_consume_binary(rdr, resolver, NULL);
+	if (rc == 0) {
+		fprintf(stderr, "Expected an error for out-of-range "
+			"union discriminant\n");
+		exit(EXIT_FAILURE);
+	}
+
+	avro_reader_free(rdr);
+	avro_consumer_free(resolver);
+	avro_schema_decref(writer);
+	avro_schema_decref(reader);
+	exit(EXIT_SUCCESS);
+}


### PR DESCRIPTION
## What is the purpose of the change

`avro_resolver_union_branch` (the `avro_consume_binary` / `avro_resolver_new` consumer path) read the writer union branch number from the datum and used it directly to index `child_resolvers`, with no bounds check. `read_union` in `consume-binary.c` decodes the discriminant as an `int64_t` and passes it to a callback typed `unsigned int`, so a negative or large value becomes a huge index; `avro_resolver_union_branch` then read `child_resolvers[discriminant]` past the array and, when that slot was non-NULL, handed the garbage pointer back as an `avro_consumer_t *` that `avro_consume_binary` dispatched through. On a two-branch union fed discriminant 100 (bytes `C8 01`), ASAN reports a heap-buffer-overflow READ of size 8 at `resolver.c:1119`.

The value decoder already rejects out-of-range discriminants; this older consumer path was missed. The check belongs here because this is the single place that indexes the resolver array with the wire value (the `avro_schema_union_branch` chokepoint used elsewhere already returns NULL on a miss).

## Verifying this change

This change added tests and can be verified as follows:

- Added `test_avro_resolver_union_bounds`, which builds a resolver for a `["null","string"]` union and feeds `avro_consume_binary` a datum whose discriminant (100) exceeds the branch count, asserting the read fails instead of crashing. Without the fix the test triggers a heap out-of-bounds read (confirmed under AddressSanitizer); with it the call returns `EILSEQ`. The full `ctest` suite passes.

## Documentation

- Does this pull request introduce a new feature? no
