### PR TITLE
AVRO-4329: [Java] Bound bytes/string allocation on non-seekable streams

### DIFF
--- a/lang/java/avro/src/main/java/org/apache/avro/io/BinaryDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/BinaryDecoder.java
@@ -297,6 +297,12 @@ public class BinaryDecoder extends Decoder {
   @Override
   public Utf8 readString(Utf8 old) throws IOException {
     int length = SystemLimitException.checkMaxStringLength(readLong());
+    if (length != 0 && requiresBoundedRead(length)) {
+      // Large declared length on a non-seekable stream: read via a growing buffer
+      // so a truncated/hostile stream fails after a bounded allocation rather than
+      // allocating the full declared length up front. See requiresBoundedRead.
+      return new Utf8(readBoundedByteArray(length));
+    }
     ensureAvailableBytes(length);
     Utf8 result = (old != null ? old : new Utf8());
     result.setByteLength(length);
@@ -321,6 +327,14 @@ public class BinaryDecoder extends Decoder {
   @Override
   public ByteBuffer readBytes(ByteBuffer old) throws IOException {
     int length = SystemLimitException.checkMaxBytesLength(readLong());
+    if (length != 0 && requiresBoundedRead(length)) {
+      // Large declared length on a non-seekable stream: read via a growing buffer
+      // so a truncated/hostile stream fails after a bounded allocation rather than
+      // allocating the full declared length up front. See requiresBoundedRead.
+      ByteBuffer result = ByteBuffer.wrap(readBoundedByteArray(length));
+      result.limit(length);
+      return result;
+    }
     ensureAvailableBytes(length);
     final ByteBuffer result;
     if (old != null && length <= old.capacity()) {
@@ -590,6 +604,68 @@ public class BinaryDecoder extends Decoder {
             "Attempted to read " + length + " bytes, but only " + remaining + " bytes are available");
       }
     }
+  }
+
+  /**
+   * Largest buffer allocated up front for a length-prefixed {@code bytes} or
+   * {@code string} value whose backing data cannot be shown to be present (see
+   * {@link #requiresBoundedRead(int)}). Above this size the value is read via a
+   * buffer that grows in bounded steps so the cost of a truncated or hostile
+   * declared length is proportional to the bytes actually delivered, not to the
+   * (attacker-chosen) declared length.
+   */
+  static final int MAX_UNVERIFIED_ALLOCATION = 16 * 1024;
+
+  /**
+   * Whether a length-prefixed value of the given declared {@code length} must be
+   * read via the bounded growing-buffer path rather than a single up-front
+   * allocation.
+   * <p>
+   * The up-front allocation is safe when the source can report that at least
+   * {@code length} bytes remain (a memory-backed or seekable source):
+   * {@link #ensureAvailableBytes(int)} rejects an over-long declaration before
+   * any allocation. On a non-seekable stream (socket, pipe, decompression stream)
+   * the remaining byte count is unknown, so a huge declared length would
+   * otherwise drive a single large allocation before a single payload byte is
+   * read. In that case, for lengths above {@link #MAX_UNVERIFIED_ALLOCATION},
+   * read incrementally instead.
+   *
+   * @param length the declared length of the value to read
+   * @return {@code true} if the value should be read incrementally
+   */
+  private boolean requiresBoundedRead(int length) {
+    return length > MAX_UNVERIFIED_ALLOCATION && (source == null || source.remainingBytes() < 0);
+  }
+
+  /**
+   * Reads exactly {@code length} bytes into a freshly allocated array, growing
+   * the backing buffer in bounded steps (starting at
+   * {@link #MAX_UNVERIFIED_ALLOCATION} and doubling, capped at {@code length}).
+   * <p>
+   * This is used when the number of bytes remaining is unknown so that a
+   * truncated or hostile stream declaring a huge length fails with an
+   * {@link EOFException} after a bounded allocation, instead of allocating the
+   * full declared length up front. The returned array is exactly {@code length}
+   * bytes long, so callers may take ownership of it without copying.
+   *
+   * @param length the number of bytes to read; must be positive
+   * @return a newly allocated array of exactly {@code length} bytes
+   * @throws EOFException if the source is exhausted before {@code length} bytes
+   *                      are read
+   */
+  byte[] readBoundedByteArray(int length) throws IOException {
+    byte[] data = new byte[Math.min(length, MAX_UNVERIFIED_ALLOCATION)];
+    int read = 0;
+    while (read < length) {
+      if (read == data.length) {
+        int next = (int) Math.min((long) length, (long) data.length * 2);
+        data = Arrays.copyOf(data, next);
+      }
+      int chunk = data.length - read;
+      doReadBytes(data, read, chunk);
+      read += chunk;
+    }
+    return data;
   }
 
   /**

--- a/lang/java/avro/src/main/java/org/apache/avro/io/BinaryDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/BinaryDecoder.java
@@ -297,7 +297,11 @@ public class BinaryDecoder extends Decoder {
   @Override
   public Utf8 readString(Utf8 old) throws IOException {
     int length = SystemLimitException.checkMaxStringLength(readLong());
-    if (length != 0 && requiresBoundedRead(length)) {
+    // Only take the bounded growing-buffer path when we would otherwise have to
+    // allocate a new backing array. When a reusable buffer of sufficient capacity
+    // is supplied there is no large up-front allocation to guard against, so honor
+    // the reuse contract and read straight into it.
+    if (length != 0 && requiresBoundedRead(length) && (old == null || length > old.getBytes().length)) {
       // Large declared length on a non-seekable stream: read via a growing buffer
       // so a truncated/hostile stream fails after a bounded allocation rather than
       // allocating the full declared length up front. See requiresBoundedRead.
@@ -327,7 +331,11 @@ public class BinaryDecoder extends Decoder {
   @Override
   public ByteBuffer readBytes(ByteBuffer old) throws IOException {
     int length = SystemLimitException.checkMaxBytesLength(readLong());
-    if (length != 0 && requiresBoundedRead(length)) {
+    // Only take the bounded growing-buffer path when we would otherwise have to
+    // allocate a new buffer. A reusable buffer of sufficient capacity carries no
+    // large up-front allocation to guard against, so honor the reuse contract
+    // (see Decoder#readBytes) and read straight into it.
+    if (length != 0 && requiresBoundedRead(length) && (old == null || length > old.capacity())) {
       // Large declared length on a non-seekable stream: read via a growing buffer
       // so a truncated/hostile stream fails after a bounded allocation rather than
       // allocating the full declared length up front. See requiresBoundedRead.

--- a/lang/java/avro/src/main/java/org/apache/avro/io/DirectBinaryDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/DirectBinaryDecoder.java
@@ -155,8 +155,21 @@ class DirectBinaryDecoder extends BinaryDecoder {
 
   @Override
   public ByteBuffer readBytes(ByteBuffer old) throws IOException {
-    long length = readLong();
-    return byteReader.read(old, SystemLimitException.checkMaxBytesLength(length));
+    int length = SystemLimitException.checkMaxBytesLength(readLong());
+    // A DirectBinaryDecoder reads straight from a (typically non-seekable) stream,
+    // so the number of bytes remaining is unknown. For a large declared length
+    // that cannot be satisfied from a reusable buffer, read via a bounded growing
+    // buffer so a truncated/hostile stream fails after a bounded allocation rather
+    // than allocating the full declared length up front. The in-memory
+    // ByteBufferInputStream path (ReuseByteReader) is left untouched: it slices
+    // from buffers already held, so it does not over-allocate from the length.
+    if (length > MAX_UNVERIFIED_ALLOCATION && (old == null || old.capacity() < length)
+        && !(byteReader instanceof ReuseByteReader)) {
+      ByteBuffer result = ByteBuffer.wrap(readBoundedByteArray(length));
+      result.limit(length);
+      return result;
+    }
+    return byteReader.read(old, length);
   }
 
   @Override

--- a/lang/java/avro/src/test/java/org/apache/avro/io/TestBinaryDecoderBoundedRead.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/io/TestBinaryDecoderBoundedRead.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.avro.io;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Regression tests for AVRO-4303: a {@code bytes}/{@code string} length prefix
+ * read from a non-seekable stream must not drive a single up-front allocation
+ * of the (attacker-declared) length. A truncated or hostile stream declaring a
+ * huge length must fail with a bounded {@link EOFException} after only a
+ * bounded allocation, rather than an {@link OutOfMemoryError} or a huge
+ * allocation.
+ */
+public class TestBinaryDecoderBoundedRead {
+
+  /**
+   * Wraps the bytes in a stream whose class is neither
+   * {@link ByteArrayInputStream} nor {@code ByteBufferInputStream}, so the
+   * decoder reports an unknown number of remaining bytes (the non-seekable case).
+   */
+  private static InputStream nonSeekable(byte[] data) {
+    return new FilterInputStream(new ByteArrayInputStream(data)) {
+    };
+  }
+
+  /**
+   * Encodes a bytes/string length prefix followed by {@code payload} raw bytes.
+   */
+  private static byte[] lengthPrefixed(long declaredLength, byte[] payload) throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    BinaryEncoder e = EncoderFactory.get().directBinaryEncoder(out, null);
+    e.writeLong(declaredLength);
+    e.flush();
+    out.write(payload);
+    return out.toByteArray();
+  }
+
+  /**
+   * A near-2GB declared length that a single {@code new byte[len]} could not
+   * satisfy on a normal test heap, so reaching an {@link EOFException} proves the
+   * decoder never attempted the full up-front allocation.
+   */
+  private static final long HUGE_LENGTH = Integer.MAX_VALUE - 8L;
+
+  @Test
+  @Timeout(value = 30, unit = TimeUnit.SECONDS)
+  void bufferedDecoderRejectsHugeBytesLengthOnStreamWithoutHugeAllocation() throws IOException {
+    byte[] data = lengthPrefixed(HUGE_LENGTH, new byte[] { 1, 2, 3, 4, 5 });
+    BinaryDecoder d = DecoderFactory.get().binaryDecoder(nonSeekable(data), null);
+    assertThrows(EOFException.class, () -> d.readBytes(null));
+  }
+
+  @Test
+  @Timeout(value = 30, unit = TimeUnit.SECONDS)
+  void bufferedDecoderRejectsHugeStringLengthOnStreamWithoutHugeAllocation() throws IOException {
+    byte[] data = lengthPrefixed(HUGE_LENGTH, new byte[] { 'a', 'b', 'c' });
+    BinaryDecoder d = DecoderFactory.get().binaryDecoder(nonSeekable(data), null);
+    assertThrows(EOFException.class, () -> d.readString(null));
+  }
+
+  @Test
+  @Timeout(value = 30, unit = TimeUnit.SECONDS)
+  void directDecoderRejectsHugeBytesLengthOnStreamWithoutHugeAllocation() throws IOException {
+    byte[] data = lengthPrefixed(HUGE_LENGTH, new byte[] { 1, 2, 3, 4, 5 });
+    BinaryDecoder d = DecoderFactory.get().directBinaryDecoder(nonSeekable(data), null);
+    assertThrows(EOFException.class, () -> d.readBytes(null));
+  }
+
+  @Test
+  @Timeout(value = 30, unit = TimeUnit.SECONDS)
+  void directDecoderRejectsHugeStringLengthOnStreamWithoutHugeAllocation() throws IOException {
+    byte[] data = lengthPrefixed(HUGE_LENGTH, new byte[] { 'a', 'b', 'c' });
+    BinaryDecoder d = DecoderFactory.get().directBinaryDecoder(nonSeekable(data), null);
+    assertThrows(EOFException.class, () -> d.readString(null));
+  }
+
+  @Test
+  void legitimateLargeBytesStillRoundTripsOnNonSeekableStream() throws IOException {
+    // Larger than the bounded-read threshold so it exercises the growing-buffer
+    // path, but a genuinely present payload must still decode intact.
+    byte[] payload = new byte[1_000_000];
+    for (int i = 0; i < payload.length; i++) {
+      payload[i] = (byte) i;
+    }
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    BinaryEncoder e = EncoderFactory.get().directBinaryEncoder(out, null);
+    e.writeBytes(payload);
+    e.flush();
+
+    BinaryDecoder d = DecoderFactory.get().binaryDecoder(nonSeekable(out.toByteArray()), null);
+    ByteBuffer result = d.readBytes(null);
+    byte[] decoded = new byte[result.remaining()];
+    result.get(decoded);
+    assertArrayEquals(payload, decoded);
+  }
+
+  @Test
+  void legitimateLargeStringStillRoundTripsOnNonSeekableStream() throws IOException {
+    StringBuilder sb = new StringBuilder();
+    while (sb.length() < 100_000) {
+      sb.append("avro-4303-");
+    }
+    String expected = sb.toString();
+    byte[] utf8 = expected.getBytes(StandardCharsets.UTF_8);
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    BinaryEncoder e = EncoderFactory.get().directBinaryEncoder(out, null);
+    e.writeString(expected);
+    e.flush();
+
+    BinaryDecoder d = DecoderFactory.get().directBinaryDecoder(nonSeekable(out.toByteArray()), null);
+    String decoded = d.readString();
+    assertEquals(expected, decoded);
+    // Sanity: the bounded path produced exactly the encoded bytes.
+    assertArrayEquals(utf8, decoded.getBytes(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void smallValuesAndSeekableSourcesKeepDirectAllocationPath() throws IOException {
+    // Small value: below the bounded-read threshold, read directly.
+    byte[] small = new byte[100];
+    Arrays.fill(small, (byte) 7);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    BinaryEncoder e = EncoderFactory.get().directBinaryEncoder(out, null);
+    e.writeBytes(small);
+    e.flush();
+    byte[] encoded = out.toByteArray();
+
+    // Seekable (byte-array) source: existing available-bytes guard rejects an
+    // over-long declared length up front, unchanged by AVRO-4303.
+    byte[] truncated = lengthPrefixed(HUGE_LENGTH, new byte[] { 1, 2, 3 });
+    BinaryDecoder seekable = DecoderFactory.get().binaryDecoder(truncated, null);
+    assertThrows(EOFException.class, () -> seekable.readBytes(null));
+
+    // Small value still decodes on a non-seekable stream via the direct path.
+    BinaryDecoder d = DecoderFactory.get().binaryDecoder(nonSeekable(encoded), null);
+    ByteBuffer result = d.readBytes(null);
+    byte[] decoded = new byte[result.remaining()];
+    result.get(decoded);
+    assertArrayEquals(small, decoded);
+  }
+}

--- a/lang/java/avro/src/test/java/org/apache/avro/io/TestBinaryDecoderBoundedRead.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/io/TestBinaryDecoderBoundedRead.java
@@ -19,6 +19,7 @@ package org.apache.avro.io;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayInputStream;
@@ -121,6 +122,29 @@ public class TestBinaryDecoderBoundedRead {
 
     BinaryDecoder d = DecoderFactory.get().binaryDecoder(nonSeekable(out.toByteArray()), null);
     ByteBuffer result = d.readBytes(null);
+    byte[] decoded = new byte[result.remaining()];
+    result.get(decoded);
+    assertArrayEquals(payload, decoded);
+  }
+
+  @Test
+  void reusableBufferWithSufficientCapacityIsHonoredOnNonSeekableStream() throws IOException {
+    // A large value on a non-seekable stream, supplied with a reusable buffer that
+    // is already big enough, must reuse it (Decoder#readBytes reuse contract)
+    // rather than take the bounded-read path and allocate a new array.
+    byte[] payload = new byte[1_000_000];
+    for (int i = 0; i < payload.length; i++) {
+      payload[i] = (byte) i;
+    }
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    BinaryEncoder e = EncoderFactory.get().directBinaryEncoder(out, null);
+    e.writeBytes(payload);
+    e.flush();
+
+    ByteBuffer reusable = ByteBuffer.allocate(payload.length + 100);
+    BinaryDecoder d = DecoderFactory.get().binaryDecoder(nonSeekable(out.toByteArray()), null);
+    ByteBuffer result = d.readBytes(reusable);
+    assertSame(reusable.array(), result.array(), "supplied buffer with sufficient capacity should be reused");
     byte[] decoded = new byte[result.remaining()];
     result.get(decoded);
     assertArrayEquals(payload, decoded);

--- a/lang/java/avro/src/test/java/org/apache/avro/io/TestBinaryDecoderBoundedRead.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/io/TestBinaryDecoderBoundedRead.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -57,6 +58,47 @@ public class TestBinaryDecoderBoundedRead {
   }
 
   /**
+   * A non-seekable stream that records the largest single {@code read} request it
+   * receives. The bounded-read guard reads in chunks capped at
+   * {@link BinaryDecoder#MAX_UNVERIFIED_ALLOCATION}; without the guard the decoder
+   * allocates the full declared length and asks the source for it in one read, so
+   * the recorded maximum distinguishes the two regardless of heap size.
+   */
+  private static final class MaxReadRecordingStream extends FilterInputStream {
+    private int maxRequested = 0;
+
+    MaxReadRecordingStream(byte[] data) {
+      super(new ByteArrayInputStream(data));
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+      maxRequested = Math.max(maxRequested, len);
+      return super.read(b, off, len);
+    }
+
+    @Override
+    public int read(byte[] b) throws IOException {
+      maxRequested = Math.max(maxRequested, b.length);
+      return super.read(b);
+    }
+  }
+
+  /**
+   * Assert the guard never asked the source for more than
+   * {@link BinaryDecoder#MAX_UNVERIFIED_ALLOCATION} bytes in one read. This is
+   * heap-independent: without the guard the decoder allocates the full declared
+   * length and requests it in a single read, so {@code maxRequested} would be the
+   * ~2 GB {@link #HUGE_LENGTH} rather than the bounded chunk size.
+   */
+  private static void assertBoundedRead(MaxReadRecordingStream stream) {
+    assertTrue(stream.maxRequested <= BinaryDecoder.MAX_UNVERIFIED_ALLOCATION,
+        "source must not be asked for more than MAX_UNVERIFIED_ALLOCATION ("
+            + BinaryDecoder.MAX_UNVERIFIED_ALLOCATION + ") bytes in one read, but was asked for "
+            + stream.maxRequested);
+  }
+
+  /**
    * Encodes a bytes/string length prefix followed by {@code payload} raw bytes.
    */
   private static byte[] lengthPrefixed(long declaredLength, byte[] payload) throws IOException {
@@ -79,32 +121,40 @@ public class TestBinaryDecoderBoundedRead {
   @Timeout(value = 30, unit = TimeUnit.SECONDS)
   void bufferedDecoderRejectsHugeBytesLengthOnStreamWithoutHugeAllocation() throws IOException {
     byte[] data = lengthPrefixed(HUGE_LENGTH, new byte[] { 1, 2, 3, 4, 5 });
-    BinaryDecoder d = DecoderFactory.get().binaryDecoder(nonSeekable(data), null);
+    MaxReadRecordingStream stream = new MaxReadRecordingStream(data);
+    BinaryDecoder d = DecoderFactory.get().binaryDecoder(stream, null);
     assertThrows(EOFException.class, () -> d.readBytes(null));
+    assertBoundedRead(stream);
   }
 
   @Test
   @Timeout(value = 30, unit = TimeUnit.SECONDS)
   void bufferedDecoderRejectsHugeStringLengthOnStreamWithoutHugeAllocation() throws IOException {
     byte[] data = lengthPrefixed(HUGE_LENGTH, new byte[] { 'a', 'b', 'c' });
-    BinaryDecoder d = DecoderFactory.get().binaryDecoder(nonSeekable(data), null);
+    MaxReadRecordingStream stream = new MaxReadRecordingStream(data);
+    BinaryDecoder d = DecoderFactory.get().binaryDecoder(stream, null);
     assertThrows(EOFException.class, () -> d.readString(null));
+    assertBoundedRead(stream);
   }
 
   @Test
   @Timeout(value = 30, unit = TimeUnit.SECONDS)
   void directDecoderRejectsHugeBytesLengthOnStreamWithoutHugeAllocation() throws IOException {
     byte[] data = lengthPrefixed(HUGE_LENGTH, new byte[] { 1, 2, 3, 4, 5 });
-    BinaryDecoder d = DecoderFactory.get().directBinaryDecoder(nonSeekable(data), null);
+    MaxReadRecordingStream stream = new MaxReadRecordingStream(data);
+    BinaryDecoder d = DecoderFactory.get().directBinaryDecoder(stream, null);
     assertThrows(EOFException.class, () -> d.readBytes(null));
+    assertBoundedRead(stream);
   }
 
   @Test
   @Timeout(value = 30, unit = TimeUnit.SECONDS)
   void directDecoderRejectsHugeStringLengthOnStreamWithoutHugeAllocation() throws IOException {
     byte[] data = lengthPrefixed(HUGE_LENGTH, new byte[] { 'a', 'b', 'c' });
-    BinaryDecoder d = DecoderFactory.get().directBinaryDecoder(nonSeekable(data), null);
+    MaxReadRecordingStream stream = new MaxReadRecordingStream(data);
+    BinaryDecoder d = DecoderFactory.get().directBinaryDecoder(stream, null);
     assertThrows(EOFException.class, () -> d.readString(null));
+    assertBoundedRead(stream);
   }
 
   @Test


### PR DESCRIPTION
## What is the purpose of the change

Java SDK implementation of AVRO-4303 (parent). The available-bytes guard added
under AVRO-4292 rejects a declared bytes/string length that exceeds the data
remaining only when the decoder can report the number of bytes remaining
(memory-backed or seekable sources). On a non-seekable stream (socket, pipe,
decompression stream) the check is a no-op, so a huge declared length still
drives a single large up-front allocation before any payload is read. A tiny
truncated input can therefore force a multi-hundred-MB allocation.

When the remaining byte count is unknown, this reads the bytes/string value into
a buffer that grows in bounded chunks rather than allocating the full
attacker-declared length up front. A truncated or hostile stream then fails with
a bounded `EOFException` after a bounded allocation instead of an
`OutOfMemoryError`. The existing single-allocation fast path is kept when the
remaining byte count is known. The same fix is applied to `DirectBinaryDecoder`,
which reads straight from a stream.

## Verifying this change

This change added tests and can be verified as follows:

- Added `TestBinaryDecoderBoundedRead`: a near-2GB declared bytes/string length
  on a truncated non-seekable stream fails with a bounded `EOFException` (not an
  `OutOfMemoryError`) for both the buffered `BinaryDecoder` and
  `DirectBinaryDecoder`; a legitimately large value on a non-seekable stream
  still round-trips; small values and seekable sources keep the direct path.
- Existing `TestBinaryDecoder` (68 tests) continues to pass.

## Documentation

- Does this pull request introduce a new feature? (no — DoS hardening)
- If yes, how is the feature documented? (JavaDocs on the new bounded-read
  helper in `BinaryDecoder`)
