### PR TITLE
AVRO-3569: [csharp] Fix infinite recursion in AvroDecimal IConvertible conversions

### DIFF
--- a/lang/csharp/src/apache/main/AvroDecimal.cs
+++ b/lang/csharp/src/apache/main/AvroDecimal.cs
@@ -917,7 +917,7 @@ namespace Avro
         /// </returns>
         bool IConvertible.ToBoolean(IFormatProvider provider)
         {
-            return Convert.ToBoolean(this, provider);
+            return (bool)((IConvertible)this).ToType(typeof(bool), provider);
         }
 
         /// <summary>
@@ -929,7 +929,7 @@ namespace Avro
         /// </returns>
         byte IConvertible.ToByte(IFormatProvider provider)
         {
-            return Convert.ToByte(this, provider);
+            return (byte)((IConvertible)this).ToType(typeof(byte), provider);
         }
 
         /// <summary>
@@ -967,7 +967,7 @@ namespace Avro
         /// </returns>
         decimal IConvertible.ToDecimal(IFormatProvider provider)
         {
-            return Convert.ToDecimal(this, provider);
+            return (decimal)((IConvertible)this).ToType(typeof(decimal), provider);
         }
 
         /// <summary>
@@ -979,7 +979,7 @@ namespace Avro
         /// </returns>
         double IConvertible.ToDouble(IFormatProvider provider)
         {
-            return Convert.ToDouble(this, provider);
+            return (double)((IConvertible)this).ToType(typeof(double), provider);
         }
 
         /// <summary>
@@ -991,7 +991,7 @@ namespace Avro
         /// </returns>
         short IConvertible.ToInt16(IFormatProvider provider)
         {
-            return Convert.ToInt16(this, provider);
+            return (short)((IConvertible)this).ToType(typeof(short), provider);
         }
 
         /// <summary>
@@ -1003,7 +1003,7 @@ namespace Avro
         /// </returns>
         int IConvertible.ToInt32(IFormatProvider provider)
         {
-            return Convert.ToInt32(this, provider);
+            return (int)((IConvertible)this).ToType(typeof(int), provider);
         }
 
         /// <summary>
@@ -1015,7 +1015,7 @@ namespace Avro
         /// </returns>
         long IConvertible.ToInt64(IFormatProvider provider)
         {
-            return Convert.ToInt64(this, provider);
+            return (long)((IConvertible)this).ToType(typeof(long), provider);
         }
 
         /// <summary>
@@ -1027,7 +1027,7 @@ namespace Avro
         /// </returns>
         sbyte IConvertible.ToSByte(IFormatProvider provider)
         {
-            return Convert.ToSByte(this, provider);
+            return (sbyte)((IConvertible)this).ToType(typeof(sbyte), provider);
         }
 
         /// <summary>
@@ -1039,7 +1039,7 @@ namespace Avro
         /// </returns>
         float IConvertible.ToSingle(IFormatProvider provider)
         {
-            return Convert.ToSingle(this, provider);
+            return (float)((IConvertible)this).ToType(typeof(float), provider);
         }
 
         /// <summary>
@@ -1051,7 +1051,7 @@ namespace Avro
         /// </returns>
         string IConvertible.ToString(IFormatProvider provider)
         {
-            return Convert.ToString(this, provider);
+            return ToString();
         }
 
         /// <summary>
@@ -1063,7 +1063,7 @@ namespace Avro
         /// </returns>
         ushort IConvertible.ToUInt16(IFormatProvider provider)
         {
-            return Convert.ToUInt16(this, provider);
+            return (ushort)((IConvertible)this).ToType(typeof(ushort), provider);
         }
 
         /// <summary>
@@ -1075,7 +1075,7 @@ namespace Avro
         /// </returns>
         uint IConvertible.ToUInt32(IFormatProvider provider)
         {
-            return Convert.ToUInt32(this, provider);
+            return (uint)((IConvertible)this).ToType(typeof(uint), provider);
         }
 
         /// <summary>
@@ -1087,7 +1087,7 @@ namespace Avro
         /// </returns>
         ulong IConvertible.ToUInt64(IFormatProvider provider)
         {
-            return Convert.ToUInt64(this, provider);
+            return (ulong)((IConvertible)this).ToType(typeof(ulong), provider);
         }
 
         /// <summary>

--- a/lang/csharp/src/apache/test/AvroDecimalTest.cs
+++ b/lang/csharp/src/apache/test/AvroDecimalTest.cs
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+using System;
 using System.Globalization;
 using NUnit.Framework;
 
@@ -90,6 +91,29 @@ namespace Avro.test
             var rightAvroDecimal = new AvroDecimal(rightDecimal);
 
             return leftAvroDecimal.CompareTo(rightAvroDecimal);
+        }
+
+        // AVRO-3569: the IConvertible conversions previously called
+        // Convert.ToXxx(this, provider), which recurses back into the same
+        // IConvertible method and overflows the stack. Verify they now return
+        // the converted value instead of crashing.
+        [Test]
+        public void TestAvroDecimalIConvertibleDoesNotRecurse()
+        {
+            var d = new AvroDecimal(42);
+            Assert.AreEqual((byte)42, Convert.ToByte(d));
+            Assert.AreEqual((sbyte)42, Convert.ToSByte(d));
+            Assert.AreEqual((short)42, Convert.ToInt16(d));
+            Assert.AreEqual(42, Convert.ToInt32(d));
+            Assert.AreEqual(42L, Convert.ToInt64(d));
+            Assert.AreEqual((ushort)42, Convert.ToUInt16(d));
+            Assert.AreEqual(42u, Convert.ToUInt32(d));
+            Assert.AreEqual(42ul, Convert.ToUInt64(d));
+            Assert.AreEqual(42d, Convert.ToDouble(d));
+            Assert.AreEqual(42f, Convert.ToSingle(d));
+            Assert.AreEqual(42m, Convert.ToDecimal(d));
+            Assert.AreEqual(true, Convert.ToBoolean(d));
+            Assert.AreEqual("42", Convert.ToString(d, CultureInfo.InvariantCulture));
         }
     }
 }


### PR DESCRIPTION
## What

Every explicit `IConvertible.ToXxx(IFormatProvider)` implementation on `AvroDecimal` called `Convert.ToXxx(this, provider)`. Since `this` is an `IConvertible`, `Convert.ToXxx(IConvertible, provider)` calls straight back into the same `IConvertible.ToXxx(provider)` method → unbounded recursion → `StackOverflowException`, which is **uncatchable in .NET and crashes the process**.

Reproducer (from the issue):
```csharp
Convert.ToByte(new AvroDecimal(0)); // StackOverflowException
```
This affected `ToBoolean, ToByte, ToDecimal, ToDouble, ToInt16/32/64, ToSByte, ToSingle, ToUInt16/32/64` and `ToString`.

## Fix

`IConvertible.ToType(Type, provider)` is the only implementation that does real work (converts the unscaled/scaled value to a `decimal` and calls `Convert.ChangeType`). Route the 12 numeric/boolean conversions through it (preserving the `IFormatProvider`), and make `ToString(provider)` use the public `ToString()` override. No `Convert.To*(this, provider)` self-calls remain.

## Tests

Adds `TestAvroDecimalIConvertibleDoesNotRecurse` exercising all conversions (each would previously overflow the stack). Full C# suite passes (**1528 tests**, 0 failures).

JIRA: https://issues.apache.org/jira/browse/AVRO-3569