### PR TITLE
AVRO-4323: [Java] Bound DataFileStream block size against available input before allocating the block buffer

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/file/DataFileStream.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/file/DataFileStream.java
@@ -320,6 +320,18 @@ public class DataFileStream<D> implements Iterator<D>, Iterable<D>, Closeable {
       if (blockSize > Integer.MAX_VALUE || blockSize < 0) {
         throw new IOException("Block size invalid or too large for this implementation: " + blockSize);
       }
+      // When the number of bytes remaining in the input is known (e.g. a
+      // byte-array- or known-length-stream-backed decoder), reject a declared
+      // block size that could not possibly be satisfied by the data available.
+      // This avoids eagerly allocating a large block buffer (see the DataBlock
+      // constructor) for a malformed, corrupted, or truncated file before any
+      // block byte has been read. A value of -1 means the remaining count is
+      // unknown, in which case the check is skipped.
+      int remaining = vin.remainingBytes();
+      if (remaining >= 0 && blockSize > remaining) {
+        throw new IOException("Block size " + blockSize + " exceeds the number of bytes remaining in the input ("
+            + remaining + "). The file is likely corrupted or truncated.");
+      }
       blockCount = blockRemaining;
       availableBlock = true;
       return true;

--- a/lang/java/avro/src/main/java/org/apache/avro/file/DataFileStream.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/file/DataFileStream.java
@@ -323,14 +323,16 @@ public class DataFileStream<D> implements Iterator<D>, Iterable<D>, Closeable {
       // When the number of bytes remaining in the input is known (e.g. a
       // byte-array- or known-length-stream-backed decoder), reject a declared
       // block size that could not possibly be satisfied by the data available.
-      // This avoids eagerly allocating a large block buffer (see the DataBlock
-      // constructor) for a malformed, corrupted, or truncated file before any
-      // block byte has been read. A value of -1 means the remaining count is
-      // unknown, in which case the check is skipped.
+      // Reading a block consumes the block bytes plus the trailing sync marker,
+      // so both must fit in the remaining input. This avoids eagerly allocating
+      // a large block buffer (see the DataBlock constructor) for a malformed,
+      // corrupted, or truncated file before any block byte has been read. A
+      // value of -1 means the remaining count is unknown, in which case the
+      // check is skipped.
       int remaining = vin.remainingBytes();
-      if (remaining >= 0 && blockSize > remaining) {
-        throw new IOException("Block size " + blockSize + " exceeds the number of bytes remaining in the input ("
-            + remaining + "). The file is likely corrupted or truncated.");
+      if (remaining >= 0 && blockSize > (long) remaining - DataFileConstants.SYNC_SIZE) {
+        throw new IOException("Block size " + blockSize + " plus sync marker exceeds the number of bytes remaining in "
+            + "the input (" + remaining + "). The file is likely corrupted or truncated.");
       }
       blockCount = blockRemaining;
       availableBlock = true;

--- a/lang/java/avro/src/test/java/org/apache/avro/TestDataFileReader.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestDataFileReader.java
@@ -319,4 +319,63 @@ public class TestDataFileReader {
 
     return output.toByteArray();
   }
+
+  /**
+   * A block header may declare a block size much larger than the data actually
+   * present in a corrupted or truncated file. When the remaining byte count is
+   * known, the reader must reject such a block up front rather than attempting to
+   * allocate a buffer of the declared size.
+   */
+  @Test
+  void oversizedBlockSizeIsRejectedBeforeAllocation() throws IOException {
+    Schema schema = new Schema.Parser().parse("{\"type\":\"int\"}");
+
+    // A spec-correct header with zero records, so no real data block is written.
+    ByteArrayOutputStream fileBytes = new ByteArrayOutputStream();
+    try (DataFileWriter<Object> w = new DataFileWriter<>(new GenericDatumWriter<>(schema))) {
+      w.create(schema, fileBytes);
+    }
+
+    // Append a single block header that declares a huge block size but no data.
+    BinaryEncoder encoder = EncoderFactory.get().binaryEncoder(fileBytes, null);
+    encoder.writeLong(1L); // block entry count
+    encoder.writeLong(2_000_000_000L); // block size in bytes, far larger than what follows
+    encoder.flush();
+
+    byte[] malformed = fileBytes.toByteArray();
+
+    // hasNextBlock() surfaces block-header IOExceptions wrapped in an
+    // AvroRuntimeException, the same way the existing "block size too large"
+    // check does.
+    AvroRuntimeException exception = assertThrows(AvroRuntimeException.class, () -> {
+      DataFileStream<Object> reader = new DataFileStream<>(new ByteArrayInputStream(malformed),
+          new GenericDatumReader<>());
+      while (reader.hasNext()) {
+        reader.next();
+      }
+    });
+    assertNotNull(exception.getMessage());
+    assertTrue(exception.getMessage().contains("Block size"), "Unexpected message: " + exception.getMessage());
+  }
+
+  /**
+   * A valid single-record file must still read normally after the guard is added.
+   */
+  @Test
+  void validFileWithSingleRecordStillReads() throws IOException {
+    Schema schema = new Schema.Parser().parse("{\"type\":\"int\"}");
+
+    ByteArrayOutputStream fileBytes = new ByteArrayOutputStream();
+    try (DataFileWriter<Object> w = new DataFileWriter<>(new GenericDatumWriter<>(schema))) {
+      w.create(schema, fileBytes);
+      w.append(42);
+    }
+
+    try (DataFileStream<Object> reader = new DataFileStream<>(new ByteArrayInputStream(fileBytes.toByteArray()),
+        new GenericDatumReader<>())) {
+      assertTrue(reader.hasNext());
+      assertEquals(42, reader.next());
+      assertFalse(reader.hasNext());
+    }
+  }
 }

--- a/lang/java/avro/src/test/java/org/apache/avro/TestDataFileReader.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestDataFileReader.java
@@ -348,10 +348,11 @@ public class TestDataFileReader {
     // AvroRuntimeException, the same way the existing "block size too large"
     // check does.
     AvroRuntimeException exception = assertThrows(AvroRuntimeException.class, () -> {
-      DataFileStream<Object> reader = new DataFileStream<>(new ByteArrayInputStream(malformed),
-          new GenericDatumReader<>());
-      while (reader.hasNext()) {
-        reader.next();
+      try (DataFileStream<Object> reader = new DataFileStream<>(new ByteArrayInputStream(malformed),
+          new GenericDatumReader<>())) {
+        while (reader.hasNext()) {
+          reader.next();
+        }
       }
     });
     assertNotNull(exception.getMessage());


### PR DESCRIPTION
## What changes were proposed in this pull request?

When reading an Avro data (container) file, `DataFileStream` reads each block's declared size as a `long` and validated it only against the `Integer` range before allocating the block `byte[]` buffer (in `DataFileStream.DataBlock`). For a malformed, corrupted, or truncated file, the declared block size can be much larger than the number of bytes actually present, so the reader eagerly allocated a very large buffer on the first `hasNext()`/`next()` call before any block byte had been read.

This adds a check: when the number of bytes remaining in the input is known (byte-array- or known-length-stream-backed decoders), a declared block size larger than the bytes remaining is rejected with a clear `IOException` before allocating. The check is skipped when the remaining count is unknown (`-1`), so non-seekable streams are unaffected.

## How was this patch tested?

- New tests in `TestDataFileReader`:
  - `oversizedBlockSizeIsRejectedBeforeAllocation` — a crafted file whose block header declares a size near `Integer.MAX_VALUE` with no block bytes now fails fast instead of attempting a large allocation.
  - `validFileWithSingleRecordStillReads` — negative control confirming a valid file still reads.
- Full `avro` module test suite passes.

### JIRA

- [AVRO-4323](https://issues.apache.org/jira/browse/AVRO-4323)
