### PR TITLE
AVRO-4321: Fix NPE on getConversionByClass

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/generic/GenericData.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/generic/GenericData.java
@@ -185,6 +185,9 @@ public class GenericData {
    */
   @SuppressWarnings("unchecked")
   public <T> Conversion<T> getConversionByClass(Class<T> datumClass, LogicalType logicalType) {
+    if (logicalType == null) {
+      return null;
+    }
     Map<String, Conversion<?>> conversions = conversionsByClass.get(datumClass);
     if (conversions != null) {
       return (Conversion<T>) conversions.get(logicalType.getName());

--- a/lang/java/avro/src/test/java/org/apache/avro/reflect/TestReflectData.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/reflect/TestReflectData.java
@@ -39,9 +39,16 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestReflectData {
+  @Test
+  void getConversionByClassWithNullLogicalTypeReturnsNull() {
+    // BigDecimal has a conversion registered by default but a null logicalType
+    assertNull(ReflectData.get().getConversionByClass(java.math.BigDecimal.class, null));
+  }
+
   @Test
   @SuppressWarnings("unchecked")
   void weakSchemaCaching() throws Exception {


### PR DESCRIPTION
## What is the purpose of the change

Fix the NPE caused by AVRO-3989 on classes that have a datum with a Conversion but not a LogicalType.

## Verifying this change

This change added tests `getConversionByClassWithNullLogicalTypeReturnsNull`

## Documentation

- Does this pull request introduce a new feature? (yes / **no**)
- If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
