### PR TITLE
AVRO-4228: [c++] Fix BinaryDecoder::arrayNext() to handle negative block counts (branch-1.12 backport)

### DIFF
--- a/lang/c++/impl/BinaryDecoder.cc
+++ b/lang/c++/impl/BinaryDecoder.cc
@@ -164,13 +164,13 @@ size_t BinaryDecoder::doDecodeItemCount() {
     auto result = doDecodeLong();
     if (result < 0) {
         doDecodeLong();
-        return static_cast<size_t>(-result);
+        return static_cast<size_t>(-(result + 1)) + 1;
     }
     return static_cast<size_t>(result);
 }
 
 size_t BinaryDecoder::arrayNext() {
-    return static_cast<size_t>(doDecodeLong());
+    return doDecodeItemCount();
 }
 
 size_t BinaryDecoder::skipArray() {


### PR DESCRIPTION
Backport of #3646 (commit `3508f0ec8d`) to `branch-1.12`.

`BinaryDecoder::arrayNext()` called `doDecodeLong()` directly instead of `doDecodeItemCount()`, so it mishandled **negative array/map block counts**. Per the Avro spec a negative block count means the absolute value is the item count, followed by a long block byte-size; `doDecodeItemCount()` handles that (and avoids UB when negating `INT64_MIN`), and is already used by `arrayStart()`/`mapStart()`.

This is the reason AVRO-4228 was reopened — the fix landed on `main` but was not cherry-picked to `branch-1.12`. Cherry-pick applies cleanly; C++ `CodecTests` (incl. the added negative-block-count test) pass.

JIRA: https://issues.apache.org/jira/browse/AVRO-4228