### PR TITLE
AVRO-4232: [Build] Install uv in the Docker build image

### DIFF
--- a/share/docker/Dockerfile
+++ b/share/docker/Dockerfile
@@ -195,6 +195,11 @@ RUN case "${BUILDARCH:?}" in \
 RUN python3 -m pip install --upgrade pip setuptools wheel \
  && python3 -m pip install tox zstandard
 
+# Install uv (Python package/build manager used by lang/py/build.sh).
+# Pinned version, installed to $HOME/.local/bin (/root/.local/bin at build
+# time). The PATH is set on the Rust/cargo line below, matching main branch.
+RUN curl -LsSf https://astral.sh/uv/0.10.4/install.sh | sh
+
 # Install Ruby
 RUN apt-get -qqy install ruby-full \
  && apt-get -qqy clean
@@ -207,7 +212,7 @@ RUN gem install bundler --no-document && \
 
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.73.0
-ENV PATH $PATH:/root/.cargo/bin/
+ENV PATH=$PATH:/root/.cargo/bin/:/root/.local/bin
 
 # Install .NET SDK
 RUN cd /opt ; \


### PR DESCRIPTION
## What changes were proposed in this pull request?

`lang/py/build.sh` on `branch-1.12` now relies on `uv` (backported in #3922), but the Docker build/test image (`share/docker/Dockerfile`) never installed it, so Python builds and tests fail inside the container.

This installs the pinned `uv 0.10.4` (matching the `main` branch) into `$HOME/.local/bin` (`/root/.local/bin` at build time) and adds that directory to `PATH` alongside cargo.

## How was this patch tested?

```
./build.sh docker        # interactive, non-root user
# inside the container:
uv --version
```

The approach mirrors how `origin/main` installs uv in the same Dockerfile.

## JIRA
- [AVRO-4232](https://issues.apache.org/jira/browse/AVRO-4232)