### PR TITLE
AVRO-3194: [c++] Throw instead of segfaulting on GenericDatum::value<T>() type mismatch

### DIFF
--- a/lang/c++/include/avro/GenericDatum.hh
+++ b/lang/c++/include/avro/GenericDatum.hh
@@ -537,14 +537,26 @@ inline LogicalType GenericDatum::logicalType() const {
 
 template<typename T>
 T &GenericDatum::value() {
-    return (type_ == AVRO_UNION) ? std::any_cast<GenericUnion>(&value_)->datum().value<T>()
-                                 : *std::any_cast<T>(&value_);
+    if (type_ == AVRO_UNION) {
+        return std::any_cast<GenericUnion>(&value_)->datum().value<T>();
+    }
+    T *ptr = std::any_cast<T>(&value_);
+    if (ptr == nullptr) {
+        throw Exception("Invalid type. Requested C++ type does not match the datum type {}", toString(type_));
+    }
+    return *ptr;
 }
 
 template<typename T>
 const T &GenericDatum::value() const {
-    return (type_ == AVRO_UNION) ? std::any_cast<GenericUnion>(&value_)->datum().value<T>()
-                                 : *std::any_cast<T>(&value_);
+    if (type_ == AVRO_UNION) {
+        return std::any_cast<GenericUnion>(&value_)->datum().value<T>();
+    }
+    const T *ptr = std::any_cast<T>(&value_);
+    if (ptr == nullptr) {
+        throw Exception("Invalid type. Requested C++ type does not match the datum type {}", toString(type_));
+    }
+    return *ptr;
 }
 
 inline size_t GenericDatum::unionBranch() const {

--- a/lang/c++/test/unittest.cc
+++ b/lang/c++/test/unittest.cc
@@ -24,6 +24,7 @@
 #include "Compiler.hh"
 #include "Decoder.hh"
 #include "Encoder.hh"
+#include "GenericDatum.hh"
 #include "Node.hh"
 #include "Parser.hh"
 #include "Schema.hh"
@@ -1066,6 +1067,25 @@ void testNestedMapSchema() {
     BOOST_CHECK_EQUAL(expected, actual.str());
 }
 
+// Regression test for AVRO-3194: GenericDatum::value<T>() with a mismatched
+// C++ type used to dereference the null pointer returned by std::any_cast,
+// causing a segmentation fault. It must now throw an avro::Exception instead.
+static void testGenericDatumValueTypeMismatch() {
+    GenericDatum datum(std::string("hello"));
+    BOOST_CHECK_EQUAL(datum.type(), AVRO_STRING);
+
+    // Correct type still works.
+    BOOST_CHECK_EQUAL(datum.value<std::string>(), std::string("hello"));
+
+    // Mismatched type must throw, not segfault.
+    BOOST_CHECK_THROW(datum.value<int32_t>(), avro::Exception);
+    BOOST_CHECK_THROW(datum.value<std::vector<uint8_t>>(), avro::Exception);
+
+    // Same guarantee through the const overload.
+    const GenericDatum &constDatum = datum;
+    BOOST_CHECK_THROW(constDatum.value<int32_t>(), avro::Exception);
+}
+
 boost::unit_test::test_suite *
 init_unit_test_suite(int /*argc*/, char * /*argv*/[]) {
     using namespace boost::unit_test;
@@ -1086,6 +1106,7 @@ init_unit_test_suite(int /*argc*/, char * /*argv*/[]) {
                                     boost::make_shared<TestResolution>()));
     test->add(BOOST_TEST_CASE(&testNestedArraySchema));
     test->add(BOOST_TEST_CASE(&testNestedMapSchema));
+    test->add(BOOST_TEST_CASE(&testGenericDatumValueTypeMismatch));
 
     return test;
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`GenericDatum::value<T>()` (both the mutable and const overloads) returned:

```cpp
return (type_ == AVRO_UNION) ? std::any_cast<GenericUnion>(&value_)->datum().value<T>()
                             : *std::any_cast<T>(&value_);
```

The pointer form of `std::any_cast<T>(&value_)` returns `nullptr` when the requested C++ type `T` does not match the type actually held by the datum. Dereferencing that result is an **unchecked null-pointer dereference** (CWE-476): undefined behaviour that manifests as a segmentation fault as soon as the returned reference is read or copied.

This is the crash reported in AVRO-3194, where user code that binds/copies the result — e.g. `const avro::GenericRecord record = datum.value<avro::GenericRecord>()` when the datum is not actually a `GenericRecord` — segfaults instead of receiving a diagnosable error.

## How was this patch fixed?

Both overloads now check the `any_cast` result and throw an `avro::Exception` describing the datum type on a mismatch, instead of dereferencing a null pointer. Correct-type access and the union-unwrapping path are unchanged.

## How was this patch tested?

New regression case `testGenericDatumValueTypeMismatch` in `test/unittest.cc`:
- correct-type access still returns the value;
- mismatched-type access (`value<int32_t>()` / `value<std::vector<uint8_t>>()` on a string datum) now throws `avro::Exception` through both the mutable and const overloads.

Verified against the current code: without the fix the test reports `exception avro::Exception expected but not raised` (the null reference is UB and segfaults when the value is copied, as in the report); with the fix the full `unittest` suite passes (`*** No errors detected`).