### PR TITLE
AVRO-4304: [java][python] Add shared must-reject binary interop vectors

### DIFF
--- a/lang/java/avro/src/test/java/org/apache/avro/TestBinaryDecodingRejections.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestBinaryDecodingRejections.java
@@ -18,7 +18,6 @@
 package org.apache.avro;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -73,10 +72,17 @@ public class TestBinaryDecodingRejections {
   }
 
   private static byte[] fromHex(String hex) {
-    int len = hex.length();
-    byte[] out = new byte[len / 2];
+    if (hex.length() % 2 != 0) {
+      throw new IllegalArgumentException("Hex string must have an even length: '" + hex + "'");
+    }
+    byte[] out = new byte[hex.length() / 2];
     for (int i = 0; i < out.length; i++) {
-      out[i] = (byte) Integer.parseInt(hex.substring(2 * i, 2 * i + 2), 16);
+      int hi = Character.digit(hex.charAt(2 * i), 16);
+      int lo = Character.digit(hex.charAt(2 * i + 1), 16);
+      if (hi < 0 || lo < 0) {
+        throw new IllegalArgumentException("Invalid hex character in '" + hex + "'");
+      }
+      out[i] = (byte) ((hi << 4) | lo);
     }
     return out;
   }
@@ -99,12 +105,11 @@ public class TestBinaryDecodingRejections {
       // malformed input was wrongly accepted) or an Error is thrown (a crash such
       // as StackOverflowError/OutOfMemoryError). Both outcomes are what the
       // hardening must prevent, so a plain bounded Exception is the pass condition.
-      try {
-        assertThrows(Exception.class, () -> decode(schemaJson, bytes, fastReader),
-            () -> "Vector '" + name + "' (" + category + ") was not rejected (fastReader=" + fastReader + ")");
-      } catch (AssertionError e) {
-        fail(e.getMessage());
-      }
+      // The original AssertionError propagates directly, preserving its full
+      // context (expected-vs-actual, any Error thrown) for diagnosis.
+      final boolean fast = fastReader;
+      assertThrows(Exception.class, () -> decode(schemaJson, bytes, fast),
+          () -> "Vector '" + name + "' (" + category + ") was not rejected (fastReader=" + fast + ")");
     }
   }
 }

--- a/lang/java/avro/src/test/java/org/apache/avro/TestBinaryDecodingRejections.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/TestBinaryDecodingRejections.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.avro;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.io.DecoderFactory;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Java harness for the shared cross-SDK "must-reject" binary decoding vectors
+ * (AVRO-4304). It loads {@code share/test/data/binary-rejections.json} and
+ * asserts that every vector is rejected by the Avro binary decoder with a
+ * bounded, well-defined error (a {@link Throwable} that is an
+ * {@link Exception}, i.e. not a
+ * {@link StackOverflowError}/{@link OutOfMemoryError} crash), for both the
+ * classic and the fast reader paths.
+ * <p>
+ * The shared fixtures guarantee that all language SDKs reject the same
+ * malformed inputs identically and do not drift.
+ */
+public class TestBinaryDecodingRejections {
+
+  private static final String RESOURCE = "/share/test/data/binary-rejections.json";
+
+  static Stream<Arguments> vectors() throws IOException {
+    List<Arguments> args = new ArrayList<>();
+    ObjectMapper mapper = new ObjectMapper();
+    try (InputStream in = TestBinaryDecodingRejections.class.getResourceAsStream(RESOURCE)) {
+      if (in == null) {
+        throw new IOException("Missing shared reject-vector fixture on classpath: " + RESOURCE);
+      }
+      JsonNode root = mapper.readTree(in);
+      for (JsonNode v : root.get("vectors")) {
+        args.add(Arguments.of(v.get("name").asText(), v.get("schema").asText(), v.get("category").asText(),
+            v.get("bytesHex").asText()));
+      }
+    }
+    if (args.isEmpty()) {
+      throw new IOException("No reject vectors found in " + RESOURCE);
+    }
+    return args.stream();
+  }
+
+  private static byte[] fromHex(String hex) {
+    int len = hex.length();
+    byte[] out = new byte[len / 2];
+    for (int i = 0; i < out.length; i++) {
+      out[i] = (byte) Integer.parseInt(hex.substring(2 * i, 2 * i + 2), 16);
+    }
+    return out;
+  }
+
+  private static void decode(String schemaJson, byte[] bytes, boolean fastReader) throws IOException {
+    Schema schema = new Schema.Parser().parse(schemaJson);
+    GenericData data = new GenericData();
+    data.setFastReaderEnabled(fastReader);
+    GenericDatumReader<Object> reader = new GenericDatumReader<>(schema, schema, data);
+    Decoder decoder = DecoderFactory.get().binaryDecoder(bytes, null);
+    reader.read(null, decoder);
+  }
+
+  @ParameterizedTest(name = "[{2}] {0}")
+  @MethodSource("vectors")
+  void vectorIsRejectedByBothReaderPaths(String name, String schemaJson, String category, String bytesHex) {
+    byte[] bytes = fromHex(bytesHex);
+    for (boolean fastReader : new boolean[] { false, true }) {
+      // assertThrows(Exception.class, ...) fails if either nothing is thrown (the
+      // malformed input was wrongly accepted) or an Error is thrown (a crash such
+      // as StackOverflowError/OutOfMemoryError). Both outcomes are what the
+      // hardening must prevent, so a plain bounded Exception is the pass condition.
+      try {
+        assertThrows(Exception.class, () -> decode(schemaJson, bytes, fastReader),
+            () -> "Vector '" + name + "' (" + category + ") was not rejected (fastReader=" + fastReader + ")");
+      } catch (AssertionError e) {
+        fail(e.getMessage());
+      }
+    }
+  }
+}

--- a/lang/py/avro/test/test_binary_decoding_rejections.py
+++ b/lang/py/avro/test/test_binary_decoding_rejections.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+##
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AVRO-4304: Python harness for the shared cross-SDK must-reject binary vectors.
+
+Loads ``share/test/data/binary-rejections.json`` and asserts that every vector
+is rejected by the Avro binary decoder with a bounded, well-defined error rather
+than being accepted or crashing. The shared fixtures guarantee that all language
+SDKs reject the same malformed inputs identically and do not drift.
+"""
+
+import io
+import json
+import unittest
+from pathlib import Path
+
+import avro
+import avro.errors
+import avro.io
+import avro.schema
+
+
+def _find_manifest() -> Path:
+    """Locate share/test/data/binary-rejections.json in the source tree."""
+    here = Path(avro.__file__).resolve()
+    for parent in here.parents:
+        candidate = parent / "share" / "test" / "data" / "binary-rejections.json"
+        if candidate.is_file():
+            return candidate
+    raise unittest.SkipTest("shared reject-vector fixture not found (not running from a source checkout)")
+
+
+class TestSharedRejectionVectors(unittest.TestCase):
+    def test_all_vectors_are_rejected(self) -> None:
+        manifest = _find_manifest()
+        vectors = json.loads(manifest.read_text())["vectors"]
+        self.assertTrue(vectors, "no reject vectors found")
+        for vector in vectors:
+            name = vector["name"]
+            schema = avro.schema.parse(vector["schema"])
+            payload = bytes.fromhex(vector["bytesHex"])
+            with self.subTest(vector=name):
+                reader = avro.io.DatumReader(schema, schema)
+                decoder = avro.io.BinaryDecoder(io.BytesIO(payload))
+                # A conformant decoder must reject the payload with a bounded Avro
+                # error rather than accepting it or crashing.
+                self.assertRaises(avro.errors.AvroException, reader.read, decoder)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/share/test/data/binary-rejections.json
+++ b/share/test/data/binary-rejections.json
@@ -1,0 +1,68 @@
+{
+  "description": "Shared cross-SDK 'must-reject' binary decoding vectors (AVRO-4304). Each vector is a schema plus a raw binary payload (hex) that a conformant Avro binary decoder MUST reject with a bounded, well-defined error (an Avro/IO error) rather than accepting it, crashing (StackOverflowError), or exhausting memory (OutOfMemoryError). Payloads are hex-encoded bytes. The 'schema' field is the Avro schema as a JSON string. The 'category' groups the kind of malformation. These vectors lock in, across every language SDK, the decoder-hardening behaviour introduced under AVRO-4292 and siblings.",
+  "vectors": [
+    {
+      "name": "long_varint_non_terminating",
+      "schema": "\"long\"",
+      "category": "overlong_varint",
+      "bytesHex": "80808080808080808080",
+      "comment": "A long varint whose continuation bit is still set after 10 bytes (64 bits) never terminates and must be rejected."
+    },
+    {
+      "name": "int_varint_non_terminating",
+      "schema": "\"int\"",
+      "category": "overlong_varint",
+      "bytesHex": "8080808080",
+      "comment": "An int varint whose continuation bit is still set after 5 bytes (32 bits) never terminates and must be rejected."
+    },
+    {
+      "name": "array_block_count_int64_min",
+      "schema": "{\"type\":\"array\",\"items\":\"int\"}",
+      "category": "negative_block_count",
+      "bytesHex": "ffffffffffffffffff0102",
+      "comment": "Array block count encoded as Long.MIN_VALUE. Its absolute value cannot be represented (negation overflows), so it must be rejected rather than driving an unbounded read."
+    },
+    {
+      "name": "bytes_length_negative",
+      "schema": "\"bytes\"",
+      "category": "negative_length",
+      "bytesHex": "01",
+      "comment": "A bytes value with a negative length prefix (-1) must be rejected."
+    },
+    {
+      "name": "string_length_negative",
+      "schema": "\"string\"",
+      "category": "negative_length",
+      "bytesHex": "01",
+      "comment": "A string value with a negative length prefix (-1) must be rejected."
+    },
+    {
+      "name": "union_branch_index_negative",
+      "schema": "[\"null\",\"int\"]",
+      "category": "union_index_out_of_range",
+      "bytesHex": "01",
+      "comment": "A union branch index of -1 is outside the range of declared branches and must be rejected."
+    },
+    {
+      "name": "union_branch_index_too_large",
+      "schema": "[\"null\",\"int\"]",
+      "category": "union_index_out_of_range",
+      "bytesHex": "0a",
+      "comment": "A union branch index of 5 exceeds the 2 declared branches and must be rejected."
+    },
+    {
+      "name": "enum_index_negative",
+      "schema": "{\"type\":\"enum\",\"name\":\"E\",\"symbols\":[\"A\",\"B\"]}",
+      "category": "enum_index_out_of_range",
+      "bytesHex": "01",
+      "comment": "An enum symbol index of -1 is outside the range of declared symbols and must be rejected."
+    },
+    {
+      "name": "enum_index_too_large",
+      "schema": "{\"type\":\"enum\",\"name\":\"E\",\"symbols\":[\"A\",\"B\"]}",
+      "category": "enum_index_out_of_range",
+      "bytesHex": "0a",
+      "comment": "An enum symbol index of 5 exceeds the 2 declared symbols and must be rejected."
+    }
+  ]
+}


### PR DESCRIPTION
## What is the purpose of the change

Decoder hardening across the SDKs now rejects a range of malformed binary
encodings (overlong varints, `Long.MIN_VALUE` collection block counts,
out-of-range union branch and enum symbol indices, negative bytes/string
lengths), but there is no shared cross-language fixture guaranteeing that every
SDK rejects the same malformed inputs identically, so the SDKs can drift (one
accepts what another rejects).

This adds a shared set of must-reject vectors under
`share/test/data/binary-rejections.json`, each a schema plus a raw binary
payload (hex) that a conformant decoder must reject with a bounded,
well-defined error rather than accepting it, crashing, or exhausting memory.
It seeds the set with cases already fixed per SDK, and wires thin per-SDK
harnesses (Java and Python) that load the vectors and assert rejection.

The shared fixture is a single cross-language artifact, so it is kept together
with its first consumers here; additional SDK harnesses can be added later as
small changes on top of the merged fixture.

## Verifying this change

This change added tests and can be verified as follows:

- Added `share/test/data/binary-rejections.json` with 9 seed vectors.
- Added the Java harness `TestBinaryDecodingRejections`, which asserts each
  vector is rejected on both the classic and fast reader paths.
- Added the Python harness `test_binary_decoding_rejections.py`, which asserts
  each vector is rejected with a bounded `AvroException`.

## Documentation

- Does this pull request introduce a new feature? (no — shared conformance test
  fixtures)
- If yes, how is the feature documented? (the fixture file carries a
  self-describing `description` field explaining the format and intent)
