### PR TITLE
AVRO-4319: [py] Pin ruff to the version in uv.lock

### DIFF
--- a/lang/py/build.sh
+++ b/lang/py/build.sh
@@ -58,11 +58,11 @@ interop-data-test() {
 }
 
 lint() {
-  uvx ruff check .
+  uv run ruff check .
 }
 
 format() {
-  uvx ruff format --diff .
+  uv run ruff format --diff .
 }
 
 test_() {

--- a/lang/py/uv.lock
+++ b/lang/py/uv.lock
@@ -52,7 +52,7 @@ provides-extras = ["snappy", "zstandard"]
 [package.metadata.requires-dev]
 dev = [
     { name = "coverage", specifier = ">=7.13.4" },
-    { name = "mypy", specifier = "<2.1.0" },
+    { name = "mypy", specifier = "<2.4.0" },
     { name = "python-snappy", specifier = ">=0.7.3" },
     { name = "ruff", specifier = ">=0.15.1" },
     { name = "setuptools", specifier = ">=82.0.0" },


### PR DESCRIPTION
## What is the purpose of the change

The current command **`uvx ruff check .`** is shorthand for `uv tool run ruff check .` which runs standalone CLI commands (ignoring any pinned `uv.lock` files).  The latest version of `ruff` in PyPI is used (at this time 0.16.1).

This PR changes the tools to  **`uv run ruff check .`**, which uses the pinned version of ruff in `uv.lock` which is 0.15.1.

Unfortunately, `ruff@0.15.1` => `ruff@0.16.1` causes many lint errors, and we'll have to fix those before bumping.

## Verifying this change

*(Please pick one of the following options)*

This change is a code cleanup without any test coverage.

It can be verified by running the `./build.sh clean test` (and hopefully the GitHub Actions that no longer fail on `main`).

## Documentation

- Does this pull request introduce a new feature? **no**
- If yes, how is the feature documented? **not applicable**
