### PR TITLE
MINOR: [c++] Add missing header <vector> in Node.cc

### DIFF
--- a/lang/c++/impl/Node.cc
+++ b/lang/c++/impl/Node.cc
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <cmath>
 #include <unordered_set>
+#include <vector>
 
 #include "Node.hh"
 


### PR DESCRIPTION
## What is the purpose of the change

`lang/c++/impl/Node.cc` uses `std::vector<std::string>` (the `raw` member of `Name`, the return type of `Name::aliases()`) without including `<vector>`, relying on a transitive include via `avro/Node.hh`.

Transitive includes are liable to break, and this one does: the libc++ shipped with clang-23 prunes the transitive path, and the translation unit stops compiling. We hit it downstream and are carrying a local patch for it.

Same class of change as #3808 (`MINOR: [C++] Add missing header <type_traits>`), hence no JIRA issue.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Documentation

- Does this pull request introduce a new feature? no