### PR TITLE
AVRO-4322: [Java] Use reader/writers constently with model

### DIFF
--- a/lang/java/avro/src/test/java/org/apache/avro/io/FastReaderBuilderJavaClassTest.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/io/FastReaderBuilderJavaClassTest.java
@@ -29,8 +29,6 @@ import java.util.Map;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericData;
-import org.apache.avro.generic.GenericDatumReader;
-import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.avro.specific.SpecificData;
@@ -70,20 +68,24 @@ public class FastReaderBuilderJavaClassTest {
           .set("prices", Map.of("-0.0002", "cheap", "12345.678", "expensive")).build();
 
   /**
-   * Reusable round-trip logic for a record, using the given model.
+   * Reusable round-trip logic for a record, using the given model. The reader is
+   * built via {@link GenericData#createDatumReader(Schema, Schema)} so that
+   * SpecificData produces a real {@code SpecificDatumReader}, rather than a
+   * {@code GenericDatumReader} wrapping a SpecificData instance.
    */
+  @SuppressWarnings("unchecked")
   public static GenericRecord roundTrip(GenericRecord record, GenericData model) throws IOException {
     byte[] serialized;
 
     try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-      GenericDatumWriter<GenericRecord> writer = new GenericDatumWriter<>(record.getSchema());
+      DatumWriter<GenericRecord> writer = model.createDatumWriter(record.getSchema());
       BinaryEncoder encoder = EncoderFactory.get().binaryEncoder(baos, null);
       writer.write(record, encoder);
       encoder.flush();
       serialized = baos.toByteArray();
     }
 
-    GenericDatumReader<GenericRecord> reader = new GenericDatumReader<>(record.getSchema(), record.getSchema(), model);
+    DatumReader<GenericRecord> reader = model.createDatumReader(record.getSchema(), record.getSchema());
     BinaryDecoder decoder = DecoderFactory.get().binaryDecoder(serialized, null);
     return reader.read(null, decoder);
   }

--- a/lang/java/avro/src/test/java/org/apache/avro/specific/TestSpecificDatumReader.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/specific/TestSpecificDatumReader.java
@@ -68,6 +68,12 @@ public class TestSpecificDatumReader {
 
   public static class MyReader extends SpecificDatumReader<MyData> {
 
+    MyReader() {
+      // Use a new data model instead of the singleton in order to avoid modifying the
+      // setFastReaderEnabled state for other tests.
+      super(null, null, new SpecificData());
+    }
+
     @Override
     protected Class findStringClass(Schema schema) {
       return MyData.class;


### PR DESCRIPTION
## What is the purpose of the change

We should be using the GenericDatumReader and SpecificDatumReader with the respective models.  The mix causes a test failure with fastread.

## Verifying this change

This change is already covered by existing tests, such as **FastReaderBuilderJavaClassTest**.

## Documentation

- Does this pull request introduce a new feature? **no**
- If yes, how is the feature documented? **not applicable**
