### PR TITLE
Add SECURITY.md + AGENTS.md pointing at the published security model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Agent Guide for avro
+
+This file is read by automated agents (security scanners, code
+analyzers, AI assistants) operating on this repository.
+
+## Security
+
+Security model: [SECURITY.md](./SECURITY.md)
+
+Agents that scan this repository should consult `SECURITY.md` and the
+threat model it links before reporting issues.
+
+Avro's security model is published on the project website; SECURITY.md points at it.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Security Policy
+
+## Reporting a Vulnerability
+
+`apache/avro` follows the [Apache Software Foundation security process](https://www.apache.org/security/). Please report suspected
+vulnerabilities privately to `security@apache.org`; do not open public
+GitHub issues or pull requests for security reports.
+
+## Threat Model
+
+What the project treats as in scope and out of scope, the security
+properties it provides and disclaims, the adversary model, and how
+findings are triaged are documented in <https://avro.apache.org/project/security/>.


### PR DESCRIPTION
**This is a proposal for the PMC to review — please correct, reject, or discuss as needed.** Nothing here is a requirement; the maintainers are the decision-makers.

This adds two small files so that an automated scanning agent can mechanically discover the project's existing security model through the conventional `AGENTS.md` → `SECURITY.md` chain:

- **`SECURITY.md`** — points at the published model at <https://avro.apache.org/project/security/>, which remains the single source of truth. Nothing is duplicated or restated here; the file is a pointer.
- **`AGENTS.md`** — a Security section linking to `SECURITY.md`.

**No existing content is changed** — both files are new, and the security model itself is untouched.

### Context

The Apache Security team is preparing the project for an automated agentic security scan we're piloting. Such scans anchor to a project's own threat model, and refuse to run when the model can't be found from the repository — refusing upfront beats spending PMC reviewer time triaging a noise-heavy report produced against no model at all.

Avro is in the good case here: the project **already has a published security model**, so nobody needs to write one. We read it against our rubric and it is usable as-is — it is explicit about what the library is responsible for, that transport is outside the library's scope, that avoiding leaks into side channels such as log files is a stated non-goal, that schema parsing itself is safe while SPIs remain a trust decision, and it places four numbered duties on applications using Avro. That is more than many projects start with.

The only gap was mechanical: there is no `AGENTS.md` or `SECURITY.md` at the repository root, so the discovery chain doesn't exist. This PR is that chain and nothing more.

This was requested on the PMC's private list — Martin Grigorov asked us to go ahead on behalf of the Avro PMC.

### Not in this PR

Separately, and explicitly **not** blocking anything, the PMC has invited us to propose deepening the published model. The sections most useful to a scanner are an enumerated adversary model, a "known non-findings" list (the single biggest lever for cutting false positives in a report), and triage dispositions. Those touch the website content rather than this repository, so they'll come as a separate proposal.

Questions and pushback welcome — happy to adjust wording or file placement to match project house style.
