### PR TITLE
AVRO-4322: [Java] Guard fast-reader-only assertions in FastReaderBuilderJavaClassTest

### DIFF
--- a/lang/java/avro/src/test/java/org/apache/avro/io/FastReaderBuilderJavaClassTest.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/io/FastReaderBuilderJavaClassTest.java
@@ -20,6 +20,7 @@ package org.apache.avro.io;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -133,6 +134,8 @@ public class FastReaderBuilderJavaClassTest {
    */
   @Test
   void specificDataModelUsesJavaClassProp() throws IOException {
+    assumeTrue(SpecificData.get().isFastReaderEnabled(),
+        "java-class conversion is only applied on the fast-reader path");
     GenericRecord result = roundTrip(RECORD_WITH_NULLABLE_CLASS_PROP, SpecificData.get());
 
     assertNotNull(result);
@@ -149,6 +152,8 @@ public class FastReaderBuilderJavaClassTest {
    */
   @Test
   void specificDataModelUsesJavaClassPropWithDirectString() throws IOException {
+    assumeTrue(SpecificData.get().isFastReaderEnabled(),
+        "java-class conversion is only applied on the fast-reader path");
     GenericRecord result = roundTrip(RECORD_WITH_CLASS_PROP, SpecificData.get());
 
     assertNotNull(result);
@@ -189,6 +194,8 @@ public class FastReaderBuilderJavaClassTest {
    */
   @Test
   void specificDataModelUsesJavaKeyClassProp() throws IOException {
+    assumeTrue(SpecificData.get().isFastReaderEnabled(),
+        "java-key-class conversion is only applied on the fast-reader path");
     GenericRecord result = roundTrip(RECORD_WITH_MAP_KEY_CLASS_PROP, SpecificData.get());
 
     assertNotNull(result);


### PR DESCRIPTION
## Problem

`FastReaderBuilderJavaClassTest` contains three `specificDataModelUses*` tests that assert the `java-class` / `java-key-class` → target-class conversion (e.g. `String` → `BigDecimal`) for the `SpecificData` model.

That conversion is implemented **only on the fast-reader path** (`FastReaderBuilder`). When the fast reader is disabled (`-Dorg.apache.avro.fastread=false`), the classic path returns `Utf8`, so those three tests fail:

```
SpecificData should use the class in 'java-class' ==>
Unexpected type, expected: <java.math.BigDecimal> but was: <org.apache.avro.util.Utf8>
```

The `avro` module's `test-without-fast-reader` surefire execution (and the JDK-11/17/21 invoker runs) run with `org.apache.avro.fastread=false`, so this is a real failure. It is currently **masked on CI by the Maven build cache** skipping the unchanged `avro` module; it surfaces whenever that module is rebuilt.

Reproduce:

```
cd lang/java
mvn -pl avro surefire:test -Dtest=FastReaderBuilderJavaClassTest -Dorg.apache.avro.fastread=false
# -> Tests run: 6, Failures: 3
```

## Fix

Guard the three fast-reader-only assertions with `assumeTrue(SpecificData.get().isFastReaderEnabled(), ...)`, so they are skipped (not failed) when the fast reader is disabled. The `genericDataModelIgnores*` tests are unaffected.

## Verification

```
# fast reader ON  -> Tests run: 6, Failures: 0, Skipped: 0
# fast reader OFF -> Tests run: 6, Failures: 0, Skipped: 3
```

Both `BUILD SUCCESS`.