### PR TITLE
AVRO-4346: [csharp] Validate enum symbols and protocol names at parse time

### DIFF
--- a/lang/csharp/src/apache/main/Protocol/Protocol.cs
+++ b/lang/csharp/src/apache/main/Protocol/Protocol.cs
@@ -126,6 +126,14 @@ namespace Avro
         private static Protocol Parse(JToken jtok)
         {
             string name = JsonHelper.GetRequiredString(jtok, "protocol");
+            try
+            {
+                SchemaName.ValidateName(name, "protocol");
+            }
+            catch (SchemaParseException e)
+            {
+                throw new ProtocolParseException($"Invalid protocol name: {name}", e);
+            }
             string space = JsonHelper.GetOptionalString(jtok, "namespace");
             string doc = JsonHelper.GetOptionalString(jtok, "doc");
 

--- a/lang/csharp/src/apache/main/Schema/EnumSchema.cs
+++ b/lang/csharp/src/apache/main/Schema/EnumSchema.cs
@@ -102,6 +102,15 @@ namespace Avro
                 if (symbolMap.ContainsKey(s))
                     throw new SchemaParseException($"Duplicate symbol: {s} at '{jtok.Path}'");
 
+                try
+                {
+                    ValidateSymbolName(s);
+                }
+                catch (AvroException e)
+                {
+                    throw new SchemaParseException($"{e.Message} at '{jtok.Path}'", e);
+                }
+
                 symbolMap[s] = i++;
                 symbols.Add(s);
             }

--- a/lang/csharp/src/apache/test/Protocol/ProtocolTest.cs
+++ b/lang/csharp/src/apache/test/Protocol/ProtocolTest.cs
@@ -198,6 +198,17 @@ namespace Avro.Test
             Assert.Throws<ProtocolParseException>(() => Protocol.Parse(str));
         }
 
+        [TestCase(@"{ ""protocol"": ""9bad"", ""types"": [], ""messages"": {} }",
+            TestName = "ProtocolNameLeadingDigit")]
+        [TestCase(@"{ ""protocol"": ""bad name"", ""types"": [], ""messages"": {} }",
+            TestName = "ProtocolNameWithSpace")]
+        [TestCase(@"{ ""protocol"": ""x; class Evil"", ""types"": [], ""messages"": {} }",
+            TestName = "ProtocolNameInjection")]
+        public static void TestInvalidProtocolName(string str)
+        {
+            Assert.Throws<ProtocolParseException>(() => Protocol.Parse(str));
+        }
+
         // Protocols match
         [TestCase(
 @"{

--- a/lang/csharp/src/apache/test/Schema/SchemaTests.cs
+++ b/lang/csharp/src/apache/test/Schema/SchemaTests.cs
@@ -85,6 +85,12 @@ namespace Avro.Test
             typeof(SchemaParseException), Description = "No name")]
         [TestCase("{\"type\": \"enum\", \"name\": \"Test\", \"symbols\" : [\"AA\", \"AA\"]}",
             typeof(SchemaParseException), Description = "Duplicate symbol")]
+        [TestCase("{\"type\": \"enum\", \"name\": \"Test\", \"symbols\" : [\"1A\"]}",
+            typeof(SchemaParseException), Description = "Symbol with leading digit")]
+        [TestCase("{\"type\": \"enum\", \"name\": \"Test\", \"symbols\" : [\"A B\"]}",
+            typeof(SchemaParseException), Description = "Symbol with space")]
+        [TestCase("{\"type\": \"enum\", \"name\": \"Test\", \"symbols\" : [\"A-B\"]}",
+            typeof(SchemaParseException), Description = "Symbol with hyphen")]
 
         // Array
         [TestCase("{\"type\": \"array\", \"items\": \"long\"}")]


### PR DESCRIPTION
## What

AVRO-4314 added Avro name-grammar validation for record/fixed/enum names, field names and aliases, and message names. This closes two parse-time paths it left unvalidated, which are then emitted verbatim as identifiers by the C# code generator:

1. **Enum symbols read from JSON** — `EnumSchema.NewInstance` only checked for duplicates and never called `ValidateSymbolName` (that ran only on the programmatic `Create()` path). An out-of-spec symbol (leading digit, space, punctuation, …) was carried through and spliced as an enum member identifier by the generator.
2. **Protocol names** — `Protocol.Parse` never validated the protocol name, which is emitted as generated class names.

## Fix

- `EnumSchema.NewInstance`: call `ValidateSymbolName` on each symbol, surfacing a `SchemaParseException` with the JSON path (consistent with the neighbouring duplicate-symbol error).
- `Protocol.Parse`: validate the protocol name via `SchemaName.ValidateName(name, "protocol")`, surfacing a `ProtocolParseException` (consistent with how message-name validation is surfaced in `Message.Parse`).

## Tests

Adds `TestBasic` cases for out-of-spec enum symbols (leading digit / space / hyphen) and a `TestInvalidProtocolName` case set (leading digit / space / injection-style name). Full C# suite passes (**1533 tests**, 0 failures).

JIRA: https://issues.apache.org/jira/browse/AVRO-4346